### PR TITLE
verify: #891 + #896 together hold macOS Smoke green

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -254,6 +254,13 @@ jobs:
       # Keep the symbol table on this runner: it is the box where the corpus
       # wedges, and the photograph is the only evidence a timeout leaves.
       CARGO_PROFILE_RELEASE_STRIP: debuginfo
+      # The other half of `--trace=scrub` below. The scrub's `memset` runs in
+      # any build, but the panic that READS the zeros — the `arena::deref`
+      # tag/object mismatch that names the deref site and attributes the free —
+      # is `#[cfg(debug_assertions)]`. Without this, the release binary scrubs
+      # and says nothing: a stale read faults near its site instead of naming
+      # it. See docs/impl/region/diagnostics.md § `--trace=scrub`.
+      CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -282,12 +289,34 @@ jobs:
       # backend only this box exercises). Scrub zeroes each released page, so
       # the first stale read panics at the deref naming its site instead of
       # failing minutes later somewhere unrelated. One memset per freed page.
+      # The panic itself needs CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS, set above.
       - name: make smoke
         run: make smoke ELLE_TEST_FLAGS=--trace=scrub
       - name: Run integration tests
         run: cargo test --test '*' -- --skip property
       - name: Run property tests
         run: "cargo test --test lib property::"
+      # A batch killed by a signal leaves the batch number and nothing else. The
+      # kernel's crash report has the faulting thread's stack, and the symbol
+      # table is kept on this runner (CARGO_PROFILE_RELEASE_STRIP above), so the
+      # frames are readable. Reports are written asynchronously by ReportCrash,
+      # so give it a moment before looking.
+      - name: Crash reports
+        if: failure()
+        run: |
+          sleep 15
+          dir=~/Library/Logs/DiagnosticReports
+          shopt -s nullglob
+          reports=("$dir"/elle*.ips "$dir"/elle*.crash)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "no crash report for elle under $dir"
+            ls -la "$dir" 2>/dev/null || echo "$dir does not exist"
+            exit 0
+          fi
+          for r in "${reports[@]}"; do
+            echo "===== $r ====="
+            cat "$r"
+          done
 
   all-checks:
     name: All Checks Passed

--- a/docs/impl/region/diagnostics.md
+++ b/docs/impl/region/diagnostics.md
@@ -35,10 +35,18 @@ the region rules ([rules.md](rules.md)) honest.
   matches no live value, so `arena::deref` panics naming the deref site. The
   cheap member of the family: `guardfree` catches a stale read at any distance
   but costs a mapping per freed page, the generation check catches a stale
-  region *resolution* but only in debug builds and only while the page is
-  unclaimed, and scrub catches a stale *content* read in release builds too,
-  for one `memset` per freed page. Reach for it when a program returns a
-  well-typed wrong answer and the leak gauges are clean.
+  region *resolution* only while the page is unclaimed, and scrub catches a
+  stale *content* read for one `memset` per freed page. Reach for it when a
+  program returns a well-typed wrong answer and the leak gauges are clean.
+
+  **The scrub and its report are separate.** The `memset` runs in any build; the
+  `arena::deref` panic that reads the zeros and names the site is
+  `#[cfg(debug_assertions)]`. A plain release build therefore scrubs and says
+  nothing — the stale read faults somewhere near its site instead of returning a
+  wrong-typed value, which is an improvement but not a report. To get the report
+  out of a release build, turn debug assertions on for it:
+  `CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true`. The macOS CI job pairs the two
+  for exactly this reason.
 - `(arena/dump)`: a Lisp-level leak localiser — prints every live mortal region
   (id, RC, object count, and the object *tags* it holds) to stderr. Where
   `arena/count` / `arena/region-count` say *that* memory grew across a loop, the

--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -237,6 +237,29 @@ parked fiber's accounting symmetric with its unpark:
   theft invisible). Pinned by `region_fiber_abort_io_protect_uaf`
   (`tests/integration/fixtures/region-fiber-abort-io-protect-uaf.lisp`);
   `tests/elle/grpc.lisp`'s `with-server` teardown is the full-scheduler witness.
+- **A propagated signal is a fresh park, and owes its own delivery reference.**
+  `fiber/propagate` installs the child's parked payload as the propagating fiber's own
+  `signal`. That fiber's resumer then reads the payload as its resume result and runs the
+  compiler-emitted release on it — the same consumer an `Emit` funds with its `EmitEscape`
+  mint. Re-parking a value the child already parked mints nothing, so that release consumes
+  a reference the propagate never took. One propagate hides the theft: an error unwind runs
+  no continuation, so the raising body's own reference is stranded and unclaimed, and the
+  release eats that instead. Two propagates do not, nor does a native error, whose payload
+  reaches `fiber.signal` with no body reference at all. The count then runs one short of the
+  recorded `fiber → payload` edges, and the last fiber's free cascade reclaims the payload
+  while the caller still holds it. So the propagate mints one itself
+  (`EscapeSite::PropagateEscape`), through the one `take_propagated_signal` helper the
+  call-, tail-, and JIT-position handlers share — all three run the same install, so all
+  three owe the same reference. Three cases take no mint. A NON-TERMINAL signal, because the
+  fiber runs again and the resume path proper governs the payload — step 6a excludes the same
+  set from its park retain, and the delivery follows the park. `SIG_HALT`, for the reason
+  `handle_emit` skips it: a halted fiber is promoted to `:dead` and `fiber/resume` refuses
+  it, so that delivery has no consumer and a retain would strand the payload. And the
+  no-signal fallback, whose error `escaping_error` builds in a fresh region already carrying
+  the reference the consumer releases — only a BORROWED payload is unfunded. The WASM tier's
+  `handle_fiber_propagate` is not this shape: it never installs into `fiber.signal`, and
+  returns the child's `(bits, value)` to its caller, whose park runs through `install_signal`
+  instead. Pinned by `tests/elle/region-fiber-propagate-uaf.lisp`.
 - **A resume value crosses counted, or not at all.** The delivery going *out* of a park
   is counted (above); the value coming *back* in is not, and by the same accounting must
   be. `VM::resume_suspended` pushes the resume value onto the parked frame's stack and

--- a/src/io/AGENTS.md
+++ b/src/io/AGENTS.md
@@ -13,7 +13,7 @@ to a backend for execution.
 |--------|----------------|
 | `types.rs` | Shared types: `PortKey`, `FdState` — used by both backends |
 | `pool.rs` | `BufferPool`, `BufferHandle` — pinned buffer management for async I/O |
-| `pending.rs` | `PendingOp` enum — in-flight async operation tracking, one variant per operation shape |
+| `pending.rs` | `PendingOp` enum — in-flight async operation tracking, one variant per operation shape — and `PendingTable`, the backend's set of them plus the ids no fiber will read. `take` answers "does anybody want this?" once, for both backends. |
 | `aio.rs` | `AsyncBackend` — async I/O with io_uring (Linux) or thread-pool fallback |
 | `request.rs` | `IoRequest` and `IoOp` types — typed I/O request descriptors |
 | `completion.rs` | `process_raw_completion` — converts raw CQE/thread results to `Completion` |
@@ -191,26 +191,50 @@ the mechanism and § "The stop pipe" for the cancellation half.
 
 ## I/O Cancellation
 
-`io/cancel` submits `IORING_OP_ASYNC_CANCEL` on io_uring. The cancel SQE's CQE uses the high-bit tag (same as timeout CQEs) and is skipped by `drain_cqes`. The cancelled operation generates a CQE with `result = -ECANCELED`.
+`io/cancel` has two halves. **Asking the operation to stop** is
+platform-specific: io_uring takes `IORING_OP_ASYNC_CANCEL` (the cancel SQE's own
+CQE carries the high-bit tag, same as a timeout CQE, and `drain_cqes` skips it;
+the operation's own CQE arrives with `result = -ECANCELED`), while a pool worker
+is asked through its stop pipe. **Marking the submission** is shared: both
+platforms record the id in `PendingTable`, and both retire the entry when its
+completion arrives instead of building a result from it.
 
-Used by `do-shutdown` in stdlib to cancel pending I/O before aborting/cancelling fibers, and by `ev/timeout`, which cancels whichever of the body and the timer lost.
+Used by `do-shutdown` in stdlib to cancel pending I/O before aborting/cancelling
+fibers, and by `ev/timeout`, which cancels whichever of the body and the timer
+lost.
 
-### What cancellation promises on the thread pool
+### What cancellation promises, on either backend
 
-A pool operation runs on its own worker thread, which holds a plain
-descriptor number and calls a syscall on it. No other thread can retract a
-syscall already running, so a cancel asks rather than interrupts: the stop
-pipe below is how it asks, and two things hold however the worker answers:
+Three things hold however the operation ends.
 
-- **The submission is accounted for.** `cancel` marks the id in
-  `cancelled` and leaves the `pending` entry in place. The worker's
-  completion still arrives, still finds its entry, and still decrements
-  `in_flight`; the cooked result is then thrown away instead of being
-  handed to a fiber. Removing the entry instead would strand the
-  submission: the worker's thread would never be accounted for again,
-  and cancellation is a path `ev/timeout` takes on every call.
-- **The descriptor outlives the operation.** See "Descriptor retirement"
-  below.
+- **The submission is accounted for.** `cancel` marks the id and leaves the
+  `pending` entry in place. The operation's completion still arrives, still
+  finds its entry, and — on the pool — still decrements `in_flight`. Removing
+  the entry at the cancel would strand the submission: the worker's thread would
+  never be accounted for again, and cancellation is a path `ev/timeout` takes on
+  every call.
+- **No completion is delivered.** `PendingTable::take` reports a cancelled
+  submission as such, and its entry is retired rather than cooked — the pooled
+  buffer released, a descriptor the completion would have wrapped in a port
+  closed, a process wait's `siginfo_t` reclaimed. Nothing is left for a fiber,
+  and nothing needs to be: every `io/cancel` caller in the scheduler
+  (`complete-fiber`, `handle-abort`, `handle-io-forward-cancel`, `do-shutdown`)
+  drops its own record of the submission first, so the id is marked precisely
+  when there is no longer a reader. Cooking it anyway would read what the
+  operation held — the port `Value`, the process handle, the fiber's
+  pre-allocated read buffer — after the finished fiber's release freed the
+  regions those live in. Pinned by
+  `a_cancelled_operation_delivers_no_completion_on_either_backend`
+  (`src/io/aio/tests/park.rs`), which holds both backends to the one answer.
+- **The descriptor outlives the operation.** See "Descriptor retirement" below.
+
+Backend teardown marks everything in flight the same way (`PendingTable::
+cancel_all`, from `quiesce_pending`), for the same reason at a larger scale: the
+heap those values live on may already be gone.
+
+A cancel for an id that is no longer in flight marks nothing. The operation
+completed and its result already reached the fiber that asked; a mark left
+behind would meet a later submission.
 
 ### The stop pipe
 

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -3,7 +3,7 @@
 //! Uses io_uring on Linux (feature-gated), thread-pool fallback elsewhere.
 
 use crate::io::completion;
-use crate::io::pending::PendingOp;
+use crate::io::pending::{PendingOp, PendingTable, Taken};
 use crate::io::pool::BufferPool;
 use crate::io::request::{
     ConnectAddr, IoOp, IoRequest, PortOp, ProcessHandle, ProcessState, SpawnRequest, TaskFn,
@@ -35,14 +35,9 @@ struct AsyncBackendInner {
     /// byte stream at cluster boundaries with it, on and off the VM thread.
     unicode_generation: crate::segment::Generation,
     fd_states: HashMap<PortKey, FdState>,
-    pending: HashMap<SubmissionId, PendingOp>,
-    /// Submissions whose result no fiber will receive. The `pending` entry
-    /// stays, so the worker's completion is still matched, counted and
-    /// released; only the cooked value is dropped. Dropping the entry instead
-    /// would strand the submission — the worker it runs on and the descriptor
-    /// it names would never come back. See src/io/AGENTS.md
-    /// § "I/O Cancellation".
-    cancelled: std::collections::HashSet<SubmissionId>,
+    /// The operations in flight, and which of them no fiber will receive a
+    /// result for. See src/io/AGENTS.md § "I/O Cancellation".
+    pending: PendingTable,
     /// Descriptors kept open past their port's close because a submitted
     /// operation still names them. A worker resolves its fd when it runs, so a
     /// number handed back to the OS while an operation holds it can be given
@@ -126,8 +121,7 @@ impl AsyncBackend {
             inner: RefCell::new(AsyncBackendInner {
                 unicode_generation: gen,
                 fd_states: HashMap::new(),
-                pending: HashMap::new(),
-                cancelled: std::collections::HashSet::new(),
+                pending: PendingTable::new(),
                 retired: HashMap::new(),
                 completions: VecDeque::new(),
                 next_id: 1,
@@ -160,8 +154,7 @@ impl AsyncBackend {
             inner: RefCell::new(AsyncBackendInner {
                 unicode_generation: crate::config::get().unicode_generation(),
                 fd_states: HashMap::new(),
-                pending: HashMap::new(),
-                cancelled: std::collections::HashSet::new(),
+                pending: PendingTable::new(),
                 retired: HashMap::new(),
                 completions: VecDeque::new(),
                 next_id: 1,
@@ -241,7 +234,7 @@ impl AsyncBackend {
     /// the entry is keyed by the id `submit` returned.
     #[cfg(test)]
     pub(crate) fn pending_ids(&self) -> Vec<SubmissionId> {
-        let mut ids: Vec<SubmissionId> = self.inner.borrow().pending.keys().copied().collect();
+        let mut ids = self.inner.borrow().pending.ids();
         ids.sort();
         ids
     }
@@ -309,22 +302,37 @@ impl AsyncBackendInner {
     /// survives this call.
     ///
     /// Ops serviced by the stdin/network channels post no CQE here; they make
-    /// no progress, so we stop after the first pass that neither shrinks
-    /// `pending` nor drains a completion. Those workers copy results through
-    /// channels and never write into a freed pooled buffer, so leaving them is
-    /// safe. The pass count is bounded as a backstop against an op that keeps
-    /// re-submitting (a continuously-readable fd reaped via resubmission).
+    /// no progress, so we stop after the first pass that does not shrink
+    /// `pending`. Those workers copy results through channels and never write
+    /// into a freed pooled buffer, so leaving them is safe. The pass count is
+    /// bounded as a backstop.
+    ///
+    /// Every entry is marked cancelled first, so each CQE retires its entry
+    /// instead of building a result from it. The values a `PendingOp` holds —
+    /// the port, the process handle — live on a heap this teardown may be
+    /// running after, and a read of one is a read of freed memory. That is also
+    /// why the shrink is the whole progress test: no completion is produced
+    /// here for a shrink to be read off.
     #[cfg(target_os = "linux")]
     fn quiesce_pending(&mut self) {
         if !matches!(self.platform, PlatformBackend::Uring(_)) || self.pending.is_empty() {
             return;
         }
+        // Where `drain_cqes` puts what it cooked. Every entry here is marked
+        // cancelled, so it stays empty; it exists because the drain is one
+        // function with one signature.
         let mut sink: VecDeque<Completion> = VecDeque::new();
         let mut passes = 0u32;
         while !self.pending.is_empty() && passes < 64 {
             passes += 1;
             let before = self.pending.len();
-            let ids: Vec<SubmissionId> = self.pending.keys().copied().collect();
+            let ids: Vec<SubmissionId> = self.pending.ids();
+
+            // Nobody is left to read any of these, and the heap their values
+            // live on may already be gone — this is the teardown a stranded
+            // backend gets (`IoBackend::quiesce`). Mark them so the drain
+            // retires each entry rather than building a result from it.
+            self.pending.cancel_all();
 
             // Cancel everything still pending. A cancel for an id the ring
             // doesn't know (a stdin/network op) returns a tagged `-ENOENT` CQE
@@ -372,10 +380,9 @@ impl AsyncBackendInner {
                 );
             }
 
-            let drained = !sink.is_empty();
             sink.clear();
-            // No CQE and no shrink ⇒ only channel-serviced ops remain; stop.
-            if !drained && self.pending.len() >= before {
+            // No shrink ⇒ only channel-serviced ops remain; stop.
+            if self.pending.len() >= before {
                 break;
             }
         }
@@ -468,7 +475,6 @@ impl AsyncBackendInner {
         let AsyncBackendInner {
             ref mut hub,
             ref mut pending,
-            ref mut cancelled,
             ref mut retired,
             ref mut fd_states,
             ref mut buffer_pool,
@@ -480,15 +486,7 @@ impl AsyncBackendInner {
                 crate::io::threadpool::RawCompletion::Pool(pc) => pc.id,
                 crate::io::threadpool::RawCompletion::Stdin(sc) => sc.id,
             });
-            let cooked = cook_raw(
-                rc,
-                pending,
-                cancelled,
-                fd_states,
-                buffer_pool,
-                origin_heap,
-                gen,
-            );
+            let cooked = cook_raw(rc, pending, fd_states, buffer_pool, origin_heap, gen);
             hub.forget_stop(id);
             if let Some(c) = cooked {
                 completions.push_back(c);
@@ -504,7 +502,7 @@ impl AsyncBackendInner {
     /// OS. Its `fd_states` entry goes with it, so per-fd buffering never spans
     /// two ports that happened to share a number.
     fn close_drained_fds(
-        pending: &HashMap<SubmissionId, PendingOp>,
+        pending: &PendingTable,
         fd_states: &mut HashMap<PortKey, FdState>,
         retired: &mut HashMap<RawFd, std::os::unix::io::OwnedFd>,
     ) {

--- a/src/io/aio/convert.rs
+++ b/src/io/aio/convert.rs
@@ -6,30 +6,18 @@ use super::*;
 /// caller discards it; the hub's `in_flight` was already decremented at the
 /// drain site, so a discarded item still balances the count.
 ///
-/// A cancelled op is discarded *before* cooking. Cooking a read writes the
-/// worker's bytes into the buffer the requesting fiber pre-allocated, and a
-/// cancelled read's fiber is gone — the write would land in a freed heap.
+/// [`PendingTable::take`] is what decides. A cancelled op is retired instead of
+/// cooked, because cooking reads the values the operation held: the bytes go
+/// into the buffer the requesting fiber pre-allocated, and the result is
+/// assembled through the port. Both belong to a fiber that is already gone.
 pub(super) fn cook_raw(
     rc: RawCompletion,
-    pending: &mut HashMap<SubmissionId, PendingOp>,
-    cancelled: &mut std::collections::HashSet<SubmissionId>,
+    pending: &mut PendingTable,
     fd_states: &mut HashMap<PortKey, FdState>,
     buffer_pool: &mut BufferPool,
     origin_heap: *mut crate::value::fiberheap::FiberHeap,
     gen: crate::segment::Generation,
 ) -> Option<Completion> {
-    let id = SubmissionId::from_raw(match &rc {
-        RawCompletion::Pool(pc) => pc.id,
-        RawCompletion::Stdin(sc) => sc.id,
-    });
-    if cancelled.remove(&id) {
-        let result_fd = match &rc {
-            RawCompletion::Pool(pc) => pc.result_code,
-            RawCompletion::Stdin(_) => 0,
-        };
-        discard_pending(id, result_fd, pending, buffer_pool);
-        return None;
-    }
     match rc {
         RawCompletion::Pool(pc) => {
             pool_to_completion(pc, pending, fd_states, buffer_pool, origin_heap, gen)
@@ -38,52 +26,23 @@ pub(super) fn cook_raw(
     }
 }
 
-/// Retire a cancelled operation's entry, releasing everything it owns without
-/// building a value for it. `result_fd` is the raw completion's result code,
-/// which for a connect is the descriptor the worker opened — nobody will take
-/// it now, so it is closed here rather than leaked.
-fn discard_pending(
-    id: SubmissionId,
-    result_fd: i32,
-    pending: &mut HashMap<SubmissionId, PendingOp>,
-    buffer_pool: &mut BufferPool,
-) {
-    let Some(op) = pending.remove(&id) else {
-        return;
-    };
-    if let Some(bh) = op.buffer_handle() {
-        buffer_pool.release(bh);
-    }
-    match op {
-        PendingOp::Connect { connect_fd, .. } => {
-            // io_uring pre-creates the socket; the pool reports it here.
-            if let Some(fd) = connect_fd.or(if result_fd > 0 { Some(result_fd) } else { None }) {
-                // SAFETY: nothing else holds this descriptor — the port that
-                // would have owned it is never built.
-                unsafe { libc::close(fd) };
-            }
-        }
-        PendingOp::Open { .. } if result_fd > 0 => {
-            // SAFETY: as above — the port for this descriptor is never built.
-            unsafe { libc::close(result_fd) };
-        }
-        PendingOp::ProcessWait { siginfo, .. } if !siginfo.is_null() => {
-            // SAFETY: allocated by `Box::into_raw` at submit; reclaimed once.
-            drop(unsafe { Box::from_raw(siginfo) });
-        }
-        _ => {}
-    }
-}
-
 /// Convert a `StdinCompletion` into a `Completion`, releasing the buffer.
 pub(super) fn stdin_to_completion(
     sc: crate::io::threadpool::StdinCompletion,
-    pending: &mut HashMap<SubmissionId, PendingOp>,
+    pending: &mut PendingTable,
     buffer_pool: &mut BufferPool,
     origin_heap: *mut crate::value::fiberheap::FiberHeap,
 ) -> Option<Completion> {
     let id = SubmissionId::from_raw(sc.id);
-    let pending_op = pending.remove(&id)?;
+    let pending_op = match pending.take(id) {
+        Taken::Live(op) => op,
+        // The stdin worker reports no descriptor, so there is none to close.
+        Taken::Cancelled(op) => {
+            op.retire(0, buffer_pool);
+            return None;
+        }
+        Taken::Unknown => return None,
+    };
     // Release BufferPool handle if present
     if let Some(bh) = pending_op.buffer_handle() {
         buffer_pool.release(bh);
@@ -165,14 +124,21 @@ pub(super) fn stdin_to_completion(
 /// Convert a `PoolCompletion` into a `Completion`, handling Connect fd stash.
 pub(super) fn pool_to_completion(
     pc: PoolCompletion,
-    pending: &mut HashMap<SubmissionId, PendingOp>,
+    pending: &mut PendingTable,
     fd_states: &mut HashMap<PortKey, FdState>,
     buffer_pool: &mut BufferPool,
     origin_heap: *mut crate::value::fiberheap::FiberHeap,
     gen: crate::segment::Generation,
 ) -> Option<Completion> {
     let id = SubmissionId::from_raw(pc.id);
-    let mut pending_op = pending.remove(&id)?;
+    let mut pending_op = match pending.take(id) {
+        Taken::Live(op) => op,
+        Taken::Cancelled(op) => {
+            op.retire(pc.result_code, buffer_pool);
+            return None;
+        }
+        Taken::Unknown => return None,
+    };
     if let PendingOp::Connect {
         ref mut connect_fd, ..
     } = pending_op

--- a/src/io/aio/poll.rs
+++ b/src/io/aio/poll.rs
@@ -3,18 +3,19 @@ use super::*;
 impl AsyncBackend {
     /// Cancel a pending I/O operation by submission ID.
     ///
-    /// For io_uring: submits IORING_OP_ASYNC_CANCEL. The original SQE will
-    /// generate a CQE with result = -ECANCELED; the cancel SQE's CQE is
-    /// tagged and skipped by drain_cqes.
+    /// Two halves, and both platforms have both. **Asking the operation to
+    /// stop** is platform-specific: io_uring takes `IORING_OP_ASYNC_CANCEL`
+    /// (its own CQE is high-bit tagged and skipped; the operation's own CQE
+    /// arrives with `-ECANCELED`), while a pool worker is asked through its stop
+    /// pipe (src/io/AGENTS.md § "The stop pipe"). **Marking the id** is shared:
+    /// the operation's completion, whenever it arrives, retires the entry
+    /// instead of building a result nobody would read.
     ///
-    /// For the thread pool: write the operation's stop pipe if it carries one
-    /// (every operation that can wait indefinitely does — see src/io/AGENTS.md
-    /// § "The stop pipe"), and mark the id so its result is dropped when it
-    /// arrives. The `pending` entry stays. The worker's `RawCompletion` then
-    /// still decrements the hub's `in_flight` at the drain site and still
-    /// releases the descriptor the operation named; removing the entry here
-    /// would strand both. We must NOT decrement `in_flight` here — the drain
-    /// site does it, and doing it twice would underflow the combined count.
+    /// The `pending` entry stays either way. The worker's `RawCompletion` still
+    /// decrements the hub's `in_flight` at the drain site and still releases the
+    /// descriptor the operation named; removing the entry here would strand
+    /// both. We must NOT decrement `in_flight` here — the drain site does it,
+    /// and doing it twice would underflow the combined count.
     pub(crate) fn cancel(&self, id: SubmissionId) -> Result<(), String> {
         let mut inner = self.inner.borrow_mut();
         match inner.platform {
@@ -22,13 +23,9 @@ impl AsyncBackend {
             PlatformBackend::Uring(ref mut ring) => {
                 crate::io::uring::submit_uring_cancel(ring, id)?;
             }
-            PlatformBackend::ThreadPool => {
-                inner.hub.stop(id);
-                if inner.pending.contains_key(&id) {
-                    inner.cancelled.insert(id);
-                }
-            }
+            PlatformBackend::ThreadPool => inner.hub.stop(id),
         }
+        inner.pending.mark_cancelled(id);
         Ok(())
     }
 
@@ -68,7 +65,6 @@ impl AsyncBackend {
                 ref mut platform,
                 ref mut hub,
                 ref mut pending,
-                ref mut cancelled,
                 ref mut buffer_pool,
                 ref mut fd_states,
                 ref mut completions,
@@ -118,15 +114,8 @@ impl AsyncBackend {
                                 crate::io::threadpool::RawCompletion::Pool(pc) => pc.id,
                                 crate::io::threadpool::RawCompletion::Stdin(sc) => sc.id,
                             });
-                            let cooked = cook_raw(
-                                rc,
-                                pending,
-                                cancelled,
-                                fd_states,
-                                buffer_pool,
-                                origin_heap,
-                                gen,
-                            );
+                            let cooked =
+                                cook_raw(rc, pending, fd_states, buffer_pool, origin_heap, gen);
                             hub.forget_stop(id);
                             if let Some(c) = cooked {
                                 completions.push_back(c);

--- a/src/io/aio/tests/fileops.rs
+++ b/src/io/aio/tests/fileops.rs
@@ -171,6 +171,70 @@ fn test_async_submit_process_wait_uring() {
     });
 }
 
+/// A failed process wait names the syscall the platform actually called.
+///
+/// One completion arm serves both backends, and they call different things:
+/// `IORING_OP_WAITID` on the ring, `waitpid(2)` in the pool worker
+/// (`src/io/threadpool/child.rs`). The trap: a report that names `waitid` on a
+/// platform that has no `waitid` call in the path sends its reader looking for
+/// code that is not there.
+///
+/// The failure is arranged by reaping the child first, so the worker's
+/// `waitpid` finds no child and returns `ECHILD` — the same shape any lost
+/// child produces.
+#[test]
+fn a_failed_pool_process_wait_names_waitpid() {
+    crate::value::arena::with_test_region(|| {
+        let mut child = std::process::Command::new("/bin/true").spawn().unwrap();
+        let pid = child.id();
+        // Reaped here, so the pool worker's own `waitpid` has no child left.
+        child.wait().unwrap();
+
+        let h = crate::primitives::ctx::TestHeap::new();
+        let handle_val = h
+            .ctx()
+            .external("process", ProcessHandle::new(pid, child_stub()));
+
+        let backend = AsyncBackend::new_thread_pool().unwrap();
+        let id = backend
+            .submit(
+                &IoRequest {
+                    op: IoOp::ProcessWait,
+                    port: handle_val,
+                    timeout: None,
+                },
+                crate::value::arena::leaked_test_heap(),
+            )
+            .unwrap();
+
+        let completions = backend.wait(5000).unwrap();
+        assert_eq!(completions.len(), 1);
+        assert_eq!(completions[0].id, id);
+        let err = completions[0]
+            .result
+            .as_ref()
+            .expect_err("a wait for a child that is gone must fail");
+        let fields = err.as_struct().expect("an io error is a struct");
+        let msg = sorted_struct_get(fields, &TableKey::Keyword("message".into()))
+            .and_then(|v| v.with_string(|s| s.to_string()))
+            .expect("an io error carries a :message");
+        assert!(
+            msg.contains("waitpid failed"),
+            "the pool's process wait must name waitpid, the call it makes; got {msg:?}",
+        );
+    });
+}
+
+/// A reaped placeholder child for a `ProcessHandle` whose real child is already
+/// gone. `ProcessHandle::new` demands a `Child`, and its `Drop` calls
+/// `try_wait`, so the stand-in is a process that has already exited.
+#[cfg(test)]
+fn child_stub() -> std::process::Child {
+    let mut child = std::process::Command::new("/bin/true").spawn().unwrap();
+    child.wait().unwrap();
+    child
+}
+
 // ── IoOp::Open integration tests ─────────────────────────────────────────
 
 #[test]

--- a/src/io/aio/tests/park.rs
+++ b/src/io/aio/tests/park.rs
@@ -264,6 +264,96 @@ fn a_cancelled_pool_open_of_a_fifo_ends_rather_than_being_abandoned() {
     });
 }
 
+/// A cancelled operation delivers no completion — on either backend.
+///
+/// Every `io/cancel` caller in the scheduler drops its record of the submission
+/// before cancelling it (`complete-fiber`, `handle-abort`,
+/// `handle-io-forward-cancel`, `do-shutdown`), so no fiber is left to receive a
+/// result. Building one anyway is not merely wasted work: the completion path
+/// dereferences the operation's port `Value`, and the release that ran when the
+/// asking fiber finished may already have freed the region that value lives in.
+///
+/// The trap: the two backends reach the same cancellation by different routes —
+/// the pool worker returns `-ECANCELED` through the hub, the ring posts a
+/// `-ECANCELED` CQE — so a discard implemented on one of them says nothing about
+/// the other. The counter-factual is the ring cooking the CQE: one completion
+/// arrives for an id nobody is waiting on, carrying a value read through the
+/// dead port.
+#[test]
+fn a_cancelled_operation_delivers_no_completion_on_either_backend() {
+    use std::os::unix::io::FromRawFd;
+    crate::value::arena::with_test_region(|| {
+        for (backend, which) in [
+            (AsyncBackend::new().unwrap(), "the platform default"),
+            (AsyncBackend::new_thread_pool().unwrap(), "the thread pool"),
+        ] {
+            // A pipe whose write end stays open and empty: the read parks, and
+            // the cancel is the only thing that can end it. The port takes a
+            // duplicate so its close and the pipe's are each of one descriptor.
+            let pipe = Pipe::new();
+            let dup_fd = unsafe { libc::dup(pipe.read_fd) };
+            assert!(dup_fd >= 0, "{which}: dup(2) failed");
+            let h = crate::primitives::ctx::TestHeap::new();
+            let port = h.ctx().external(
+                "port",
+                Port::new_file(
+                    unsafe { std::os::unix::io::OwnedFd::from_raw_fd(dup_fd) },
+                    Direction::Read,
+                    Encoding::Binary,
+                    "<pipe>".into(),
+                ),
+            );
+            let id = backend
+                .submit(
+                    &IoRequest {
+                        op: PortOp::ReadAll.into(),
+                        port,
+                        timeout: None,
+                    },
+                    crate::value::arena::leaked_test_heap(),
+                )
+                .unwrap();
+
+            // The pool cancels a worker that is already waiting; give it the
+            // thread before asking. The ring has no worker to wait for.
+            for _ in 0..200 {
+                if backend.workers() > 0 {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            backend.cancel(id).unwrap();
+
+            // Bounded, because the property is that this terminates: the entry
+            // must be retired by the cancelled operation's own completion.
+            let mut delivered = Vec::new();
+            for _ in 0..40 {
+                delivered.extend(backend.wait(50).unwrap().into_iter().map(|c| c.id));
+                if !backend.has_pending() && backend.workers() == 0 {
+                    break;
+                }
+            }
+
+            assert!(
+                delivered.is_empty(),
+                "{which}: a cancelled operation delivered {} completion(s) — \
+                 no fiber is waiting for one, and building it reads the port \
+                 value the finished fiber's release may already have freed",
+                delivered.len(),
+            );
+            assert!(
+                !backend.has_pending(),
+                "{which}: the cancelled operation kept its pending entry",
+            );
+            assert_eq!(
+                backend.workers(),
+                0,
+                "{which}: the cancelled operation never gave its worker back",
+            );
+        }
+    });
+}
+
 /// `ev/poll-fd` answers an expired wait with 0 — on either backend.
 ///
 /// That is the primitive's documented contract, and what lets a caller poll in

--- a/src/io/completion.rs
+++ b/src/io/completion.rs
@@ -75,6 +75,16 @@ pub(super) fn process_raw_completion(
             // buffer_pool.release is already called at the top of process_raw_completion.
 
             if result_code < 0 {
+                // Which syscall actually ran is what the `siginfo` allocation
+                // says: the kernel fills one for `IORING_OP_WAITID`, and the
+                // pool worker — which calls `waitpid(2)` itself — leaves it
+                // null. Naming the other one sends a reader looking for a call
+                // this platform never makes.
+                let syscall = if siginfo.is_null() {
+                    "waitpid"
+                } else {
+                    "waitid"
+                };
                 // On the uring path, reclaim siginfo before returning.
                 if !siginfo.is_null() {
                     unsafe { drop(Box::from_raw(*siginfo)) };
@@ -84,7 +94,12 @@ pub(super) fn process_raw_completion(
                     id,
                     crate::io::io_error(
                         "exec-error",
-                        format!("subprocess/wait: waitid failed: errno {}", errno),
+                        format!(
+                            "subprocess/wait: {} failed: errno {} ({})",
+                            syscall,
+                            errno,
+                            errno_message(errno)
+                        ),
                         origin_heap,
                     ),
                 );

--- a/src/io/pending.rs
+++ b/src/io/pending.rs
@@ -1,10 +1,12 @@
 //! PendingOp — in-flight async I/O operation tracking.
 
-use crate::io::pool::BufferHandle;
+use crate::io::pool::{BufferHandle, BufferPool};
 use crate::io::request::{ConnectAddr, PortOp};
 use crate::io::types::PortKey;
+use crate::io::SubmissionId;
 use crate::port::PortKind;
 use crate::value::Value;
+use std::collections::{HashMap, HashSet};
 use std::os::unix::io::RawFd;
 use std::time::Duration;
 
@@ -148,6 +150,252 @@ impl PendingOp {
     pub(super) fn set_filled(&mut self, val: usize) {
         if let PendingOp::Port { filled, .. } = self {
             *filled = val;
+        }
+    }
+
+    /// Give back everything this operation owns, without building a value for
+    /// it: the pooled buffer, a descriptor the completion would have wrapped in
+    /// a port, and the `siginfo_t` a process wait allocated.
+    ///
+    /// `result_fd` is the raw completion's result code, which for a connect or
+    /// an open is the descriptor the worker opened. Nobody will take it now, so
+    /// it is closed here rather than leaked.
+    pub(crate) fn retire(self, result_fd: i32, buffer_pool: &mut BufferPool) {
+        if let Some(bh) = self.buffer_handle() {
+            buffer_pool.release(bh);
+        }
+        match self {
+            PendingOp::Connect { connect_fd, .. } => {
+                // io_uring pre-creates the socket; the pool reports it here.
+                if let Some(fd) = connect_fd.or(if result_fd > 0 { Some(result_fd) } else { None })
+                {
+                    // SAFETY: nothing else holds this descriptor — the port that
+                    // would have owned it is never built.
+                    unsafe { libc::close(fd) };
+                }
+            }
+            PendingOp::Open { .. } if result_fd > 0 => {
+                // SAFETY: as above — the port for this descriptor is never built.
+                unsafe { libc::close(result_fd) };
+            }
+            PendingOp::ProcessWait { siginfo, .. } if !siginfo.is_null() => {
+                // SAFETY: allocated by `Box::into_raw` at submit; reclaimed once.
+                drop(unsafe { Box::from_raw(siginfo) });
+            }
+            _ => {}
+        }
+    }
+}
+
+/// What a completion found when it looked its submission up.
+pub(crate) enum Taken {
+    /// The operation, with a fiber waiting for its result. Cook it.
+    Live(PendingOp),
+    /// The operation, with nobody to receive it. Retire it instead: building
+    /// the result would read heap values whose regions the finished fiber's
+    /// release may already have freed.
+    Cancelled(PendingOp),
+    /// No entry under this id — already reaped, or never filed.
+    Unknown,
+}
+
+/// The operations a backend has in flight, and which of them no fiber will
+/// receive a result for.
+///
+/// The two facts live together because one decision reads both. An arriving
+/// completion asks a single question — "does anybody want this?" — and
+/// [`take`](Self::take) answers it, so neither backend can honour the
+/// cancellation contract on one half and forget it on the other.
+///
+/// A cancelled operation KEEPS its entry until its own completion arrives. The
+/// worker it runs on and the descriptor it names come back with that
+/// completion; dropping the entry at the cancel would strand both.
+#[derive(Default)]
+pub(crate) struct PendingTable {
+    ops: HashMap<SubmissionId, PendingOp>,
+    /// Ids whose result no fiber will receive. Every `io/cancel` caller in the
+    /// scheduler drops its own record of the submission before cancelling, so
+    /// the id is marked here precisely when there is no longer a reader.
+    cancelled: HashSet<SubmissionId>,
+}
+
+impl PendingTable {
+    pub(crate) fn new() -> Self {
+        PendingTable::default()
+    }
+
+    /// File a fresh submission's entry under the id it was dispatched with.
+    pub(crate) fn insert(&mut self, id: SubmissionId, op: PendingOp) {
+        self.ops.insert(id, op);
+    }
+
+    /// Take the entry a completion resolves through, and say whether anybody
+    /// is waiting for its result.
+    pub(crate) fn take(&mut self, id: SubmissionId) -> Taken {
+        let was_cancelled = self.cancelled.remove(&id);
+        match self.ops.remove(&id) {
+            Some(op) if was_cancelled => Taken::Cancelled(op),
+            Some(op) => Taken::Live(op),
+            None => Taken::Unknown,
+        }
+    }
+
+    /// Mark `id` as having no reader, so its completion is retired rather than
+    /// cooked. A no-op for an id that is not in flight — that operation has
+    /// already been reaped and its result already handed to the fiber that
+    /// asked, so there is nothing left to withhold and a mark would sit in the
+    /// set with no completion coming to clear it.
+    pub(crate) fn mark_cancelled(&mut self, id: SubmissionId) {
+        if self.ops.contains_key(&id) {
+            self.cancelled.insert(id);
+        }
+    }
+
+    /// Mark every operation still in flight as having no reader. Backend
+    /// teardown: the fibers are gone and the heap that carried their values may
+    /// be too, so the drain that follows must retire rather than cook.
+    pub(crate) fn cancel_all(&mut self) {
+        self.cancelled.extend(self.ops.keys().copied());
+    }
+
+    /// Put a resubmitted operation's entry back. The operation is the same one
+    /// — a read that needs another syscall to reach its newline, its count, or
+    /// its EOF — so this is one operation's entry moving, not a new submission.
+    pub(crate) fn restore(&mut self, id: SubmissionId, op: PendingOp) {
+        self.ops.insert(id, op);
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.ops.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.ops.len()
+    }
+
+    /// The ids in flight. Callers that submit while iterating take this rather
+    /// than borrowing the table.
+    pub(crate) fn ids(&self) -> Vec<SubmissionId> {
+        self.ops.keys().copied().collect()
+    }
+
+    /// The entry filed under `id`, for a test reporting on an operation still
+    /// in flight. Production code takes its entry with [`take`](Self::take),
+    /// which is where the cancellation question is answered; a borrow that
+    /// skips that question is exactly what this table exists to prevent.
+    #[cfg(test)]
+    pub(crate) fn get(&self, id: SubmissionId) -> Option<&PendingOp> {
+        self.ops.get(&id)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&SubmissionId, &PendingOp)> {
+        self.ops.iter()
+    }
+
+    pub(crate) fn values(&self) -> impl Iterator<Item = &PendingOp> {
+        self.ops.values()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::pool::BufferPool;
+
+    /// A `Sleep` entry: the one variant that owns nothing but its buffer, so a
+    /// table test can file and retire it without a port, a child or a socket.
+    fn sleep_op(pool: &mut BufferPool) -> PendingOp {
+        PendingOp::Sleep {
+            buffer_handle: pool.alloc(0),
+        }
+    }
+
+    fn id(n: u64) -> SubmissionId {
+        SubmissionId::from_raw(n)
+    }
+
+    /// An uncancelled submission's completion is handed its entry to cook.
+    #[test]
+    fn a_live_submission_is_taken_live() {
+        let mut pool = BufferPool::new();
+        let mut table = PendingTable::new();
+        table.insert(id(1), sleep_op(&mut pool));
+        assert!(matches!(table.take(id(1)), Taken::Live(_)));
+        assert!(table.is_empty(), "taking an entry removes it");
+    }
+
+    /// A cancelled submission's completion is told so, and only once: the mark
+    /// leaves with the entry, so nothing about this id survives to affect a
+    /// later lookup.
+    #[test]
+    fn a_cancelled_submission_is_taken_cancelled_exactly_once() {
+        let mut pool = BufferPool::new();
+        let mut table = PendingTable::new();
+        table.insert(id(1), sleep_op(&mut pool));
+        table.mark_cancelled(id(1));
+        match table.take(id(1)) {
+            Taken::Cancelled(op) => op.retire(0, &mut pool),
+            _ => panic!("a marked submission must be reported cancelled"),
+        }
+        assert!(matches!(table.take(id(1)), Taken::Unknown));
+    }
+
+    /// Cancelling an id that is no longer in flight marks nothing.
+    ///
+    /// The trap: `io/cancel` races the completion it is trying to prevent, so a
+    /// cancel routinely arrives for an operation already reaped and delivered.
+    /// A mark filed then would have no completion coming to clear it.
+    #[test]
+    fn cancelling_a_reaped_submission_marks_nothing() {
+        let mut pool = BufferPool::new();
+        let mut table = PendingTable::new();
+        table.insert(id(1), sleep_op(&mut pool));
+        assert!(matches!(table.take(id(1)), Taken::Live(_)));
+
+        table.mark_cancelled(id(1));
+        assert!(matches!(table.take(id(1)), Taken::Unknown));
+    }
+
+    /// A resubmitted operation is still in flight, so a cancel still reaches
+    /// it.
+    ///
+    /// A read that needs another syscall to reach its newline, its count or its
+    /// EOF leaves the table and comes back (`drain_cqes`). What must not follow
+    /// is the entry reading as reaped in between — a cancel issued after the
+    /// restore would then mark nothing, and the next completion would be cooked
+    /// for a fiber that is gone.
+    #[test]
+    fn a_resubmitted_operation_can_still_be_cancelled() {
+        let mut pool = BufferPool::new();
+        let mut table = PendingTable::new();
+        table.insert(id(1), sleep_op(&mut pool));
+        let op = match table.take(id(1)) {
+            Taken::Live(op) => op,
+            _ => panic!("an unmarked entry is live"),
+        };
+        table.restore(id(1), op);
+
+        table.mark_cancelled(id(1));
+        match table.take(id(1)) {
+            Taken::Cancelled(op) => op.retire(0, &mut pool),
+            _ => panic!("a resubmitted operation must still be cancellable"),
+        }
+    }
+
+    /// Teardown withholds every result at once.
+    #[test]
+    fn cancel_all_marks_everything_in_flight() {
+        let mut pool = BufferPool::new();
+        let mut table = PendingTable::new();
+        for n in 1..=3 {
+            table.insert(id(n), sleep_op(&mut pool));
+        }
+        table.cancel_all();
+        for n in 1..=3 {
+            assert!(
+                matches!(table.take(id(n)), Taken::Cancelled(_)),
+                "submission {n} must be withheld at teardown",
+            );
         }
     }
 }

--- a/src/io/pending.rs
+++ b/src/io/pending.rs
@@ -254,6 +254,13 @@ impl PendingTable {
     /// Mark every operation still in flight as having no reader. Backend
     /// teardown: the fibers are gone and the heap that carried their values may
     /// be too, so the drain that follows must retire rather than cook.
+    ///
+    /// Only `quiesce_pending` calls this, and only the ring has a teardown
+    /// drain, so the allow is narrowed to the platforms that compile that path
+    /// out rather than a blanket `dead_code`. The three below are the same
+    /// story: `restore` is the ring's resubmission, `len` and `ids` are what the
+    /// teardown loop reads.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) fn cancel_all(&mut self) {
         self.cancelled.extend(self.ops.keys().copied());
     }
@@ -261,6 +268,7 @@ impl PendingTable {
     /// Put a resubmitted operation's entry back. The operation is the same one
     /// — a read that needs another syscall to reach its newline, its count, or
     /// its EOF — so this is one operation's entry moving, not a new submission.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) fn restore(&mut self, id: SubmissionId, op: PendingOp) {
         self.ops.insert(id, op);
     }
@@ -269,12 +277,14 @@ impl PendingTable {
         self.ops.is_empty()
     }
 
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) fn len(&self) -> usize {
         self.ops.len()
     }
 
     /// The ids in flight. Callers that submit while iterating take this rather
     /// than borrowing the table.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) fn ids(&self) -> Vec<SubmissionId> {
         self.ops.keys().copied().collect()
     }

--- a/src/io/uring.rs
+++ b/src/io/uring.rs
@@ -2,7 +2,7 @@
 
 use crate::io::aio::{EVENTFD_USER_DATA, TIMEOUT_USER_DATA_TAG};
 use crate::io::completion::process_raw_completion;
-use crate::io::pending::PendingOp;
+use crate::io::pending::{PendingOp, PendingTable, Taken};
 use crate::io::pool::{BufferHandle, BufferPool};
 use crate::io::request::{apply_socket_options, ConnectAddr, PortOp};
 use crate::io::types::{FdState, PortKey};

--- a/src/io/uring/drain.rs
+++ b/src/io/uring/drain.rs
@@ -41,12 +41,13 @@ fn push_resubmit(
 /// This is the **single** CQE processing path — used by both poll (non-blocking)
 /// and wait (after blocking). Handles:
 /// - Timeout CQE filtering (high-bit user_data tag)
+/// - Cancelled submissions (retired rather than cooked)
 /// - Connect fd cleanup on error
 /// - PortOp-aware buffer extraction (only reads buffer for stream reads)
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn drain_cqes(
     ring: &mut io_uring::IoUring,
-    pending: &mut HashMap<SubmissionId, PendingOp>,
+    pending: &mut PendingTable,
     buffer_pool: &mut BufferPool,
     fd_states: &mut HashMap<PortKey, FdState>,
     completions: &mut VecDeque<Completion>,
@@ -85,7 +86,16 @@ pub(crate) fn drain_cqes(
         }
 
         let id = SubmissionId::from_raw(user_data);
-        if let Some(mut pending_op) = pending.remove(&id) {
+        // A cancelled submission is retired here rather than cooked. Everything
+        // below reads what the operation held — the port, the process handle,
+        // the fiber's pre-allocated buffer — and the fiber that owned all three
+        // is gone by the time its cancel is issued.
+        let taken = pending.take(id);
+        if let Taken::Cancelled(op) = taken {
+            op.retire(result_code, buffer_pool);
+            continue;
+        }
+        if let Taken::Live(mut pending_op) = taken {
             // Connect: on failure, close the pre-created socket.
             if let PendingOp::Connect {
                 ref mut connect_fd, ..
@@ -430,7 +440,7 @@ pub(crate) fn drain_cqes(
                 .build()
                 .user_data(id.as_u64())
             };
-            pending.insert(id, pending_op);
+            pending.restore(id, pending_op);
             link_timeouts.extend(push_resubmit(ring, id, sqe, op_timeout));
         } else {
             // `ReadAll` lands here: it has no pre-allocated fiber buffer to
@@ -457,7 +467,7 @@ pub(crate) fn drain_cqes(
                 *buffer_handle = Some(new_buf);
                 *filled = 0;
             }
-            pending.insert(id, pending_op);
+            pending.restore(id, pending_op);
             link_timeouts.extend(push_resubmit(ring, id, sqe, op_timeout));
         }
     }
@@ -494,7 +504,7 @@ pub(crate) fn drain_cqes(
         // payload larger than one syscall would otherwise be unbounded from
         // its second chunk on, and a peer that stops reading would hang a
         // write that asked for a timeout.
-        pending.insert(id, pending_op);
+        pending.restore(id, pending_op);
         link_timeouts.extend(push_resubmit(ring, id, sqe, timeout));
     }
 
@@ -506,7 +516,7 @@ pub(crate) fn drain_cqes(
 pub(crate) fn wait_uring(
     ring: &mut io_uring::IoUring,
     timeout: Option<u64>,
-    pending: &mut HashMap<SubmissionId, PendingOp>,
+    pending: &mut PendingTable,
     buffer_pool: &mut BufferPool,
     fd_states: &mut HashMap<PortKey, FdState>,
     completions: &mut VecDeque<Completion>,

--- a/src/io/uring/tests.rs
+++ b/src/io/uring/tests.rs
@@ -242,7 +242,7 @@ fn short_write_resubmits_until_the_payload_is_gone() {
     )
     .expect("submit_uring_stream");
 
-    let mut pending: HashMap<SubmissionId, PendingOp> = HashMap::new();
+    let mut pending = crate::io::pending::PendingTable::new();
     pending.insert(
         id,
         PendingOp::Port {
@@ -266,7 +266,7 @@ fn short_write_resubmits_until_the_payload_is_gone() {
         assert!(
             Instant::now() < deadline,
             "write never completed: {} of {} bytes reported after 20s",
-            pending.get(&id).map(|p| p.filled()).unwrap_or(0),
+            pending.get(id).map(|p| p.filled()).unwrap_or(0),
             PAYLOAD
         );
         let ts = io_uring::types::Timespec::new().sec(1).nsec(0);

--- a/src/value/arena.rs
+++ b/src/value/arena.rs
@@ -182,6 +182,12 @@ pub enum EscapeSite {
     /// An emitted value the scheduler holds via `fiber.signal` past the
     /// matching compiler-emitted `DecrefRegion`.
     EmitEscape,
+    /// A child's parked payload re-installed as the propagating fiber's own
+    /// `signal` (`fiber/propagate`). The install is a fresh park, so it owes the
+    /// delivery reference its resumer's result release consumes — the child's
+    /// park funded its own resumer, not this one (docs/impl/region/owner.md
+    /// § "Park/unpark symmetry").
+    PropagateEscape,
     /// A child fiber's set-once terminal result, park-retained until the fiber
     /// is freed (released by the signal scan — asymmetric by Rule 7).
     TerminalSignal,
@@ -207,6 +213,7 @@ impl EscapeSite {
             EscapeSite::ChanSend => "chan-send",
             EscapeSite::SuspendEscape => "suspend-escape",
             EscapeSite::EmitEscape => "emit-escape",
+            EscapeSite::PropagateEscape => "propagate-escape",
             EscapeSite::TerminalSignal => "terminal-signal",
             EscapeSite::ParamBaseline => "param-baseline",
         }

--- a/src/value/fiberheap/freelog.rs
+++ b/src/value/fiberheap/freelog.rs
@@ -116,14 +116,20 @@ pub(crate) fn guard_armed() -> bool {
 /// The third instrument in this family, and the cheap one. `guardfree` never
 /// reuses a page, so it catches a stale read at any distance but costs a
 /// mapping per freed page; the generation check catches a stale *region
-/// resolution* but only in debug builds and only while the page is still
-/// unclaimed. Scrub instead makes the page's contents wrong on purpose: a
-/// stale read lands on an all-zero `HeapObject` slot, whose tag matches no
-/// live value, so `arena::deref` panics naming the deref site — in release
-/// builds too, at the cost of one `memset` of the bytes the dying region
-/// wrote. Off by default, because the ordinary contract is that a claimed
-/// page's body is unspecified, not blank (docs/impl/region/model.md
-/// § "Page recycling").
+/// resolution* but only while the page is still unclaimed. Scrub instead makes
+/// the page's contents wrong on purpose: a stale read lands on an all-zero
+/// `HeapObject` slot, whose tag matches no live value. It costs one `memset` of
+/// the bytes the dying region wrote. Off by default, because the ordinary
+/// contract is that a claimed page's body is unspecified, not blank
+/// (docs/impl/region/model.md § "Page recycling").
+///
+/// **What the scrub buys depends on `debug_assertions`.** The report — the
+/// `arena::deref` panic that names the deref site and attributes the free — is
+/// `#[cfg(debug_assertions)]`, so a plain release build never prints it: there
+/// the zeroed slot merely turns a wrong-typed value into a fault somewhere near
+/// the stale read, with nothing said. A build that wants the report must carry
+/// debug assertions, which is why the macOS CI job sets
+/// `CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS` alongside `--trace=scrub`.
 pub(crate) fn scrub_armed() -> bool {
     crate::config::get().has_trace("scrub")
 }

--- a/src/vm/fiber/jit.rs
+++ b/src/vm/fiber/jit.rs
@@ -70,12 +70,10 @@ impl VM {
             }
         };
 
-        let (child_bits, child_value) = handle.with(|fiber| fiber.signal).unwrap_or_else(|| {
-            (
-                SIG_ERROR,
-                self.escaping_error("internal-error", "fiber/propagate: no signal"),
-            )
-        });
+        // Same install as the bytecode handlers, so the same delivery reference
+        // is owed — routed through the one helper rather than a third copy
+        // (docs/impl/region/owner.md § "Park/unpark symmetry").
+        let (child_bits, child_value) = self.take_propagated_signal(&handle);
 
         self.fiber.child = Some(handle);
         self.fiber.child_value = Some(fiber_value);

--- a/src/vm/fiber/propagate.rs
+++ b/src/vm/fiber/propagate.rs
@@ -5,6 +5,56 @@ use crate::value::{SignalBits, Value, SIG_ERROR, SIG_HALT};
 use crate::vm::core::VM;
 
 impl VM {
+    /// Read the child's parked signal, minting the DELIVERY reference the
+    /// re-park owes. Shared by the call-, tail-, and JIT-position handlers —
+    /// all three run the same install, so all three owe the same reference.
+    ///
+    /// Installing the child's payload as this fiber's own `signal` is a fresh
+    /// park: this fiber's resumer reads the payload as its resume result and
+    /// runs the compiler-emitted release on it. The child's park funded its own
+    /// resumer's release, not this one, so without a mint here that release
+    /// consumes a reference nothing took — the payload's count then runs one
+    /// short of the recorded `fiber → payload` edges and the free cascade
+    /// reclaims it under the caller (docs/impl/region/owner.md § "Park/unpark
+    /// symmetry").
+    ///
+    /// Three cases take no mint, each because the delivery already has an owner
+    /// or no consumer:
+    ///
+    /// - A NON-TERMINAL signal (a yield, an io request). The fiber runs again,
+    ///   so the resume path proper governs the payload — `release_parked_signal`
+    ///   for an io request, the resumed body's own pending release otherwise.
+    ///   `with_child_fiber` step 6a excludes exactly this set from its park
+    ///   retain for the same reason ("retaining here would leak"), and the
+    ///   delivery follows the park.
+    /// - `SIG_HALT`, for the reason `VM::handle_emit` skips it: a halt promotes
+    ///   the fiber to `:dead`, `fiber/resume` refuses it, so that delivery has
+    ///   no consumer and a retain would strand the payload.
+    /// - The no-signal fallback, whose error `escaping_error` builds in a fresh
+    ///   region already carrying the one reference the consumer's
+    ///   `DecrefValueRegion` releases — only a BORROWED payload is unfunded.
+    pub(super) fn take_propagated_signal(
+        &mut self,
+        handle: &crate::value::FiberHandle,
+    ) -> (SignalBits, Value) {
+        let Some((bits, value)) = handle.with(|fiber| fiber.signal) else {
+            return (
+                SIG_ERROR,
+                self.escaping_error("internal-error", "fiber/propagate: no signal"),
+            );
+        };
+        if super::is_terminal_signal(bits) && !bits.intersects(SIG_HALT) {
+            let heap = unsafe { &mut *self.heap_ptr };
+            let region = crate::value::arena::region_of(heap, value);
+            crate::value::arena::incref_for_escape(
+                heap,
+                region,
+                crate::value::arena::EscapeSite::PropagateEscape,
+            );
+        }
+        (bits, value)
+    }
+
     /// Handle SIG_PROPAGATE from fiber/propagate (Call position).
     pub(in crate::vm) fn handle_fiber_propagate_signal(
         &mut self,
@@ -19,12 +69,7 @@ impl VM {
             }
         };
 
-        let (child_bits, child_value) = handle.with(|fiber| fiber.signal).unwrap_or_else(|| {
-            (
-                SIG_ERROR,
-                self.escaping_error("internal-error", "fiber/propagate: no signal"),
-            )
-        });
+        let (child_bits, child_value) = self.take_propagated_signal(&handle);
 
         self.fiber.child = Some(handle);
         self.fiber.child_value = Some(fiber_value);
@@ -59,12 +104,7 @@ impl VM {
             }
         };
 
-        let (child_bits, child_value) = handle.with(|fiber| fiber.signal).unwrap_or_else(|| {
-            (
-                SIG_ERROR,
-                self.escaping_error("internal-error", "fiber/propagate: no signal"),
-            )
-        });
+        let (child_bits, child_value) = self.take_propagated_signal(&handle);
 
         self.fiber.child = Some(handle);
         self.fiber.child_value = Some(fiber_value);

--- a/tests/elle/region-fiber-propagate-uaf.lisp
+++ b/tests/elle/region-fiber-propagate-uaf.lisp
@@ -1,0 +1,225 @@
+(elle/epoch 12)
+# A propagated signal is a fresh park, and owes its own delivery reference
+# (docs/impl/region/owner.md § "Park/unpark symmetry").
+#
+# `fiber/propagate` installs the child's parked payload as the propagating
+# fiber's own `signal`. That fiber's resumer reads the payload as its resume
+# result and runs the compiler-emitted release on it — the consumer an `Emit`
+# funds with its `EmitEscape` mint. Re-parking a value the child already parked
+# mints nothing, so the release consumes a reference the propagate never took.
+#
+# The trap: ONE propagate hides it. An error unwind runs no continuation, so the
+# raising body's own reference is stranded and unclaimed, and the release eats
+# that instead — which is why the obvious three-line reproducer is green. The
+# witnesses below each remove that cover, by propagating twice or by raising the
+# error from a native, whose payload reaches `fiber.signal` owning nothing.
+#
+# The counter-factual: without the mint the payload's count runs one short of
+# the recorded `fiber → payload` edges, so the last fiber's free cascade
+# reclaims it while the caller still holds it. Every witness reads a HEAP field
+# of the payload after the carrying fibers are gone, never just `(not ok?)` —
+# a bare status check passes over a freed payload and would have missed this.
+#
+# `defer` is the propagate in production form: it resumes a body fiber, runs
+# cleanup, then `(fiber/propagate f)` when the body did not complete. `protect`
+# supplies the outermost catch and hands the payload back as data.
+
+# ── (a) two propagates: the second has no stranded reference to steal ────────
+(defn a-inner [n]
+  (defer
+    nil
+    (error {:reason :bang :tag (string "a" n)})))
+(defn a-middle [n]
+  (defer
+    nil
+    (a-inner n)))
+(defn w-two-propagates [n]
+  (let [[ok? err] (protect (a-middle n))]
+    (assert (not ok?) "two-propagate witness completed instead of erroring")
+    (assert (= err:reason :bang) "two-propagate payload lost its :reason")
+    (length err:tag)))
+
+# ── (b) three propagates — the shortfall is per park, not per value ──────────
+(defn b-deep [n]
+  (defer
+    nil
+    (defer
+      nil
+      (defer
+        nil
+        (error {:reason :deep :tag (string "b" n)})))))
+(defn w-three-propagates [n]
+  (let [[ok? err] (protect (b-deep n))]
+    (assert (not ok?) "three-propagate witness completed instead of erroring")
+    (length err:tag)))
+
+# ── (c) a NATIVE error through one propagate ─────────────────────────────────
+# A native raise builds its payload and installs it without leaving a body
+# reference behind, so a single propagate is already one short.
+(defn c-native [n]
+  (defer
+    nil
+    (get nil :missing)))
+(defn w-native [n]
+  (let [[ok? err] (protect (c-native n))]
+    (assert (not ok?) "native-error witness completed instead of erroring")
+    (assert (= err:error :type-error) "native payload lost its :error tag")
+    (length err:message)))
+
+# ── (d) the payload read through `fiber/value`, not the protect tuple ────────
+# The explicit form of the same park: propagate out of a hand-rolled fiber and
+# read the result off the outer fiber after control has left it.
+(defn d-body [n]
+  (defer
+    nil
+    (error {:reason :bang :tag (string "d" n)})))
+(defn w-fiber-value [n]
+  (let [f (fiber/new (fn () (d-body n)) 1)]
+    (fiber/resume f nil)
+    (assert (not (= (fiber/status f) :dead))
+            "fiber-value witness completed instead of erroring")
+    (let [err (fiber/value f)]
+      (length err:tag))))
+
+# ── (e) the payload outlives the read, in a container ────────────────────────
+# Nothing on the stack holds it after the protect returns; the holder that must
+# still find it alive is the array the driver reads back out.
+(def @errsink @[])
+(defn w-stored [n]
+  (let [[ok? err] (protect (a-middle n))]
+    (push errsink err)
+    (length err:tag)))
+
+# ── controls — each removes one ingredient; balanced without a minted ref ────
+
+# (f) ONE propagate of a body-allocated payload: the stranded raise reference
+# covers the delivery, so this is green with or without the mint.
+(defn g-one [n]
+  (defer
+    nil
+    (error {:reason :bang :tag (string "f" n)})))
+(defn c-one-propagate [n]
+  (let [[ok? err] (protect (g-one n))]
+    (length err:tag)))
+
+# (g) the body COMPLETES, so `defer` never propagates at all.
+(defn g-ok [n]
+  (defer
+    nil
+    (string "g" n)))
+(defn c-completed [n]
+  (let [[ok? v] (protect (g-ok n))]
+    (assert ok? "control: completing body reported an error")
+    (length v)))
+
+# (h) the payload is an IMMEDIATE — no region crosses, so nothing is delivered.
+(defn h-imm [n]
+  (defer
+    nil
+    (defer
+      nil
+      (error 42))))
+(defn c-immediate [n]
+  (let [[ok? err] (protect (h-imm n))]
+    (assert (not ok?) "control: immediate-payload witness did not error")
+    (if (= err 42) 1 0)))
+
+# ── drive: a fresh payload per iteration keeps region ids churning, so a ─────
+# recycled id detonates on its generation stamp rather than reading stale bytes.
+
+(defn drive [reps]
+  (var i 0)
+  (var a 0)
+  (var b 0)
+  (var c 0)
+  (var d 0)
+  (var e 0)
+  (var f 0)
+  (var g 0)
+  (var h 0)
+  (while (%lt i reps)
+    (assign a (w-two-propagates i))
+    (assign b (w-three-propagates i))
+    (assign c (w-native i))
+    (assign d (w-fiber-value i))
+    (assign e (w-stored i))
+    (assign f (c-one-propagate i))
+    (assign g (c-completed i))
+    (assign h (c-immediate i))
+    # Witness (e)'s holder is the module-level array by design: read the stored
+    # payload back out — it must still be alive — then drain so the driver's
+    # own retention stays flat for the growth gauge below.
+    (let [held (get errsink (%sub (length errsink) 1))]
+      (assert (%gt (length held:tag) 0)
+              "stored payload freed by the propagating fibers' free cascade"))
+    (assign errsink @[])
+    (assign i (%add i 1)))
+  (list a b c d e f g h))
+
+(let [r (drive 400)]
+  (assert (> (get r 0) 0) "payload freed by the second of two propagates")
+  (assert (> (get r 1) 0) "payload freed by the third of three propagates")
+  (assert (> (get r 2) 0) "native-error payload freed by its propagate")
+  (assert (> (get r 3) 0) "payload freed under a `fiber/value` read")
+  (assert (> (get r 4) 0) "payload freed under the container read")
+  (assert (> (get r 5) 0) "control: single propagate mis-read (harness broken)")
+  (assert (> (get r 6) 0) "control: completing body mis-read")
+  (assert (> (get r 7) 0) "control: immediate payload mis-read"))
+
+# ── the leak face: the mint must fund exactly one consumer, per park ─────────
+# A mint no release answers strands one region per propagate, so the gauge is
+# DIFFERENTIAL in propagate depth, not absolute: raise the same payload through
+# zero, one, and three propagates and compare the growth of each.
+#
+# The trap: absolute flatness is not available to measure against. `(protect
+# (error {...}))` already strands two regions per iteration with no propagate
+# anywhere in it — the raising body's own reference to the payload it allocated,
+# whose release lives in a continuation an error unwind never runs. That leak
+# predates this mint and is identical with and without it. Asserting a flat
+# region count here would pin that unrelated leak and fail forever.
+#
+# The counter-factual: an unconsumed mint makes growth scale with depth, so
+# `d3` would exceed `d0` by three regions per iteration and the slack below
+# would not absorb it.
+
+(defn d0 [n]
+  (let [[ok? err] (protect (error {:reason :bang :tag (string "z" n)}))]
+    (length err:tag)))
+(defn d1 [n]
+  (let [[ok? err] (protect (defer
+                             nil
+                             (error {:reason :bang :tag (string "z" n)})))]
+    (length err:tag)))
+(defn d3 [n]
+  (let [[ok? err] (protect (defer
+                             nil
+                             (defer
+                               nil
+                               (defer
+                                 nil
+                                 (error {:reason :bang :tag (string "z" n)})))))]
+    (length err:tag)))
+
+(defn growth-of [f reps]
+  (var i 0)
+  (while (%lt i 50)
+    (f i)
+    (assign i (%add i 1)))
+  (let [before (arena/region-count)]
+    (assign i 0)
+    (while (%lt i reps)
+      (f i)
+      (assign i (%add i 1)))
+    (%sub (arena/region-count) before)))
+
+(let [g0 (growth-of d0 400)
+      g1 (growth-of d1 400)
+      g3 (growth-of d3 400)]
+  (assert (%lt (%sub g1 g0) 40)
+          (string "one propagate strands regions: growth " g1 " vs " g0
+                  " with no propagate, over 400 iterations"))
+  (assert (%lt (%sub g3 g0) 40)
+          (string "each propagate strands a region: growth " g3
+                  " at depth three vs " g0 " at depth zero, over 400 iterations")))
+
+(println "region-fiber-propagate-uaf: ok")


### PR DESCRIPTION
Do not merge. This draft exists to run macOS Smoke, repeatedly, on the union of #891 and #896.

The union is the experiment's arm. The control already ran: #896 alone carries the armed stale-deref check, and its macOS job failed in corpus batch 1 with the check naming the defect that #891 fixes (stale region deref, generation 0 vs 1, in fiber resume). The same armed build on x86_64 Linux fails `tests/elle/http.lisp` — a batch-1 file and #891's own witness — deterministically on main, and passes with #891 applied.

If this PR's macOS Smoke stays green over several re-runs while unfixed branches keep failing, the two fixes close the corruption CI has been hitting, and they should merge in their own PRs. This branch then closes unmerged.