### PR TITLE
vm: a parameterize pushes its frame whatever signal is pending

### DIFF
--- a/src/vm/dispatch/interp/params.rs
+++ b/src/vm/dispatch/interp/params.rs
@@ -13,7 +13,17 @@ impl VM {
     /// The stack holds pairs pushed as `[param1, val1, param2, val2, ...]`, so
     /// they pop in reverse (last pair first); we re-reverse to restore source
     /// order before installing. A non-parameter operand raises a type-error and
-    /// aborts the frame (pushing nil for the aborted `parameterize` result).
+    /// aborts the frame (pushing nil for the aborted `parameterize` result);
+    /// the error's unwind also skips the scope-end `PopParamFrame`, so push
+    /// and pop stay balanced on both paths.
+    ///
+    /// The abort must be decided by THIS opcode's own failure, never by
+    /// `fiber.signal`: that slot ambiently carries the `(SIG_OK, value)`
+    /// return-value handoff between frames, so a signal can be pending while
+    /// execution is entirely healthy. Gating the push on it skips a frame
+    /// whose balanced pop still runs, and that pop then consumes the frame
+    /// below — an enclosing `parameterize`'s, or the fiber's seeded parameter
+    /// baseline (pinned by `tests/elle/param-frame-balance.lisp`).
     #[inline]
     pub(super) fn handle_push_param_frame(&mut self, bc: &[u8], ip: &mut usize) {
         let count = bc[*ip] as usize;
@@ -42,11 +52,9 @@ impl VM {
                     format!("parameterize: {} is not a parameter", param.type_name()),
                 );
                 self.fiber.stack.push(Value::NIL);
-                break;
+                return;
             }
         }
-        if self.fiber.signal.is_none() {
-            self.fiber.param_frames.push(frame);
-        }
+        self.fiber.param_frames.push(frame);
     }
 }

--- a/tests/elle/param-frame-balance.lisp
+++ b/tests/elle/param-frame-balance.lisp
@@ -1,0 +1,31 @@
+(elle/epoch 12)
+## tests/elle/param-frame-balance.lisp — a `parameterize` frame survives work
+## that completes with the interpreter's return-value handoff signal still
+## parked in `fiber.signal`.
+##
+## The trap: `PushParamFrame` used to skip its push whenever ANY signal was
+## pending, reading the ambient `(SIG_OK, value)` return handoff as its own
+## type-error flag. The body then ran without its frame, and the balanced
+## `PopParamFrame` at scope end popped the frame BELOW — here the outer
+## `parameterize`'s, in a spawned fiber its seeded parameter baseline, whose
+## recorded fiber → value edges then trip the free-time edge oracle
+## (the `tests/elle/process.lisp` teardown drift).
+##
+## The counter-factual: with the buggy guard, `(*witness*)` reads :fallback
+## after the scheduler run — the binding silently vanished — while every
+## other observable behavior stays green. A status-only check would pass.
+
+(def process ((import-file "lib/process.lisp")))
+(def backend (*io-backend*))
+
+(def *witness* (make-parameter :fallback))
+
+(parameterize ((*witness* :bound))
+  # `process:run` enters lib/process's own `parameterize` (sched-run rebinds
+  # *spawn*) at a moment when the caller's frame-return handoff signal is
+  # still parked — the distilled shape of the external-API scheduler run in
+  # tests/elle/process.lisp.
+  (let [sched (process:make-scheduler :backend backend)]
+    (process:run sched (fn () nil)))
+  (assert (= (*witness*) :bound)
+          "a dynamic binding survives a process scheduler run"))


### PR DESCRIPTION
Fixes defect A of #887 (the `tests/elle/process.lisp` teardown drift).

## The defect

`PushParamFrame` gated its push on `fiber.signal` being empty, reading the slot as its own type-error flag. The slot also carries the `(SIG_OK, value)` return handoff between frames, so a healthy pending signal skipped the push while the scope-end `PopParamFrame` still ran. Each occurrence pops the frame below the vanished one: an enclosing `parameterize`'s binding silently disappears, or a spawned fiber loses its seeded parameter baseline — whose recorded fiber → value edges then trip the free-time edge oracle at the fiber's free.

The distilled trigger is one `process:run` inside a `parameterize`: the scheduler enters lib/process's own `parameterize` while the caller's handoff signal is parked, the rebind frame is skipped, and the caller's binding is consumed in its place. The binding loss is silent — every other observable stays green — which is why this surfaced only as intermittent corruption on the macOS runner and, once the detector was armed (#896's job change), as the deterministic `process.lisp` drift on both OSes with identical region ids.

## The fix

The abort is now decided by this opcode's own failure alone, exactly as the JIT arm already decides it: a non-parameter operand raises the type-error and returns without pushing. That error's unwind also skips the pop, so both paths stay balanced.

## Verification

| Check | Before | After |
|---|---|---|
| `tests/elle/param-frame-balance.lisp` (new pin, plain build) | fails, both tiers | passes |
| `tests/elle/process.lisp` armed (`CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS`) | 2 drift panics | green, both tiers |
| Armed corpus sweep (`--trace=scrub`, both backends) | drift in the process.lisp batch | that batch green |
| `cargo test -p elle --lib` | — | 2165 pass |
| clippy | — | clean |

The armed sweep still fails on the unrelated `region-def-in-lambda-capture.lisp` closure-template UAF (defect B of #887, batch-context-dependent); that is the next piece of work and does not gate this fix.