### PR TITLE
capabilities: a denial crosses a thread, and a refusal is not a death

### DIFF
--- a/docs/signals/capabilities.md
+++ b/docs/signals/capabilities.md
@@ -144,6 +144,22 @@ A child can never gain capabilities its parent lacks. Requesting to
 deny something the parent already withholds is a no-op (silently
 absorbed).
 
+Withheld capabilities also cross a thread. `sys/spawn` and
+`sys/spawn-vm` run a deep-copied closure in a fresh VM, and that VM's
+root fiber starts with the spawning fiber's withheld set. A worker
+cannot reach what the fiber that spawned it could not.
+
+A worker has no parent to suspend into, so a denial there cannot be
+mediated. The thread ends instead, and the join reports it:
+
+```text
+(sys/join (sys/spawn-vm (fn [] (file/write path "x"))))
+# from a fiber denying :fs => [:failed "..."], and nothing is written
+```
+
+Mediate on the fiber side of the boundary, before the work is handed to
+a thread.
+
 ## Mediation
 
 The parent can catch a denial, perform the operation on the child's
@@ -160,6 +176,45 @@ behalf, and resume the child with the result:
       (let [result (apply length (val :args))]
         (fiber/resume f result)))))
 ```
+
+### Refusing
+
+Resuming with an ordinary value tells the child the call succeeded and
+returned that value. A mediator that wants to say *no* must not do that:
+agent-written code reads the resume value as `file/write`'s return and
+proceeds as though the write happened.
+
+`fiber/refuse` raises the denied call as a failure **at the child's own
+call site**. The child's `protect` or `try` catches it, and the child
+keeps running:
+
+```lisp
+(with-temp-dir dir
+  (let [target (path/join dir "notes")
+        f (fiber/new
+             (fn []
+               (let [[ok? err] (protect (file/write target "x"))]
+                 (list :refused (not ok?) err)))
+             |:fs :error|
+             :deny |:fs|)]
+    (fiber/resume f)
+    (fiber/refuse f :not-permitted)
+    (fiber/value f)))
+# => (:refused true :not-permitted)
+```
+
+The fiber stays alive. A refused call is an ordinary event in a mediated
+session — the child is told no and carries on, and may be refused again
+on its next call.
+
+Refuse with `:fs`, not with `:error`. The child's own `protect` runs
+primitives that declare `:error`, so a fiber denying that bit has no
+working recovery path for the refusal to land in, and it ends `:error`
+whatever the parent does.
+
+An uncaught refusal is an ordinary uncaught error: it unwinds the child
+through any `defer` blocks and the fiber ends `:error`. To end a fiber
+outright rather than refuse one call, use `fiber/abort`.
 
 ## Specialized instructions
 

--- a/docs/signals/primitives.md
+++ b/docs/signals/primitives.md
@@ -19,6 +19,7 @@ User-facing fiber operations and patterns.
 | `fiber/propagate` | `(fiber) → (propagates)` | Propagate caught signal, preserve chain |
 | `fiber/cancel` | `(fiber value?) → value` | Hard-kill: set to :error, no unwinding |
 | `fiber/abort` | `(fiber value?) → value` | Graceful: inject error, resume for unwinding |
+| `fiber/refuse` | `(fiber value?) → value` | Refuse a paused fiber's call: raise at its call site, fiber lives on |
 | `fiber?` | `(value) → bool` | Type predicate |
 
 Primitives that need VM-side execution (`fiber/resume`) signal the VM

--- a/docs/threads.md
+++ b/docs/threads.md
@@ -18,6 +18,11 @@ open ports) will error at spawn time. The thread's result comes back the
 same way: it is serialized into a shared slot and reconstructed in the
 joining thread's heap.
 
+A worker does inherit one thing: the spawning fiber's withheld
+capabilities. A thread cannot reach what the fiber that spawned it could
+not — see [capabilities](signals/capabilities.md) for what a denial in a
+worker does, since a worker has no parent to mediate it.
+
 ### Two worker environments: `sys/spawn` vs `sys/spawn-vm`
 
 Both run a deep-copied closure on a fresh OS thread with its own VM; they

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -118,6 +118,12 @@ fn spawn_closure_impl(
     // The worker inherits the spawning VM's Unicode generation: a program is
     // one set of string semantics, whichever VM computes a length.
     let unicode_generation = ctx.unicode_generation();
+    // Capabilities flow down across a thread, as they do across a fiber
+    // (docs/signals/capabilities.md § Transitivity). The worker runs in a fresh
+    // VM whose root fiber is what the capability gate reads, so without this the
+    // spawned closure runs with an empty withheld set — and a sandboxed fiber
+    // escapes every denial by spawning a thread.
+    let withheld = ctx.vm().fiber.withheld;
 
     // Size the worker's stack to the main thread's (see `worker_stack_size`):
     // the worker compiles arbitrary Elle, and the frontend recurses deep — the
@@ -298,6 +304,14 @@ fn spawn_closure_impl(
                 // self-recursive spawned closure resolves its self-reference to
                 // the reconstructed value.
                 vm.pending_entry_closure = closure_val;
+                // Install the inherited denial for the spawned closure only. The
+                // runtime setup above — primitive registration, `init_stdlib`,
+                // reconstructing the bundle — is the VM standing itself up, not
+                // the sandboxed body, and a worker whose `:error` is withheld
+                // could not stand up at all. The worker has no parent to suspend
+                // into, so a denial here ends the thread and `sys/join` reports
+                // it rather than offering the mediation a fiber gets.
+                vm.fiber.withheld = withheld;
                 let result = vm.execute_code(closure.template.code(), Some(&env_rc));
 
                 let send_result = match result {

--- a/src/primitives/fiber_introspect.rs
+++ b/src/primitives/fiber_introspect.rs
@@ -178,6 +178,73 @@ pub(crate) fn prim_fiber_cancel(
 
 /// (fiber/abort fiber \[value\]) → value
 ///
+/// Install `error_value` as an error raised at a PAUSED fiber's own suspension
+/// point and hand the VM the abort signal that resumes it there.
+///
+/// Shared by `fiber/abort` and `fiber/refuse`. The two differ in intent and in
+/// which fiber states they accept, not in the injection: both raise the error
+/// where the fiber stopped, so the fiber's `protect` and `defer` see it. Keeping
+/// one body means the region bookkeeping below cannot drift between them.
+fn inject_error_at_suspension(
+    ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
+    fiber_value: Value,
+    handle: &crate::value::fiber::FiberHandle,
+    error_value: Value,
+) -> (SignalBits, Value) {
+    // A parked TERMINAL result this install displaces carries a park-retain +
+    // recorded content edge the free-time signal scan will never see
+    // (`release_displaced_terminal_signal`); a parked non-terminal signal's
+    // strand here is the dead-continuation residual (docs/impl/region/owner.md
+    // § "Park/unpark symmetry"), not released blind.
+    let parked = handle.with(|fiber| fiber.signal);
+    crate::vm::fiber::release_displaced_terminal_signal(ctx.heap_mut(), fiber_value, parked);
+    handle.with_mut(|fiber| {
+        fiber.signal = Some((SIG_ERROR, error_value));
+    });
+    // The VM injects the error, resumes the fiber, and lets it unwind.
+    (SIG_ABORT, fiber_value)
+}
+
+/// (fiber/refuse fiber) → value
+/// (fiber/refuse fiber error) → value
+///
+/// Refuse the call a paused fiber is suspended on: raise `error` as a failure
+/// at the fiber's own call site, so its `protect` or `try` catches it there.
+///
+/// A refusal is not a termination. A fiber that catches keeps running and may
+/// be refused again on its next call — which is what a mediator needs, since a
+/// refused operation is an ordinary event in a mediated session. A fiber that
+/// does not catch unwinds through its `defer` blocks and ends `:error`, as any
+/// uncaught error would.
+///
+/// Only a `:paused` fiber can be refused: refusal answers a call the fiber is
+/// waiting on, and no other state has one. This is the guard that separates it
+/// from `fiber/abort`, which hard-kills a `:new` fiber and no-ops a `:dead` one
+/// — reasonable when ending a fiber, wrong when answering a request.
+pub(crate) fn prim_fiber_refuse(
+    ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
+    args: &[Value],
+) -> (SignalBits, Value) {
+    let handle = prim_arg!(ctx, args, 0, as_fiber, "fiber/refuse", "fiber");
+
+    let error_value = args.get(1).copied().unwrap_or(Value::NIL);
+    let status = handle.with(|fiber| fiber.status);
+
+    match status {
+        FiberStatus::Paused => inject_error_at_suspension(ctx, args[0], handle, error_value),
+        other => (
+            SIG_ERROR,
+            ctx.error(
+                "state-error",
+                format!(
+                    "fiber/refuse: expected a paused fiber, got :{}",
+                    other.as_str()
+                ),
+            ),
+        ),
+    }
+}
+
 /// Gracefully terminate a fiber by injecting an error and resuming it.
 /// The fiber's error handlers (protect) and cleanup blocks (defer) will
 /// execute. The fiber's final state depends on what its code does with
@@ -195,21 +262,7 @@ pub(crate) fn prim_fiber_abort(
     let status = handle.with(|fiber| fiber.status);
 
     match status {
-        FiberStatus::Paused => {
-            // Store the error value on the fiber for do_fiber_abort to pick up.
-            // A parked TERMINAL result this install displaces carries a
-            // park-retain + recorded content edge the free-time signal scan
-            // will never see (`release_displaced_terminal_signal`); a parked
-            // non-terminal signal's strand here is the dead-continuation residual
-            // (docs/impl/region/owner.md § "Park/unpark symmetry"), not released blind.
-            let parked = handle.with(|fiber| fiber.signal);
-            crate::vm::fiber::release_displaced_terminal_signal(ctx.heap_mut(), args[0], parked);
-            handle.with_mut(|fiber| {
-                fiber.signal = Some((SIG_ERROR, error_value));
-            });
-            // Return SIG_ABORT — VM will inject error, resume, let it unwind
-            (SIG_ABORT, args[0])
-        }
+        FiberStatus::Paused => inject_error_at_suspension(ctx, args[0], handle, error_value),
         FiberStatus::New => {
             // Nothing to unwind — hard-kill directly (like cancel), freeing
             // anything the never-started fiber owned (its fiber owner node; a
@@ -367,6 +420,21 @@ primitive! {
         // mints the caller's reference (the unwinding exit runs no `Return` to
         // mint it). Aborting an already-dead fiber hands back that fiber's
         // terminal value, read out of the fiber argument: unbounded.
+        effect: RegionEffect::Delivers { args: &[1] },
+    }
+    "fiber/refuse" => prim_fiber_refuse {
+        signal: Signal::of(SIG_ERROR.union(SIG_ABORT)),
+        arity: Arity::Range(1, 2),
+        doc: "Refuse the call a paused fiber is suspended on: raise the error at the fiber's own call site, where its protect catches it. The fiber stays alive and runs on.",
+        params: &["fiber", "error?"],
+        category: "fiber",
+        example: "(fiber/refuse f)\n(fiber/refuse f :not-permitted)",
+        // Same delivery accounting as `fiber/abort`: the injected error is
+        // installed in the fiber's signal slot and taken straight back out by
+        // `do_fiber_abort`, and where it comes back OUT as the result,
+        // `handle_fiber_abort_signal` mints the caller's reference. Refusal
+        // accepts only a `:paused` fiber, so neither the `kill_fiber` park nor
+        // the dead-fiber terminal-value read applies.
         effect: RegionEffect::Delivers { args: &[1] },
     }
 }

--- a/tests/elle/caps-fs.lisp
+++ b/tests/elle/caps-fs.lisp
@@ -145,5 +145,29 @@
   (assert ((fiber/caps f) :fs) ":deny |:io| leaves :fs held")
   (assert (not ((fiber/caps f) :io)) "fiber/caps omits :io when denied"))
 
+# ── The gate holds on a hot, already-compiled call site ───────────────
+
+# The trap: running this file under `--jit=eager` does NOT make this claim.
+# Eager compiles everything up front, so it never produces the shape that
+# matters — a function the adaptive tier compiled because it got hot, then
+# called from inside a denied fiber. Warm the function OUTSIDE any denial
+# so it is compiled by the time the denied fiber reaches it.
+(defn hot-writer [p]
+  (file/write p "x"))
+
+(let [warm (path/join root "WARM")]
+  (each i (range 0 500)
+    (hot-writer warm))
+  (assert (path/exists? warm) "the function is warm and its writes land"))
+
+(let [victim (path/join root "HOT-DENIED")
+      f (fiber/new (fn [] (hot-writer victim)) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (assert (= (fiber/status f) :paused)
+          "a compiled call site denies exactly as a cold one does")
+  (assert (= "file/write" (get (fiber/value f) :primitive))
+          "and names the same primitive")
+  (assert (not (path/exists? victim)) "the hot path wrote nothing"))
+
 (file/delete-dir-all root)
 (println "caps-fs: OK")

--- a/tests/elle/caps-refuse.lisp
+++ b/tests/elle/caps-refuse.lisp
@@ -1,0 +1,107 @@
+(elle/epoch 12)
+# ── Refusing a denied call ─────────────────────────────────────────────
+#
+# A mediator that resumes a denied fiber with an ordinary value tells the
+# child the call SUCCEEDED and returned that value. For agent-written code
+# that is unsafe: the model writes (file/write path content), reads a
+# struct back, and proceeds as though the write landed.
+#
+# `fiber/refuse` raises the refusal at the child's own call site instead,
+# where its `protect` catches it. The contract this file pins is that a
+# refusal is not a termination — the child survives and may be refused
+# again — because that is what makes refusal usable in a session that
+# keeps running. `handle_fiber_abort_signal` forces :error only on an
+# UNCAUGHT error; a refactor that forced it unconditionally would take the
+# whole mechanism away, and every assertion here would still be about a
+# fiber that merely died in the right order.
+#
+# The trap: this cannot be written against `:deny |:error|`. The child's
+# own `protect` runs primitives that declare `:error`, so denying that bit
+# breaks the recovery path the refusal is delivered into and the fiber
+# ends :error no matter what. `:fs` is the narrow bit a mediator actually
+# withholds (see caps-fs.lisp).
+
+(def root (file/mktempdir))
+(def a (path/join root "A"))
+(def b (path/join root "B"))
+
+# ── A refused fiber survives and runs on ──────────────────────────────
+
+(let [f (fiber/new (fn []
+                     (let [[ok1? e1] (protect (file/write a "x"))
+                           [ok2? e2] (protect (file/write b "y"))]
+                       (list ok1? ok2? (= e1 :first) (= e2 :second))))
+                   |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (assert (= (fiber/status f) :paused) "the child traps on the first write")
+  (fiber/refuse f :first)
+  (assert (= (fiber/status f) :paused)
+          "a refused child that catches stays alive and reaches its next call")
+  (assert (= "file/write" (get (fiber/value f) :primitive))
+          "and the next call traps on its own account")
+  (assert (= b (get (get (fiber/value f) :args) 0))
+          "the second denial names the second path")
+  (fiber/refuse f :second)
+  (assert (= (fiber/status f) :dead) "and then runs to its own completion")
+  (assert (= (list false false true true) (fiber/value f))
+          "both writes failed at the call site, each with the parent's reason")
+  (assert (not (path/exists? a)) "neither refused write reached the disk")
+  (assert (not (path/exists? b)) "including the second"))
+
+# ── The refusal is a failure, not a return value ──────────────────────
+
+# The counter-factual for the whole mechanism: a plain resume is a value
+# the child cannot tell from a real result.
+(let [f (fiber/new (fn [] (protect (file/write a "x"))) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (fiber/resume f :pretend)
+  (assert (= [true :pretend] (fiber/value f))
+          "a plain resume reads as the call's successful return"))
+
+(let [f (fiber/new (fn [] (protect (file/write a "x"))) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (fiber/refuse f :nope)
+  (assert (= [false :nope] (fiber/value f))
+          "a refusal reads as the call's failure"))
+
+# A mediator refuses with whatever it wants the child to see.
+(let [f (fiber/new (fn [] (protect (file/write a "x"))) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (fiber/refuse f (struct :error :capability-refused :path a))
+  (let [[ok? err] (fiber/value f)]
+    (assert (not ok?) "the child sees a failure")
+    (assert (= :capability-refused (get err :error))
+            "carrying the parent's own structured reason")
+    (assert (= a (get err :path)) "including the path it refused")))
+
+# ── An uncaught refusal is an ordinary uncaught error ─────────────────
+
+(let [order @[]
+      f (fiber/new (fn []
+                     (defer
+                       (push order :cleanup)
+                       (file/write a "x"))) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (fiber/refuse f :fatal)
+  (assert (= (fiber/status f) :error) "an uncaught refusal ends the fiber")
+  (assert (= [:cleanup] (freeze order))
+          "and unwinds it through its defer blocks"))
+
+# ── Refusal answers a call, so it needs a fiber waiting on one ────────
+
+(let [f (fiber/new (fn [] 42) |:fs :error| :deny |:fs|)
+      [ok? err] (protect (fiber/refuse f :nope))]
+  (assert (not ok?) "a :new fiber has no call to refuse")
+  (assert (= :state-error (get err :error))
+          "refusing it is a state error, where fiber/abort would hard-kill it"))
+
+(let [f (fiber/new (fn [] 42) |:fs :error|)]
+  (fiber/resume f)
+  (assert (= (fiber/status f) :dead) "the fiber completed on its own")
+  (let [[ok? err] (protect (fiber/refuse f :nope))]
+    (assert (not ok?) "a :dead fiber has no call to refuse")
+    (assert (= :state-error (get err :error))
+            "refusing it is a state error, where fiber/abort would no-op")))
+
+(file/delete-dir-all root)
+(println "caps-refuse: OK")

--- a/tests/elle/caps-thread.lisp
+++ b/tests/elle/caps-thread.lisp
@@ -1,0 +1,68 @@
+(elle/epoch 12)
+# ── Withheld capabilities cross a thread ───────────────────────────────
+#
+# `sys/spawn` and `sys/spawn-vm` deep-copy a closure into a FRESH VM with
+# its own root fiber. That root fiber's withheld set is what the
+# capability gate reads (`call_inner`: def.signal ∩ withheld ∩ CAP_MASK),
+# so unless the spawning fiber's withheld travels with the closure, a
+# sandboxed fiber escapes every denial by spawning a thread.
+#
+# The trap: `file/write` is synchronous. An earlier attempt to settle this
+# with `:exec` saw `{:error :thread-error :message "Unexpected yield
+# outside fiber context"}` and read it as enforcement. It was not — the
+# subprocess primitive tried to suspend and found no fiber context. A
+# synchronous primitive never hits that wall, so the escape was real and
+# invisible.
+#
+# A worker has no parent to suspend into, so a denial there cannot be
+# mediated. The thread ends and the join reports it.
+
+(def root (file/mktempdir))
+
+# ── The escape is closed ──────────────────────────────────────────────
+
+# Counterfactual: without propagation the worker runs with an empty
+# withheld set, the file appears on disk, and the join succeeds.
+(defn spawn-write [spawner victim]
+  (let [f (fiber/new (fn [] (spawner (fn [] (file/write victim "x"))))
+                     |:fs :error| :deny |:fs|)]
+    (fiber/resume f)))
+
+(let [victim (path/join root "VIA-SPAWN-VM")
+      handle (spawn-write sys/spawn-vm victim)
+      [ok? err] (protect (sys/join handle))]
+  (assert (not ok?) "the worker fails rather than writing")
+  (assert (= :thread-error (get err :error)) "the join reports a thread error")
+  (assert (not (path/exists? victim))
+          "a thread cannot write what the fiber that spawned it may not"))
+
+(let [victim (path/join root "VIA-SPAWN")
+      handle (spawn-write sys/spawn victim)
+      [ok? _err] (protect (sys/join handle))]
+  (assert (not ok?) "the heavy worker fails too")
+  (assert (not (path/exists? victim))
+          "sys/spawn carries the denial exactly as sys/spawn-vm does"))
+
+# ── The worker sees the denial, not just its effect ───────────────────
+
+(let [f (fiber/new (fn [] (sys/spawn-vm (fn [] (fiber/caps)))) |:fs :error|
+                   :deny |:fs|)
+      caps (sys/join (fiber/resume f))]
+  (assert (not (caps :fs)) "the worker's root fiber lacks :fs")
+  (assert (caps :io) "and holds every capability that was not withheld"))
+
+# ── An unrestricted fiber is untouched ────────────────────────────────
+
+(let [allowed (path/join root "ALLOWED")
+      f (fiber/new (fn [] (sys/spawn-vm (fn [] (file/write allowed "x"))))
+                   |:fs :error|)]
+  (sys/join (fiber/resume f))
+  (assert (path/exists? allowed)
+          "a fiber that denies nothing spawns a worker that writes"))
+
+(let [allowed (path/join root "TOP-LEVEL")]
+  (sys/join (sys/spawn-vm (fn [] (file/write allowed "x"))))
+  (assert (path/exists? allowed) "the default path is untouched"))
+
+(file/delete-dir-all root)
+(println "caps-thread: OK")


### PR DESCRIPTION
Closes #902.

Follows #897, which merged while this was in review; rebased onto `main`, so
the diff is this change alone. Every test here denies `:fs`.

Three items from #902. One was a hole, one was a mechanism nobody could find,
one was a claim no test made.

## A denial crosses a thread

The hole. A fiber denied `:fs` wrote any path it liked:

```lisp
(fiber/new (fn [] (sys/join (sys/spawn-vm (fn [] (file/write victim "x")))))
           |:fs :error| :deny |:fs|)
; the fiber reports :dead, and the file is on disk
```

`sys/spawn` and `sys/spawn-vm` deep-copy the closure into a fresh VM, and that
VM's root fiber is built with an empty `withheld`. The gate in `call_inner`
reads the running fiber's `withheld`, so in the worker it read nothing and
every primitive ran. Every other escape we have tested was already closed —
child fibers with an unrestricted mask, `eval` of source the child composes,
the port route to a path — and this one was a `(sys/spawn-vm (fn [] …))` away.

Carry the spawning fiber's `withheld` into the worker's root fiber, so
capabilities flow down across a thread as they do across a fiber.

It is installed for the spawned closure only, immediately before
`execute_code`. Everything above it — primitive registration, `init_stdlib`,
reconstructing the `SendBundle` — is the VM standing itself up, not the
sandboxed body; a worker whose `:error` were withheld could not stand up at
all.

A worker has no parent to suspend into, so a denial there cannot be mediated.
The thread ends and `sys/join` reports `{:error :thread-error}`. That is the
documented contract now, and the reason to mediate on the fiber side of the
boundary.

Note this closes the question #888 got wrong: it read
`"Unexpected yield outside fiber context"` from an `:exec` probe as
enforcement. It was not — that was a subprocess primitive failing to suspend.
A synchronous `file/write` never hits that wall, which is why the escape was
both real and invisible.

## Refusal has a name

#888 asked for "a failure the child observes at the call site, without killing
the fiber" and reported it missing. It was not missing. Injecting the error at
a paused fiber's own suspension point lets the child's `protect` catch it, and
`handle_fiber_abort_signal` forces `:error` only when the error escapes
uncaught — so a child that catches keeps running.

That behavior lived under `fiber/abort`, documented as "Gracefully terminate a
fiber". No mediator would look there, and no test held it down; a refactor of
the abort status logic would have taken it away silently.

`fiber/refuse` names it, over the same injection helper so the region
bookkeeping cannot drift between the two. It differs from `fiber/abort` in the
states it accepts: only `:paused`. Refusal answers a call the fiber is waiting
on, and no other state has one — where `abort` hard-kills a `:new` fiber and
no-ops a `:dead` one, which is right for ending a fiber and wrong for
answering a request.

One finding worth recording, because it bit the first draft of both the test
and the doc: **refusal cannot be demonstrated against `:deny |:error|`.** The
child's own `protect` runs primitives that declare `:error`, so denying that
bit breaks the recovery path the refusal is delivered into, and the fiber ends
`:error` whatever the parent does. Both now use `:fs`, and the constraint is
written down in each.

## The JIT gate has a test

The gate was already correct — `jit_capability_denial` and the gates in
`callops.rs` / `callops/arraycall.rs`. What was missing is a test that makes
the claim. Running the corpus under `--jit=eager` does not: eager compiles
everything up front and never produces the shape that matters, a function the
adaptive tier compiled *because it got hot*, then called from inside a denied
fiber. `caps-fs.lisp` now warms one to 500 calls outside any denial and denies
it after.

## Tests

- `tests/elle/caps-thread.lisp` — both spawn primitives, the worker's own
  `fiber/caps` missing `:fs`, and two no-regression cases (an undenied fiber's
  worker still writes; a top-level spawn still writes).
- `tests/elle/caps-refuse.lisp` — survive-and-run-on, the refusal read as a
  failure where a plain resume reads as a successful return, a structured
  refusal reason reaching the child, an uncaught refusal unwinding through
  `defer`, and the two state errors.
- `tests/elle/caps-fs.lisp` — the warm-then-deny case.

Counter-factuals: the thread test fails by writing the file and reporting a
successful join; the refusal test's plain-resume case is the counter-factual
for the whole mechanism, since `[true :pretend]` is exactly what the child
cannot distinguish from a real result.

Green locally: `cargo test --lib` 2170/0, `make smoke` (corpus + doctest +
embedding), all three files under `--jit=off`, `adaptive`, `eager`, and `5`,
`cargo fmt`/`clippy`/`elle fmt` clean.
