### PR TITLE
region: a captured def's cell outlives the release routed through it

### DIFF
--- a/docs/impl/region/bindings.md
+++ b/docs/impl/region/bindings.md
@@ -659,6 +659,36 @@ which no `assign` repoints (mechanism.md § "A mutated holder poisons its value
 route, not its cell box"). So the env cell of a *reassigned* capture relocates
 exactly as an unreassigned one does; refusing it strands one box per activation.
 
+**A cell's release lands at or after every release routed through that cell.** A
+captured binding whose init allocates owes two releases, and for an env-celled
+binding both are addressed by the same env index. The init value's
+`DecrefValueRegion` loads the cell RAW and lets `result_region_of` unwrap it to
+the content, so it READS the cell's page; the box's `DecrefCellRegion` frees that
+page. The value release therefore has to be emitted first.
+
+Where the two land on one `decref_point` the release order already says so: a
+`DecrefValueRegion` that unwraps a cell reads deepest and sorts ahead of the
+`DecrefCellRegion` that frees the page ([rules.md](rules.md) Rule 4). Across two
+points nothing does, and the two points genuinely diverge. Both regions ride the
+binding's uses through the binding-chain extension, so they start together; the
+value region then takes a second, later bound from its **allocation site's** last
+use, which follows the `def` form's own value out to whatever consumes it. The
+cell region is a phantom placeholder with no allocation site, so it keeps the
+binding-use bound alone. The box is then freed at the capture while the value
+release still has the enclosing statement to reach, and that release unwraps a
+reclaimed page — a stray release of whatever region id the recycled page spells.
+
+The rule is a clamp, run after every other `decref_point` pass: a cell-release
+region's release lands at or after the release of the region a value route reads
+through that cell. That is the region the binding's own binder ALLOCATED — the
+one entry `record_region_slot` makes against the binder's slot, which for an
+env-celled binding is the env index. A region the binding merely NAMES records no
+slot and is released by id, reading no page: `(def @c n)` names its parameter's
+phantom region and allocates nothing, so its box owes that region's release
+nothing. The clamp is a maximum like every other pin, so it only moves the box
+release later, and the point it produces is taken out of any enclosing loop by
+the once-per-activation hoist above.
+
 Named, tolerated edge (not specific to binding cells — true of every mutable
 container): a read consumed *within the same expression* that also removes or
 overwrites the value (`(list x (begin (assign x nil) 1))`) can observe the

--- a/src/hir/region/infer/analyze.rs
+++ b/src/hir/region/infer/analyze.rs
@@ -172,6 +172,7 @@ pub fn analyze_regions_with(
         &break_sites,
         &break_skip_blocks,
         &frame_replacing_tail_calls,
+        &reassigns.binder_init_sites,
     );
     let last_use = &last_use_info.per_node;
 

--- a/src/hir/region/infer/analyze/decref.rs
+++ b/src/hir/region/infer/analyze/decref.rs
@@ -30,6 +30,7 @@ pub(super) fn populate_decref_points(
     break_sites: &[(HirId, Vec<Region>)],
     break_skip_blocks: &[(HirId, Vec<HirId>)],
     frame_replacing_tail_calls: &rustc_hash::FxHashSet<HirId>,
+    binder_init_sites: &HashMap<Binding, Option<HirId>>,
 ) {
     let ord = |id: HirId| order.get(&id).copied().unwrap_or(0);
     let porder = ProgramOrder::new(order);
@@ -66,6 +67,22 @@ pub(super) fn populate_decref_points(
     // inference's binding_regions[b].
     let binding_uses = &du.uses;
 
+    // Every iterative scope with its post-order subtree interval `[low, order]`,
+    // so containment of a HirId is an interval test. Computed once for the three
+    // cell passes that read it — the fn-local container's demise hoist, the env
+    // cell's once-per-activation hoist, and the clamp that follows the value
+    // releases routed through an env cell — and skipped entirely when the unit
+    // has no cell of either kind.
+    let iter_scopes: Vec<(HirId, u32, u32)> =
+        if info.cell_containers.is_empty() && info.cell_release_regions.is_empty() {
+            Vec::new()
+        } else {
+            let low = compute_subtree_low(hir, order);
+            let mut scopes = Vec::new();
+            collect_iter_scopes(hir, order, &low, &mut scopes);
+            scopes
+        };
+
     // ── The fn-local 1-slot container's content drop ──────────────────────
     // The cell's own reference to its current content dies at its last access —
     // the latest of its reads and its writes — with one hoist: a cell CARRIED
@@ -79,10 +96,8 @@ pub(super) fn populate_decref_points(
     // loop (the `(while … (assign acc …)) acc` idiom), which is why the hoist
     // is a max and not a move.
     if !info.cell_containers.is_empty() {
-        let low = compute_subtree_low(hir, order);
-        let mut loops: Vec<(HirId, u32, u32)> = Vec::new();
-        collect_iter_scopes(hir, order, &low, &mut loops);
-        let loop_ids: rustc_hash::FxHashSet<HirId> = loops.iter().map(|&(id, _, _)| id).collect();
+        let loop_ids: rustc_hash::FxHashSet<HirId> =
+            iter_scopes.iter().map(|&(id, _, _)| id).collect();
         // Each scope node by the region it introduces, so a binding's scope node
         // is one lookup through `binding_region`.
         let scope_of_region: HashMap<Region, HirId> =
@@ -251,32 +266,15 @@ pub(super) fn populate_decref_points(
     // release must stay per-iteration, but an env cell's allocation is
     // loop-independent. See docs/impl/region/bindings.md "Env cells in loops:
     // release once per activation, not per iteration".
-    if !info.cell_release_regions.is_empty() {
-        let low = compute_subtree_low(hir, order);
-        let mut iter_scopes: Vec<(HirId, u32, u32)> = Vec::new();
-        collect_iter_scopes(hir, order, &low, &mut iter_scopes);
-        if !iter_scopes.is_empty() {
-            // Snapshot the cell regions first — the loop mutates `region_data`.
-            let cell_regions: Vec<Region> = info.cell_release_regions.iter().copied().collect();
-            for r in cell_regions {
-                let Some(dp) = info.region_data.get(&r).map(|d| d.decref_point) else {
-                    continue;
-                };
-                let dord = ord(dp);
-                // Outermost enclosing loop = the iter-scope whose post-order
-                // subtree interval `[low, order]` contains `dp` with the largest
-                // `order` (an ancestor has the largest post-order index). `None`
-                // if `dp` is in no loop — no hoist needed.
-                let outermost = iter_scopes
-                    .iter()
-                    .filter(|&&(_, lo, hi)| lo <= dord && dord <= hi)
-                    .max_by_key(|&&(_, _, hi)| hi)
-                    .map(|&(id, _, _)| id);
-                if let Some(loop_id) = outermost {
-                    if ord(loop_id) > dord {
-                        info.region_data.get_mut(&r).unwrap().decref_point = loop_id;
-                    }
-                }
+    if !info.cell_release_regions.is_empty() && !iter_scopes.is_empty() {
+        // Snapshot the cell regions first — the loop mutates `region_data`.
+        let cell_regions: Vec<Region> = info.cell_release_regions.iter().copied().collect();
+        for r in cell_regions {
+            let Some(dp) = info.region_data.get(&r).map(|d| d.decref_point) else {
+                continue;
+            };
+            if let Some(loop_id) = post_loop_placement(dp, &iter_scopes, order) {
+                info.region_data.get_mut(&r).unwrap().decref_point = loop_id;
             }
         }
     }
@@ -430,9 +428,120 @@ pub(super) fn populate_decref_points(
         frame_replacing_tail_calls,
     );
 
-    // Runs LAST: it reads each region's FINAL `decref_point` to decide whether
-    // the break jumps over it, so every extension above must already have landed.
+    // Reads each region's FINAL `decref_point` to decide whether the break jumps
+    // over it, so every extension above must already have landed.
     pin_break_skipped_releases(info, hir, order, last_use, break_skip_blocks);
+
+    // Runs after the break window, and so after every pass that can place a
+    // release: what it clamps against is where the value releases FINALLY land.
+    pin_cell_release_after_routed_releases(
+        info,
+        order,
+        &iter_scopes,
+        inference_binding_regions,
+        binder_init_sites,
+    );
+}
+
+/// Clamp each env cell's box release to at-or-after every release routed THROUGH
+/// that cell (docs/impl/region/bindings.md § "A cell's release lands at or after
+/// every release routed through that cell").
+///
+/// A captured binding's init value and the box that holds it are addressed by one
+/// env index. The value's `DecrefValueRegion` loads the box RAW and lets
+/// `result_region_of` unwrap it to the content, so it READS the box's page; the
+/// box's `DecrefCellRegion` frees that page. Emitted in the other order, the
+/// unwrap reads memory the free reclaimed.
+///
+/// At one `decref_point` the release order already states this — a value release
+/// that unwraps a cell reads deepest and sorts ahead of the cell release that
+/// frees the page (`lir::lower::Lowerer::order_releases`,
+/// docs/impl/region/rules.md Rule 4). Across two points nothing does, and the two
+/// points diverge by construction: both regions
+/// ride the binding's uses through the binding-chain extension, then the VALUE
+/// region takes a second, later bound from its allocation site's last use, which
+/// follows the binder's own value out to whatever consumes it. The cell region is
+/// a phantom placeholder with no allocation site, so it keeps the binding-use
+/// bound alone and the box is freed at the capture.
+///
+/// The one region a value route reads through the cell is the region the
+/// binding's own binder ALLOCATED — the entry `record_region_slot` makes against
+/// the binder's slot, which for an env-celled binding is the env index
+/// (`lir::lower::binding::define`). A region the binding merely NAMES records no
+/// slot and takes the release-by-id route, which reads no page: `(def @c n)`
+/// names its parameter's phantom region and allocates nothing, so its box owes
+/// that region's release nothing. A binder whose init allocates nothing, a
+/// binding two binders claim, and a captured-reassigned binding (whose init
+/// reference is dropped off its own register rather than through the cell) are
+/// all absent from the route for the same reason, and are left alone here.
+///
+/// The clamp is a maximum like every other pin, so it can only move the box
+/// release later; the point it produces is then taken out of any enclosing loop,
+/// because an env cell is minted once per activation and its release must fire
+/// once per activation whatever drew it inward.
+fn pin_cell_release_after_routed_releases(
+    info: &mut RegionInfo,
+    order: &HashMap<HirId, u32>,
+    iter_scopes: &[(HirId, u32, u32)],
+    inference_binding_regions: &HashMap<Binding, Vec<Region>>,
+    binder_init_sites: &HashMap<Binding, Option<HirId>>,
+) {
+    if info.cell_release_regions.is_empty() {
+        return;
+    }
+    let porder = ProgramOrder::new(order);
+    // Staged: the scan reads one region's `decref_point` while the pin writes
+    // another's, which one pass over `region_data` cannot borrow.
+    let mut pins: Vec<(Region, HirId)> = Vec::new();
+    for (b, regions) in inference_binding_regions {
+        let cells: Vec<Region> = regions
+            .iter()
+            .copied()
+            .filter(|r| info.cell_release_regions.contains(r))
+            .collect();
+        if cells.is_empty() || info.captured_reassigned_bindings.contains(b) {
+            continue;
+        }
+        let Some(&Some(init)) = binder_init_sites.get(b) else {
+            continue;
+        };
+        let Some(routed) = info.alloc_region.get(&init).copied() else {
+            continue;
+        };
+        let Some(at) = info.region_data.get(&routed).map(|d| d.decref_point) else {
+            continue;
+        };
+        let at = post_loop_placement(at, iter_scopes, order).unwrap_or(at);
+        for c in cells {
+            pins.push((c, at));
+        }
+    }
+    for (cell, at) in pins {
+        info.region_data.pin_to(cell, at, porder);
+    }
+}
+
+/// The node an env cell's release takes instead of `at`, so that it fires once
+/// per activation rather than once per iteration: the OUTERMOST `While`/`Loop`
+/// enclosing `at`, which the lowerer emits after the loop. `None` when `at` is in
+/// no loop, or is already at or past the enclosing loop's own node — a release
+/// anchored at the loop node already runs once per execution of the loop.
+///
+/// An ancestor carries the largest post-order index, so the outermost enclosing
+/// scope is the containing interval with the greatest high end.
+fn post_loop_placement(
+    at: HirId,
+    iter_scopes: &[(HirId, u32, u32)],
+    order: &HashMap<HirId, u32>,
+) -> Option<HirId> {
+    let ord = |id: HirId| order.get(&id).copied().unwrap_or(0);
+    let at_ord = ord(at);
+    iter_scopes
+        .iter()
+        .filter(|&&(_, lo, hi)| lo <= at_ord && at_ord <= hi)
+        .max_by_key(|&&(_, _, hi)| hi)
+        .map(|&(id, _, _)| id)
+        .filter(|&id| ord(id) > at_ord)
 }
 
 /// Re-anchor a release that landed inside one arm of a branch onto the branch.

--- a/src/hir/region/infer/tests/cells.rs
+++ b/src/hir/region/infer/tests/cells.rs
@@ -512,3 +512,103 @@ fn letrec_init_does_not_overwrite_destructure_binding_regions() {
         r_covers,
     );
 }
+
+/// The captured `def` inside a lambda: `p` is env-celled, and the closure that
+/// captures it makes the capture `p`'s last binding-use. Its init is a CALL, so
+/// the init owns a `call_result` region whose release is value-routed THROUGH
+/// the cell (`LoadCaptureRaw` + `DecrefValueRegion`, which unwraps the box).
+const CAPTURED_DEF_IN_LAMBDA: &str = "((fn [] \
+     (def p (f 1)) \
+     (let [r (fn [] (g p))] :built)))";
+
+/// The env-celled binding of `CAPTURED_DEF_IN_LAMBDA`: the `Define` under a
+/// `Lambda` whose binding needs a capture cell.
+fn captured_define_binding(hir: &Hir, arena: &BindingArena) -> Option<Binding> {
+    fn walk(h: &Hir, arena: &BindingArena, in_lambda: bool) -> Option<Binding> {
+        let inner = in_lambda || matches!(&h.kind, HirKind::Lambda { .. });
+        if in_lambda {
+            if let HirKind::Define { binding, .. } = &h.kind {
+                if arena.get(*binding).needs_capture() {
+                    return Some(*binding);
+                }
+            }
+        }
+        let mut found = None;
+        h.for_each_child(|c| {
+            if found.is_none() {
+                found = walk(c, arena, inner);
+            }
+        });
+        found
+    }
+    walk(hir, arena, false)
+}
+
+#[test]
+fn a_cell_release_lands_at_or_after_the_release_routed_through_it() {
+    // A value release routed through an env cell READS the cell's page: it
+    // loads the box raw and `result_region_of` unwraps it to the content. The
+    // cell's own `DecrefCellRegion` FREES that page. So the cell's release must
+    // be placed at or after every such value release
+    // (docs/impl/region/bindings.md § "A cell's release lands at or after every
+    // release routed through that cell").
+    //
+    // The counter-factual this pins: both regions ride the binding's uses, so
+    // the binding-chain extension gives them the same point — but the VALUE
+    // region takes a second, later bound from its allocation site's last use
+    // (the `def` form's own value flows out to the enclosing `let`), which the
+    // phantom cell placeholder has no allocation site to receive. Without the
+    // clamp the cell dies at the capture and the value release then unwraps a
+    // reclaimed page.
+    let (hir, arena, _symbols) = crate::hir::testkit::HirFixture::new()
+        .stubs(crate::hir::testkit::STUBS_RETURNING_ARGS)
+        .build(CAPTURED_DEF_IN_LAMBDA);
+    let info = analyze_regions(&hir, &arena);
+    let b =
+        captured_define_binding(&hir, &arena).expect("expected a captured `def` inside the lambda");
+    let regions = info
+        .binding_source_regions
+        .get(&b)
+        .cloned()
+        .unwrap_or_default();
+    let cells: Vec<_> = regions
+        .iter()
+        .copied()
+        .filter(|r| info.cell_release_regions.contains(r))
+        .collect();
+    let routed: Vec<_> = regions
+        .iter()
+        .copied()
+        .filter(|r| info.call_result_regions.contains(r) && !info.cell_release_regions.contains(r))
+        .collect();
+    assert!(
+        !cells.is_empty(),
+        "the captured `def` must own an env-cell placeholder region; \
+         binding_source_regions={regions:?} — if the walk changed, update the \
+         shape so this test keeps biting",
+    );
+    assert!(
+        !routed.is_empty(),
+        "the captured `def`'s init must own a call-result region released \
+         through the cell; binding_source_regions={regions:?} — if the walk \
+         changed, update the shape so this test keeps biting",
+    );
+    let order = compute_order(&hir);
+    let ord = |id: HirId| order.get(&id).copied().unwrap_or(0);
+    for cell in &cells {
+        let cell_dp = info.region_data[cell].decref_point;
+        for value in &routed {
+            let value_dp = info.region_data[value].decref_point;
+            assert!(
+                ord(cell_dp) >= ord(value_dp),
+                "cell region r{} is released at @{} — BEFORE the value release \
+                 of r{} at @{}, which unwraps that very cell. The box's free \
+                 reclaims the page the unwrap reads.",
+                cell.0,
+                cell_dp.0,
+                value.0,
+                value_dp.0,
+            );
+        }
+    }
+}

--- a/src/lir/lower/tests/release/order.rs
+++ b/src/lir/lower/tests/release/order.rs
@@ -442,3 +442,73 @@ fn letrec_init_release_fires_after_cell_store() {
         check(c);
     }
 }
+
+#[test]
+fn a_cell_box_release_follows_every_release_that_unwraps_it() {
+    // Two releases address one env index: `DecrefValueRegion` loads the box RAW
+    // and unwraps it to the content (so it READS the box's page), and
+    // `DecrefCellRegion` frees that page. Emitting the free first leaves the
+    // unwrap reading reclaimed memory — a stray release of whatever region id
+    // the recycled page spells (docs/impl/region/bindings.md § "A cell's release
+    // lands at or after every release routed through that cell").
+    //
+    // The shape is a `def` inside a lambda captured by a sibling closure: `p` is
+    // env-celled, its init is a call so it owns a value region of its own, and
+    // the capture is `p`'s last binding-use — which puts the box's release at
+    // the capture and the value's release at the enclosing `let`.
+    let module = compile_to_lir(
+        "((fn [] \
+            (def p (f 1)) \
+            (let [r (fn [] (g p))] :built)))",
+    );
+    let mut checked = 0usize;
+    for func in std::iter::once(&module.entry).chain(module.closures.iter()) {
+        let instrs = flat_instrs(func);
+        // Which env index each register was loaded raw from. A register id is
+        // reused across a function, so the map records the LATEST load, which is
+        // the one the release right after it names.
+        let mut raw_from: rustc_hash::FxHashMap<Reg, u16> = rustc_hash::FxHashMap::default();
+        // Per env index: where its box is freed, and where its content is last
+        // unwrapped out of that box.
+        let mut frees: rustc_hash::FxHashMap<u16, usize> = rustc_hash::FxHashMap::default();
+        let mut unwraps: rustc_hash::FxHashMap<u16, usize> = rustc_hash::FxHashMap::default();
+        for (pos, instr) in instrs.iter().enumerate() {
+            match instr {
+                LirInstr::LoadCaptureRaw { dst, index } => {
+                    raw_from.insert(*dst, *index);
+                }
+                LirInstr::DecrefValueRegion { src } => {
+                    if let Some(&index) = raw_from.get(src) {
+                        let e = unwraps.entry(index).or_insert(pos);
+                        *e = (*e).max(pos);
+                    }
+                }
+                LirInstr::DecrefCellRegion { src } => {
+                    if let Some(&index) = raw_from.get(src) {
+                        let e = frees.entry(index).or_insert(pos);
+                        *e = (*e).max(pos);
+                    }
+                }
+                _ => {}
+            }
+        }
+        for (index, free_at) in &frees {
+            checked += 1;
+            let Some(&unwrap_at) = unwraps.get(index) else {
+                continue;
+            };
+            assert!(
+                *free_at > unwrap_at,
+                "cap[{index}]'s DecrefCellRegion at #{free_at} frees the box before \
+                 the DecrefValueRegion at #{unwrap_at} unwraps that same box — the \
+                 unwrap reads a reclaimed page. instrs={instrs:?}",
+            );
+        }
+    }
+    assert!(
+        checked > 0,
+        "expected the captured-`def` shape to emit at least one DecrefCellRegion \
+         off a LoadCaptureRaw — if lowering changed, update the shape so this test \
+         keeps biting",
+    );
+}

--- a/tests/region_cell_release_order.rs
+++ b/tests/region_cell_release_order.rs
@@ -1,0 +1,94 @@
+//! An env cell's box must outlive every release routed through that cell.
+//!
+//! A `def` inside a function body that a sibling closure captures is
+//! materialized as a per-value env cell. Such a binding owes two releases at the
+//! same env index: the init value's `DecrefValueRegion`, which loads the box RAW
+//! and unwraps it to the content, and the box's own `DecrefCellRegion`, which
+//! frees the page that unwrap reads. The box release must land at or after the
+//! value release (docs/impl/region/bindings.md § "A cell's release lands at or
+//! after every release routed through that cell").
+//!
+//! Each shape below gives the two releases different placements to reconcile:
+//! the init is a CALL, so it owns a region of its own, and the capture is the
+//! binding's last use, so the box's release is drawn to the capture while the
+//! value's is drawn out to the enclosing form.
+//!
+//! The shapes run with `--trace=scrub` armed, and that is the whole point of
+//! this file. A freed page keeps its bytes, so the stale unwrap returns the
+//! right answer and every one of these programs passes on a plain build whether
+//! the box release is correctly placed or not — the mis-ordering only detonates
+//! once other work has recycled the page. Scrub blanks a released page's body,
+//! so the unwrap lands on an all-zero slot and `arena::deref` raises at the
+//! deref site instead (docs/impl/region/diagnostics.md).
+//!
+//! This file is its OWN test binary because `config::init` is process-global:
+//! arming scrub inside the shared integration binary would blank pages for every
+//! other test in it.
+
+use elle::{init_stdlib, register_primitives, SymbolTable, VM};
+
+/// Run `source` on a fresh VM and return its result rendered as a string.
+fn run(source: &str) -> String {
+    let mut symbols = SymbolTable::new();
+    let mut vm = VM::new();
+    let _ = register_primitives(&mut vm, &mut symbols);
+    let mut cctx = elle::pipeline::CompileCtx::new();
+    vm.set_compile_ctx(&mut cctx as *mut elle::pipeline::CompileCtx);
+    vm.set_symbols(&mut symbols as *mut SymbolTable);
+    init_stdlib(&mut vm, &mut symbols, &mut cctx);
+    match elle::eval_all(source, &mut symbols, &mut vm, &mut cctx, "<cell-release>") {
+        Ok(v) => format!("{}", v.display_with(Some(&symbols))),
+        Err(e) => format!("error: {e}"),
+    }
+}
+
+/// `(name, one expression, the answer the semantics require)`.
+const SHAPES: &[(&str, &str, &str)] = &[
+    (
+        "the sibling closure is never called",
+        "((fn []
+            (def joined (path/join \"/x\" \"b\"))
+            (let [_reader (fn [] (string? joined))] :built)))",
+        ":built",
+    ),
+    (
+        "the sibling closure is called",
+        "((fn []
+            (def joined (path/join \"/x\" \"b\"))
+            (let [reader (fn [] (string? joined))] (reader))))",
+        "true",
+    ),
+    (
+        "the enclosing form reads the def after the capture",
+        "((fn []
+            (def joined (path/join \"/x\" \"b\"))
+            (let [_reader (fn [] (string? joined))] (string? joined))))",
+        "true",
+    ),
+    (
+        "the init is an allocating call other than a path join",
+        "((fn []
+            (def parts (list 10 20))
+            (let [_reader (fn [] (length parts))] :built)))",
+        ":built",
+    ),
+];
+
+#[test]
+fn a_cell_box_outlives_the_release_routed_through_it() {
+    let mut cfg = elle::config::Config::default();
+    cfg.trace_keywords.push("scrub".to_string());
+    elle::config::init(cfg);
+
+    for (name, source, want) in SHAPES {
+        let got = run(source);
+        assert_eq!(
+            &got, want,
+            "under --trace=scrub, {name} answered {got} instead of {want} — the \
+             env cell's box was freed before the value release that unwraps it, \
+             so that release read a reclaimed page (docs/impl/region/bindings.md \
+             § \"A cell's release lands at or after every release routed through \
+             that cell\")",
+        );
+    }
+}


### PR DESCRIPTION
Fixes #900 — defect B of #887.

## The defect

A captured `def` inside a lambda owes two releases at one env index. The init
value's `DecrefValueRegion` loads the box RAW and lets `result_region_of` unwrap
it to the content, so it READS the box's page; the box's own `DecrefCellRegion`
frees that page. The value release has to come first.

Where the two land on one `decref_point`, `order_releases` already says so — a
value release that unwraps a cell reads deepest and sorts ahead of the cell
release that frees the page. Across two points nothing did, and the two points
diverge by construction:

- Both regions sit in the binding's `binding_source_regions`, so the
  binding-chain extension starts them together at the binding's last use — the
  capture.
- The VALUE region then takes a second, later bound from its **allocation
  site's** last use, which follows the `def` form's own value out to whatever
  consumes it.
- The CELL region is a phantom placeholder with no allocation site, so it keeps
  the binding-use bound alone.

On the 7-line witness of #900 that is visible directly in the analysis
(`--dump=regions`): the cell region dies at the lambda that captures it, the
init's call-result region one node later, at the enclosing `let`. The emitted
LIR frees the box and then unwraps it:

```
r8 ← cap[1] (raw)
decref-cell-region r8      ; the box is freed here
decref-region 10384
r9 ← :built
r10 ← cap[1] (raw)         ; ← reads the reclaimed page
decref-value-region r10
```

In a release build that unwrap becomes a stray `DecrefValueRegion` of whatever
region id the recycled page spells — a premature free of a live region, which
under batch pressure surfaced as the closure-template tag/object mismatch on a
scrubbed page.

## The fix

`pin_cell_release_after_routed_releases` (`hir/region/infer/analyze/decref.rs`)
clamps a cell-release region's `decref_point` to at-or-after the release of the
region the binding's own binder **allocated** — the one entry
`record_region_slot` makes against the binder's slot, which for an env-celled
binding is the env index. It runs after every other `decref_point` pass, so what
it clamps against is where the value release finally lands, and the point it
produces is taken out of any enclosing loop, so the box still releases once per
activation.

A region the binding merely NAMES records no slot and is released by id, reading
no page: `(def @c n)` names its parameter's phantom region and allocates
nothing, so its box owes that region's release nothing. Reading the clamp any
wider withdraws the env-cell branch compensations, which the four
`compensate`/`frameexit` pins keep honest.

The env cell's once-per-activation loop hoist and the new clamp now share one
`post_loop_placement` helper and one `iter_scopes` computation.

## Verification

| Check | Before | After |
|---|---|---|
| `tests/region_cell_release_order.rs` (new, `--trace=scrub`) | `arena::deref` tag/object mismatch in `result_region_of` | passes |
| `a_cell_release_lands_at_or_after_the_release_routed_through_it` (new) | cell released one node before the value | passes |
| `a_cell_box_release_follows_every_release_that_unwraps_it` (new) | `DecrefCellRegion` emitted before the unwrap | passes |
| `elle --trace=guardfree` on the #900 witness | SIGSEGV, use-after-free | clean |
| `elle --trace=guardfree tests/elle/region-def-in-lambda-capture.lisp` | guardfree reports | no reports |
| `make smoke` (release) | — | all smoke tests passed |
| `cargo test -p elle --lib` | — | 2172 pass |
| `cargo test --test '*'` | — | pass |
| clippy, fmt, rustdoc | — | clean |

## Scope

Independent of #891, #896 and #899. The corpus is green UNARMED either way —
a freed page keeps its bytes, so the stale unwrap answers correctly until other
work recycles it, which is why the new runtime pin arms `--trace=scrub` and is
its own test binary.
