### PR TITLE
wasm: a stale module-cache entry is a miss, not a failure

### DIFF
--- a/docs/impl/wasm.md
+++ b/docs/impl/wasm.md
@@ -261,6 +261,26 @@ Arithmetic and comparisons are already inline WASM (no host calls).
 3. **Separate stdlib compilation**: compile stdlib as a separate WASM
    module, cached independently. Link user code against it.
 
+### A stale cache entry is a miss, not a failure
+
+The disk cache keys a pre-compiled module on a hash of its WASM bytes alone, so an
+entry outlives the wasmtime build that wrote it. `Module::deserialize` rejects what
+another build produced — `Module was compiled with incompatible version 'N'` — which
+makes every entry in the directory unreadable the moment the toolchain moves.
+
+So a read that fails to deserialize is treated as a cache MISS: the module is
+recompiled and the stale entry overwritten. The cache heals itself on the next run
+rather than failing every run until someone clears the directory by hand. This covers
+a truncated or corrupt file by the same route, and it is why the `unsafe` deserialize
+is safe to attempt — wasmtime rejects a foreign entry instead of mis-parsing it.
+
+The directory is shared by every checkout inheriting the same `TMPDIR`, so two
+checkouts built against different wasmtime versions land on the same keys. With the
+fallback they overwrite each other's entries — each run recompiles, which costs the
+cache's benefit but stays correct. Without it, whichever version wrote last breaks the
+other outright. wasmtime exports no version constant to fold into the key, so the
+fallback is what makes the shared directory safe.
+
 ### Debug builds optimize dependencies
 
 The `830ms cold` figure is a release build. A **debug** build applies

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -185,38 +185,63 @@ pub fn eval_wasm_with_stdlib(source: &str, source_name: &str) -> Result<String, 
     eval_wasm_raw(source, source_name, true)
 }
 
-/// Compile a WASM module, checking the disk cache first.
+/// Load a pre-compiled module from the disk cache, or compile and cache it.
 ///
-/// Returns a compiled Module. On cache miss, compiles from bytes,
-/// serializes, and caches atomically.
-fn compile_or_cache_module(
+/// `prefix` names the entry family (`closure` / `module`); `compile` builds the
+/// module on a miss. `cache_dir` is threaded in rather than read from the global
+/// config so a test can point it at a scratch directory instead of the shared one.
+///
+/// An entry that fails to deserialize is a MISS, not an error. The key is a hash of
+/// the wasm bytes alone, so an entry outlives the wasmtime build that wrote it, and
+/// `Module::deserialize` rejects a foreign one ("Module was compiled with incompatible
+/// version"). Recompiling overwrites it, so the directory heals on the next run
+/// instead of failing every run until someone clears it by hand — which matters
+/// because every checkout inheriting the same `TMPDIR` shares it
+/// (docs/impl/wasm.md § "A stale cache entry is a miss, not a failure").
+fn cached_module(
     engine: &wasmtime::Engine,
+    prefix: &str,
     wasm_bytes: &[u8],
+    cache_dir: Option<&str>,
+    compile: impl FnOnce() -> Result<wasmtime::Module, String>,
 ) -> Result<wasmtime::Module, String> {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
-    if let Some(cache_dir) = &crate::config::get().cache {
-        let mut hasher = DefaultHasher::new();
-        wasm_bytes.hash(&mut hasher);
-        let hash = hasher.finish();
-        let cache_path =
-            std::path::PathBuf::from(cache_dir).join(format!("closure_{:016x}.bin", hash));
+    let Some(cache_dir) = cache_dir else {
+        return compile();
+    };
+    let mut hasher = DefaultHasher::new();
+    wasm_bytes.hash(&mut hasher);
+    let cache_path =
+        std::path::PathBuf::from(cache_dir).join(format!("{prefix}_{:016x}.bin", hasher.finish()));
 
-        if let Ok(bytes) = std::fs::read(&cache_path) {
-            return unsafe { wasmtime::Module::deserialize(engine, &bytes) }
-                .map_err(|e| e.to_string());
+    if let Ok(bytes) = std::fs::read(&cache_path) {
+        // SAFETY: the bytes came from `Module::serialize` below. An entry another
+        // wasmtime build wrote is REJECTED by `deserialize` rather than mis-parsed,
+        // which is what makes falling through to a recompile sound.
+        if let Ok(module) = unsafe { wasmtime::Module::deserialize(engine, &bytes) } {
+            return Ok(module);
         }
-
-        let module = wasmtime::Module::new(engine, wasm_bytes).map_err(|e| e.to_string())?;
-        if let Ok(serialized) = module.serialize() {
-            std::fs::create_dir_all(cache_dir).ok();
-            store::atomic_write(&cache_path, &serialized);
-        }
-        Ok(module)
-    } else {
-        wasmtime::Module::new(engine, wasm_bytes).map_err(|e| e.to_string())
     }
+
+    let module = compile()?;
+    if let Ok(serialized) = module.serialize() {
+        std::fs::create_dir_all(cache_dir).ok();
+        store::atomic_write(&cache_path, &serialized);
+    }
+    Ok(module)
+}
+
+/// Compile a single closure's WASM module, checking the disk cache first.
+fn compile_or_cache_module(
+    engine: &wasmtime::Engine,
+    wasm_bytes: &[u8],
+    cache_dir: Option<&str>,
+) -> Result<wasmtime::Module, String> {
+    cached_module(engine, "closure", wasm_bytes, cache_dir, || {
+        wasmtime::Module::new(engine, wasm_bytes).map_err(|e| e.to_string())
+    })
 }
 
 /// Build the source the full-module WASM path actually compiles: the stdlib
@@ -394,7 +419,11 @@ fn eval_wasm_raw(source: &str, source_name: &str, with_stdlib: bool) -> Result<S
             if let Some(standalone) =
                 emit::emit_single_closure(closure_func, Some(&lir_module), vm.heap_ptr, sym_ptr)
             {
-                if let Ok(module) = compile_or_cache_module(&engine, &standalone.wasm_bytes) {
+                if let Ok(module) = compile_or_cache_module(
+                    &engine,
+                    &standalone.wasm_bytes,
+                    crate::config::get().cache.as_deref(),
+                ) {
                     precached[i] = Some(host::PrecachedClosure {
                         module,
                         const_pool: standalone.const_pool,
@@ -444,31 +473,13 @@ fn eval_wasm_raw(source: &str, source_name: &str, with_stdlib: bool) -> Result<S
     let t3 = std::time::Instant::now();
 
     // Module cache: hash the WASM bytes, check for a cached pre-compiled module.
-    let module = if let Some(cache_dir) = &crate::config::get().cache {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-        let mut hasher = DefaultHasher::new();
-        result.wasm_bytes.hash(&mut hasher);
-        let hash = hasher.finish();
-        let cache_path =
-            std::path::PathBuf::from(&cache_dir).join(format!("module_{:016x}.bin", hash));
-
-        if let Ok(bytes) = std::fs::read(&cache_path) {
-            // SAFETY: we trust our own cache files.
-            unsafe { wasmtime::Module::deserialize(&engine, &bytes) }
-                .map_err(|e: wasmtime::Error| e.to_string())?
-        } else {
-            let module =
-                store::compile_module(&engine, &result.wasm_bytes).map_err(|e| e.to_string())?;
-            if let Ok(serialized) = module.serialize() {
-                std::fs::create_dir_all(cache_dir).ok();
-                store::atomic_write(&cache_path, &serialized);
-            }
-            module
-        }
-    } else {
-        store::compile_module(&engine, &result.wasm_bytes).map_err(|e| e.to_string())?
-    };
+    let module = cached_module(
+        &engine,
+        "module",
+        &result.wasm_bytes,
+        crate::config::get().cache.as_deref(),
+        || store::compile_module(&engine, &result.wasm_bytes).map_err(|e| e.to_string()),
+    )?;
     let t4 = std::time::Instant::now();
     let ret = store::run_module(&linker, &mut wasm_store, &module).map_err(|e| e.to_string());
     let t5 = std::time::Instant::now();

--- a/src/wasm/tests.rs
+++ b/src/wasm/tests.rs
@@ -851,3 +851,59 @@ fn wasm_full_non_allocating_calls_strand_nothing() {
          mint is materializing region entries"
     );
 }
+
+#[test]
+fn a_cache_entry_another_wasmtime_wrote_is_a_miss_not_a_failure() {
+    // The trap: the cache keys a pre-compiled module on a hash of its WASM
+    // bytes alone, so an entry outlives the wasmtime build that wrote it.
+    // `Module::deserialize` then rejects it with "Module was compiled with
+    // incompatible version 'N'". Propagating that error makes EVERY wasm run
+    // fail until the directory is cleared by hand — and the directory is shared
+    // by every checkout inheriting the same TMPDIR, so one toolchain bump
+    // breaks them all at once.
+    //
+    // The counter-factual: an assertion that only checked "the module loads"
+    // would pass against the propagating version too, because a fresh cache has
+    // no stale entry to trip over. This writes the poisoned entry first.
+    let dir = std::env::temp_dir().join(format!(
+        "elle-wasm-cache-test-{}-{:p}",
+        std::process::id(),
+        &0u8 as *const u8
+    ));
+    std::fs::create_dir_all(&dir).expect("temp cache dir");
+    let cache = dir.to_str().expect("utf-8 temp path").to_string();
+
+    let engine = wasmtime::Engine::default();
+    // The 8-byte empty module: magic + version. Enough to compile and
+    // serialize, and it keeps this test off the `wat` crate.
+    let wasm: &[u8] = b"\0asm\x01\x00\x00\x00";
+
+    // Poison the entry this call will look for.
+    let first = super::compile_or_cache_module(&engine, wasm, Some(&cache))
+        .expect("cold compile populates the cache");
+    drop(first);
+    let entry = std::fs::read_dir(&dir)
+        .expect("cache dir readable")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .find(|p| p.extension().is_some_and(|x| x == "bin"))
+        .expect("the cold compile wrote a cache entry");
+    std::fs::write(&entry, b"not a serialized wasmtime module").expect("poison the entry");
+
+    let reloaded = super::compile_or_cache_module(&engine, wasm, Some(&cache));
+    assert!(
+        reloaded.is_ok(),
+        "a cache entry that fails to deserialize must be a MISS, not an error: {:?}",
+        reloaded.err()
+    );
+
+    // And the stale entry is overwritten, so the cache heals rather than
+    // recompiling forever.
+    let healed = std::fs::read(&entry).expect("entry still present");
+    assert_ne!(
+        healed, b"not a serialized wasmtime module",
+        "the recompile must overwrite the stale entry"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
The WASM disk cache keys a pre-compiled module on a hash of its wasm bytes alone, so an entry outlives the wasmtime build that wrote it. `Module::deserialize` rejects what another build produced — `Module was compiled with incompatible version 'N'` — and that error was propagated, so **one poisoned entry failed every wasm run** until the directory was cleared by hand.

The directory is `$TMPDIR/elle-cache` by default, shared by every checkout on the machine that inherits the same `TMPDIR`. So a second checkout built against a different wasmtime version poisons the first.

## Not hypothetical

This is #886 and #883 landing on a developer box. With `main` on wasmtime 44 in one worktree and #883's branch on 46 in another, both resident:

```
test result: FAILED. 2223 passed; 10 failed
```

All ten: `Module was compiled with incompatible version '46'`, on a 44 build. Re-running an hour later, after the other worktree had done more work, gave **18** — the poisoning grows as the other checkout runs. Nothing in the failing checkout had changed.

Whichever way #886 is decided, the transition itself does this to everyone's cache, in both directions, and the error names wasmtime rather than the cache, so the first encounter costs a debugging session.

## The fix

A read that fails to deserialize is now a **miss**, not an error: the module is recompiled and the stale entry overwritten, so the cache heals on the next run. Two checkouts on different versions overwrite each other's entries — that costs the cache's benefit but stays correct, where failing outright did not. The same route covers a truncated or corrupt entry.

`deserialize` rejects a foreign entry rather than mis-parsing it, which is what makes attempting it and falling through sound; the `unsafe` block's contract is unchanged.

Folding the wasmtime version into the key would avoid the mutual overwrite, but wasmtime exports no version constant to fold in, and stale entries would become unreachable garbage in a shared temp directory rather than overwritten ones.

Both call sites ran their own copy of the read/compile/serialize dance. They now share one helper, which takes the cache directory as a parameter so a test can point it at a scratch dir instead of the shared one.

## The pin

`a_cache_entry_another_wasmtime_wrote_is_a_miss_not_a_failure` populates the cache, overwrites the entry with bytes `deserialize` will reject, and asserts the next load succeeds **and** that the stale entry was overwritten — so the cache heals rather than recompiling forever.

The counter-factual matters here: an assertion that only checked "the module loads" would pass against the propagating version too, because a fresh cache has no stale entry to trip over. The test writes the poisoned entry first. Verified failing with the fallback removed, passing with it.

## Verification

All 35 wasm unit tests pass. Full `make test ELLE=./target/release/elle CARGO_PROFILE=--release`: corpus `SMOKE EXIT=0`, `cargo test --workspace --lib --all-features` 2234 pass / 0 fail, integration 905 pass / 0 fail, fmt / clippy / rustdoc / crosscheck clean.

Note that `cargo test --lib` **without** `--all-features` never compiles these tests, which is why a default-feature test run reports green on a poisoned cache.
