### PR TITLE
plugins: pin to main and retire the v2 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "plugins"]
 	path = plugins
 	url = https://github.com/elle-lisp/plugins.git
-	branch = v2
+	branch = main
 [submodule "mcp"]
 	path = mcp
 	url = https://github.com/elle-lisp/mcp.git


### PR DESCRIPTION
elle is 2.0.0, so the plugins split that v2 existed to hold is over. v2's remaining work is merged into plugins main, the branch is deleted upstream, and the submodule tracks main.

The new pin carries proto3 default encoding and decoding, TLS ALPN and client certificates, offline TLS integration tests, and the encrypt buffer sized from what rustls asks for.