### PR TITLE
signals: filesystem authority is :fs, not :io

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,6 +79,32 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D warnings"
 
+  # The documentation site is generated from docs/*.md plus the Elle sources
+  # under src/, so it breaks on a renamed heading or a moved source file as
+  # readily as on a code change. Its only other run is the push-to-main job
+  # that publishes the site, which discovers such a break after the merge
+  # rather than before it. This job is that run, minus the publish.
+  #
+  # It carries no `if: needs.changes.outputs.source` gate on purpose: the
+  # filter reads `source` off .rs/.lisp/Cargo/Makefile paths, so a PR that
+  # touches only Markdown — exactly the PR most able to break the generator —
+  # would skip the one job that checks it.
+  docs:
+    name: Documentation Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install graphviz
+        run: sudo apt-get update && sudo apt-get install -y graphviz
+      - name: Build Elle
+        run: cargo build --release
+      - name: Generate pipeline diagram
+        run: make docs
+      - name: Generate Elle documentation site
+        run: ./target/release/elle demos/docgen/generate.lisp
+
   tests:
     name: VM+JIT Tests
     needs: changes

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,15 +1,35 @@
-name: Weekly Toolchain Check
+name: Weekly Checks
 
 on:
   schedule:
-    # Weekly toolchain check: Sunday 06:00 UTC
+    # Weekly toolchain and advisory check: Sunday 06:00 UTC
     - cron: '0 6 * * 0'
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
 jobs:
+  # A RustSec advisory lands against a dependency version, not against a
+  # commit, so a frozen Cargo.lock goes from clean to vulnerable with nothing
+  # pushed. A schedule is what notices that; a per-PR run would instead turn
+  # every open PR red the day an advisory is published, for a lockfile none of
+  # them touched. Non-blocking for the same reason the push-to-main copy is:
+  # the report is the product, and the fix is a deliberate dependency bump.
+  audit:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install and run cargo-audit
+        run: |
+          cargo install cargo-audit
+          cargo audit
+
   toolchain-check:
     name: Toolchain Check
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -319,60 +319,124 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8628cc4ba7f88a9205a7ee42327697abc61195a1e3d92cfae172d6a946e722e"
+checksum = "3867f7a56768640a79fc660d2f60298251dc6d65b5d1c907706cd1afff024957"
 dependencies = [
- "cranelift-assembler-x64-meta",
+ "cranelift-assembler-x64-meta 0.131.3",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aadfd45214f09461ba0406f7dacecce5cac39bf0bdb4890eeb468f4ef090e07"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.133.3",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d582754487e6c9a065a91c42ccf1bdd8d5977af33468dac5ae9bec0ce88acb3e"
+checksum = "a0661d63dcf8fc4a6538c1ee4d523917c5b27e9fce7a4114cdf9e2b30b4043cf"
 dependencies = [
- "cranelift-srcgen",
+ "cranelift-srcgen 0.131.3",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57069faede9bd1f926364b4cf69ccc9bebc6f4af5ab897083581b7bc991bf20a"
+dependencies = [
+ "cranelift-srcgen 0.133.3",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb59c81ace12ee7c33074db7903d4d75d1f40b28cd3e8e6f491de57b29129eb9"
+checksum = "a8d535b489159ea63e3c40dfbe8d0e12bfb71f2a14845ef2407353e06c5a697c"
 dependencies = [
- "cranelift-entity",
- "wasmtime-internal-core",
+ "cranelift-entity 0.131.3",
+ "wasmtime-internal-core 44.0.3",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1221450f2f9efaa996d916bf53a0a4d13346a4a75468afb828390209a4fdd4"
+dependencies = [
+ "cranelift-entity 0.133.3",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25c06993a681be9cf3140798a3d4ac5bec955e7444416a2fdc87fda8567285d"
+checksum = "c3af4f7d421b2354deb01d714266022f38fcdbebc9f5f1ec6d310d3c27286d9e"
+dependencies = [
+ "wasmtime-internal-core 44.0.3",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97706f2b466d67bdf0f69d1cf5c5c4a5cd31087cf1fa2e8e5fe0450dddc8661d"
 dependencies = [
  "serde",
  "serde_derive",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b61f95c5a211918f5d336254a61a488b36a5818de47a868e8c4658dce9cccc"
+checksum = "09fe4c289e67e0221d1705734a57f95e25c289ed0ead7728743ea21285fc4cf1"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
+ "cranelift-assembler-x64 0.131.3",
+ "cranelift-bforest 0.131.3",
+ "cranelift-bitset 0.131.3",
+ "cranelift-codegen-meta 0.131.3",
+ "cranelift-codegen-shared 0.131.3",
+ "cranelift-control 0.131.3",
+ "cranelift-entity 0.131.3",
+ "cranelift-isle 0.131.3",
  "gimli",
  "hashbrown 0.16.1",
+ "libm",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core 44.0.3",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "432246ee44b2fc0140b412dca55801d200d6fb25d2d7d18c44bb29e8cd71268b"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64 0.133.3",
+ "cranelift-bforest 0.133.3",
+ "cranelift-bitset 0.133.3",
+ "cranelift-codegen-meta 0.133.3",
+ "cranelift-codegen-shared 0.133.3",
+ "cranelift-control 0.133.3",
+ "cranelift-entity 0.133.3",
+ "cranelift-isle 0.133.3",
+ "gimli",
+ "hashbrown 0.17.0",
  "libm",
  "log",
  "postcard",
@@ -384,56 +448,106 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b85aa822fce72080d041d7c2cf7c3f5c6ecdea7afae68379ba4ef85269c4fa5"
+checksum = "b3063e5363dc5ee6ee8edd930314582c08eb91c209b9564da1cd667f6424b9b3"
 dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared",
- "cranelift-srcgen",
+ "cranelift-assembler-x64-meta 0.131.3",
+ "cranelift-codegen-shared 0.131.3",
+ "cranelift-srcgen 0.131.3",
+ "heck",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aa51eff0949f06a5c8f3d5adefef94a12ea99f71cd8985047b91d45f367150"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.133.3",
+ "cranelift-codegen-shared 0.133.3",
+ "cranelift-srcgen 0.133.3",
  "heck",
  "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9fc89326cd072cc19e96892f09b5692c0dfe17cd4da2858ba30c2cd85c0"
+checksum = "c34b9c8dbc9edf37744918e56898d4979ef1e764e8e4bbe8b4d50250838ddfe8"
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6095e7095930b6169490138b4262fe7ec24290d3f604d7fe62e1e3138e740daa"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d005320f487e6e8a3edcc7f2fd4f43fcc9946d1013bf206ea649789ac1617fc"
+checksum = "4eed9dc54204dc99aad19669bca50142659ed583396d9a99a2aef34d7c136ef4"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-control"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e61dfa0766c0eadf42b3febd145a35f81f31086e207f534e5fb406fc3d08fc47"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e62ef34c6e720f347a79ece043e8584e242d168911da640bac654a33a6aaaf5"
+checksum = "9aa2846b239a046217ecf95cfed0e31be4e86843785d07438ad33f456871e888"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.131.3",
+ "wasmtime-internal-core 44.0.3",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93867a79a06dd5d9ffeb96f7563dc7b6b142b5d89e42ab77e458a408a8aa9d5"
+dependencies = [
+ "cranelift-bitset 0.133.3",
  "serde",
  "serde_derive",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa2ad00399dd47e7e7e33cb1dc23b0e39ed9dcd01e8f026fc37af91655031b8"
+checksum = "144f70fa9cd07efb83497c12dc8fb73f360a690cd990c44e8ceebc293d8c13b5"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.131.3",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1991dc32fefa54f14d2a63570d1e963826257605e478558733f83450b7e7661"
+dependencies = [
+ "cranelift-codegen 0.133.3",
+ "hashbrown 0.17.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -441,57 +555,80 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c51975ed217b4e8e5a7fd11e9ec83a96104bdff311dddcb505d1d8a9fd7fc6"
+checksum = "0733ca5b2aaa5f6d5d6a1439e3c44280d34730d4d5c262ca08c6775c8d83f191"
+
+[[package]]
+name = "cranelift-isle"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784546de9988ff6e1df0fd4d2450760469a7607344156c661e69ec28082c5da4"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4070d2acc5c976887c10c273d38dd2bebebb472fd1ba65fa17b548adf5f56350"
+checksum = "96aa44fbb64b5b652fd77aa0a5bb3a1609ca4eae7204fd547991245cc19a18d0"
 dependencies = [
  "anyhow",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
+ "cranelift-codegen 0.131.3",
+ "cranelift-control 0.131.3",
+ "cranelift-entity 0.131.3",
  "cranelift-module",
- "cranelift-native",
+ "cranelift-native 0.131.3",
  "libc",
  "log",
  "region",
  "target-lexicon",
- "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-jit-icache-coherence 44.0.3",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052a396328dbc7dadc29d1bd27d4aa57d9e9e493ead8ef6e2ab3b75c1bf9644c"
+checksum = "dab212cf4630da14726d76333152920694c52f544ff5cc520329b4fa256fe78c"
 dependencies = [
  "anyhow",
- "cranelift-codegen",
- "cranelift-control",
+ "cranelift-codegen 0.131.3",
+ "cranelift-control 0.131.3",
 ]
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b1889e00da9729d8f8525f3c12998ded86ea709058ff844ebe00b97548de0e"
+checksum = "75b1290d6193b171172d5fe9a6e42326edf487a79f211fbf1e76f912a4aed035"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.131.3",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7107a4ae4a2ba48b5df8648365e638b08322fa1da11e86206bf5eddb862b21dd"
+dependencies = [
+ "cranelift-codegen 0.133.3",
  "libc",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.1"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a8f82fd5124f009f72167e60139245cd3b56cfd4b53050f22110c48c5f4da1"
+checksum = "ce0d5c2b4d719566816a0f1c9a9712d35d61e27df0ffd6c72a9afec9048db6c0"
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.133.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3f161aa81ee5dd8d7b0eb8828988f57baf2f78d288e62b6b3714b37aa6d6a1"
 
 [[package]]
 name = "crc32fast"
@@ -559,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -640,11 +777,11 @@ version = "2.0.0"
 dependencies = [
  "bumpalo",
  "camino",
- "cranelift-codegen",
- "cranelift-frontend",
+ "cranelift-codegen 0.131.3",
+ "cranelift-frontend 0.131.3",
  "cranelift-jit",
  "cranelift-module",
- "cranelift-native",
+ "cranelift-native 0.131.3",
  "criterion",
  "crossbeam-channel",
  "io-uring",
@@ -955,8 +1092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -966,6 +1101,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1184,6 +1321,12 @@ checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "melior"
@@ -1476,21 +1619,21 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9326e3a0093d170582cf64ed9e4cf253b8aac155ec4a294ff62330450bbf094"
+checksum = "3f647f8aefd39efd5e38b484a8b7a926dd035ae366127df75c1d94d196f0a4ba"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.133.3",
  "log",
  "pulley-macros",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
 name = "pulley-macros"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c6433917e3789605b1f4cd2a589f637ff17212344e7fa5ba99544625ba52c7"
+checksum = "3e902032e329008b189b67498b1be7784d5849276f32402eca17441df08a6bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1605,13 +1748,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "log",
  "rustc-hash",
  "serde",
@@ -1655,7 +1798,7 @@ checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
- "mach2",
+ "mach2 0.4.3",
  "windows-sys 0.52.0",
 ]
 
@@ -2175,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.246.2"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
+checksum = "b089037d7eb453ed57b560fe7833de0707411c8b9fdc429745ced77e2a1bacb9"
 dependencies = [
  "anyhow",
  "heck",
@@ -2185,8 +2328,8 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wat",
 ]
 
@@ -2208,6 +2351,26 @@ checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.246.2",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.251.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.257.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.257.1",
 ]
 
 [[package]]
@@ -2241,28 +2404,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
  "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.17.0",
  "indexmap",
  "semver",
  "serde",
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.246.2"
+name = "wasmparser"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
+checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
+dependencies = [
+ "bitflags 2.11.1",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372db8bbad8ec962038101f75ab2c3ffcd18797d7d3ae877a58ab9873cd0c4bd"
+checksum = "d39226663bd765601279a79b88645a7c4a4d3c2fe73040afdc27bead02ee6659"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -2277,7 +2462,7 @@ dependencies = [
  "ittapi",
  "libc",
  "log",
- "mach2",
+ "mach2 0.6.0",
  "memfd",
  "object",
  "once_cell",
@@ -2293,37 +2478,37 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 46.0.3",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
  "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-jit-icache-coherence 46.0.3",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.61.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e15aa0d1545e48d9b25ca604e9e27b4cd6d5886d30ac5787b57b3a2daf85b57"
+checksum = "2595a168541e8a7faeacf21e3d59da93628ee71468cd69fee9fc2a92c9b1c7d8"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-entity",
+ "cranelift-bforest 0.133.3",
+ "cranelift-bitset 0.133.3",
+ "cranelift-entity 0.133.3",
  "gimli",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap",
  "log",
  "object",
@@ -2335,18 +2520,18 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5441170843ac2ab28a1d7646b04a93a46d63bd4083274fd246c6a80189b37767"
+checksum = "a37d629957320219db11336663e0947e19afe77150403509cac21c47ead60c69"
 dependencies = [
  "base64",
  "directories-next",
@@ -2364,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c136cb0d2d47850d6d04a58157130ac98b0df4c17626cd30b083d26b607b7027"
+checksum = "9abf0fb4ce458eb6edbfaf6cbf13fcbf4216eac5a85febfe90224a1f6064c990"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -2374,39 +2559,49 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.246.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df3d3b4fa2119c6fd161e475b4e21aaefb51d082353b922b433bea37facc65"
+checksum = "0e50df18c9a8e0deec353ad1e6364ef50538231719a12d80fa5dcb300be8d36b"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.1"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2c7fa6523647262bfb4095dbdf4087accefe525813e783f81a0c682f418ce4"
+checksum = "aedd3947487d0afdd37accb981466fcd60571e898004c8955111f88686581dfc"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "46.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93b097389e5fad89c8ff8ee0aeafd16447b5a288d52aa1131f17ab4c19fd5be3"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "serde",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c032f422e39061dfc43f32190c0a3526b04161ec4867f362958f3fe9d1fe29"
+checksum = "08b3e909115836655b83c8bdef7c2e20a34293e785218d9f71a4e5382a09c6b0"
 dependencies = [
  "cfg-if",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
+ "cranelift-codegen 0.133.3",
+ "cranelift-control 0.133.3",
+ "cranelift-entity 0.133.3",
+ "cranelift-frontend 0.133.3",
+ "cranelift-native 0.133.3",
  "gimli",
  "itertools 0.14.0",
  "log",
@@ -2415,18 +2610,18 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 46.0.3",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dd76d80adf450cc260ba58f23c28030401930b19149695b1d121f7d621e791"
+checksum = "a000d1124dd40417ce8433d07de1063ecc9be7cac21745c8de7f9cf7684c3ead"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2439,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab453cc600b28ee5d3f9495aa6d4cb2c81eda40903e9287296b548fba8b2391d"
+checksum = "a7439956e78ba68e2cd766f34c3f056d625fad9a055eafb0c4569ac91c09e6b4"
 dependencies = [
  "cc",
  "object",
@@ -2451,24 +2646,36 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.1"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1859e920871515d324fb9757c3e448d6ed1512ca6ccdff14b6e016505d6ada"
+checksum = "10005b038e662775ac002f233e429447a58892e89918580fa67ce8cdd9192d0a"
 dependencies = [
  "cfg-if",
  "libc",
- "wasmtime-internal-core",
+ "wasmtime-internal-core 44.0.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "46.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3a381a9dd1ffe3893507733300b420605f465655d78c7a75a965a09d7b43d5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core 46.0.3",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dfe405bd6adb1386d935a30f16a236bd4ef0d3c383e7cbbab98d063c9d9b73"
+checksum = "22f951f78a1a09001547838fa557522d56655385db97e47307d0f582ca866974"
 dependencies = [
  "cfg-if",
- "cranelift-codegen",
+ "cranelift-codegen 0.133.3",
  "log",
  "object",
  "wasmtime-environ",
@@ -2476,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a9b9165fc45d42c81edfe3e9cb458e58720594ad5db6553c4079ea041a4a581"
+checksum = "51e06f9fabbe647e5c2ed186e6920ab1fb48174688d7d3fdadbda537b8499b51"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2486,53 +2693,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "44.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f439b70ba3855a8c808d2cd798eef79bcd389f78aa48a8a694ea8e2904410c"
-dependencies = [
- "cranelift-codegen",
- "gimli",
- "log",
- "object",
- "target-lexicon",
- "wasmparser 0.246.2",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "44.0.1"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c7ced16dc16d2027f9f8d3a503e191dcce0f53fe9218e7990135b31f8f6fdb"
+checksum = "f49ac5121036c2255bdc203b1b75a1c04544744cd5f51c93240b58bddca9f0f1"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
  "heck",
  "indexmap",
- "wit-parser 0.246.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wast"
-version = "246.0.2"
+version = "257.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
+checksum = "3c416ee8044cf88c5280e3d87c322b009525eb25142cf7428f0a90ea88febc3b"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.246.2",
+ "wasm-encoder 0.257.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.246.2"
+version = "1.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
+checksum = "672e5495f00c5fc6c6b502205bae4708aa4dd13d969754438743afe0a8af0f1d"
 dependencies = [
  "wast",
 ]
@@ -2577,25 +2767,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "44.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da7c536f3cfe5ff63537f795902fed56b8b5adcc7a87843a86dd8d4e57a7946"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.246.2",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
-]
 
 [[package]]
 name = "windows-link"
@@ -2796,12 +2967,12 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.246.2"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
+checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "id-arena",
  "indexmap",
  "log",
@@ -2810,7 +2981,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,11 +319,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3867f7a56768640a79fc660d2f60298251dc6d65b5d1c907706cd1afff024957"
+checksum = "f8628cc4ba7f88a9205a7ee42327697abc61195a1e3d92cfae172d6a946e722e"
 dependencies = [
- "cranelift-assembler-x64-meta 0.131.3",
+ "cranelift-assembler-x64-meta 0.131.1",
 ]
 
 [[package]]
@@ -337,11 +337,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0661d63dcf8fc4a6538c1ee4d523917c5b27e9fce7a4114cdf9e2b30b4043cf"
+checksum = "d582754487e6c9a065a91c42ccf1bdd8d5977af33468dac5ae9bec0ce88acb3e"
 dependencies = [
- "cranelift-srcgen 0.131.3",
+ "cranelift-srcgen 0.131.1",
 ]
 
 [[package]]
@@ -355,12 +355,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d535b489159ea63e3c40dfbe8d0e12bfb71f2a14845ef2407353e06c5a697c"
+checksum = "fb59c81ace12ee7c33074db7903d4d75d1f40b28cd3e8e6f491de57b29129eb9"
 dependencies = [
- "cranelift-entity 0.131.3",
- "wasmtime-internal-core 44.0.3",
+ "cranelift-entity 0.131.1",
+ "wasmtime-internal-core 44.0.1",
 ]
 
 [[package]]
@@ -375,11 +375,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3af4f7d421b2354deb01d714266022f38fcdbebc9f5f1ec6d310d3c27286d9e"
+checksum = "f25c06993a681be9cf3140798a3d4ac5bec955e7444416a2fdc87fda8567285d"
 dependencies = [
- "wasmtime-internal-core 44.0.3",
+ "wasmtime-internal-core 44.0.1",
 ]
 
 [[package]]
@@ -395,19 +395,19 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fe4c289e67e0221d1705734a57f95e25c289ed0ead7728743ea21285fc4cf1"
+checksum = "27b61f95c5a211918f5d336254a61a488b36a5818de47a868e8c4658dce9cccc"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.131.3",
- "cranelift-bforest 0.131.3",
- "cranelift-bitset 0.131.3",
- "cranelift-codegen-meta 0.131.3",
- "cranelift-codegen-shared 0.131.3",
- "cranelift-control 0.131.3",
- "cranelift-entity 0.131.3",
- "cranelift-isle 0.131.3",
+ "cranelift-assembler-x64 0.131.1",
+ "cranelift-bforest 0.131.1",
+ "cranelift-bitset 0.131.1",
+ "cranelift-codegen-meta 0.131.1",
+ "cranelift-codegen-shared 0.131.1",
+ "cranelift-control 0.131.1",
+ "cranelift-entity 0.131.1",
+ "cranelift-isle 0.131.1",
  "gimli",
  "hashbrown 0.16.1",
  "libm",
@@ -417,7 +417,7 @@ dependencies = [
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-core 44.0.3",
+ "wasmtime-internal-core 44.0.1",
 ]
 
 [[package]]
@@ -453,13 +453,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3063e5363dc5ee6ee8edd930314582c08eb91c209b9564da1cd667f6424b9b3"
+checksum = "0b85aa822fce72080d041d7c2cf7c3f5c6ecdea7afae68379ba4ef85269c4fa5"
 dependencies = [
- "cranelift-assembler-x64-meta 0.131.3",
- "cranelift-codegen-shared 0.131.3",
- "cranelift-srcgen 0.131.3",
+ "cranelift-assembler-x64-meta 0.131.1",
+ "cranelift-codegen-shared 0.131.1",
+ "cranelift-srcgen 0.131.1",
  "heck",
 ]
 
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34b9c8dbc9edf37744918e56898d4979ef1e764e8e4bbe8b4d50250838ddfe8"
+checksum = "833eb9fc89326cd072cc19e96892f09b5692c0dfe17cd4da2858ba30c2cd85c0"
 
 [[package]]
 name = "cranelift-codegen-shared"
@@ -490,9 +490,9 @@ checksum = "6095e7095930b6169490138b4262fe7ec24290d3f604d7fe62e1e3138e740daa"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eed9dc54204dc99aad19669bca50142659ed583396d9a99a2aef34d7c136ef4"
+checksum = "9d005320f487e6e8a3edcc7f2fd4f43fcc9946d1013bf206ea649789ac1617fc"
 dependencies = [
  "arbitrary",
 ]
@@ -508,12 +508,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2846b239a046217ecf95cfed0e31be4e86843785d07438ad33f456871e888"
+checksum = "5e62ef34c6e720f347a79ece043e8584e242d168911da640bac654a33a6aaaf5"
 dependencies = [
- "cranelift-bitset 0.131.3",
- "wasmtime-internal-core 44.0.3",
+ "cranelift-bitset 0.131.1",
+ "wasmtime-internal-core 44.0.1",
 ]
 
 [[package]]
@@ -530,11 +530,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f70fa9cd07efb83497c12dc8fb73f360a690cd990c44e8ceebc293d8c13b5"
+checksum = "dfa2ad00399dd47e7e7e33cb1dc23b0e39ed9dcd01e8f026fc37af91655031b8"
 dependencies = [
- "cranelift-codegen 0.131.3",
+ "cranelift-codegen 0.131.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0733ca5b2aaa5f6d5d6a1439e3c44280d34730d4d5c262ca08c6775c8d83f191"
+checksum = "02c51975ed217b4e8e5a7fd11e9ec83a96104bdff311dddcb505d1d8a9fd7fc6"
 
 [[package]]
 name = "cranelift-isle"
@@ -567,42 +567,42 @@ checksum = "784546de9988ff6e1df0fd4d2450760469a7607344156c661e69ec28082c5da4"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96aa44fbb64b5b652fd77aa0a5bb3a1609ca4eae7204fd547991245cc19a18d0"
+checksum = "4070d2acc5c976887c10c273d38dd2bebebb472fd1ba65fa17b548adf5f56350"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.131.3",
- "cranelift-control 0.131.3",
- "cranelift-entity 0.131.3",
+ "cranelift-codegen 0.131.1",
+ "cranelift-control 0.131.1",
+ "cranelift-entity 0.131.1",
  "cranelift-module",
- "cranelift-native 0.131.3",
+ "cranelift-native 0.131.1",
  "libc",
  "log",
  "region",
  "target-lexicon",
- "wasmtime-internal-jit-icache-coherence 44.0.3",
+ "wasmtime-internal-jit-icache-coherence 44.0.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab212cf4630da14726d76333152920694c52f544ff5cc520329b4fa256fe78c"
+checksum = "052a396328dbc7dadc29d1bd27d4aa57d9e9e493ead8ef6e2ab3b75c1bf9644c"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.131.3",
- "cranelift-control 0.131.3",
+ "cranelift-codegen 0.131.1",
+ "cranelift-control 0.131.1",
 ]
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b1290d6193b171172d5fe9a6e42326edf487a79f211fbf1e76f912a4aed035"
+checksum = "f9b1889e00da9729d8f8525f3c12998ded86ea709058ff844ebe00b97548de0e"
 dependencies = [
- "cranelift-codegen 0.131.3",
+ "cranelift-codegen 0.131.1",
  "libc",
  "target-lexicon",
 ]
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.3"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0d5c2b4d719566816a0f1c9a9712d35d61e27df0ffd6c72a9afec9048db6c0"
+checksum = "d5a8f82fd5124f009f72167e60139245cd3b56cfd4b53050f22110c48c5f4da1"
 
 [[package]]
 name = "cranelift-srcgen"
@@ -777,11 +777,11 @@ version = "2.0.0"
 dependencies = [
  "bumpalo",
  "camino",
- "cranelift-codegen 0.131.3",
- "cranelift-frontend 0.131.3",
+ "cranelift-codegen 0.131.1",
+ "cranelift-frontend 0.131.1",
  "cranelift-jit",
  "cranelift-module",
- "cranelift-native 0.131.3",
+ "cranelift-native 0.131.1",
  "criterion",
  "crossbeam-channel",
  "io-uring",
@@ -861,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1163,7 +1163,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1824,7 +1824,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2027,7 +2027,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2570,9 +2570,9 @@ checksum = "0e50df18c9a8e0deec353ad1e6364ef50538231719a12d80fa5dcb300be8d36b"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.3"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedd3947487d0afdd37accb981466fcd60571e898004c8955111f88686581dfc"
+checksum = "8f2c7fa6523647262bfb4095dbdf4087accefe525813e783f81a0c682f418ce4"
 dependencies = [
  "hashbrown 0.16.1",
  "libm",
@@ -2646,13 +2646,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.3"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10005b038e662775ac002f233e429447a58892e89918580fa67ce8cdd9192d0a"
+checksum = "6a1859e920871515d324fb9757c3e448d6ed1512ca6ccdff14b6e016505d6ada"
 dependencies = [
  "cfg-if",
  "libc",
- "wasmtime-internal-core 44.0.3",
+ "wasmtime-internal-core 44.0.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2759,7 +2759,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ cranelift-native = { version = "0.131", optional = true }
 target-lexicon = { version = "0.13", optional = true }
 
 # WASM backend (optional, enable with --features wasm)
-wasmtime = { version = "44", features = ["incremental-cache"], optional = true }
+wasmtime = { version = "46", features = ["incremental-cache"], optional = true }
 wasm-encoder = { version = "0.246", optional = true }
 
 # MLIR backend (optional, requires LLVM 22 + MLIR)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,11 @@ else
   CARGO_PROFILE :=
 endif
 TIMEOUT ?= 30s
-LISP_FILES := $(shell find stdlib.lisp prelude.lisp lib/ tests/ demos/ -name '*.lisp' 2>/dev/null)
+# `find` is told to be quiet about a missing root, so a root that moves drops
+# silently out of the format gate rather than failing it. The pin that every
+# Elle source in the tree stays reachable from this list is
+# tests/integration/paths.rs.
+LISP_FILES := $(shell find src/ lib/ tests/ demos/ tools/ -name '*.lisp' 2>/dev/null)
 
 # oracle.lisp is the leak-measurement instrument: a couple of hundred adaptive
 # empirical-Bernstein probes, each looping blocks of heap ops until its interval

--- a/demos/docgen/generate.lisp
+++ b/demos/docgen/generate.lisp
@@ -14,7 +14,10 @@
 (def @src-dir "src")
 (def @prelude-path (path/join src-dir "prelude.lisp"))
 (def @stdlib-path (path/join src-dir "stdlib.lisp"))
-(def @github-base "https://github.com/anthropics/elle/blob/main")
+# Every stdlib entry carries a source link built on this. Cargo.toml's
+# `repository` is the canonical spelling of the URL; tests/integration/paths.rs
+# pins the two together.
+(def @github-base "https://github.com/elle-lisp/elle/blob/main")
 
 # ── Imports ────────────────────────────────────────────────────────
 

--- a/demos/docgen/generate.lisp
+++ b/demos/docgen/generate.lisp
@@ -8,6 +8,12 @@
 (def @docs-root "docs")
 (def @output-dir "site")
 (def @docs-dir "demos/docgen/docs")
+# The Elle sources whose comments and defns become the API reference.
+# Every path here is resolved against the repository root, which is where
+# the generator is invoked from.
+(def @src-dir "src")
+(def @prelude-path (path/join src-dir "prelude.lisp"))
+(def @stdlib-path (path/join src-dir "stdlib.lisp"))
 (def @github-base "https://github.com/anthropics/elle/blob/main")
 
 # ── Imports ────────────────────────────────────────────────────────
@@ -218,7 +224,7 @@
 
 (defn generate-prelude-html []
   "Generate HTML for prelude macros."
-  (let [source (slurp "prelude.lisp")]
+  (let [source (slurp prelude-path)]
     (def @html @"")
     (push html
           "<p>Macros loaded automatically before user code. These expand at compile time.</p>\n")
@@ -268,8 +274,8 @@
 
 (defn generate-stdlib-html []
   "Generate HTML for stdlib functions with signal profiles."
-  (let* [source (slurp "stdlib.lisp")
-         analysis (compile/analyze source {:file "stdlib.lisp"})
+  (let* [source (slurp stdlib-path)
+         analysis (compile/analyze source {:file stdlib-path})
          syms (compile/symbols analysis)
          fn-syms (filter (fn [s] (= (get s :kind) :function)) syms)
          lines (string/split source "\n")]
@@ -328,7 +334,7 @@
                    desc (or (get fn-comments fn-name) "")
                    line-num (get fn-lines fn-name)
                    source-link (when line-num
-                                 (string github-base "/stdlib.lisp#L"
+                                 (string github-base "/" stdlib-path "#L"
                                  (string line-num)))]
               (push html "<div class=\"api-entry\">")
               (push html

--- a/docs/analysis/testing.md
+++ b/docs/analysis/testing.md
@@ -120,11 +120,35 @@ value. Otherwise, write Elle test scripts.
 | Runtime error message inspection | `tests/integration/` | Substring matching on error strings |
 | VM internals (scope stack, frames) | `tests/vm/` | Below integration, above unit |
 | Invariants across generated inputs | `tests/property/` | Property-based tests with proptest |
+| Reads or perturbs process-global state | `tests/<name>.rs`, its own binary | A process-wide counter, an rlimit, a signal disposition, a re-exec, or a fault the harness must survive |
 
 For Rust integration tests that don't call stdlib functions (map, filter,
 fold, etc.), prefer `eval_source_bare` over `eval_source` — it skips stdlib
 initialization and is faster. Prelude macros (defn, let*, ->, etc.) are
 still available with `eval_source_bare`.
+
+### Process-global state needs its own binary
+
+Everything under `tests/lib.rs` — `unittests/`, `integration/`, `property/` —
+compiles into ONE binary, and libtest runs its tests concurrently on many
+threads. A test there shares the process with a thousand others.
+
+That is fine for a test whose subject is a value it owns. It is wrong for a
+test whose subject is a process-wide fact, because a concurrent sibling
+changes that fact underneath the measurement and the test cannot tell the
+two apart. A page counter reads a sibling's allocation as its own leak. An
+rlimit or a signal disposition one test installs stays installed for every
+test that follows it. A deliberate fault takes the whole binary down, and
+with it every unrelated test.
+
+Give such a test its own file directly under `tests/`. Cargo builds one
+binary per file there, so the process holds only that test and whatever it
+starts. Name the file for the subject (`worker_heap.rs`,
+`region_process_teardown.rs`), and say in its header which global it reads —
+that is the fact the next reader needs and cannot see from the assertion.
+
+A test that merely runs slowly does not qualify. The cost is a whole extra
+link of the crate per file, so the reason must be the shared process itself.
 
 
 ## Running tests

--- a/docs/impl/wasm.md
+++ b/docs/impl/wasm.md
@@ -356,6 +356,28 @@ elle --wasm=11 tests/elle/wasm-tier.lisp
 cargo test wasm
 ```
 
+## The module cache is a cache
+
+`--cache=path` stores each compiled module as a serialized wasmtime artifact
+named for a hash of the WASM bytes it was compiled from. Those bytes are the
+only thing the name captures, and they are not the whole of what the artifact
+depends on: `Module::deserialize` accepts an artifact only from the wasmtime
+that wrote it, and refuses one written by any other version.
+
+So a read that yields no usable module is a MISS, not an error. The compiler
+falls back to compiling the WASM fresh and overwrites the entry, which repairs
+the cache in place. The same fallback covers every other reason the bytes on
+disk may be unusable — a truncated write, a file another tool put there, a
+host whose CPU features no longer match.
+
+The alternative is to fail the run, and it fails it for good: nothing in the
+program deletes the entry, so every later run reads the same unusable bytes
+and stops the same way. An upgrade would strand every user holding a warm
+cache until they cleared it by hand, and the error naming a wasmtime version
+gives no hint that a directory is what needs deleting. A cache that cannot
+miss is not a cache. `wasm::tests::cache_entry_that_cannot_be_deserialized_recompiles`
+pins the fallback on both cached paths.
+
 ## CLI flags
 
 | Flag | Effect |

--- a/docs/signals/capabilities.md
+++ b/docs/signals/capabilities.md
@@ -30,20 +30,58 @@ can't do. They're independent:
 
 ## Deniable capabilities
 
-The following signal keywords can be denied:
+Every signal bit is a capability bit. A fiber's `:deny` set is tested
+against the bits a primitive *declares*, so any bit a primitive declares
+is one a parent can withhold. Some bits also drive dispatch — `:io`
+routes a request through the scheduler, `:yield` suspends — and some do
+no dispatch work at all. That distinction belongs to the VM. It does not
+change what a mask can deny.
 
-| Keyword | Bit | Effect when denied |
-|---------|-----|--------------------|
-| `:error` | 0 | Blocks primitives that may error (~66% of all) |
-| `:yield` | 1 | Blocks cooperative suspension |
-| `:debug` | 2 | Blocks breakpoints/tracing |
-| `:ffi` | 4 | Blocks foreign function calls |
-| `:halt` | 8 | Blocks VM termination |
-| `:io` | 9 | Blocks I/O operations |
-| `:exec` | 11 | Blocks subprocess execution |
+| Keyword | Bit | Effect when denied | Dispatch |
+|---------|-----|--------------------|----------|
+| `:error` | 0 | Blocks primitives that may error (~66% of all) | yes |
+| `:yield` | 1 | Blocks cooperative suspension | yes |
+| `:debug` | 2 | Blocks breakpoints/tracing | yes |
+| `:ffi` | 4 | Blocks foreign function calls | no |
+| `:halt` | 8 | Blocks VM termination | yes |
+| `:io` | 9 | Blocks operations that reach the I/O scheduler | yes |
+| `:exec` | 11 | Blocks subprocess execution | no |
+| `:gpu` | 15 | Blocks GPU dispatch | no |
+| `:os-signal` | 16 | Blocks POSIX signal send/raise | no |
+| `:fs` | 17 | Blocks filesystem access | no |
 
 VM-internal signals (resume, propagate, abort, query, terminal,
 switch, wait) cannot be denied.
+
+## Filesystem authority is `:fs`, not `:io`
+
+`:io` means "this request reaches the I/O scheduler". It is a dispatch
+bit that a fiber can also deny, and it covers ports, sockets, and the
+subprocess pipes — everything that suspends into the event loop.
+
+The filesystem primitives are synchronous `std::fs` calls. They never
+reach the scheduler, so they carry no `:io`, and denying `:io` never
+stopped them. `:fs` is the bit that means "resolves a filesystem path",
+and it is the one to deny to close the disk off:
+
+```text
+(fiber/new body |:error| :deny |:fs|)
+```
+
+The two bits are independent on purpose. A worker can keep `:io` — so it
+still writes to stdout and talks to the network — while the disk is
+denied and mediated by its parent. Deny both to close off all of it.
+
+`port/open` carries both. It resolves a path (`:fs`) and it opens that
+path through the scheduler (`:io`), so either denial blocks it. Without
+the `:fs` bit on it, a fiber denied `:fs` alone could open a port on any
+path and read it, which is the same authority `file/read` grants.
+
+A primitive carries `:fs` when its implementation resolves a filesystem
+path, decided by reading the implementation and not the name. `path/join`,
+`path/parent`, and `path/normalize` are string operations and do not carry
+it. `path/exists?`, `path/canonicalize`, and `path/cwd` reach the
+filesystem and do.
 
 ## What happens on denial
 
@@ -76,11 +114,11 @@ capability space that is NOT withheld:
 
 ```lisp
 (fiber/caps)
-# => |:error :yield :debug :ffi :halt :io :exec|
+# => |:debug :error :exec :ffi :fs :gpu :halt :io :os-signal :yield|
 
-(let [f (fiber/new (fn [] 42) |:error| :deny |:io :ffi|)]
+(let [f (fiber/new (fn [] 42) |:error| :deny |:fs :ffi|)]
   (fiber/caps f))
-# => |:error :yield :debug :halt :exec|
+# => |:debug :error :exec :gpu :halt :io :os-signal :yield|
 ```
 
 ## Transitivity
@@ -91,15 +129,15 @@ A child inherits its parent's restrictions plus any `:deny` of its own:
 ```lisp
 (let [outer (fiber/new
                (fn []
-                 # inner denies :ffi, inherits :io denial from outer
+                 # inner denies :ffi, inherits :fs denial from outer
                  (let [inner (fiber/new (fn [] (fiber/caps))
                                         |:error| :deny |:ffi|)]
                    (fiber/resume inner)))
                |:error|
-               :deny |:io|)]
+               :deny |:fs|)]
   (fiber/resume outer))
-# => |:error :yield :debug :halt :exec|
-# (missing :io from parent, missing :ffi from own deny)
+# => |:debug :error :exec :gpu :halt :io :os-signal :yield|
+# (missing :fs from parent, missing :ffi from own deny)
 ```
 
 A child can never gain capabilities its parent lacks. Requesting to
@@ -133,9 +171,13 @@ blocks `length` but not `+`.
 ## Examples
 
 ```text
-# Pure computation sandbox — no IO, no FFI, no subprocess
-(let [f (fiber/new compute |:io :ffi :exec :error|
-                    :deny |:io :ffi :exec|)]
+# Pure computation sandbox — no IO, no filesystem, no FFI, no subprocess
+(let [f (fiber/new compute |:io :fs :ffi :exec :error|
+                    :deny |:io :fs :ffi :exec|)]
+  (fiber/resume f))
+
+# Mediated worker — keeps stdout and the network, mediates the disk
+(let [f (fiber/new worker |:fs :error| :deny |:fs|)]
   (fiber/resume f))
 
 # Capability-check a plugin before running it

--- a/src/primitives/fileio.rs
+++ b/src/primitives/fileio.rs
@@ -190,7 +190,7 @@ pub(crate) fn prim_read_lines(
 // Declarative primitive definitions for file I/O operations.
 primitive! {
     "file/read" => prim_slurp {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Read entire file as a string",
         params: &["path"],
@@ -200,7 +200,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "file/write" => prim_spit {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(2),
         doc: "Write string content to a file (overwrites if exists)",
         params: &["path", "content"],
@@ -210,7 +210,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "file/append" => prim_append_file {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(2),
         doc: "Append string content to a file",
         params: &["path", "content"],
@@ -220,7 +220,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "file/delete" => prim_delete_file {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Delete a file",
         params: &["path"],
@@ -230,7 +230,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "file/delete-dir" => prim_delete_directory {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Delete a directory (must be empty)",
         params: &["path"],
@@ -240,7 +240,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "file/delete-dir-all" => prim_delete_directory_all {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Delete a directory and everything under it (need not be empty)",
         params: &["path"],
@@ -250,7 +250,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "file/mktempdir" => prim_make_temp_directory {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(0),
         doc: "Create a uniquely-named directory under the platform temp root \
               (TMPDIR on Unix, %TEMP% on Windows) and return its path",
@@ -261,7 +261,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "file/mkdir" => prim_create_directory {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Create a directory",
         params: &["path"],
@@ -271,7 +271,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "file/mkdir-all" => prim_create_directory_all {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Create a directory and all parent directories",
         params: &["path"],
@@ -281,7 +281,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "file/rename" => prim_rename_file {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(2),
         doc: "Rename a file",
         params: &["old-path", "new-path"],
@@ -291,7 +291,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "file/copy" => prim_copy_file {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(2),
         doc: "Copy a file",
         params: &["src", "dst"],
@@ -301,7 +301,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "file/size" => prim_file_size {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Get file size in bytes",
         params: &["path"],
@@ -311,7 +311,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "file/stat" => prim_file_stat {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Get filesystem metadata as a struct (follows symlinks)",
         params: &["path"],
@@ -320,7 +320,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "file/lstat" => prim_file_lstat {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Get filesystem metadata as a struct (does not follow symlinks)",
         params: &["path"],
@@ -329,7 +329,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "file/ls" => prim_list_directory {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "List directory contents",
         params: &["path"],
@@ -339,7 +339,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "file/lines" => prim_read_lines {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Read lines from a file and return as a list of strings",
         params: &["path"],

--- a/src/primitives/modules.rs
+++ b/src/primitives/modules.rs
@@ -364,8 +364,9 @@ pub(crate) fn prim_import_file(
 
 // Declarative primitive definitions for module loading operations
 primitive! {
+    // Resolves the specifier against the search paths and reads the file.
     "import" => prim_import_file {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Import a module by specifier. Resolves via search paths (CWD, --path, --home) with extension probing (.lisp, native plugins). Binary files that fail UTF-8 reading are automatically tried as plugins.",
         params: &["spec"],

--- a/src/primitives/path.rs
+++ b/src/primitives/path.rs
@@ -322,8 +322,9 @@ primitive! {
         example: "(path/normalize \"./a/../b\")",
         effect: RegionEffect::Fresh,
     }
+    // Reads the cwd (`std::env::current_dir`) to resolve a relative path.
     "path/absolute" => prim_path_absolute {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Compute absolute path (does not require path to exist)",
         params: &["path"],
@@ -332,7 +333,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "path/canonicalize" => prim_path_canonicalize {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Resolve path through filesystem (symlinks resolved, must exist)",
         params: &["path"],
@@ -377,14 +378,14 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "path/cwd" => prim_path_cwd {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         doc: "Get current working directory",
         category: "path",
         example: "(path/cwd)",
         effect: RegionEffect::Fresh,
     }
     "path/exists?" => prim_path_exists {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Check if path exists",
         params: &["path"],
@@ -394,7 +395,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "path/file?" => prim_path_is_file {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Check if path is a regular file",
         params: &["path"],
@@ -404,7 +405,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "path/dir?" => prim_path_is_dir {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Check if path is a directory",
         params: &["path"],

--- a/src/primitives/ports.rs
+++ b/src/primitives/ports.rs
@@ -39,7 +39,7 @@ use query::*;
 
 primitive! {
     "port/open" => prim_port_open {
-        signal: Signal::io_yields_errors(),
+        signal: Signal::fs_io_yields_errors(),
         arity: Arity::AtLeast(2),
         doc: "Open a file as a text (UTF-8) port. Accepts optional :timeout ms keyword.",
         params: &["path", "mode"],
@@ -50,7 +50,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "port/open-bytes" => prim_port_open_bytes {
-        signal: Signal::io_yields_errors(),
+        signal: Signal::fs_io_yields_errors(),
         arity: Arity::AtLeast(2),
         doc: "Open a file as a binary port. Accepts optional :timeout ms keyword.",
         params: &["path", "mode"],

--- a/src/primitives/unix.rs
+++ b/src/primitives/unix.rs
@@ -201,8 +201,11 @@ pub(crate) fn prim_unix_shutdown(
 // ---------------------------------------------------------------------------
 
 primitive! {
+    // Binds a socket at a filesystem path, and unlinks that path first.
+    // Abstract-namespace names ("@name") touch no filesystem, but the
+    // primitive accepts either, so the capability covers both.
     "unix/listen" => prim_unix_listen {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(1),
         doc: "Listen on a Unix domain socket. Returns a listener port.",
         params: &["path"],
@@ -222,7 +225,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "unix/connect" => prim_unix_connect {
-        signal: Signal::io_yields_errors(),
+        signal: Signal::fs_io_yields_errors(),
         arity: Arity::AtLeast(1),
         doc: "Connect to a Unix domain socket. Returns a stream port.",
         params: &["path"],

--- a/src/primitives/watch.rs
+++ b/src/primitives/watch.rs
@@ -146,7 +146,7 @@ primitive! {
         effect: RegionEffect::Fresh,
     }
     "watch-add" => prim_watch_add {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Range(2, 3),
         doc: "Add a path to the watcher. Recursive by default. Optional third arg: {:recursive false}.",
         params: &["watcher", "path", "opts?"],
@@ -155,7 +155,7 @@ primitive! {
         effect: RegionEffect::Immediate,
     }
     "watch-remove" => prim_watch_remove {
-        signal: Signal::errors(),
+        signal: Signal::fs_errors(),
         arity: Arity::Exact(2),
         doc: "Remove a watched path from the watcher.",
         params: &["watcher", "path"],

--- a/src/signals/AGENTS.md
+++ b/src/signals/AGENTS.md
@@ -65,14 +65,21 @@ The global signal registry maps signal keywords to bit positions. It is a proces
 | `:io` | 9 | I/O request to scheduler |
 | `:exec` | 11 | Subprocess execution (spawn, wait, kill) |
 | `:fuel` | 12 | Instruction budget exhaustion |
-| `:switch` | 13 | Context switch |
 | `:wait` | 14 | Blocking wait |
+| `:gpu` | 15 | GPU hardware dispatch |
+| `:os-signal` | 16 | POSIX signal send/raise |
+| `:fs` | 17 | Filesystem access |
 
-Bits 3, 5, 6, 7, 10, 15 are VM-internal.
+Bits 3, 5, 6, 7, 10, and 13 are VM-internal and are not registered.
+
+`:exec`, `:gpu`, `:os-signal`, and `:fs` do no dispatch work. They exist so
+a fiber mask can withhold the authority, which is what `VM::call_inner`
+tests against `def.signal.bits`. Every bit is deniable; only some also
+route the call somewhere.
 
 ### User-Defined Signals
 
-User signals are allocated bits 32–63 (up to 32 user signals per compilation unit). Bits 16–31 are reserved for future runtime signals. The registry is append-only — once a keyword is registered, its bit position is fixed for the lifetime of the process.
+User signals are allocated bits 32–63 (up to 32 user signals per compilation unit). Bits 18–31 are reserved for future runtime signals. The registry is append-only — once a keyword is registered, its bit position is fixed for the lifetime of the process.
 
 ### Registry Interface
 

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -49,7 +49,8 @@ use std::fmt;
 //   Bit  14:    Wait - structured concurrency wait request
 //   Bit  15:    GPU
 //   Bit  16:    OsSignal — POSIX signal send/raise capability (access control; NOT a dispatch bit)
-//   Bits 17-31: Runtime-reserved (future runtime signals)
+//   Bit  17:    Fs — filesystem capability (access control; NOT a dispatch bit)
+//   Bits 18-31: Runtime-reserved (future runtime signals)
 //   Bits 32-63: User-defined signal types
 
 pub const SIG_OK: SignalBits = SignalBits::EMPTY; // no bits set = normal return
@@ -70,6 +71,13 @@ pub const SIG_SWITCH: SignalBits = SignalBits::new(1 << 13); // fiber switch tra
 pub const SIG_WAIT: SignalBits = SignalBits::new(1 << 14); // structured concurrency wait request
 pub const SIG_GPU: SignalBits = SignalBits::new(1 << 15); // GPU hardware dispatch (capability bit)
 pub const SIG_OS_SIGNAL: SignalBits = SignalBits::new(1 << 16); // POSIX signal send/raise (capability bit)
+pub const SIG_FS: SignalBits = SignalBits::new(1 << 17); // filesystem access (capability bit, not dispatch)
+
+/// The scheduler round trip: the dispatch bit that routes a request to the
+/// I/O backend, the suspension it implies, and the error it may come back
+/// with. Every async primitive carries these three; a capability-gated one
+/// adds its own bit on top, so the base cannot drift between them.
+const IO_ROUND_TRIP: SignalBits = SIG_IO.union(SIG_YIELD).union(SIG_ERROR);
 
 /// VM-internal signal bits: infrastructure signals that user code cannot
 /// produce. These are emitted exclusively by the VM's own dispatch machinery.
@@ -215,7 +223,37 @@ impl Signal {
     /// suspends the calling fiber until the backend completes it.
     pub const fn io_yields_errors() -> Self {
         Signal {
-            bits: SIG_IO.union(SIG_YIELD).union(SIG_ERROR),
+            bits: IO_ROUND_TRIP,
+            propagates: 0,
+        }
+    }
+
+    /// Resolves a filesystem path and may error (SIG_FS | SIG_ERROR).
+    ///
+    /// The signal of every primitive whose implementation reaches the
+    /// filesystem synchronously. `SIG_FS` is a capability bit only: these are
+    /// `std::fs` calls that return their result directly, so nothing about
+    /// dispatch or the event loop changes. Carrying `SIG_IO` instead would be
+    /// wrong twice over — it claims a scheduler round trip that never happens,
+    /// and it ties the disk to the bit that governs ports and sockets.
+    pub const fn fs_errors() -> Self {
+        Signal {
+            bits: SIG_FS.union(SIG_ERROR),
+            propagates: 0,
+        }
+    }
+
+    /// Opens a filesystem path through the I/O scheduler
+    /// (SIG_FS | SIG_IO | SIG_YIELD | SIG_ERROR).
+    ///
+    /// Both capabilities apply and either denial blocks the call: `SIG_FS` for
+    /// the path the primitive resolves, `SIG_IO` for the scheduler round trip
+    /// that opens it. Without `SIG_FS`, a fiber denied only the filesystem
+    /// could open a port on any path and read it — the same authority
+    /// `file/read` grants.
+    pub const fn fs_io_yields_errors() -> Self {
+        Signal {
+            bits: IO_ROUND_TRIP.union(SIG_FS),
             propagates: 0,
         }
     }
@@ -229,7 +267,7 @@ impl Signal {
     /// permit or deny spawning at all.
     pub const fn subprocess() -> Self {
         Signal {
-            bits: SIG_EXEC.union(SIG_IO).union(SIG_YIELD).union(SIG_ERROR),
+            bits: IO_ROUND_TRIP.union(SIG_EXEC),
             propagates: 0,
         }
     }

--- a/src/signals/registry.rs
+++ b/src/signals/registry.rs
@@ -1,12 +1,12 @@
 use super::{
-    SIG_DEBUG, SIG_ERROR, SIG_EXEC, SIG_FFI, SIG_FUEL, SIG_GPU, SIG_HALT, SIG_IO, SIG_OS_SIGNAL,
-    SIG_WAIT, SIG_YIELD,
+    SIG_DEBUG, SIG_ERROR, SIG_EXEC, SIG_FFI, SIG_FS, SIG_FUEL, SIG_GPU, SIG_HALT, SIG_IO,
+    SIG_OS_SIGNAL, SIG_WAIT, SIG_YIELD,
 };
 /// Signal registry for mapping signal keywords to bit positions.
 ///
 /// The registry maintains a global mapping of signal keywords (`:error`, `:yield`, etc.)
-/// to their corresponding bit positions. Built-in signals occupy bits 0-15,
-/// bits 16-31 are runtime-reserved, and user-defined signals are allocated
+/// to their corresponding bit positions. Built-in signals occupy bits 0-17,
+/// bits 18-31 are runtime-reserved, and user-defined signals are allocated
 /// from bits 32-63.
 use std::sync::{Mutex, OnceLock};
 
@@ -52,6 +52,9 @@ impl SignalRegistry {
     /// - `:exec` at bit 11
     /// - `:fuel` at bit 12
     /// - `:wait` at bit 14
+    /// - `:gpu` at bit 15
+    /// - `:os-signal` at bit 16
+    /// - `:fs` at bit 17
     pub fn with_builtins() -> Self {
         let mut registry = Self::new();
         // These unwraps are safe because we're registering unique built-in names
@@ -66,6 +69,7 @@ impl SignalRegistry {
         let _ = registry.register_builtin("wait", SIG_WAIT.trailing_zeros());
         let _ = registry.register_builtin("gpu", SIG_GPU.trailing_zeros());
         let _ = registry.register_builtin("os-signal", SIG_OS_SIGNAL.trailing_zeros());
+        let _ = registry.register_builtin("fs", SIG_FS.trailing_zeros());
         registry
     }
 

--- a/src/signals/tests.rs
+++ b/src/signals/tests.rs
@@ -365,3 +365,57 @@ fn squelched_bits_subtracts_the_pause_rather_than_exempting_the_signal() {
         SIG_YIELD
     );
 }
+
+// ── Filesystem capability ───────────────────────────────────────────
+
+/// The filesystem primitives are synchronous `std::fs` calls. `:fs` marks the
+/// authority; it must not claim the scheduler round trip that `:io` means.
+#[test]
+fn fs_errors_carries_authority_without_dispatch() {
+    let s = Signal::fs_errors();
+    assert!(s.bits.intersects(SIG_FS));
+    assert!(s.may_error());
+    assert!(
+        !s.bits.intersects(SIG_IO),
+        ":fs must not imply a scheduler round trip"
+    );
+    assert!(!s.may_yield(), ":fs must not imply suspension");
+}
+
+/// `port/open` resolves a path AND opens it through the scheduler, so either
+/// denial must block it. Without `:fs` a fiber denied only the filesystem
+/// could open a port on any path and read it.
+#[test]
+fn fs_io_yields_errors_is_deniable_from_either_side() {
+    let s = Signal::fs_io_yields_errors();
+    assert!(s.bits.intersects(SIG_FS));
+    assert!(s.may_io());
+    assert!(s.may_yield());
+    assert!(s.may_error());
+}
+
+/// The three async constructors share one base, so a change to what a
+/// scheduler round trip means cannot reach one and miss the others.
+#[test]
+fn capability_gated_io_constructors_extend_the_same_base() {
+    let base = Signal::io_yields_errors().bits;
+    assert_eq!(Signal::subprocess().bits, base.union(SIG_EXEC));
+    assert_eq!(Signal::fs_io_yields_errors().bits, base.union(SIG_FS));
+}
+
+/// Every signal bit is a capability bit: a fiber mask can withhold `:fs`
+/// exactly as it withholds `:io` or `:exec`.
+#[test]
+fn fs_is_deniable_and_not_vm_internal() {
+    assert!(CAP_MASK.intersects(SIG_FS), ":fs must be deniable");
+    assert!(!VM_INTERNAL.intersects(SIG_FS), ":fs is not VM-internal");
+}
+
+/// The keyword a `:deny |:fs|` mask is written with must resolve to the bit
+/// the primitives declare, or the mask silently withholds nothing.
+#[test]
+fn fs_keyword_resolves_to_the_declared_bit() {
+    let registry = registry::SignalRegistry::with_builtins();
+    assert_eq!(registry.lookup("fs"), Some(SIG_FS.trailing_zeros()));
+    assert_eq!(registry.to_signal_bits("fs"), Some(SIG_FS));
+}

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -25,7 +25,7 @@ pub use signalbits::SignalBits;
 // owner). Re-exported here so existing `use crate::value::fiber::SIG_*`
 // imports continue to work.
 pub use crate::signals::{
-    SIG_ABORT, SIG_DEBUG, SIG_ERROR, SIG_EXEC, SIG_FFI, SIG_FUEL, SIG_HALT, SIG_IO, SIG_OK,
+    SIG_ABORT, SIG_DEBUG, SIG_ERROR, SIG_EXEC, SIG_FFI, SIG_FS, SIG_FUEL, SIG_HALT, SIG_IO, SIG_OK,
     SIG_PROPAGATE, SIG_QUERY, SIG_RESUME, SIG_SWITCH, SIG_TERMINAL, SIG_WAIT, SIG_YIELD,
 };
 

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -193,30 +193,8 @@ fn compile_or_cache_module(
     engine: &wasmtime::Engine,
     wasm_bytes: &[u8],
 ) -> Result<wasmtime::Module, String> {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-
-    if let Some(cache_dir) = &crate::config::get().cache {
-        let mut hasher = DefaultHasher::new();
-        wasm_bytes.hash(&mut hasher);
-        let hash = hasher.finish();
-        let cache_path =
-            std::path::PathBuf::from(cache_dir).join(format!("closure_{:016x}.bin", hash));
-
-        if let Ok(bytes) = std::fs::read(&cache_path) {
-            return unsafe { wasmtime::Module::deserialize(engine, &bytes) }
-                .map_err(|e| e.to_string());
-        }
-
-        let module = wasmtime::Module::new(engine, wasm_bytes).map_err(|e| e.to_string())?;
-        if let Ok(serialized) = module.serialize() {
-            std::fs::create_dir_all(cache_dir).ok();
-            store::atomic_write(&cache_path, &serialized);
-        }
-        Ok(module)
-    } else {
-        wasmtime::Module::new(engine, wasm_bytes).map_err(|e| e.to_string())
-    }
+    let cache_path = store::cache_path_for("closure", wasm_bytes);
+    store::cached_or_compile(engine, wasm_bytes, cache_path.as_deref()).map_err(|e| e.to_string())
 }
 
 /// Build the source the full-module WASM path actually compiles: the stdlib
@@ -443,32 +421,9 @@ fn eval_wasm_raw(source: &str, source_name: &str, with_stdlib: bool) -> Result<S
     let linker = linker::create_linker(&engine).map_err(|e| e.to_string())?;
     let t3 = std::time::Instant::now();
 
-    // Module cache: hash the WASM bytes, check for a cached pre-compiled module.
-    let module = if let Some(cache_dir) = &crate::config::get().cache {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-        let mut hasher = DefaultHasher::new();
-        result.wasm_bytes.hash(&mut hasher);
-        let hash = hasher.finish();
-        let cache_path =
-            std::path::PathBuf::from(&cache_dir).join(format!("module_{:016x}.bin", hash));
-
-        if let Ok(bytes) = std::fs::read(&cache_path) {
-            // SAFETY: we trust our own cache files.
-            unsafe { wasmtime::Module::deserialize(&engine, &bytes) }
-                .map_err(|e: wasmtime::Error| e.to_string())?
-        } else {
-            let module =
-                store::compile_module(&engine, &result.wasm_bytes).map_err(|e| e.to_string())?;
-            if let Ok(serialized) = module.serialize() {
-                std::fs::create_dir_all(cache_dir).ok();
-                store::atomic_write(&cache_path, &serialized);
-            }
-            module
-        }
-    } else {
-        store::compile_module(&engine, &result.wasm_bytes).map_err(|e| e.to_string())?
-    };
+    let cache_path = store::cache_path_for("module", &result.wasm_bytes);
+    let module = store::cached_or_compile(&engine, &result.wasm_bytes, cache_path.as_deref())
+        .map_err(|e| e.to_string())?;
     let t4 = std::time::Instant::now();
     let ret = store::run_module(&linker, &mut wasm_store, &module).map_err(|e| e.to_string());
     let t5 = std::time::Instant::now();

--- a/src/wasm/store.rs
+++ b/src/wasm/store.rs
@@ -64,6 +64,54 @@ impl wasmtime::CacheStore for DiskCache {
     }
 }
 
+/// Where `--cache` keeps the compiled artifact for `wasm_bytes`, or `None`
+/// when no cache directory is configured. `kind` separates the two module
+/// shapes that share the directory ("closure", "module").
+pub(crate) fn cache_path_for(kind: &str, wasm_bytes: &[u8]) -> Option<std::path::PathBuf> {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let cache_dir = crate::config::get().cache.as_ref()?;
+    let mut hasher = DefaultHasher::new();
+    wasm_bytes.hash(&mut hasher);
+    Some(std::path::PathBuf::from(cache_dir).join(format!("{kind}_{:016x}.bin", hasher.finish())))
+}
+
+/// Compile `wasm_bytes`, reusing the artifact at `cache_path` when one is
+/// there and this wasmtime can load it.
+///
+/// A cache read that does not yield a usable module is a MISS: the name records
+/// a hash of the WASM bytes and nothing else, while `Module::deserialize`
+/// accepts an artifact only from the wasmtime that wrote it. Compiling fresh
+/// and overwriting repairs the entry in place, which is what keeps a wasmtime
+/// upgrade from stranding every warm cache
+/// (docs/impl/wasm.md § "The module cache is a cache").
+pub(crate) fn cached_or_compile(
+    engine: &Engine,
+    wasm_bytes: &[u8],
+    cache_path: Option<&std::path::Path>,
+) -> Result<Module> {
+    let Some(path) = cache_path else {
+        return Module::new(engine, wasm_bytes);
+    };
+
+    if let Ok(bytes) = std::fs::read(path) {
+        // SAFETY: the cache directory holds artifacts this process wrote.
+        if let Ok(module) = unsafe { Module::deserialize(engine, &bytes) } {
+            return Ok(module);
+        }
+    }
+
+    let module = Module::new(engine, wasm_bytes)?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).ok();
+    }
+    if let Ok(serialized) = module.serialize() {
+        atomic_write(path, &serialized);
+    }
+    Ok(module)
+}
+
 /// Write data to a file atomically: write to a temp file in the same
 /// directory, then rename into place. Prevents readers from seeing
 /// partial writes.

--- a/src/wasm/tests.rs
+++ b/src/wasm/tests.rs
@@ -851,3 +851,60 @@ fn wasm_full_non_allocating_calls_strand_nothing() {
          mint is materializing region entries"
     );
 }
+
+// ── The module cache is a cache ──────────────────────────────────────
+
+/// A module small enough to compile instantly. `Module::new` reads WAT text as
+/// readily as binary, so the cache path needs no binary fixture.
+const FIXTURE_WAT: &str = "(module (func (export \"f\") (result i32) i32.const 7))";
+
+// The trap: a `--cache` entry is named for a hash of the WASM bytes, and
+// wasmtime's `Module::deserialize` accepts an artifact only from the version
+// that wrote it. So the name can hit while the bytes are unusable, and the
+// two conditions are indistinguishable to the caller until deserialize runs.
+//
+// The counter-factual is a run that treats that as an error rather than a
+// miss. It reports `Module was compiled with incompatible version 'N'` and
+// nothing ever deletes the entry, so every later run reads the same bytes and
+// stops the same way — a wasmtime bump strands every warm cache until someone
+// clears the directory by hand, with an error that never names one.
+// Poisoned bytes stand in for the version mismatch here: deserialize refuses
+// both, by the same path, without pinning the test to a wasmtime version.
+#[test]
+fn cache_entry_that_cannot_be_deserialized_recompiles() {
+    let dir = tempfile::tempdir().expect("a temp cache directory");
+    let path = dir.path().join("module_dead0000beef0000.bin");
+    let engine = wasmtime::Engine::default();
+    let wasm = FIXTURE_WAT.as_bytes();
+
+    // A cold cache compiles and leaves an artifact behind.
+    super::store::cached_or_compile(&engine, wasm, Some(&path)).expect("cold compile");
+    assert!(
+        path.exists(),
+        "a cold compile must populate the cache entry"
+    );
+    let cached = std::fs::read(&path).expect("read the artifact");
+
+    std::fs::write(&path, b"not a wasmtime artifact").expect("poison the entry");
+    super::store::cached_or_compile(&engine, wasm, Some(&path))
+        .expect("an unusable cache entry is a miss, not a failed compile");
+
+    let repaired = std::fs::read(&path).expect("read the repaired artifact");
+    assert_ne!(
+        repaired, b"not a wasmtime artifact",
+        "the miss must overwrite the unusable entry, or every later run repeats it"
+    );
+    assert_eq!(
+        repaired, cached,
+        "the repaired entry must be the artifact a cold compile writes"
+    );
+}
+
+// No cache directory configured is the same compile without the disk round
+// trip — the `--cache`-less default every plain `--wasm=full` run takes.
+#[test]
+fn uncached_compile_needs_no_cache_path() {
+    let engine = wasmtime::Engine::default();
+    let wasm = FIXTURE_WAT.as_bytes();
+    super::store::cached_or_compile(&engine, wasm, None).expect("compile without a cache");
+}

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -23,7 +23,16 @@ tests/
 ├── unittests/          # Unit tests for individual modules
 │   ├── mod.rs          # Module declarations
 │   └── *.rs            # One file per module under test
+└── *.rs                # One standalone binary each — see below
 ```
+
+Everything under `lib.rs` shares one binary and one process. A file directly
+under `tests/` gets a binary of its own, which is what a test needs when its
+subject is process-global: a counter, an rlimit, a signal disposition, a
+re-exec, or a fault that would take every other test down with it
+(`worker_heap.rs`, `region_process_teardown.rs`, `wasm_smoke.rs`, …). See
+[docs/analysis/testing.md](../docs/analysis/testing.md) § "Process-global state
+needs its own binary" for when to reach for one.
 
 In addition to the `tests/` directory:
 

--- a/tests/elle/caps-fs.lisp
+++ b/tests/elle/caps-fs.lisp
@@ -1,0 +1,149 @@
+(elle/epoch 12)
+# ── Filesystem capability (:fs) ────────────────────────────────────────
+#
+# `:io` is the dispatch bit for requests that reach the I/O scheduler.
+# The filesystem primitives are synchronous std::fs calls that never
+# reach it, so `:deny |:io|` never stopped them. `:fs` is the bit that
+# means "resolves a filesystem path".
+#
+# The trap this file guards: before `:fs` existed, the only bit that
+# reached the disk was `:error`, which ~66% of primitives declare —
+# including `type-of` and `length`, which the compiler emits. Denying
+# `:error` to stop a write also traps the VM's own calls, and a mediator
+# answering those corrupts the child silently. The compute-loop test
+# below is what says `:fs` is worth having over `:error`.
+#
+# Arithmetic compiles to specialized bytecode that bypasses primitive
+# dispatch, so enforcement tests use `length` / `type-of` (see caps.lisp).
+
+(def root (file/mktempdir))
+
+# ── The denial happens, and the write does not ────────────────────────
+
+# Counterfactual: without the :fs bit this fiber runs to completion and
+# the file appears on disk.
+(let [victim (path/join root "ESCAPED")
+      f (fiber/new (fn [] (file/write victim "x")) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (assert (= (fiber/status f) :paused) "file/write under :deny |:fs| suspends")
+  (assert (not (path/exists? victim)) "the denied write never reached the disk"))
+
+(let [secret (path/join root "SECRET")]
+  (file/write secret "classified")
+  (let [f (fiber/new (fn [] (file/read secret)) |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (assert (= (fiber/status f) :paused) "file/read under :deny |:fs| suspends")
+    (assert (not (= (fiber/value f) "classified"))
+            "the denied read never returned the contents")))
+
+# ── The payload lets a parent decide by path ──────────────────────────
+
+(let [victim (path/join root "BY-PATH")
+      f (fiber/new (fn [] (file/write victim "x")) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (let [v (fiber/value f)]
+    (assert (= :capability-denied (get v :error))
+            "payload is a capability denial")
+    (assert ((get v :denied) :fs) "payload names :fs as the denied bit")
+    (assert (= "file/write" (get v :primitive)) "payload names the primitive")
+    (assert (= victim (get (get v :args) 0))
+            "payload carries the path the parent decides on")))
+
+# The parent performs the call and resumes; the child reads the return
+# value and runs on to its own result.
+(let [allowed (path/join root "MEDIATED")
+      f (fiber/new (fn []
+                     (do
+                       (file/write allowed "mediated")
+                       :done)) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (let [v (fiber/value f)
+        result (apply (get v :func) (get v :args))]
+    (assert (= :done (fiber/resume f result))
+            "the child continues to its own result")
+    (assert (= (fiber/status f) :dead) "the mediated child ran to completion")
+    (assert (= "mediated" (file/read allowed)) "the parent's write landed")))
+
+# ── :fs is narrow where :error is not ─────────────────────────────────
+
+# The regression guard for the coarseness that makes :error unusable as a
+# sandbox: a loop that only computes returns the same value denied or not.
+(defn compute []
+  (let [@acc 0
+        @i 0]
+    (while (< i 200)
+      (assign acc (+ acc (length "abc")))
+      (assign i (+ i 1)))
+    (list acc (type-of acc))))
+
+(let [open (fiber/new compute |:fs :error|)
+      denied (fiber/new compute |:fs :error| :deny |:fs|)]
+  (assert (= (fiber/resume open) (fiber/resume denied))
+          ":deny |:fs| does not trap length, type-of, or arithmetic")
+  (assert (= (fiber/status denied) :dead)
+          "a compute-only fiber under :deny |:fs| never traps"))
+
+# ── Pure path operations stay open; path syscalls do not ──────────────
+
+(let [f (fiber/new (fn [] (path/normalize (path/join (path/parent "/a/b") "c")))
+                   |:fs :error| :deny |:fs|)]
+  (assert (= "/a/c" (fiber/resume f)) "pure path string operations stay allowed")
+  (assert (= (fiber/status f) :dead) "no trap for lexical path work"))
+
+(defn denied-primitive-name [body]
+  (let [f (fiber/new body |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (assert (= (fiber/status f) :paused) "a filesystem syscall is denied")
+    (get (fiber/value f) :primitive)))
+
+(assert (= "path/exists?" (denied-primitive-name (fn [] (path/exists? root))))
+        "path/exists? reaches the filesystem and is denied")
+(assert (= "path/cwd" (denied-primitive-name (fn [] (path/cwd))))
+        "path/cwd reaches the filesystem and is denied")
+(assert (= "path/canonicalize"
+           (denied-primitive-name (fn [] (path/canonicalize root))))
+        "path/canonicalize reaches the filesystem and is denied")
+
+# ── The port route to a path is closed too ────────────────────────────
+
+# port/open resolves a path and reads its bytes. Without :fs on it, a
+# fiber denied :fs alone would open a port on the path instead.
+(let [secret (path/join root "SECRET")
+      f (fiber/new (fn [] (port/open secret :read)) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (assert (= (fiber/status f) :paused) "port/open under :deny |:fs| suspends")
+  (assert (= "port/open" (get (fiber/value f) :primitive))
+          "the denial names port/open"))
+
+# ── The denial cannot be escaped from inside ──────────────────────────
+
+(let [victim (path/join root "VIA-EVAL")
+      f (fiber/new (fn []
+                     (eval (read (string/join ["(file/write \"" victim
+                                 "\" \"x\")"] "")))) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (assert (not (path/exists? victim)) "code the child evals inherits the denial"))
+
+(let [victim (path/join root "VIA-CHILD")
+      f (fiber/new (fn []
+                     (let [inner (fiber/new (fn [] (file/write victim "x"))
+                           |:fs :error|)]
+                       (fiber/resume inner))) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (assert (not (path/exists? victim))
+          "a child fiber with an unrestricted mask cannot re-grant :fs"))
+
+# ── Introspection, and independence from :io ──────────────────────────
+
+(assert ((fiber/caps) :fs) "the root fiber holds :fs")
+
+(let [f (fiber/new (fn [] 42) |:error| :deny |:fs|)]
+  (assert (not ((fiber/caps f) :fs)) "fiber/caps omits :fs when denied")
+  (assert ((fiber/caps f) :io) ":deny |:fs| leaves :io held"))
+
+(let [f (fiber/new (fn [] 42) |:error| :deny |:io|)]
+  (assert ((fiber/caps f) :fs) ":deny |:io| leaves :fs held")
+  (assert (not ((fiber/caps f) :io)) "fiber/caps omits :io when denied"))
+
+(file/delete-dir-all root)
+(println "caps-fs: OK")

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -104,6 +104,7 @@ Tests are organized by feature area in separate files:
 | ~~`table_keys.rs`~~ | Migrated to `tests/elle/table-keys.lisp` |
 | `glob.rs` | Glob patterns |
 | `elle_scripts.rs` | Process-global runtime-mode pins (guardfree/no-uring/mlir-off); the corpus itself runs via `elle test` |
+| `paths.rs` | The paths and URLs the Makefile and the doc generator name in text, checked against the tree |
 | `environment.rs` | Environment variables |
 | `escape.rs` | Escape analysis |
 | `arena.rs` | Arena allocation |

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -159,6 +159,9 @@ mod subprocess_sigmask {
 mod unicode_generation {
     include!("unicode_generation.rs");
 }
+mod paths {
+    include!("paths.rs");
+}
 
 // Temporarily disabled while sorting out compilation caching.
 // mod fn_flow {

--- a/tests/integration/paths.rs
+++ b/tests/integration/paths.rs
@@ -1,0 +1,144 @@
+// Every Elle source path a build or doc driver names must resolve.
+//
+// Both drivers below name their inputs as text, so a moved file leaves a
+// reference that no compiler checks. Worse, both fail QUIETLY: the Makefile's
+// `find` roots are swallowed by `2>/dev/null`, so a missing root drops its
+// files out of the format gate and the gate still exits 0; the doc generator
+// runs only on a push to main, so a stale `slurp` path turns main red after
+// the merge that caused it. These tests are the cheap standing check that the
+// text still points at the tree.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Directories whose `.lisp` files are not this repository's to format:
+/// build output, git internals, and the `plugins` submodule (which runs its
+/// own format gate from its own Makefile).
+const UNOWNED: &[&str] = &["target", ".git", "plugins"];
+
+/// Every `*.lisp` file under `dir`, recursively, skipping `UNOWNED`.
+/// Paths come back relative to the repository root.
+fn collect_lisp(dir: &Path, root: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => panic!("cannot read {}: {}", dir.display(), e),
+    };
+    for entry in entries {
+        let path = entry.expect("directory entry").path();
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if path.is_dir() {
+            if !UNOWNED.contains(&name) {
+                collect_lisp(&path, root, out);
+            }
+        } else if path.extension().and_then(|e| e.to_str()) == Some("lisp") {
+            out.push(path.strip_prefix(root).expect("under root").to_path_buf());
+        }
+    }
+}
+
+/// The roots the Makefile hands to `find` when it builds `LISP_FILES` — the
+/// exact set of directories `make fmt` and `make fmt-check` walk.
+fn makefile_find_roots() -> Vec<String> {
+    let makefile = fs::read_to_string(repo_root().join("Makefile")).expect("read Makefile");
+    let line = makefile
+        .lines()
+        .find(|l| l.starts_with("LISP_FILES :="))
+        .expect("Makefile defines LISP_FILES");
+    let (_, after_find) = line.split_once("find ").expect("LISP_FILES calls find");
+    let (roots, _) = after_find.split_once(" -name").expect("find passes -name");
+    let roots: Vec<String> = roots.split_whitespace().map(str::to_string).collect();
+    assert!(!roots.is_empty(), "LISP_FILES names no find roots: {line}");
+    roots
+}
+
+// The format gate is only as wide as its `find` roots, and a root that no
+// longer exists costs nothing at the shell — `find` reports it on stderr and
+// the Makefile discards that. So the files under it stop being formatted and
+// nothing anywhere fails. Counter-factual: with `src/` absent from the roots,
+// the five Elle sources under src/ (prelude, stdlib, core, test, the Lua
+// prelude) went unformatted and unchecked, and `make fmt-check` stayed green.
+#[test]
+fn format_gate_covers_every_elle_source() {
+    let root = repo_root();
+    let roots = makefile_find_roots();
+
+    for named in &roots {
+        assert!(
+            root.join(named).exists(),
+            "Makefile LISP_FILES names `{named}`, which does not exist. \
+             `find` reports this to the discarded stderr, so every .lisp file \
+             under it silently leaves the format gate."
+        );
+    }
+
+    let mut sources = Vec::new();
+    collect_lisp(&root, &root, &mut sources);
+    assert!(
+        sources.len() > 100,
+        "found only {} .lisp files; the walk is broken, not the gate",
+        sources.len()
+    );
+
+    let uncovered: Vec<_> = sources
+        .iter()
+        .filter(|src| {
+            !roots
+                .iter()
+                .any(|named| src.starts_with(named.trim_end_matches('/')))
+        })
+        .collect();
+    assert!(
+        uncovered.is_empty(),
+        "these Elle sources are outside every Makefile LISP_FILES root, so \
+         `make fmt-check` never sees them: {uncovered:?}"
+    );
+}
+
+// The doc generator reads the Elle sources whose comments and defns become the
+// API reference. It runs on a push to main and nowhere earlier, so a path that
+// no longer resolves is a red main rather than a failed PR. Counter-factual:
+// the generator slurped "prelude.lisp" and "stdlib.lisp" from the repo root
+// after both moved under src/, and every gate before the merge passed.
+#[test]
+fn docgen_source_inputs_exist() {
+    let root = repo_root();
+    let generator = root.join("demos/docgen/generate.lisp");
+    let text = fs::read_to_string(&generator).expect("read the doc generator");
+
+    let src_dir = text
+        .split_once("(def @src-dir \"")
+        .and_then(|(_, rest)| rest.split_once('"'))
+        .map(|(dir, _)| dir.to_string())
+        .expect("the generator defines src-dir");
+
+    // Each `(path/join src-dir "NAME.lisp")` in the configuration block.
+    let inputs: Vec<String> = text
+        .split("(path/join src-dir \"")
+        .skip(1)
+        .filter_map(|rest| rest.split_once('"').map(|(name, _)| name.to_string()))
+        .collect();
+
+    // A rewrite that changes the shape must fail here rather than quietly
+    // check nothing: the generator documents the prelude and the stdlib.
+    assert!(
+        inputs.len() >= 2,
+        "found {} source inputs in {}; expected the prelude and the stdlib. \
+         If the generator's configuration changed shape, teach this test the \
+         new shape — do not let it pass by matching nothing.",
+        inputs.len(),
+        generator.display()
+    );
+
+    for name in &inputs {
+        let path = root.join(&src_dir).join(name);
+        assert!(
+            path.exists(),
+            "the doc generator reads {}, which does not exist",
+            path.display()
+        );
+    }
+}

--- a/tests/integration/paths.rs
+++ b/tests/integration/paths.rs
@@ -1,18 +1,23 @@
-// Every Elle source path a build or doc driver names must resolve.
+// What the Makefile and the doc generator name in text must match the tree.
 //
-// Both drivers below name their inputs as text, so a moved file leaves a
-// reference that no compiler checks. Worse, both fail QUIETLY: the Makefile's
-// `find` roots are swallowed by `2>/dev/null`, so a missing root drops its
-// files out of the format gate and the gate still exits 0; the doc generator
-// runs only on a push to main, so a stale `slurp` path turns main red after
-// the merge that caused it. These tests are the cheap standing check that the
-// text still points at the tree.
+// Neither driver is compiled, so every path and URL in them is a reference
+// nothing checks. Both also fail quietly when a reference goes stale. The
+// Makefile's `find` roots are swallowed by `2>/dev/null`, so a root that no
+// longer exists narrows the format gate and the gate still exits 0. The doc
+// generator runs on a push to main and nowhere earlier, so a stale path or a
+// wrong URL reaches the published site before anything reports it. These
+// tests are the standing check, and they cost a filesystem walk.
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The doc generator, whose configuration block both generator tests read.
+fn generator_path() -> PathBuf {
+    repo_root().join("demos/docgen/generate.lisp")
 }
 
 /// Directories whose `.lisp` files are not this repository's to format:
@@ -58,9 +63,9 @@ fn makefile_find_roots() -> Vec<String> {
 // The format gate is only as wide as its `find` roots, and a root that no
 // longer exists costs nothing at the shell — `find` reports it on stderr and
 // the Makefile discards that. So the files under it stop being formatted and
-// nothing anywhere fails. Counter-factual: with `src/` absent from the roots,
-// the five Elle sources under src/ (prelude, stdlib, core, test, the Lua
-// prelude) went unformatted and unchecked, and `make fmt-check` stayed green.
+// nothing anywhere fails. The counter-factual: drop `src/` from the roots and
+// the five Elle sources under it — prelude, stdlib, core, test, the Lua
+// prelude — leave the gate, while `make fmt-check` still exits 0.
 #[test]
 fn format_gate_covers_every_elle_source() {
     let root = repo_root();
@@ -100,14 +105,14 @@ fn format_gate_covers_every_elle_source() {
 
 // The doc generator reads the Elle sources whose comments and defns become the
 // API reference. It runs on a push to main and nowhere earlier, so a path that
-// no longer resolves is a red main rather than a failed PR. Counter-factual:
-// the generator slurped "prelude.lisp" and "stdlib.lisp" from the repo root
-// after both moved under src/, and every gate before the merge passed.
+// no longer resolves is a red main rather than a failed PR. The
+// counter-factual: point `src-dir` back at the repository root, where the
+// prelude and the stdlib used to live, and every gate ahead of the merge
+// still passes.
 #[test]
 fn docgen_source_inputs_exist() {
+    let text = fs::read_to_string(generator_path()).expect("read the doc generator");
     let root = repo_root();
-    let generator = root.join("demos/docgen/generate.lisp");
-    let text = fs::read_to_string(&generator).expect("read the doc generator");
 
     let src_dir = text
         .split_once("(def @src-dir \"")
@@ -130,7 +135,7 @@ fn docgen_source_inputs_exist() {
          If the generator's configuration changed shape, teach this test the \
          new shape — do not let it pass by matching nothing.",
         inputs.len(),
-        generator.display()
+        generator_path().display()
     );
 
     for name in &inputs {
@@ -141,4 +146,36 @@ fn docgen_source_inputs_exist() {
             path.display()
         );
     }
+}
+
+// Every stdlib entry on the published site carries a source link built on the
+// generator's `github-base`. Cargo.toml's `repository` is where this project
+// spells its own URL, so the generator's copy has to agree with it or the
+// whole API reference links somewhere else. A wrong host still generates, still
+// publishes, and still renders — it fails only when a reader clicks a link, and
+// nothing in the build is watching for that.
+#[test]
+fn docgen_source_links_point_at_this_repository() {
+    let manifest =
+        fs::read_to_string(repo_root().join("Cargo.toml")).expect("read the crate manifest");
+    let repository = manifest
+        .lines()
+        .find_map(|l| l.strip_prefix("repository = \""))
+        .and_then(|rest| rest.split_once('"'))
+        .map(|(url, _)| url.trim_end_matches('/').to_string())
+        .expect("Cargo.toml declares a repository URL");
+
+    let text = fs::read_to_string(generator_path()).expect("read the doc generator");
+    let github_base = text
+        .split_once("(def @github-base \"")
+        .and_then(|(_, rest)| rest.split_once('"'))
+        .map(|(url, _)| url.to_string())
+        .expect("the generator defines github-base");
+
+    assert!(
+        github_base.starts_with(&repository),
+        "the doc generator builds source links on {github_base}, but this crate \
+         is published from {repository} (Cargo.toml). Every source link in the \
+         generated API reference points at the wrong repository."
+    );
 }

--- a/tests/integration/thread_transfer.rs
+++ b/tests/integration/thread_transfer.rs
@@ -29,6 +29,6 @@ mod errors {
 mod closures {
     include!("thread_transfer/closures.rs");
 }
-mod heap {
-    include!("thread_transfer/heap.rs");
-}
+// The worker-heap slope lives in tests/worker_heap.rs, its own binary, because
+// it reads a process-wide page counter (docs/analysis/testing.md
+// § "Process-global state needs its own binary").

--- a/tests/worker_heap.rs
+++ b/tests/worker_heap.rs
@@ -1,4 +1,8 @@
-// A worker thread's heap dies with the thread.
+//! A worker thread's heap dies with the thread.
+//!
+//! Its own binary: `mapped_bytes` is one process-wide counter, and the window
+//! measured below is a minute and a half wide (docs/analysis/testing.md
+//! § "Process-global state needs its own binary").
 //
 // `os/spawn` stands a whole instance up on the worker: a VM, a symbol table, a
 // compile context, and the region heap every value it builds lives in. The
@@ -20,7 +24,10 @@
 // must outlive them), each heavy worker left its whole instance mapped —
 // ~7 MB of stdlib apiece, plus anything the body left live.
 
-use super::*;
+#[path = "common/mod.rs"]
+mod common;
+
+use common::eval_source;
 use elle::value::fiberheap::mapped_bytes;
 
 /// Spawn `n` heavy workers one after another, joining each before the next.


### PR DESCRIPTION
Closes #884.

`:deny |:io|` never restricted the filesystem. On `main`, a fiber that
withholds `:io` reads and writes any path it likes:

```lisp
(def f (fiber/new (fn [] (file/read "/etc/hostname")) |:io :error| :deny |:io|))
(fiber/resume f)     ; => the file's contents
(fiber/caps f)       ; => :io is withheld
```

`:io` means "this request reaches the I/O scheduler". The filesystem
primitives are synchronous `std::fs` calls that never reach it, so they
declared `Signal::errors()` and nothing else — no bit meant "touches the
disk". The only lever that reached the disk was `:error`, which ~66% of
primitives declare, including `type-of` and `length` that the compiler
emits. Denying `:error` to stop a write also traps the VM's own calls.

The asymmetry was sharpest on a single path: `port/open` declares
`io_yields_errors()` and was denied, while `file/read` on the same path
was not.

## The bit

`SIG_FS` at bit 17, deniable as `:fs`, following `SIG_EXEC` (11),
`SIG_GPU` (15), and `SIG_OS_SIGNAL` (16): a capability bit that does no
dispatch work. Nothing about the event loop changes.

`:fs` and `:io` stay independent so a mediating parent can deny the disk
while the child keeps stdout and the network — deny both to close off
all of it.

## Primitives that declare it

Decided by reading each implementation, not by the name prefix.

| Module | Primitives |
|---|---|
| `fileio.rs` | all 16 |
| `path.rs` | `path/absolute`, `path/canonicalize`, `path/cwd`, `path/exists?`, `path/file?`, `path/dir?` |
| `ports.rs` | `port/open`, `port/open-bytes` (`:fs` alongside the existing `:io`) |
| `watch.rs` | `watch-add`, `watch-remove` |
| `unix.rs` | `unix/listen`, `unix/connect` |
| `modules.rs` | `import` |

The other eleven `path/*` primitives are string operations — `path/join`,
`path/parent`, `path/normalize` and friends — and do not carry the bit.
`port/close`, `port/seek`, `port/tell`, `unix/accept`, and
`unix/shutdown` act on an already-open fd; the authority was granted at
open.

`port/open` needs both bits. Without `:fs` on it, a fiber denied only the
filesystem could open a port on any path and read it — the same authority
`file/read` grants.

Deliberately not covered: `subprocess/*` and `ffi/*` reach the filesystem
but are already gated by `:exec` and `:ffi`. `debug/memory` reads
`/proc/self/status`, resolves no user-supplied path, and is currently
declared silent — a capability bit there would flip `may_suspend()` and
change JIT eligibility for no gain.

Error behavior is unchanged. The bit is added to each declaration and
replaces nothing, so a permitted `file/read` of a missing file fails
exactly as before.

## Tests

`tests/elle/caps-fs.lisp` — the denial and the absent file, the payload
carrying the path a parent decides on, mediation through to the child's
own result, the port route, `eval` inside a denied fiber, a child fiber
with an unrestricted mask, pure path operations staying open, and
`fiber/caps` in both directions.

Its counter-factual is the first case: with the bit defined but not yet
declared on any primitive, that test fails by *writing the file*, with
the fiber reporting `:dead`.

The regression guard for why `:fs` beats `:error`: a loop calling
`length` and `type-of` 200 times returns the same value denied or not,
and never traps.

Rust unit tests in `src/signals/tests.rs` pin that `:fs` carries no
dispatch bit, that the three async constructors extend one shared base,
and that the `:fs` keyword resolves to the bit the primitives declare —
without which a `:deny |:fs|` mask would silently withhold nothing.

## Still open

#888 asks for four more things this PR does not deliver: a refusal the
child observes as a failure at the call site, denial crossing
`sys/spawn` / `sys/spawn-vm`, and confirmation on a JIT-compiled call
site. `caps-fs.lisp` passes under `--jit=eager` and `--jit=adaptive`, but
that is not the same as a test that pins a hot call site.
