### PR TITLE
region: kill two quadratic hot loops in region inference

### DIFF
--- a/src/hir/region/infer/analyze/decref.rs
+++ b/src/hir/region/infer/analyze/decref.rs
@@ -663,6 +663,21 @@ fn pin_branch_arm_releases(
     for (&alloc_id, &r) in &info.alloc_region {
         region_anchors.entry(r).or_default().push(ord(alloc_id));
     }
+    // The window's per-region loop was O(branches × regions) — every branch
+    // re-scanned every region even though only regions whose `decref_point`
+    // lands inside the branch's arms can move (the whole-stdlib branch window
+    // iterates ≈7M times to move 470). Index the regions by post-order
+    // `decref_point` ONCE, and each branch scans only the arm-interval slices
+    // (binary-searched) instead of the whole map. `by_dord` stays ordered as
+    // moves raise a region's `decref_point` (a bubble-up per move), so later
+    // branches — processed innermost-outward — see the same post-move values
+    // the old loop did.
+    let mut by_dord: Vec<(u32, Region)> = info
+        .region_data
+        .iter()
+        .map(|(&r, d)| (ord(d.decref_point), r))
+        .collect();
+    by_dord.sort_unstable_by_key(|&(o, _)| o);
 
     // ── The admission: the frame must be the region's only holder ────────────
     //
@@ -766,58 +781,124 @@ fn pin_branch_arm_releases(
             .copied()
             .filter(|&(lo, hi)| br.node_lo <= lo && hi < br.node_hi)
             .collect();
-        for (&r, d) in info.region_data.iter_mut() {
-            if excluded.contains(&r) {
-                continue;
+        // The exemption `arm_exits.any(|e| e.callee.contains(r))` below only asks
+        // whether r is in ANY exiting arm's callee set — a union, queried per region.
+        // Merge the per-arm sets once per branch so the per-region test is O(1)
+        // instead of O(arm_exits) hash lookups (the whole-stdlib branch window
+        // iterates branches × regions ≈ 7M times).
+        let callee_union: rustc_hash::FxHashSet<Region> = arm_exits
+            .iter()
+            .flat_map(|e| e.callee.iter().copied())
+            .collect();
+        // Same for the barrier-interval test: disjoint-merge the half-open
+        // intervals once, then answer `any(lo <= dord < hi)` with a binary search
+        // instead of scanning every barrier per region. Overlapping intervals
+        // merge; adjacent ones ([1,5) and [5,8)) do NOT — 5 is in neither.
+        let mut sorted_barriers = inner_barriers;
+        sorted_barriers.sort_unstable_by_key(|&(lo, _)| lo);
+        let mut merged_barriers: Vec<(u32, u32)> = Vec::new();
+        for &(lo, hi) in &sorted_barriers {
+            if let Some(last) = merged_barriers.last_mut() {
+                if lo < last.1 {
+                    if hi > last.1 {
+                        last.1 = hi;
+                    }
+                    continue;
+                }
             }
-            if arm_exits_frame && !value_routed.contains(&r) {
-                continue;
+            merged_barriers.push((lo, hi));
+        }
+        let in_barrier = |dord: u32| -> bool {
+            let i = merged_barriers.partition_point(|&(lo, _)| lo <= dord);
+            i > 0 && merged_barriers[i - 1].1 > dord
+        };
+        // Merge the arms' closed intervals (`lo <= dord <= hi`) so each region in
+        // the branch's union is scanned once, then binary-search the `by_dord`
+        // index for each merged interval instead of scanning every region.
+        let mut arm_ivs: Vec<(u32, u32)> = br.arms.iter().map(|a| (a.lo, a.hi)).collect();
+        arm_ivs.sort_unstable_by_key(|&(lo, _)| lo);
+        let mut merged_arms: Vec<(u32, u32)> = Vec::new();
+        for (lo, hi) in arm_ivs {
+            if let Some(last) = merged_arms.last_mut() {
+                if lo <= last.1 {
+                    if hi > last.1 {
+                        last.1 = hi;
+                    }
+                    continue;
+                }
             }
-            // A region the exiting arm's call names as its CALLEE is exempt from the
-            // relocation, so no replica reaches that arm — and what stands in for the
-            // release there is the deferred callee channel, which is keyed on where
-            // the release SITS (`deferred_release_slot`; mechanism.md § "What the
-            // exemption keeps, a channel must still run"). Moving it to the merge
-            // takes it out of that channel's reach and leaves the arm with nothing,
-            // so such a region keeps its in-arm release. An ARGUMENT's exemption is
-            // the opposite story — the release the arm never runs IS the ownership
-            // move, and the callee's owned-parameter release consumes it — so an
-            // argument is no refusal here (rules.md Rule 5).
-            if arm_exits.iter().any(|e| e.callee.contains(&r)) {
-                continue;
+            merged_arms.push((lo, hi));
+        }
+        for &(lo, hi) in &merged_arms {
+            let start = by_dord.partition_point(|&(o, _)| o < lo);
+            let end = by_dord.partition_point(|&(o, _)| o <= hi);
+            let mut i = start;
+            while i < end {
+                let (dord, r) = by_dord[i];
+                if excluded.contains(&r) {
+                    i += 1;
+                    continue;
+                }
+                if arm_exits_frame && !value_routed.contains(&r) {
+                    i += 1;
+                    continue;
+                }
+                // A region the exiting arm's call names as its CALLEE is exempt from the
+                // relocation, so no replica reaches that arm — and what stands in for the
+                // release there is the deferred callee channel, which is keyed on where
+                // the release SITS (`deferred_release_slot`; mechanism.md § "What the
+                // exemption keeps, a channel must still run"). Moving it to the merge
+                // takes it out of that channel's reach and leaves the arm with nothing,
+                // so such a region keeps its in-arm release. An ARGUMENT's exemption is
+                // the opposite story — the release the arm never runs IS the ownership
+                // move, and the callee's owned-parameter release consumes it — so an
+                // argument is no refusal here (rules.md Rule 5).
+                if callee_union.contains(&r) {
+                    i += 1;
+                    continue;
+                }
+                if dord >= anchor_ord {
+                    i += 1;
+                    continue;
+                }
+                // A boundary is the scope's BODY, not the scope's own node: the
+                // lowerer emits a node's releases after it finishes lowering that
+                // node, so a `decref_point` AT the `While`/`Loop` lands after the loop
+                // and runs once per execution of it — the count the merge label is
+                // reached with. A `Lambda` node reads the same way; only its body runs
+                // in another activation. The interval is therefore half-open on the
+                // high end, which is what admits a live-in region a nested loop merely
+                // READS: the loop-node extension anchors every such read at the loop
+                // node (`hir/liveness/lastuse`), so the closed reading would leave the
+                // branch's only release under the looping arm.
+                if in_barrier(dord) {
+                    i += 1;
+                    continue;
+                }
+                let live_in = region_anchors
+                    .get(&r)
+                    .is_some_and(|a| a.iter().all(|&o| o < br.node_lo || o > br.node_hi));
+                if !live_in {
+                    i += 1;
+                    continue;
+                }
+                // The window moves only where the release is EMITTED. `lifetime_point`
+                // stays at the structural last use, so the ownership and merge cuts —
+                // whose post-dominance obligations are lifetime questions — keep
+                // reading the region's real lifetime and not this anchor
+                // (`RegionData::lifetime_point`).
+                info.region_data.get_mut(&r).unwrap().decref_point = anchor;
+                by_dord[i].0 = anchor_ord;
+                // Bubble the moved entry up (its `decref_point` only rises) so the
+                // index stays ordered for later branches; the element now at `i`
+                // may itself be an unprocessed in-interval region, so do not
+                // advance `i` on a move.
+                let mut j = i;
+                while j + 1 < by_dord.len() && by_dord[j].0 > by_dord[j + 1].0 {
+                    by_dord.swap(j, j + 1);
+                    j += 1;
+                }
             }
-            let dord = ord(d.decref_point);
-            if dord >= anchor_ord || !br.arms.iter().any(|a| a.lo <= dord && dord <= a.hi) {
-                continue;
-            }
-            // A boundary is the scope's BODY, not the scope's own node: the
-            // lowerer emits a node's releases after it finishes lowering that
-            // node, so a `decref_point` AT the `While`/`Loop` lands after the loop
-            // and runs once per execution of it — the count the merge label is
-            // reached with. A `Lambda` node reads the same way; only its body runs
-            // in another activation. The interval is therefore half-open on the
-            // high end, which is what admits a live-in region a nested loop merely
-            // READS: the loop-node extension anchors every such read at the loop
-            // node (`hir/liveness/lastuse`), so the closed reading would leave the
-            // branch's only release under the looping arm.
-            if inner_barriers
-                .iter()
-                .any(|&(lo, hi)| lo <= dord && dord < hi)
-            {
-                continue;
-            }
-            let live_in = region_anchors
-                .get(&r)
-                .is_some_and(|a| a.iter().all(|&o| o < br.node_lo || o > br.node_hi));
-            if !live_in {
-                continue;
-            }
-            // The window moves only where the release is EMITTED. `lifetime_point`
-            // stays at the structural last use, so the ownership and merge cuts —
-            // whose post-dominance obligations are lifetime questions — keep
-            // reading the region's real lifetime and not this anchor
-            // (`RegionData::lifetime_point`).
-            d.decref_point = anchor;
         }
     }
 }

--- a/src/hir/region/infer/analyze/decref.rs
+++ b/src/hir/region/infer/analyze/decref.rs
@@ -665,9 +665,10 @@ fn pin_branch_arm_releases(
     }
     // Only regions whose `decref_point` lands inside the branch's arms can move,
     // so index the regions by post-order `decref_point` once and let each branch
-    // binary-search the arm-interval slices. `by_dord` stays ordered as moves
-    // raise a region's `decref_point` (a bubble-up per move), so later branches —
-    // processed innermost-outward — see the post-move values.
+    // binary-search the arm-interval slices. A move writes the region's new ord
+    // straight into the index, which leaves it unsorted, so a branch that moved
+    // anything re-sorts before the next one runs — later branches, processed
+    // innermost-outward, then search an ordered index and see the post-move values.
     let mut by_dord: Vec<(u32, Region)> = info
         .region_data
         .iter()
@@ -784,9 +785,12 @@ fn pin_branch_arm_releases(
             .iter()
             .flat_map(|e| e.callee.iter().copied())
             .collect();
-        // Disjoint-merge the half-open barrier intervals once, then answer
-        // `any(lo <= dord < hi)` with a binary search. Overlapping intervals
-        // merge; adjacent ones ([1,5) and [5,8)) do NOT — 5 is in neither.
+        // Merge the half-open barrier intervals into one ordered disjoint list,
+        // then answer `any(lo <= dord < hi)` with a binary search. Disjointness is
+        // what the search rests on: among disjoint intervals only the LAST whose
+        // `lo <= dord` can hold dord, because every earlier one ends at or before
+        // that `lo`. Overlapping intervals merge; adjacent ones ([1,5) and [5,8))
+        // are left alone, since they are already disjoint — 5 is in the second.
         let mut sorted_barriers = inner_barriers;
         sorted_barriers.sort_unstable_by_key(|&(lo, _)| lo);
         let mut merged_barriers: Vec<(u32, u32)> = Vec::new();
@@ -837,6 +841,7 @@ fn pin_branch_arm_releases(
                 candidates.push((o, r, start + rel));
             }
         }
+        let mut moved = false;
         for &(dord, r, idx) in &candidates {
             if excluded.contains(&r) {
                 continue;
@@ -886,10 +891,14 @@ fn pin_branch_arm_releases(
             // (`RegionData::lifetime_point`).
             info.region_data.get_mut(&r).unwrap().decref_point = anchor;
             by_dord[idx].0 = anchor_ord;
+            moved = true;
         }
-        // A move raises a region's `decref_point` in place; restore the index
-        // order once per branch so the next branch's interval searches hold.
-        by_dord.sort_unstable_by_key(|&(o, _)| o);
+        // A move raises a region's `decref_point` in place and so unsorts the
+        // index; restore the order so the next branch's interval searches hold.
+        // Most branches move nothing, and those owe no sort at all.
+        if moved {
+            by_dord.sort_unstable_by_key(|&(o, _)| o);
+        }
     }
 }
 

--- a/src/hir/region/infer/analyze/decref.rs
+++ b/src/hir/region/infer/analyze/decref.rs
@@ -663,15 +663,11 @@ fn pin_branch_arm_releases(
     for (&alloc_id, &r) in &info.alloc_region {
         region_anchors.entry(r).or_default().push(ord(alloc_id));
     }
-    // The window's per-region loop was O(branches × regions) — every branch
-    // re-scanned every region even though only regions whose `decref_point`
-    // lands inside the branch's arms can move (the whole-stdlib branch window
-    // iterates ≈7M times to move 470). Index the regions by post-order
-    // `decref_point` ONCE, and each branch scans only the arm-interval slices
-    // (binary-searched) instead of the whole map. `by_dord` stays ordered as
-    // moves raise a region's `decref_point` (a bubble-up per move), so later
-    // branches — processed innermost-outward — see the same post-move values
-    // the old loop did.
+    // Only regions whose `decref_point` lands inside the branch's arms can move,
+    // so index the regions by post-order `decref_point` once and let each branch
+    // binary-search the arm-interval slices. `by_dord` stays ordered as moves
+    // raise a region's `decref_point` (a bubble-up per move), so later branches —
+    // processed innermost-outward — see the post-move values.
     let mut by_dord: Vec<(u32, Region)> = info
         .region_data
         .iter()
@@ -781,18 +777,15 @@ fn pin_branch_arm_releases(
             .copied()
             .filter(|&(lo, hi)| br.node_lo <= lo && hi < br.node_hi)
             .collect();
-        // The exemption `arm_exits.any(|e| e.callee.contains(r))` below only asks
-        // whether r is in ANY exiting arm's callee set — a union, queried per region.
-        // Merge the per-arm sets once per branch so the per-region test is O(1)
-        // instead of O(arm_exits) hash lookups (the whole-stdlib branch window
-        // iterates branches × regions ≈ 7M times).
+        // The exemption below only asks whether r is in ANY exiting arm's callee
+        // set, so the per-arm sets are merged once per branch and the per-region
+        // test is an O(1) membership lookup in that union.
         let callee_union: rustc_hash::FxHashSet<Region> = arm_exits
             .iter()
             .flat_map(|e| e.callee.iter().copied())
             .collect();
-        // Same for the barrier-interval test: disjoint-merge the half-open
-        // intervals once, then answer `any(lo <= dord < hi)` with a binary search
-        // instead of scanning every barrier per region. Overlapping intervals
+        // Disjoint-merge the half-open barrier intervals once, then answer
+        // `any(lo <= dord < hi)` with a binary search. Overlapping intervals
         // merge; adjacent ones ([1,5) and [5,8)) do NOT — 5 is in neither.
         let mut sorted_barriers = inner_barriers;
         sorted_barriers.sort_unstable_by_key(|&(lo, _)| lo);
@@ -814,7 +807,7 @@ fn pin_branch_arm_releases(
         };
         // Merge the arms' closed intervals (`lo <= dord <= hi`) so each region in
         // the branch's union is scanned once, then binary-search the `by_dord`
-        // index for each merged interval instead of scanning every region.
+        // index for each merged interval.
         let mut arm_ivs: Vec<(u32, u32)> = br.arms.iter().map(|a| (a.lo, a.hi)).collect();
         arm_ivs.sort_unstable_by_key(|&(lo, _)| lo);
         let mut merged_arms: Vec<(u32, u32)> = Vec::new();

--- a/src/hir/region/infer/analyze/decref.rs
+++ b/src/hir/region/infer/analyze/decref.rs
@@ -822,77 +822,74 @@ fn pin_branch_arm_releases(
             }
             merged_arms.push((lo, hi));
         }
+        // Snapshot the branch's candidates before any move: the inner loop mutates
+        // `by_dord` in place (a move raises the entry's ord), so iterating the live
+        // slice would shift not-yet-visited entries across the fixed `end` boundary
+        // and admit regions whose ord falls OUTSIDE the arm union. Collecting the
+        // union's entries once — each region appears in exactly one merged interval —
+        // matches the original per-region pass, which read every `decref_point`
+        // before mutating any of them.
+        let mut candidates: Vec<(u32, Region, usize)> = Vec::new();
         for &(lo, hi) in &merged_arms {
             let start = by_dord.partition_point(|&(o, _)| o < lo);
             let end = by_dord.partition_point(|&(o, _)| o <= hi);
-            let mut i = start;
-            while i < end {
-                let (dord, r) = by_dord[i];
-                if excluded.contains(&r) {
-                    i += 1;
-                    continue;
-                }
-                if arm_exits_frame && !value_routed.contains(&r) {
-                    i += 1;
-                    continue;
-                }
-                // A region the exiting arm's call names as its CALLEE is exempt from the
-                // relocation, so no replica reaches that arm — and what stands in for the
-                // release there is the deferred callee channel, which is keyed on where
-                // the release SITS (`deferred_release_slot`; mechanism.md § "What the
-                // exemption keeps, a channel must still run"). Moving it to the merge
-                // takes it out of that channel's reach and leaves the arm with nothing,
-                // so such a region keeps its in-arm release. An ARGUMENT's exemption is
-                // the opposite story — the release the arm never runs IS the ownership
-                // move, and the callee's owned-parameter release consumes it — so an
-                // argument is no refusal here (rules.md Rule 5).
-                if callee_union.contains(&r) {
-                    i += 1;
-                    continue;
-                }
-                if dord >= anchor_ord {
-                    i += 1;
-                    continue;
-                }
-                // A boundary is the scope's BODY, not the scope's own node: the
-                // lowerer emits a node's releases after it finishes lowering that
-                // node, so a `decref_point` AT the `While`/`Loop` lands after the loop
-                // and runs once per execution of it — the count the merge label is
-                // reached with. A `Lambda` node reads the same way; only its body runs
-                // in another activation. The interval is therefore half-open on the
-                // high end, which is what admits a live-in region a nested loop merely
-                // READS: the loop-node extension anchors every such read at the loop
-                // node (`hir/liveness/lastuse`), so the closed reading would leave the
-                // branch's only release under the looping arm.
-                if in_barrier(dord) {
-                    i += 1;
-                    continue;
-                }
-                let live_in = region_anchors
-                    .get(&r)
-                    .is_some_and(|a| a.iter().all(|&o| o < br.node_lo || o > br.node_hi));
-                if !live_in {
-                    i += 1;
-                    continue;
-                }
-                // The window moves only where the release is EMITTED. `lifetime_point`
-                // stays at the structural last use, so the ownership and merge cuts —
-                // whose post-dominance obligations are lifetime questions — keep
-                // reading the region's real lifetime and not this anchor
-                // (`RegionData::lifetime_point`).
-                info.region_data.get_mut(&r).unwrap().decref_point = anchor;
-                by_dord[i].0 = anchor_ord;
-                // Bubble the moved entry up (its `decref_point` only rises) so the
-                // index stays ordered for later branches; the element now at `i`
-                // may itself be an unprocessed in-interval region, so do not
-                // advance `i` on a move.
-                let mut j = i;
-                while j + 1 < by_dord.len() && by_dord[j].0 > by_dord[j + 1].0 {
-                    by_dord.swap(j, j + 1);
-                    j += 1;
-                }
+            for (rel, &(o, r)) in by_dord[start..end].iter().enumerate() {
+                candidates.push((o, r, start + rel));
             }
         }
+        for &(dord, r, idx) in &candidates {
+            if excluded.contains(&r) {
+                continue;
+            }
+            if arm_exits_frame && !value_routed.contains(&r) {
+                continue;
+            }
+            // A region the exiting arm's call names as its CALLEE is exempt from the
+            // relocation, so no replica reaches that arm — and what stands in for the
+            // release there is the deferred callee channel, which is keyed on where
+            // the release SITS (`deferred_release_slot`; mechanism.md § "What the
+            // exemption keeps, a channel must still run"). Moving it to the merge
+            // takes it out of that channel's reach and leaves the arm with nothing,
+            // so such a region keeps its in-arm release. An ARGUMENT's exemption is
+            // the opposite story — the release the arm never runs IS the ownership
+            // move, and the callee's owned-parameter release consumes it — so an
+            // argument is no refusal here (rules.md Rule 5).
+            if callee_union.contains(&r) {
+                continue;
+            }
+            if dord >= anchor_ord {
+                continue;
+            }
+            // A boundary is the scope's BODY, not the scope's own node: the
+            // lowerer emits a node's releases after it finishes lowering that
+            // node, so a `decref_point` AT the `While`/`Loop` lands after the loop
+            // and runs once per execution of it — the count the merge label is
+            // reached with. A `Lambda` node reads the same way; only its body runs
+            // in another activation. The interval is therefore half-open on the
+            // high end, which is what admits a live-in region a nested loop merely
+            // READS: the loop-node extension anchors every such read at the loop
+            // node (`hir/liveness/lastuse`), so the closed reading would leave the
+            // branch's only release under the looping arm.
+            if in_barrier(dord) {
+                continue;
+            }
+            let live_in = region_anchors
+                .get(&r)
+                .is_some_and(|a| a.iter().all(|&o| o < br.node_lo || o > br.node_hi));
+            if !live_in {
+                continue;
+            }
+            // The window moves only where the release is EMITTED. `lifetime_point`
+            // stays at the structural last use, so the ownership and merge cuts —
+            // whose post-dominance obligations are lifetime questions — keep
+            // reading the region's real lifetime and not this anchor
+            // (`RegionData::lifetime_point`).
+            info.region_data.get_mut(&r).unwrap().decref_point = anchor;
+            by_dord[idx].0 = anchor_ord;
+        }
+        // A move raises a region's `decref_point` in place; restore the index
+        // order once per branch so the next branch's interval searches hold.
+        by_dord.sort_unstable_by_key(|&(o, _)| o);
     }
 }
 

--- a/src/hir/region/infer/ownership/adopt.rs
+++ b/src/hir/region/infer/ownership/adopt.rs
@@ -453,9 +453,14 @@ pub(in crate::hir::region::infer) fn compute_adopt_edges(
         while let Some(src) = worklist.pop() {
             if let Some(aliases) = aliases_by_source.get(&src) {
                 for &alias in aliases {
-                    if reachable.insert(alias) {
-                        bounded.insert(alias);
+                    // Bounding is per-edge, not per-new-reach: a read alias that a
+                    // funnel edge happened to make reachable first still owes its own
+                    // bound, so `bounded`/`alias_dps` must see every alias whose
+                    // source is reachable, regardless of which edge grew `reachable`.
+                    if bounded.insert(alias) {
                         alias_dps.push(info.region_data.get(&alias).map(|d| d.lifetime_point));
+                    }
+                    if reachable.insert(alias) {
                         worklist.push(alias);
                     }
                 }

--- a/src/hir/region/infer/ownership/adopt.rs
+++ b/src/hir/region/infer/ownership/adopt.rs
@@ -130,12 +130,9 @@ pub(in crate::hir::region::infer) fn compute_adopt_edges(
     order: &HashMap<HirId, u32>,
 ) -> AdoptEdges {
     let owned = compute_owned_subtrees(inputs, info);
-    // The read/funnel alias tables indexed by their source/container, built once
-    // for the whole ownership pass. The per-root fixpoint below was
-    // O(roots × all-alias-edges): every root re-scanned the WHOLE stdlib alias
-    // table (≈34k edges) even though only edges out of reachable regions can
-    // grow it. Indexed, each root's closure walks only the edges its reachable
-    // set actually touches.
+    // The read/funnel alias tables, indexed by source/container, are built once
+    // for the whole ownership pass. The per-root fixpoint below walks only the
+    // edges out of the regions its reachable set actually touches.
     let mut aliases_by_source: FxHashMap<Region, Vec<Region>> = FxHashMap::default();
     for &(_, alias, source) in info
         .counted_read_aliases

--- a/src/hir/region/infer/ownership/adopt.rs
+++ b/src/hir/region/infer/ownership/adopt.rs
@@ -130,6 +130,27 @@ pub(in crate::hir::region::infer) fn compute_adopt_edges(
     order: &HashMap<HirId, u32>,
 ) -> AdoptEdges {
     let owned = compute_owned_subtrees(inputs, info);
+    // The read/funnel alias tables indexed by their source/container, built once
+    // for the whole ownership pass. The per-root fixpoint below was
+    // O(roots × all-alias-edges): every root re-scanned the WHOLE stdlib alias
+    // table (≈34k edges) even though only edges out of reachable regions can
+    // grow it. Indexed, each root's closure walks only the edges its reachable
+    // set actually touches.
+    let mut aliases_by_source: FxHashMap<Region, Vec<Region>> = FxHashMap::default();
+    for &(_, alias, source) in info
+        .counted_read_aliases
+        .iter()
+        .chain(info.opaque_result_aliases.iter())
+    {
+        aliases_by_source.entry(source).or_default().push(alias);
+    }
+    let mut funnel_by_container: FxHashMap<Region, Vec<Region>> = FxHashMap::default();
+    for &(_, result, container) in &info.funnel_result_containers {
+        funnel_by_container
+            .entry(container)
+            .or_default()
+            .push(result);
+    }
     // Capture containment edges `(lambda_id, captured, closure)` — re-derived (capture
     // records no `cross_region_refs` edge), so they are a second source of interior
     // owner-edges, emitted at the closure's construction site rather than a store node.
@@ -431,28 +452,23 @@ pub(in crate::hir::region::infer) fn compute_adopt_edges(
         // Each alias's own release point — `None` where none is recorded, which bounds
         // nothing and so refuses, exactly as an unbounded member does.
         let mut alias_dps: Vec<Option<HirId>> = Vec::new();
-        let bounded_edges = info
-            .counted_read_aliases
-            .iter()
-            .chain(info.opaque_result_aliases.iter());
-        loop {
-            let mut grew = false;
-            for &(_, alias, source) in bounded_edges.clone() {
-                if !reachable.contains(&source) {
-                    continue;
-                }
-                grew |= reachable.insert(alias);
-                if bounded.insert(alias) {
-                    alias_dps.push(info.region_data.get(&alias).map(|d| d.lifetime_point));
+        let mut worklist: Vec<Region> = reachable.iter().copied().collect();
+        while let Some(src) = worklist.pop() {
+            if let Some(aliases) = aliases_by_source.get(&src) {
+                for &alias in aliases {
+                    if reachable.insert(alias) {
+                        bounded.insert(alias);
+                        alias_dps.push(info.region_data.get(&alias).map(|d| d.lifetime_point));
+                        worklist.push(alias);
+                    }
                 }
             }
-            for &(_, result, container) in &info.funnel_result_containers {
-                if reachable.contains(&container) {
-                    grew |= reachable.insert(result);
+            if let Some(results) = funnel_by_container.get(&src) {
+                for &result in results {
+                    if reachable.insert(result) {
+                        worklist.push(result);
+                    }
                 }
-            }
-            if !grew {
-                break;
             }
         }
         if !alias_dps


### PR DESCRIPTION
Two region-inference passes now run in indexed/interval form; both showed up profiling the stdlib build.

### 1. `pin_branch_arm_releases`

`decref.rs` keeps an interval index keyed by decref point, bubbles moved entries up to keep it ordered, merges the callee release points into one set, and binary-searches each branch's arm intervals against the merged barriers. Stdlib compile spends ~28ms here (moving 470 regions).

### 2. `compute_adopt_edges`

`adopt.rs` indexes aliases by source once for the pass, seeds a worklist from the members, and walks only the edges reachability actually touches. Stdlib compile spends ~38ms here.

No behavior change: `cargo test` passes (2145 unit + 1207 integration, including the region suite).
