### PR TITLE
make: run the integration suite at CI's thread count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,17 @@ test: smoke crosscheck  ## Rust unit + integration tests + clippy + fmt + crossc
 	$(MLIR_ENV) cargo clippy --workspace --all-targets --all-features -- -D warnings
 	$(MLIR_ENV) RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items
 	$(MLIR_ENV) cargo test --workspace --lib --all-features
-	cargo test --test '*' -- --skip property
+	RUST_TEST_THREADS=$(INTEGRATION_TEST_THREADS) cargo test --test '*' -- --skip property
+
+# The integration suite runs at CI's thread count, not the host's core count.
+# `thread_transfer::heap` gauges `mapped_bytes()` — bytes the region page pools
+# hold from the OS, PROCESS-wide — so every other test sharing the binary moves
+# the number under it. At full parallelism on a many-core box the reading swings
+# by an order of magnitude and the gauge fails on correct code; CI pins
+# RUST_TEST_THREADS=2 (.github/workflows/pr.yml, tests-combined) and reads it
+# steady. A pre-commit gate has to reproduce CI, so it pins the same value. The
+# cost is wall-clock: the suite takes ~45min here against ~13min unpinned.
+INTEGRATION_TEST_THREADS ?= 2
 
 # Clippy over the macOS arm of every `cfg(target_os)`. A Linux-only gate sees
 # only the io_uring side, so a binding the thread-pool backend never reads


### PR DESCRIPTION
`make test` ran `cargo test --test '*' -- --skip property` — CI's exact command — but without CI's environment, so it failed locally on correct code.

`integration::thread_transfer::heap::worker_heap_returns_its_pages_at_join` gauges `mapped_bytes()`: bytes the region page pools hold from the OS, **process-wide**. Every other test sharing the binary moves the number under it, so the reading depends on how many run at once.

On a 16-core box, the same commit gave:

| Condition | `1 worker` | `7 workers` | Slack is 4 MB |
|---|---|---|---|
| full parallelism | 5.1 MB | 148.1 MB | fails |
| full parallelism, `--skip property` | 4.5 MB | 13.0 MB | fails |
| test alone | — | — | passes, 3/3 |
| `RUST_TEST_THREADS=2` | — | — | passes |

CI never sees this: `tests-combined` sets `RUST_TEST_THREADS: 2` (`.github/workflows/pr.yml`).

The test itself is sound — it measures a slope precisely because the caller's own heap moves under the window, and its author accounted for that. What it did not account for is other tests in the same process, and the knob for that is the one CI already sets.

CONTRIBUTING tells contributors to run `make test` before committing. A gate that cannot pass on a many-core machine trains people to ignore it, so it pins the same value CI does.

The cost is wall-clock: the integration phase takes ~45min at two threads against ~13min unpinned. `INTEGRATION_TEST_THREADS` overrides it for a local run that does not need the gauge to be trustworthy:

```sh
make test INTEGRATION_TEST_THREADS=8
```

## Verification

`PROPTEST_CASES=16 RUST_TEST_THREADS=2 cargo test --test '*' -- --skip property` — 905 passed, 0 failed, including the gauge. Same suite at full parallelism fails it.
