### PR TITLE
region: fiber/propagate owes the delivery reference its re-park consumes

### DIFF
--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -237,6 +237,29 @@ parked fiber's accounting symmetric with its unpark:
   theft invisible). Pinned by `region_fiber_abort_io_protect_uaf`
   (`tests/integration/fixtures/region-fiber-abort-io-protect-uaf.lisp`);
   `tests/elle/grpc.lisp`'s `with-server` teardown is the full-scheduler witness.
+- **A propagated signal is a fresh park, and owes its own delivery reference.**
+  `fiber/propagate` installs the child's parked payload as the propagating fiber's own
+  `signal`. That fiber's resumer then reads the payload as its resume result and runs the
+  compiler-emitted release on it — the same consumer an `Emit` funds with its `EmitEscape`
+  mint. Re-parking a value the child already parked mints nothing, so that release consumes
+  a reference the propagate never took. One propagate hides the theft: an error unwind runs
+  no continuation, so the raising body's own reference is stranded and unclaimed, and the
+  release eats that instead. Two propagates do not, nor does a native error, whose payload
+  reaches `fiber.signal` with no body reference at all. The count then runs one short of the
+  recorded `fiber → payload` edges, and the last fiber's free cascade reclaims the payload
+  while the caller still holds it. So the propagate mints one itself
+  (`EscapeSite::PropagateEscape`), through the one `take_propagated_signal` helper the
+  call-, tail-, and JIT-position handlers share — all three run the same install, so all
+  three owe the same reference. Three cases take no mint. A NON-TERMINAL signal, because the
+  fiber runs again and the resume path proper governs the payload — step 6a excludes the same
+  set from its park retain, and the delivery follows the park. `SIG_HALT`, for the reason
+  `handle_emit` skips it: a halted fiber is promoted to `:dead` and `fiber/resume` refuses
+  it, so that delivery has no consumer and a retain would strand the payload. And the
+  no-signal fallback, whose error `escaping_error` builds in a fresh region already carrying
+  the reference the consumer releases — only a BORROWED payload is unfunded. The WASM tier's
+  `handle_fiber_propagate` is not this shape: it never installs into `fiber.signal`, and
+  returns the child's `(bits, value)` to its caller, whose park runs through `install_signal`
+  instead. Pinned by `tests/elle/region-fiber-propagate-uaf.lisp`.
 - **A resume value crosses counted, or not at all.** The delivery going *out* of a park
   is counted (above); the value coming *back* in is not, and by the same accounting must
   be. `VM::resume_suspended` pushes the resume value onto the parked frame's stack and

--- a/src/value/arena.rs
+++ b/src/value/arena.rs
@@ -182,6 +182,12 @@ pub enum EscapeSite {
     /// An emitted value the scheduler holds via `fiber.signal` past the
     /// matching compiler-emitted `DecrefRegion`.
     EmitEscape,
+    /// A child's parked payload re-installed as the propagating fiber's own
+    /// `signal` (`fiber/propagate`). The install is a fresh park, so it owes the
+    /// delivery reference its resumer's result release consumes — the child's
+    /// park funded its own resumer, not this one (docs/impl/region/owner.md
+    /// § "Park/unpark symmetry").
+    PropagateEscape,
     /// A child fiber's set-once terminal result, park-retained until the fiber
     /// is freed (released by the signal scan — asymmetric by Rule 7).
     TerminalSignal,
@@ -207,6 +213,7 @@ impl EscapeSite {
             EscapeSite::ChanSend => "chan-send",
             EscapeSite::SuspendEscape => "suspend-escape",
             EscapeSite::EmitEscape => "emit-escape",
+            EscapeSite::PropagateEscape => "propagate-escape",
             EscapeSite::TerminalSignal => "terminal-signal",
             EscapeSite::ParamBaseline => "param-baseline",
         }

--- a/src/vm/fiber/jit.rs
+++ b/src/vm/fiber/jit.rs
@@ -70,12 +70,10 @@ impl VM {
             }
         };
 
-        let (child_bits, child_value) = handle.with(|fiber| fiber.signal).unwrap_or_else(|| {
-            (
-                SIG_ERROR,
-                self.escaping_error("internal-error", "fiber/propagate: no signal"),
-            )
-        });
+        // Same install as the bytecode handlers, so the same delivery reference
+        // is owed — routed through the one helper rather than a third copy
+        // (docs/impl/region/owner.md § "Park/unpark symmetry").
+        let (child_bits, child_value) = self.take_propagated_signal(&handle);
 
         self.fiber.child = Some(handle);
         self.fiber.child_value = Some(fiber_value);

--- a/src/vm/fiber/propagate.rs
+++ b/src/vm/fiber/propagate.rs
@@ -5,6 +5,56 @@ use crate::value::{SignalBits, Value, SIG_ERROR, SIG_HALT};
 use crate::vm::core::VM;
 
 impl VM {
+    /// Read the child's parked signal, minting the DELIVERY reference the
+    /// re-park owes. Shared by the call-, tail-, and JIT-position handlers —
+    /// all three run the same install, so all three owe the same reference.
+    ///
+    /// Installing the child's payload as this fiber's own `signal` is a fresh
+    /// park: this fiber's resumer reads the payload as its resume result and
+    /// runs the compiler-emitted release on it. The child's park funded its own
+    /// resumer's release, not this one, so without a mint here that release
+    /// consumes a reference nothing took — the payload's count then runs one
+    /// short of the recorded `fiber → payload` edges and the free cascade
+    /// reclaims it under the caller (docs/impl/region/owner.md § "Park/unpark
+    /// symmetry").
+    ///
+    /// Three cases take no mint, each because the delivery already has an owner
+    /// or no consumer:
+    ///
+    /// - A NON-TERMINAL signal (a yield, an io request). The fiber runs again,
+    ///   so the resume path proper governs the payload — `release_parked_signal`
+    ///   for an io request, the resumed body's own pending release otherwise.
+    ///   `with_child_fiber` step 6a excludes exactly this set from its park
+    ///   retain for the same reason ("retaining here would leak"), and the
+    ///   delivery follows the park.
+    /// - `SIG_HALT`, for the reason `VM::handle_emit` skips it: a halt promotes
+    ///   the fiber to `:dead`, `fiber/resume` refuses it, so that delivery has
+    ///   no consumer and a retain would strand the payload.
+    /// - The no-signal fallback, whose error `escaping_error` builds in a fresh
+    ///   region already carrying the one reference the consumer's
+    ///   `DecrefValueRegion` releases — only a BORROWED payload is unfunded.
+    pub(super) fn take_propagated_signal(
+        &mut self,
+        handle: &crate::value::FiberHandle,
+    ) -> (SignalBits, Value) {
+        let Some((bits, value)) = handle.with(|fiber| fiber.signal) else {
+            return (
+                SIG_ERROR,
+                self.escaping_error("internal-error", "fiber/propagate: no signal"),
+            );
+        };
+        if super::is_terminal_signal(bits) && !bits.intersects(SIG_HALT) {
+            let heap = unsafe { &mut *self.heap_ptr };
+            let region = crate::value::arena::region_of(heap, value);
+            crate::value::arena::incref_for_escape(
+                heap,
+                region,
+                crate::value::arena::EscapeSite::PropagateEscape,
+            );
+        }
+        (bits, value)
+    }
+
     /// Handle SIG_PROPAGATE from fiber/propagate (Call position).
     pub(in crate::vm) fn handle_fiber_propagate_signal(
         &mut self,
@@ -19,12 +69,7 @@ impl VM {
             }
         };
 
-        let (child_bits, child_value) = handle.with(|fiber| fiber.signal).unwrap_or_else(|| {
-            (
-                SIG_ERROR,
-                self.escaping_error("internal-error", "fiber/propagate: no signal"),
-            )
-        });
+        let (child_bits, child_value) = self.take_propagated_signal(&handle);
 
         self.fiber.child = Some(handle);
         self.fiber.child_value = Some(fiber_value);
@@ -59,12 +104,7 @@ impl VM {
             }
         };
 
-        let (child_bits, child_value) = handle.with(|fiber| fiber.signal).unwrap_or_else(|| {
-            (
-                SIG_ERROR,
-                self.escaping_error("internal-error", "fiber/propagate: no signal"),
-            )
-        });
+        let (child_bits, child_value) = self.take_propagated_signal(&handle);
 
         self.fiber.child = Some(handle);
         self.fiber.child_value = Some(fiber_value);

--- a/tests/elle/region-fiber-propagate-uaf.lisp
+++ b/tests/elle/region-fiber-propagate-uaf.lisp
@@ -1,0 +1,225 @@
+(elle/epoch 12)
+# A propagated signal is a fresh park, and owes its own delivery reference
+# (docs/impl/region/owner.md § "Park/unpark symmetry").
+#
+# `fiber/propagate` installs the child's parked payload as the propagating
+# fiber's own `signal`. That fiber's resumer reads the payload as its resume
+# result and runs the compiler-emitted release on it — the consumer an `Emit`
+# funds with its `EmitEscape` mint. Re-parking a value the child already parked
+# mints nothing, so the release consumes a reference the propagate never took.
+#
+# The trap: ONE propagate hides it. An error unwind runs no continuation, so the
+# raising body's own reference is stranded and unclaimed, and the release eats
+# that instead — which is why the obvious three-line reproducer is green. The
+# witnesses below each remove that cover, by propagating twice or by raising the
+# error from a native, whose payload reaches `fiber.signal` owning nothing.
+#
+# The counter-factual: without the mint the payload's count runs one short of
+# the recorded `fiber → payload` edges, so the last fiber's free cascade
+# reclaims it while the caller still holds it. Every witness reads a HEAP field
+# of the payload after the carrying fibers are gone, never just `(not ok?)` —
+# a bare status check passes over a freed payload and would have missed this.
+#
+# `defer` is the propagate in production form: it resumes a body fiber, runs
+# cleanup, then `(fiber/propagate f)` when the body did not complete. `protect`
+# supplies the outermost catch and hands the payload back as data.
+
+# ── (a) two propagates: the second has no stranded reference to steal ────────
+(defn a-inner [n]
+  (defer
+    nil
+    (error {:reason :bang :tag (string "a" n)})))
+(defn a-middle [n]
+  (defer
+    nil
+    (a-inner n)))
+(defn w-two-propagates [n]
+  (let [[ok? err] (protect (a-middle n))]
+    (assert (not ok?) "two-propagate witness completed instead of erroring")
+    (assert (= err:reason :bang) "two-propagate payload lost its :reason")
+    (length err:tag)))
+
+# ── (b) three propagates — the shortfall is per park, not per value ──────────
+(defn b-deep [n]
+  (defer
+    nil
+    (defer
+      nil
+      (defer
+        nil
+        (error {:reason :deep :tag (string "b" n)})))))
+(defn w-three-propagates [n]
+  (let [[ok? err] (protect (b-deep n))]
+    (assert (not ok?) "three-propagate witness completed instead of erroring")
+    (length err:tag)))
+
+# ── (c) a NATIVE error through one propagate ─────────────────────────────────
+# A native raise builds its payload and installs it without leaving a body
+# reference behind, so a single propagate is already one short.
+(defn c-native [n]
+  (defer
+    nil
+    (get nil :missing)))
+(defn w-native [n]
+  (let [[ok? err] (protect (c-native n))]
+    (assert (not ok?) "native-error witness completed instead of erroring")
+    (assert (= err:error :type-error) "native payload lost its :error tag")
+    (length err:message)))
+
+# ── (d) the payload read through `fiber/value`, not the protect tuple ────────
+# The explicit form of the same park: propagate out of a hand-rolled fiber and
+# read the result off the outer fiber after control has left it.
+(defn d-body [n]
+  (defer
+    nil
+    (error {:reason :bang :tag (string "d" n)})))
+(defn w-fiber-value [n]
+  (let [f (fiber/new (fn () (d-body n)) 1)]
+    (fiber/resume f nil)
+    (assert (not (= (fiber/status f) :dead))
+            "fiber-value witness completed instead of erroring")
+    (let [err (fiber/value f)]
+      (length err:tag))))
+
+# ── (e) the payload outlives the read, in a container ────────────────────────
+# Nothing on the stack holds it after the protect returns; the holder that must
+# still find it alive is the array the driver reads back out.
+(def @errsink @[])
+(defn w-stored [n]
+  (let [[ok? err] (protect (a-middle n))]
+    (push errsink err)
+    (length err:tag)))
+
+# ── controls — each removes one ingredient; balanced without a minted ref ────
+
+# (f) ONE propagate of a body-allocated payload: the stranded raise reference
+# covers the delivery, so this is green with or without the mint.
+(defn g-one [n]
+  (defer
+    nil
+    (error {:reason :bang :tag (string "f" n)})))
+(defn c-one-propagate [n]
+  (let [[ok? err] (protect (g-one n))]
+    (length err:tag)))
+
+# (g) the body COMPLETES, so `defer` never propagates at all.
+(defn g-ok [n]
+  (defer
+    nil
+    (string "g" n)))
+(defn c-completed [n]
+  (let [[ok? v] (protect (g-ok n))]
+    (assert ok? "control: completing body reported an error")
+    (length v)))
+
+# (h) the payload is an IMMEDIATE — no region crosses, so nothing is delivered.
+(defn h-imm [n]
+  (defer
+    nil
+    (defer
+      nil
+      (error 42))))
+(defn c-immediate [n]
+  (let [[ok? err] (protect (h-imm n))]
+    (assert (not ok?) "control: immediate-payload witness did not error")
+    (if (= err 42) 1 0)))
+
+# ── drive: a fresh payload per iteration keeps region ids churning, so a ─────
+# recycled id detonates on its generation stamp rather than reading stale bytes.
+
+(defn drive [reps]
+  (var i 0)
+  (var a 0)
+  (var b 0)
+  (var c 0)
+  (var d 0)
+  (var e 0)
+  (var f 0)
+  (var g 0)
+  (var h 0)
+  (while (%lt i reps)
+    (assign a (w-two-propagates i))
+    (assign b (w-three-propagates i))
+    (assign c (w-native i))
+    (assign d (w-fiber-value i))
+    (assign e (w-stored i))
+    (assign f (c-one-propagate i))
+    (assign g (c-completed i))
+    (assign h (c-immediate i))
+    # Witness (e)'s holder is the module-level array by design: read the stored
+    # payload back out — it must still be alive — then drain so the driver's
+    # own retention stays flat for the growth gauge below.
+    (let [held (get errsink (%sub (length errsink) 1))]
+      (assert (%gt (length held:tag) 0)
+              "stored payload freed by the propagating fibers' free cascade"))
+    (assign errsink @[])
+    (assign i (%add i 1)))
+  (list a b c d e f g h))
+
+(let [r (drive 400)]
+  (assert (> (get r 0) 0) "payload freed by the second of two propagates")
+  (assert (> (get r 1) 0) "payload freed by the third of three propagates")
+  (assert (> (get r 2) 0) "native-error payload freed by its propagate")
+  (assert (> (get r 3) 0) "payload freed under a `fiber/value` read")
+  (assert (> (get r 4) 0) "payload freed under the container read")
+  (assert (> (get r 5) 0) "control: single propagate mis-read (harness broken)")
+  (assert (> (get r 6) 0) "control: completing body mis-read")
+  (assert (> (get r 7) 0) "control: immediate payload mis-read"))
+
+# ── the leak face: the mint must fund exactly one consumer, per park ─────────
+# A mint no release answers strands one region per propagate, so the gauge is
+# DIFFERENTIAL in propagate depth, not absolute: raise the same payload through
+# zero, one, and three propagates and compare the growth of each.
+#
+# The trap: absolute flatness is not available to measure against. `(protect
+# (error {...}))` already strands two regions per iteration with no propagate
+# anywhere in it — the raising body's own reference to the payload it allocated,
+# whose release lives in a continuation an error unwind never runs. That leak
+# predates this mint and is identical with and without it. Asserting a flat
+# region count here would pin that unrelated leak and fail forever.
+#
+# The counter-factual: an unconsumed mint makes growth scale with depth, so
+# `d3` would exceed `d0` by three regions per iteration and the slack below
+# would not absorb it.
+
+(defn d0 [n]
+  (let [[ok? err] (protect (error {:reason :bang :tag (string "z" n)}))]
+    (length err:tag)))
+(defn d1 [n]
+  (let [[ok? err] (protect (defer
+                             nil
+                             (error {:reason :bang :tag (string "z" n)})))]
+    (length err:tag)))
+(defn d3 [n]
+  (let [[ok? err] (protect (defer
+                             nil
+                             (defer
+                               nil
+                               (defer
+                                 nil
+                                 (error {:reason :bang :tag (string "z" n)})))))]
+    (length err:tag)))
+
+(defn growth-of [f reps]
+  (var i 0)
+  (while (%lt i 50)
+    (f i)
+    (assign i (%add i 1)))
+  (let [before (arena/region-count)]
+    (assign i 0)
+    (while (%lt i reps)
+      (f i)
+      (assign i (%add i 1)))
+    (%sub (arena/region-count) before)))
+
+(let [g0 (growth-of d0 400)
+      g1 (growth-of d1 400)
+      g3 (growth-of d3 400)]
+  (assert (%lt (%sub g1 g0) 40)
+          (string "one propagate strands regions: growth " g1 " vs " g0
+                  " with no propagate, over 400 iterations"))
+  (assert (%lt (%sub g3 g0) 40)
+          (string "each propagate strands a region: growth " g3
+                  " at depth three vs " g0 " at depth zero, over 400 iterations")))
+
+(println "region-fiber-propagate-uaf: ok")


### PR DESCRIPTION
`fiber/propagate` installs the child fiber's parked payload as the propagating fiber's own `signal`. That install is a fresh park: the propagating fiber's resumer reads the payload as its resume result and runs the compiler-emitted release on it. The child's park funded its own resumer's release, not this one, and nothing minted a second — so the release consumed a reference no one took.

One propagate hides the theft. An error unwind runs no continuation, so the raising body's own reference to the payload is stranded and unclaimed, and the release eats that instead. Two propagates do not, nor does a native error, whose payload reaches `fiber.signal` owning nothing. The count then runs one short of the recorded `fiber → payload` edges, and the last fiber's free cascade reclaims the payload while the caller still holds it.

## The witness on main

`tests/elle/http.lisp` fails on `main` today. `do-request` wraps its body in `defer` — `fiber/propagate` in production form — inside the caller's `protect`, and the transport raises from a native. It reads `err:reason` back as `nil` in release, and panics on the generation stamp in debug:

```
stale region deref: … region 78646 generation 0, but generation 1 is current
  at src/value/fiberheap/regionstore/pointer.rs:82
```

CI stayed green because the generation check sits behind `cfg!(debug_assertions)` (`pointer.rs:59`), and `Makefile:8-18` builds release under `GITHUB_ACTIONS`. Every job that runs the corpus runs release, where the check is compiled out and the freed payload simply reads back as `nil`. **The new pin fails in release too**, so it closes that gap rather than depending on the debug-only detector.

## The fix

One `take_propagated_signal` helper mints `EscapeSite::PropagateEscape` on the borrowed payload. The call-, tail- and JIT-position handlers each carried their own copy of the same install, so each carried the same shortfall; all three now route through the helper.

Three cases take no mint:

- a **non-terminal** signal — the fiber runs again, so the resume path proper governs the payload (`release_parked_signal` for an io request, the resumed body's own pending release otherwise). `with_child_fiber` step 6a excludes the same set from its park retain, and the delivery follows the park;
- `SIG_HALT`, for the reason `handle_emit` skips it — a halted fiber is promoted to `:dead` and `fiber/resume` refuses it, so that delivery has no consumer;
- the no-signal fallback, whose error `escaping_error` already builds carrying the reference the consumer releases.

Minting on non-terminal signals as well is not merely redundant: it broke `tests/elle/process-teardown.lisp` in release, with the same tag/object mismatch this class produces.

## The pin

`tests/elle/region-fiber-propagate-uaf.lisp` — five witnesses (two and three propagates, a native error through one, a `fiber/value` read, a container holder) and three controls. Each reads a **heap field** of the payload after the carrying fibers are gone; a bare `(not ok?)` status check passes over a freed payload and would have missed this.

Its leak face is **differential in propagate depth** rather than absolute. `(protect (error {...}))` already strands two regions per iteration with no propagate in it at all, identically with and without this change — a flat-count assertion would pin that unrelated pre-existing leak and fail forever. That leak is the raising body's own reference to the payload it allocated, whose release lives in a continuation an error unwind never runs; the old unfunded release was quietly consuming it. Worth a separate fix.

## Verification

`make test ELLE=./target/release/elle CARGO_PROFILE=--release`, with #wasm-cache-heals applied so the wasm unit tests can run at all on a machine whose module cache was poisoned by another checkout:

| Gate | Result |
|---|---|
| Corpus (`smoke-elle`, vm + jit) | `SMOKE EXIT=0` — 891 pass, 7 skip, 0 fail |
| `cargo test --workspace --lib --all-features` | 2234 pass, 0 fail |
| Integration (`--skip property`, `RUST_TEST_THREADS=2`) | 905 pass, 0 fail |
| fmt / clippy / rustdoc / crosscheck | clean |
| New pin, debug **and** release | fails before, passes after |
