### PR TITLE
stdlib: disk cache for the compiled standard library

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,5 @@
 [env]
 RUST_TEST_THREADS = { value = "16", force = false }
-MLIR_SYS_220_PREFIX = { value = "/home/adavidoff/git/tmp/mlir-install", force = false }
 LIBCLANG_PATH = { value = "/usr/lib/llvm/20/lib64", force = false }
 
 [target.x86_64-unknown-linux-gnu]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +649,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 name = "elle"
 version = "2.0.0"
 dependencies = [
+ "bincode",
  "bumpalo",
  "camino",
  "cranelift-codegen",
@@ -659,6 +669,7 @@ dependencies = [
  "proptest",
  "rustc-hash",
  "rustyline",
+ "serde",
  "serde_json",
  "smallvec",
  "stats_alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ libffi = { version = "5.1", optional = true }
 rustyline = "14"
 libc = "0.2"
 serde_json = "1.0"
+serde = { version = "1", features = ["derive"] }
+bincode = "1.3"
 tempfile = "3"
 # Grapheme segmentation tables define string semantics (length, get,
 # slice count clusters). This exact pin is generation G17 in

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -93,6 +93,7 @@ make smoke                 # run all tests (~30s)
 | [values](docs/impl/values.md) | Value representation, tagged union |
 | [symbol](docs/impl/symbol.md) | Symbol and keyword identity: name hash, per-instance display memo, ordering |
 | [image](docs/impl/image.md) | Image persistence design: boot image, environment save/load |
+| [stdlib-cache](docs/impl/stdlib-cache.md) | Disk cache for the compiled standard library |
 
 ## Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,8 +69,7 @@ Focused files covering one topic each, all runnable via `elle docs/<file>.md`.
 
 | Directory | Content |
 |-----------|---------|
-| [impl/](impl/) | Reader, HIR, LIR, bytecode, VM, JIT, WASM, MLIR, SPIR-V, GPU, values, symbols |
-| [stdlib-cache.md](stdlib-cache.md) | Disk cache for the standard-library compilation |
+| [impl/](impl/) | Reader, HIR, LIR, bytecode, VM, JIT, WASM, MLIR, SPIR-V, GPU, values, symbols, stdlib cache |
 
 ## Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ Focused files covering one topic each, all runnable via `elle docs/<file>.md`.
 | Directory | Content |
 |-----------|---------|
 | [impl/](impl/) | Reader, HIR, LIR, bytecode, VM, JIT, WASM, MLIR, SPIR-V, GPU, values, symbols |
+| [stdlib-cache.md](stdlib-cache.md) | Disk cache for the standard-library compilation |
 
 ## Reference
 

--- a/docs/impl/mlir.md
+++ b/docs/impl/mlir.md
@@ -2,7 +2,10 @@
 
 > **Feature-gated:** The MLIR backend requires `--features mlir` at build
 > time and a working LLVM 22 + MLIR install (the `melior` crate links to
-> them). It is disabled by default.
+> them). It is disabled by default. If your MLIR install lives outside the
+> system prefix, set `MLIR_SYS_220_PREFIX` to its root in the `[env]` table
+> of `~/.cargo/config.toml`. That file is per-user, so the repository
+> carries no machine-specific paths.
 
 The MLIR backend is a tier-2 path that takes a hot, **GPU-eligible**
 `LirFunction`, lowers it through the MLIR `arith` / `func` / `cf` /

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -111,6 +111,26 @@ is ordinary, and writing the path directly lets one read the other's
 half-written file, or edits an inode a reader already holds open. Same
 directory because a rename is atomic only within one filesystem.
 
+## What the cached path does not restore
+
+`ClosureTemplate.syntax` — the original lambda node, captured for eval
+environment reconstruction — does not cross the cache. Its only reader is
+`(meta/origin f)`, which reports a closure's `{:file :line :col}` from that
+node's span, so a stdlib closure has an origin on the compiled path and `nil`
+on the cached one.
+
+Nothing in the tree depends on it: the corpus exercises `meta/origin` only on
+closures it compiles itself. The loss is bounded to values the cache restored —
+a closure a cache-hit runtime compiles still carries its syntax — and
+`a_cached_stdlib_closure_has_no_origin_but_user_code_keeps_its_own` pins both
+halves.
+
+Carrying it would mean shipping a syntax tree per template through
+`SendSyntax`, which cannot represent `SyntaxLiteral` (the macro-template symbol
+quasiquote embeds) and would grow the file substantially. The image work in
+docs/impl/image.md makes syntax region-native, at which point it is ordinary
+body data rather than a codec's problem.
+
 ## Serialization format
 
 The payload is a single `StoredBytecode` struct

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -63,6 +63,13 @@ instance that wrote a cache from the instance that read it.
 cache that silently never hits still yields a working runtime, so behaviour
 alone cannot distinguish the two; the tests assert on this instead.
 
+A `sys/spawn` worker builds its own runtime on a new thread and runs
+`init_stdlib` there, so it caches too. It reaches the spawning instance only
+through `ctx.vm()`, so the policy is recorded on the VM by
+`RuntimeCore::load_stdlib` and moved into the worker thread beside the Unicode
+generation — a worker caches where its parent was told to, never in the
+process-wide directory.
+
 ## Serialization format
 
 The on-disk format is a single `StoredBytecode` struct

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -27,15 +27,21 @@ recompile, and store failures are silently ignored.
 ## Cache key and invalidation
 
 ```
-cache_key = hash(stdlib source, elle version, FORMAT_VERSION,
+cache_key = hash(stdlib source, build identity, FORMAT_VERSION,
                  primitive-table identity) + ".bin"
 ```
 
 - **stdlib source**: the text embedded via `include_str!`; a source change
   naturally invalidates it.
-- **elle version**: `CARGO_PKG_VERSION`. Compiler changes alter emitted
-  bytecode, so the version is part of the key; override with the
-  `ELLE_CACHE_VERSION` env var (tests and debugging).
+- **build identity**: the running executable's length and modification time
+  (`std::env::current_exe`). Not the version string: two builds of one version
+  compile stdlib differently the moment the emitter or a pass changes, and a
+  key blind to the rebuild hands every `Runtime::new()` — the one in each test
+  included — bytecode the previous binary produced, so a test failure stops
+  implicating the branch that caused it. It also covers the ids `prim_id_of`
+  appends outside the canonical tables (trait methods, FFI callbacks), which
+  the table identity below cannot see. A binary that cannot identify itself
+  gets no cache at all rather than sharing one.
 - **FORMAT_VERSION**: a hard version number bumped manually on incompatible
   layout changes; validated on load.
 - **primitive-table identity**: the ordered names and aliases of every

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -94,6 +94,12 @@ compiles.
 This detects corruption and truncation, not forgery. A writable cache directory
 is a code-execution surface like any other loadable artifact.
 
+A store never writes the final path. It writes a temporary file in the same
+directory and renames it over the target: two elle processes starting at once
+is ordinary, and writing the path directly lets one read the other's
+half-written file, or edits an inode a reader already holds open. Same
+directory because a rename is atomic only within one filesystem.
+
 ## Serialization format
 
 The payload is a single `StoredBytecode` struct

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -44,8 +44,24 @@ cache_key = hash(stdlib source, elle version, FORMAT_VERSION,
   that minted it, so any addition, removal, rename, or reorder must
   invalidate the cache.
 
-Cache directory defaults to `$XDG_CACHE_HOME/elle/stdlib-cache`
-(`~/.cache` without XDG); override with `ELLE_CACHE_DIR`.
+## Where the cache lives
+
+The directory is a **construction parameter**, `StdlibCache`, passed to
+`Runtime::with_stdlib_cache` and threaded to `try_load`/`try_store`. It is not
+read from process-global state: the suite builds many runtimes across threads,
+and a directory that travels with the instance is what keeps one runtime's
+cache invisible to the runtime beside it — and what lets a test tell the
+instance that wrote a cache from the instance that read it.
+
+| Variant | Directory |
+|---------|-----------|
+| `Process` (the default) | `stdlib-cache` beneath the `--cache=<dir>` directory; `--cache=` turns caching off for the process |
+| `Dir(path)` | `path`, whatever the process-wide choice is |
+| `Off` | none — always compile |
+
+`Runtime::stdlib_source()` reports which side of the fork an instance took. A
+cache that silently never hits still yields a working runtime, so behaviour
+alone cannot distinguish the two; the tests assert on this instead.
 
 ## Serialization format
 

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -27,7 +27,8 @@ recompile, and store failures are silently ignored.
 ## Cache key and invalidation
 
 ```
-cache_key = hash(stdlib source, elle version, FORMAT_VERSION) + ".bin"
+cache_key = hash(stdlib source, elle version, FORMAT_VERSION,
+                 primitive-table identity) + ".bin"
 ```
 
 - **stdlib source**: the text embedded via `include_str!`; a source change
@@ -37,6 +38,11 @@ cache_key = hash(stdlib source, elle version, FORMAT_VERSION) + ".bin"
   `ELLE_CACHE_VERSION` env var (tests and debugging).
 - **FORMAT_VERSION**: a hard version number bumped manually on incompatible
   layout changes; validated on load.
+- **primitive-table identity**: the ordered names and aliases of every
+  canonical primitive (`hash_prim_table_identity`). A serialized native-fn
+  immediate carries a `prim_id` that is only valid against the exact table
+  that minted it, so any addition, removal, rename, or reorder must
+  invalidate the cache.
 
 Cache directory defaults to `$XDG_CACHE_HOME/elle/stdlib-cache`
 (`~/.cache` without XDG); override with `ELLE_CACHE_DIR`.
@@ -104,14 +110,16 @@ These two fields were missing from `SendableClosure`; adding them makes the
 send/spawn path and the cache path share the same machinery and incidentally
 fixes a send/spawn omission.
 
-### `SendValue` uses a symmetric hand-written Mirror enum serde
+### `SendValue` and `TableKey` serialize through symmetric mirror enums
 
-For scalar values (int/float/bool/nil/keyword/symbol/native-fn), hand-written
-tuple serialization can drift from derived deserialization (bincode's enum-tag
-encoding differs), so both sides are written against a symmetric Mirror enum.
-Heap values (string/struct/closure instances, …) are rejected on this path —
-compound literals in the constant pool lower to `MaterializeConst` templates at
-compile time and never enter the pool.
+Hand-written tuple serialization drifts from derived deserialization
+(bincode's enum-tag encoding differs), so both directions of each impl go
+through one derived mirror enum (`src/value/send/mirror.rs`). A symbol
+`TableKey` or symbol `Value` refuses to serialize: it carries only a
+process-local id, no name a loader could re-intern — symbols cross by name as
+`SendValue::Symbol` or `LirConst::Symbol` instead. Heap `Value`s are likewise
+rejected — compound literals in the constant pool lower to `MaterializeConst`
+templates at compile time and never enter the pool.
 
 ## Integration point
 

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -94,6 +94,17 @@ compiles.
 This detects corruption and truncation, not forgery. A writable cache directory
 is a code-execution surface like any other loadable artifact.
 
+A store prunes: after the rename, every other `.bin` in the directory is
+removed. The key follows the binary, so every rebuild mints a new one and
+orphans the last one's file — at ~16 MB each, a day of rebuilds fills a
+directory nobody looks at. Pruning runs *after* the rename, never before, so a
+store that fails leaves the directory as it found it. A removal that fails is
+ignored; it is disk hygiene, not correctness.
+
+One consequence worth knowing: a debug and a release binary sharing one
+directory evict each other, so alternating between them costs one stdlib
+compile per switch. Give them separate directories (`--cache=`) if that matters.
+
 A store never writes the final path. It writes a temporary file in the same
 directory and renames it over the target: two elle processes starting at once
 is ordinary, and writing the path directly lets one read the other's

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -76,9 +76,27 @@ through `ctx.vm()`, so the policy is recorded on the VM by
 generation — a worker caches where its parent was told to, never in the
 process-wide directory.
 
+## File layout
+
+A cache file is an 8-byte little-endian hash of its payload, then the payload:
+
+```
+[u64 payload hash][bincode StoredBytecode]
+```
+
+`bincode` reports that bytes *decoded*, never that they are the bytes this
+binary wrote. Without the prefix, eight flipped bytes decode "successfully" and
+arrive at the VM as instructions (`invalid opcode 0xff`), and a flip deeper in
+a payload is absorbed into stdlib and reported as a hit. A hash mismatch, or a
+file shorter than the prefix, is a **miss**: the loader says so and the caller
+compiles.
+
+This detects corruption and truncation, not forgery. A writable cache directory
+is a code-execution surface like any other loadable artifact.
+
 ## Serialization format
 
-The on-disk format is a single `StoredBytecode` struct
+The payload is a single `StoredBytecode` struct
 (`src/compiler/stdlib_cache.rs`), **100% owned data** — no `Rc`, no pointers,
 no process-local symbol-table ids:
 

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -246,6 +246,6 @@ bincode.
   automatically; the cost is one recompile after upgrading elle. Acceptable.
 - **Fate of `Value` scalar serde**: entry constants now go entirely through
   `SendableClosure`, no longer through `StoredValue`; but LIR `ValueConst`
-  still uses the scalar serde, so it stays for now.
-- **Silent store failure**: the cache is only a speedup; a failed write does
+- **Store failure does not block startup**: the cache is only a speedup; a
+  failed write is reported on stderr and the fresh compile proceeds.
   not block startup.

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -242,8 +242,8 @@ bincode.
 
 ## Trade-offs
 
-- **Cache key includes the elle version**: compiler changes invalidate
-  automatically; the cost is one recompile after upgrading elle. Acceptable.
+- **Cache key follows the binary**: any rebuild invalidates automatically; the
+  cost is one recompile per new binary. Acceptable.
 - **Fate of `Value` scalar serde**: entry constants now go entirely through
   `SendableClosure`, no longer through `StoredValue`; but LIR `ValueConst`
 - **Store failure does not block startup**: the cache is only a speedup; a

--- a/docs/stdlib-cache.md
+++ b/docs/stdlib-cache.md
@@ -1,0 +1,159 @@
+# Standard Library Disk Cache
+
+`stdlib.lisp` (~2850 lines) is recompiled on every process start. The
+`compile_file` front end (expand → analyze → regions → lower → emit) costs
+~2.4s (release) while the compiled artifact takes ~5ms to execute. The front
+end is **deterministic**: same source, same elle binary → same bytecode. This
+design turns that work into a one-time cost by serializing the compiled
+`Bytecode` to disk, so later processes deserialize instead of recompiling.
+
+## High-level flow
+
+```
+First start                  Later starts
+────────────                  ────────────
+compile_file(STDLIB)         try_load (cache hit)
+      │                            │
+      ▼                            ▼
+ try_store ──► cache.bin ──► deserialize & rebuild Bytecode
+      │                            │
+      └──────────► vm.execute ◄────┘
+```
+
+The cache is a speedup, not a correctness dependency: any failure (no directory
+permission, corrupt file, format-version mismatch) falls back to a full
+recompile, and store failures are silently ignored.
+
+## Cache key and invalidation
+
+```
+cache_key = hash(stdlib source, elle version, FORMAT_VERSION) + ".bin"
+```
+
+- **stdlib source**: the text embedded via `include_str!`; a source change
+  naturally invalidates it.
+- **elle version**: `CARGO_PKG_VERSION`. Compiler changes alter emitted
+  bytecode, so the version is part of the key; override with the
+  `ELLE_CACHE_VERSION` env var (tests and debugging).
+- **FORMAT_VERSION**: a hard version number bumped manually on incompatible
+  layout changes; validated on load.
+
+Cache directory defaults to `$XDG_CACHE_HOME/elle/stdlib-cache`
+(`~/.cache` without XDG); override with `ELLE_CACHE_DIR`.
+
+## Serialization format
+
+The on-disk format is a single `StoredBytecode` struct
+(`src/compiler/stdlib_cache.rs`), **100% owned data** — no `Rc`, no pointers,
+no process-local symbol-table ids:
+
+```rust
+struct StoredBytecode {
+    format_version: u32,
+    entry: SendableClosure,               // synthetic entry template
+    intern_table: Vec<SendableClosure>,   // intern table of entry-reachable closure constants
+    signal_projection: Option<HashMap<String, Signal>>,
+}
+```
+
+### Why wrap the whole Bytecode in a synthetic entry `ClosureTemplate`?
+
+The stdlib compile product is a `Bytecode` (entry instructions + constant pool
++ `child_protos` nested-lambda blueprints). Besides scalars, the constant pool
+holds **36 closures with environments and 78 CaptureCells** (`init_stdlib`'s
+returned closure, `map`, …), with cycles (closures referencing templates and
+templates referencing closures in their constants). A bespoke scalar format
+cannot handle this graph, but elle's send module (`value/send`, used to move
+closures across threads/processes) already has an intern-table mechanism for
+cycles.
+
+So the `Bytecode` is wrapped as a synthetic `ClosureTemplate` with arity
+`Exact(0)` (the entry runs as a thunk and is not JIT'd) and serialized through
+`serialize_templates` uniformly:
+
+- `instructions` → bytecode
+- `constants` → entry constant pool
+- `child_protos` → nested-lambda blueprints
+- `frame_release_slots/regions`, `merged_slots` → region release tables
+- closure instances in the constant pool are deep-copied and interned by pointer
+
+The two extra fields on `StoredBytecode` (`signal_projection`,
+`format_version`) don't exist on `ClosureTemplate`, so they ride alongside.
+
+### LIR must be preserved
+
+The JIT compiles from `ClosureTemplate.lir_function` in the background. If the
+cache dropped LIR, every stdlib function would run **interpreted forever** (no
+LIR → never submitted to the JIT worker) — a silent runtime regression, worse
+than not caching. LIR is therefore serialized with the templates; only the
+`doc`/`syntax` `Rc` fields are skipped (they are already `None` after the
+cross-thread conversion, and the JIT never reads them).
+
+### Symbols across processes
+
+Symbol ids are process-local and cannot be serialized directly. Every
+symbol/keyword is carried **by name** and re-interned into the loading
+process's table. `LirConst::Symbol` in LIR materializes ids directly, so the
+`symbol_names` map is used to remap LIR symbol ids wholesale before
+deserialization.
+
+### `frame_release_slots/regions` added to `SendableClosure`
+
+Probing showed 346 templates carrying 4479 release slots — not droppable.
+These two fields were missing from `SendableClosure`; adding them makes the
+send/spawn path and the cache path share the same machinery and incidentally
+fixes a send/spawn omission.
+
+### `SendValue` uses a symmetric hand-written Mirror enum serde
+
+For scalar values (int/float/bool/nil/keyword/symbol/native-fn), hand-written
+tuple serialization can drift from derived deserialization (bincode's enum-tag
+encoding differs), so both sides are written against a symmetric Mirror enum.
+Heap values (string/struct/closure instances, …) are rejected on this path —
+compound literals in the constant pool lower to `MaterializeConst` templates at
+compile time and never enter the pool.
+
+## Integration point
+
+`init_stdlib` in `primitives/module_init.rs`:
+
+1. `try_load`: on hit, deserialize and rebuild the `Bytecode`, then execute.
+2. On miss (or decode failure): `compile_file`, then `try_store` to disk,
+   then execute.
+3. Hit and miss share `register_exports` (registering exports into the
+   compilation cache's PrimitiveMeta), so both paths behave identically.
+
+## Measured effect
+
+Release build, cordis-pi startup (`[timing] boot`):
+
+| Scenario | boot time |
+|---|---|
+| No cache (first compile of stdlib) | 3.13s |
+| Cache hit | 1.36–1.86s |
+| of which deserialization | 190–300ms |
+
+Saves ~1.5s per start (~50%). Deserialization is the main remaining cost;
+future work could lazy-load LIR separately or switch to a faster encoder than
+bincode.
+
+## Tests
+
+- `bytecode_roundtrip_preserves_lir_and_closures`: after store → load the
+  bytecode is equivalent (instructions identical, scalar-constant kinds/counts
+  identical, LIR presence identical) and executes to the same result
+  (`5 == 5`).
+- `stdlib_cache_hit_produces_working_runtime`: two `Runtime`s created in
+  sequence; the second must hit the disk cache and produce a fully working
+  stdlib. The assertion is functional — timing is asserted in the release-mode
+  boot benchmark, since debug compile time masks the difference.
+
+## Trade-offs
+
+- **Cache key includes the elle version**: compiler changes invalidate
+  automatically; the cost is one recompile after upgrading elle. Acceptable.
+- **Fate of `Value` scalar serde**: entry constants now go entirely through
+  `SendableClosure`, no longer through `StoredValue`; but LIR `ValueConst`
+  still uses the scalar serde, so it stays for now.
+- **Silent store failure**: the cache is only a speedup; a failed write does
+  not block startup.

--- a/src/compiler/AGENTS.md
+++ b/src/compiler/AGENTS.md
@@ -1,12 +1,13 @@
 # compiler
 
-Bytecode instruction definitions and debug formatting.
+Bytecode instruction definitions, debug formatting, and the stdlib disk cache.
 
 ## Responsibility
 
 - Define the `Instruction` enum (bytecode opcodes)
 - Define the `Bytecode` struct (instructions + constants)
 - Provide debug formatting for bytecode disassembly
+- Persist and restore the compiled standard library
 
 ## Submodules
 
@@ -15,6 +16,7 @@ Bytecode instruction definitions and debug formatting.
 | `bytecode.rs` | `Bytecode` struct, encoding, disassembly entry points |
 | `bytecode/instruction.rs` | `Instruction` enum, opcode decoding |
 | `bytecode/disasm.rs` | Debug formatting for bytecode disassembly |
+| `stdlib_cache.rs` | Disk cache for the compiled stdlib (docs/impl/stdlib-cache.md) |
 
 ## Dependents
 
@@ -35,6 +37,13 @@ Bytecode instruction definitions and debug formatting.
 |------|----------|---------|
 | `Instruction` | `bytecode/instruction.rs` | Bytecode opcodes |
 | `Bytecode` | `bytecode.rs` | Instructions + constants |
+| `StdlibCache` | `stdlib_cache.rs` | Where a runtime caches its stdlib: `Process`, `Dir`, or `Off`. A construction parameter, passed to `Runtime::with_stdlib_cache` — never read from process-global state |
+| `StoredBytecode` | `stdlib_cache.rs` | The cache file's payload: fully owned data, symbols by name, LIR preserved |
+
+The cache is an optimization with no correctness role: every failure — an
+unidentifiable binary, a hash mismatch, a truncated file, a format bump — falls
+back to a full compile, and a rejected file is replaced rather than left to be
+rejected again. `Runtime::stdlib_source()` says which path an instance took.
 ## Type guard instructions
 
 Type guard instructions are used in pattern matching to check value types:

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,4 +1,5 @@
 pub mod bytecode;
+pub mod stdlib_cache;
 
 pub use bytecode::{
     disassemble, disassemble_lines, format_bytecode_with_constants, format_bytecode_with_protos,

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -259,6 +259,26 @@ fn store_atomically(
         .map_err(|e| std::io::Error::other(e.to_string()))
 }
 
+/// Refuse a `SendableClosure` whose LIR names a symbol its `symbol_names`
+/// cannot translate. Recurses through `child_protos`.
+fn check_lir_symbols_are_translatable(
+    sc: &crate::value::send::SendableClosure,
+) -> Result<(), String> {
+    if let Some(lir) = sc.lir_function.as_ref() {
+        let missing = crate::value::send::untranslatable_lir_symbols(lir, &sc.symbol_names);
+        if !missing.is_empty() {
+            return Err(format!(
+                "LIR of {} names symbol ids absent from its symbol_names: {missing:?}",
+                sc.name.as_deref().unwrap_or("<anonymous>")
+            ));
+        }
+    }
+    for child in &sc.child_protos {
+        check_lir_symbols_are_translatable(child)?;
+    }
+    Ok(())
+}
+
 /// Remove every cache file in `dir` except `keep`.
 ///
 /// The key follows the binary, so every rebuild mints a new one and orphans
@@ -328,6 +348,15 @@ pub fn store_bytecode(
     let (templates, intern_table) =
         crate::value::send::serialize_templates(std::slice::from_ref(&entry), vm.heap(), symbols)?;
     let entry = templates.into_iter().next().expect("one template");
+    // Every LIR symbol must be translatable on load. The load-path remap is a
+    // lookup: an id absent from `symbol_names` survives untouched into the
+    // loading process, where the JIT materializes it as whatever symbol happens
+    // to hold that id. Refuse to write a file that would do that — a missing
+    // cache costs a compile, a wrong symbol costs a wrong program.
+    check_lir_symbols_are_translatable(&entry)?;
+    for sc in &intern_table {
+        check_lir_symbols_are_translatable(sc)?;
+    }
     Ok(StoredBytecode {
         format_version: FORMAT_VERSION,
         entry,

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -63,19 +63,37 @@ pub struct StoredBytecode {
     /// difference on the cached path.
     pub(crate) fn_inline: crate::hir::typeinfer::StoredFnInlineRegistry,
 }
-/// Cache directory, honoring `ELLE_CACHE_DIR` override (used in tests).
-fn cache_dir() -> std::path::PathBuf {
-    if let Ok(dir) = std::env::var("ELLE_CACHE_DIR") {
-        return std::path::PathBuf::from(dir);
+/// Where a runtime caches its compiled stdlib.
+///
+/// This is a construction parameter, not process-global state. A `Runtime` is
+/// built per instance and the suite builds many of them across threads, so the
+/// directory has to travel with the instance that uses it: a global would make
+/// one test's cache visible to every other test running beside it, and the
+/// runtime that wrote it indistinguishable from the runtime that read it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum StdlibCache {
+    /// The process-wide choice: `stdlib-cache` beneath the `--cache=<dir>`
+    /// directory. `--cache=` (empty) turns caching off for the process.
+    #[default]
+    Process,
+    /// Cache in this directory, whatever the process-wide choice is.
+    Dir(std::path::PathBuf),
+    /// Never read or write a cache file; compile every time.
+    Off,
+}
+
+impl StdlibCache {
+    /// The directory to cache in, or `None` when caching is off.
+    fn dir(&self) -> Option<std::path::PathBuf> {
+        match self {
+            StdlibCache::Off => None,
+            StdlibCache::Dir(d) => Some(d.clone()),
+            StdlibCache::Process => crate::config::get()
+                .cache
+                .as_ref()
+                .map(|base| std::path::PathBuf::from(base).join("stdlib-cache")),
+        }
     }
-    let base = std::env::var("XDG_CACHE_HOME")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| {
-            std::env::var("HOME")
-                .map(|h| std::path::PathBuf::from(h).join(".cache"))
-                .unwrap_or_else(|_| std::path::PathBuf::from(".cache"))
-        });
-    base.join("elle").join("stdlib-cache")
 }
 
 /// Content hash of the stdlib source + elle version + primitive-table
@@ -106,11 +124,12 @@ fn cache_key(stdlib_source: &str) -> String {
 /// the caller recompiles, and the next store overwrites the bad file.
 pub fn try_load(
     stdlib_source: &str,
+    cache: &StdlibCache,
     vm: &mut crate::vm::VM,
     symbols: &mut crate::symbol::SymbolTable,
     cctx: &mut crate::pipeline::CompileCtx,
 ) -> Option<Result<Bytecode, String>> {
-    let path = cache_dir().join(cache_key(stdlib_source));
+    let path = cache.dir()?.join(cache_key(stdlib_source));
     let bytes = std::fs::read(&path).ok()?;
     let stored: StoredBytecode = match bincode::deserialize(&bytes) {
         Ok(s) => s,
@@ -123,12 +142,13 @@ pub fn try_load(
 /// cache is an optimization; a fresh compile is always valid.
 pub fn try_store(
     stdlib_source: &str,
+    cache: &StdlibCache,
     bytecode: &Bytecode,
     vm: &mut crate::vm::VM,
     symbols: &crate::symbol::SymbolTable,
     cctx: &mut crate::pipeline::CompileCtx,
 ) {
-    let dir = cache_dir();
+    let Some(dir) = cache.dir() else { return };
     if let Err(e) = std::fs::create_dir_all(&dir) {
         eprintln!("[stdlib-cache] mkdir failed: {e}");
         return;
@@ -266,6 +286,7 @@ pub fn load_bytecode(
 mod tests {
     use super::*;
     use crate::pipeline::compile_file;
+    use crate::primitives::module_init::StdlibSource;
     use crate::runtime::Runtime;
 
     /// Compile a snippet through the full pipeline, then assert that
@@ -273,9 +294,10 @@ mod tests {
     /// and constants, closures rebuilt, LIR preserved).
     #[test]
     fn bytecode_roundtrip_preserves_lir_and_closures() {
-        let _dir = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("ELLE_CACHE_DIR", _dir.path());
-        let mut rt = Runtime::new(); // full stdlib: `map` is a stdlib fn
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Its own directory: this test writes a cache and must not read, write,
+        // or be read by whatever else the suite is running beside it.
+        let mut rt = Runtime::with_stdlib_cache(StdlibCache::Dir(dir.path().to_path_buf()));
         let (result, loaded) = {
             let (vm, symbols, cctx) = rt.parts();
             let src = r#"
@@ -330,22 +352,36 @@ mod tests {
         let r_loaded = run(&loaded);
         assert_eq!(r_orig, r_loaded, "original and reloaded bytecode agree");
         eprintln!("roundtrip ok: {r_orig} == {r_loaded}");
-        std::env::remove_var("ELLE_CACHE_DIR");
     }
 
-    /// Two Runtime instances: the first compiles stdlib and writes the cache,
-    /// the second must hit it (cache-load path) and produce working stdlib.
+    /// Two runtimes over one cache directory: the first compiles stdlib and
+    /// writes the cache, the second must load from it — and must still have a
+    /// working stdlib afterwards.
     #[test]
-    fn stdlib_cache_hit_produces_working_runtime() {
+    fn second_runtime_on_a_shared_cache_dir_loads_stdlib_from_it() {
         let dir = tempfile::tempdir().expect("tempdir");
-        std::env::set_var("ELLE_CACHE_DIR", dir.path());
-        let mut a = Runtime::new(); // compiles stdlib, writes cache
-                                    // The second runtime must hit the disk cache (not recompile) and
-                                    // produce a fully working stdlib. Functional check only — timing is
-                                    // asserted in the release-mode boot benchmark instead (debug builds
-                                    // skew it).
-        let mut b = Runtime::new(); // must load from cache
-        let probe = |rt: &mut Runtime| {
+        let cache = StdlibCache::Dir(dir.path().to_path_buf());
+
+        let mut a = Runtime::with_stdlib_cache(cache.clone());
+        assert_eq!(
+            a.stdlib_source(),
+            StdlibSource::Compiled,
+            "the first runtime meets an empty directory, so it must compile"
+        );
+
+        let mut b = Runtime::with_stdlib_cache(cache);
+        assert_eq!(
+            b.stdlib_source(),
+            StdlibSource::Cache,
+            "the second runtime must load what the first wrote; a cache that \
+             silently never hits still yields a working runtime, so behaviour \
+             alone cannot tell the two apart"
+        );
+
+        // Working stdlib on both sides. Functional check only — timing is
+        // asserted in the release-mode boot benchmark instead (debug builds
+        // skew it).
+        let probe = |rt: &mut Runtime| -> crate::value::Value {
             use crate::pipeline::compile_file_repl;
             let (vm, symbols, cctx) = rt.parts();
             let src = "(map (fn [x] (* x 2)) (quote (1 2 3)))";
@@ -355,6 +391,5 @@ mod tests {
         };
         let _ = probe(&mut a);
         let _ = probe(&mut b);
-        std::env::remove_var("ELLE_CACHE_DIR");
     }
 }

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -32,7 +32,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 /// Version tag: bump when the serialized layout changes in an incompatible way.
-const FORMAT_VERSION: u32 = 3;
+const FORMAT_VERSION: u32 = 4;
 
 /// Bytes of payload hash a cache file carries ahead of its `StoredBytecode`.
 const PAYLOAD_HASH_BYTES: usize = 8;

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -224,12 +224,37 @@ pub fn try_store(
             let path = dir.join(key);
             let mut file = payload_hash(&bytes).to_le_bytes().to_vec();
             file.extend_from_slice(&bytes);
-            if let Err(e) = std::fs::write(&path, file) {
+            // Write beside the target and rename over it. Two elle processes
+            // starting at once is ordinary, and writing the final path directly
+            // lets one read the other's half-written file — or edits the inode a
+            // reader already holds open. A rename is one atomic step within a
+            // directory, so the name refers to a complete file or the old one.
+            if let Err(e) = store_atomically(&dir, &path, &file) {
                 eprintln!("[stdlib-cache] write failed: {e}");
             }
         }
         Err(e) => eprintln!("[stdlib-cache] serialize failed: {e}"),
     }
+}
+
+/// Write `bytes` to `path` by way of a temporary file in the same directory.
+///
+/// Same directory because a rename is atomic only within one filesystem; a
+/// temp file elsewhere would fall back to a copy and reintroduce the torn read.
+fn store_atomically(
+    dir: &std::path::Path,
+    path: &std::path::Path,
+    bytes: &[u8],
+) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    tmp.write_all(bytes)?;
+    tmp.flush()?;
+    // `persist` renames; on failure the temp file is removed with the error, so
+    // a failed store leaves the directory as it found it.
+    tmp.persist(path)
+        .map(|_| ())
+        .map_err(|e| std::io::Error::other(e.to_string()))
 }
 
 /// Serialize compiled stdlib bytecode into the cache format.
@@ -588,6 +613,50 @@ mod tests {
             StdlibSource::Cache,
             "the runtime that rejected the file must also replace it, or every \
              later start pays the full compile again"
+        );
+    }
+
+    /// Two elle processes starting at once is an ordinary event, and a store
+    /// that writes the final path directly lets one of them read the other's
+    /// half-written file. The store must land whole or not at all.
+    ///
+    /// A held descriptor is the observable: writing the path in place edits the
+    /// inode the reader already has, while a rename leaves that inode alone and
+    /// swings the name to a new one.
+    #[test]
+    fn a_store_replaces_the_cache_file_instead_of_rewriting_it() {
+        use std::io::Read;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = StdlibCache::Dir(dir.path().to_path_buf());
+
+        drop(Runtime::with_stdlib_cache(cache.clone()));
+        let path = std::fs::read_dir(dir.path())
+            .expect("read cache dir")
+            .next()
+            .expect("the seeding runtime wrote a cache file")
+            .expect("entry")
+            .path();
+
+        // Unreadable, so the next runtime rejects it and must store over it.
+        const SENTINEL: &[u8] = b"the inode a reader already holds";
+        std::fs::write(&path, SENTINEL).expect("plant a rejected file");
+        let mut held = std::fs::File::open(&path).expect("hold the old inode open");
+
+        drop(Runtime::with_stdlib_cache(cache));
+
+        let mut seen = Vec::new();
+        held.read_to_end(&mut seen)
+            .expect("read through the held fd");
+        // Compared as a bool: the rewritten file is megabytes, and dumping it
+        // into the failure would bury the one fact that matters.
+        assert!(
+            seen == SENTINEL,
+            "the store must rename a complete file into place; rewriting the \
+             path edits the inode another process is already reading — the \
+             held descriptor saw {} bytes, not the {}-byte sentinel",
+            seen.len(),
+            SENTINEL.len()
         );
     }
 }

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -1,0 +1,534 @@
+//! Disk cache for the standard-library compilation.
+//!
+//! `init_stdlib` recompiles stdlib.lisp (~2850 lines) on every process start,
+//! costing ~2.4s in `compile_file` before execution (5ms) even runs. The whole
+//! front end (expand → analyze → regions → lower → emit) is deterministic:
+//! same stdlib source, same elle binary → same bytecode. This module turns that
+//! work into a one-time cost by serializing the compiled `Bytecode` (plus the
+//! per-closure `ClosureTemplate`s and their LIR, so the JIT keeps working) to a
+//! content-addressed cache file, keyed by elle version + stdlib source hash.
+//!
+//! Serialization strategy: the cache format is a plain `StoredBytecode` struct
+//! that is 100% owned data — no `Rc`, no pointers, no symbol-table ids. Symbols
+//! and keywords are carried *by name* (their ids are per-process), and are
+//! re-interned on load. `Value`s that appear in the constant pool are scalars
+//! (int/float/bool/nil/keyword/symbol) by construction — string and compound
+//! literals lower to `MaterializeConst` templates, not pool constants — so the
+//! pool serializes cheaply. Closures recurse via `child_protos`.
+//!
+//! LIR: the JIT compiles from `ClosureTemplate.lir_function` in the background.
+//! If the cache dropped LIR, every stdlib function would run interpreted
+//! forever (no LIR → never submitted to the JIT worker) — a silent runtime
+//! regression, so LIR is serialized too, with its `doc`/`syntax` Rc fields
+//! skipped (they are already `None` after the cross-thread conversion in
+//! `sendable_from_template`; JIT never reads them).
+
+use crate::compiler::Bytecode;
+use crate::signals::Signal;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Version tag: bump when the serialized layout changes in an incompatible way.
+const FORMAT_VERSION: u32 = 1;
+
+/// The on-disk form of a compiled module's entry `Bytecode`.
+///
+/// The whole `Bytecode` is wrapped as a synthetic entry `ClosureTemplate` and
+/// serialized through the send module's template path (`serialize_templates`),
+/// which deep-copies the entry constant pool (it may contain live closure
+/// instances — stdlib's `init_stdlib` result closure, `map`, etc.), the
+/// nested-lambda blueprints, their LIR, and the region-release tables. The
+/// two extra fields below (`signal_projection`, `format_version`) don't exist
+/// on `ClosureTemplate`, so they ride alongside.
+#[derive(Serialize, Deserialize)]
+pub struct StoredBytecode {
+    pub format_version: u32,
+    /// The entry template: `instructions` → bytecode, `constants` → entry
+    /// pool, `child_protos` → nested lambdas. Symbols by name; LIR preserved.
+    pub entry: crate::value::send::SendableClosure,
+    /// Intern table of closure constants reachable from the entry's pool and
+    /// its child templates, referenced by `Ref(idx)`.
+    pub intern_table: Vec<crate::value::send::SendableClosure>,
+    pub signal_projection: Option<HashMap<String, Signal>>,
+    /// Cross-unit dispatch-wrapper registry (stdlib `push`/`put`/`add`
+    /// monomorphization), snapshotted because the disk cache skips the stdlib
+    /// compile that would otherwise populate it.
+    pub(crate) dispatch_wrappers: crate::hir::typeinfer::StoredDispatchRegistry,
+    /// Cross-unit inline-fn registry (stdlib `inc`/`dec`/… HOF-argument
+    /// inlining), likewise snapshotted. Templates whose body contains a `let`
+    /// are omitted (their clone needs the defining arena); a performance-only
+    /// difference on the cached path.
+    pub(crate) fn_inline: crate::hir::typeinfer::StoredFnInlineRegistry,
+}
+/// Cache directory, honoring `ELLE_CACHE_DIR` override (used in tests).
+fn cache_dir() -> std::path::PathBuf {
+    if let Ok(dir) = std::env::var("ELLE_CACHE_DIR") {
+        return std::path::PathBuf::from(dir);
+    }
+    let base = std::env::var("XDG_CACHE_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::env::var("HOME")
+                .map(|h| std::path::PathBuf::from(h).join(".cache"))
+                .unwrap_or_else(|_| std::path::PathBuf::from(".cache"))
+        });
+    base.join("elle").join("stdlib-cache")
+}
+
+/// Content hash of the stdlib source + elle version, forming the cache key.
+fn cache_key(stdlib_source: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    stdlib_source.hash(&mut hasher);
+    // Include the binary/format identity so a changed elle (e.g. a compiler
+    // change that alters emitted bytecode) naturally invalidates the cache.
+    std::env::var("ELLE_CACHE_VERSION")
+        .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string())
+        .hash(&mut hasher);
+    FORMAT_VERSION.hash(&mut hasher);
+    format!("{:016x}.bin", hasher.finish())
+}
+
+/// Try to load the compiled stdlib from the disk cache.
+///
+/// Returns `None` when no cache is enabled or the file is absent; `Some(Err)`
+/// when the cache file exists but fails to parse (corrupt / version drift) —
+/// the caller recompiles, and the next store overwrites the bad file.
+pub fn try_load(
+    stdlib_source: &str,
+    vm: &mut crate::vm::VM,
+    symbols: &mut crate::symbol::SymbolTable,
+    cctx: &mut crate::pipeline::CompileCtx,
+) -> Option<Result<Bytecode, String>> {
+    let path = cache_dir().join(cache_key(stdlib_source));
+    let bytes = std::fs::read(&path).ok()?;
+    let stored: StoredBytecode = match bincode::deserialize(&bytes) {
+        Ok(s) => s,
+        Err(e) => return Some(Err(format!("cache decode: {e}"))),
+    };
+    Some(load_bytecode(stored, vm, symbols, cctx))
+}
+
+/// Store the compiled stdlib to the disk cache. Failures are ignored — the
+/// cache is an optimization; a fresh compile is always valid.
+pub fn try_store(
+    stdlib_source: &str,
+    bytecode: &Bytecode,
+    vm: &mut crate::vm::VM,
+    symbols: &crate::symbol::SymbolTable,
+    cctx: &mut crate::pipeline::CompileCtx,
+) {
+    let dir = cache_dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("[stdlib-cache] mkdir failed: {e}");
+        return;
+    }
+    let stored = match store_bytecode(bytecode, vm, symbols, cctx) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[stdlib-cache] store failed: {e}");
+            return;
+        }
+    };
+    match bincode::serialize(&stored) {
+        Ok(bytes) => {
+            let path = dir.join(cache_key(stdlib_source));
+            if let Err(e) = std::fs::write(&path, bytes) {
+                eprintln!("[stdlib-cache] write failed: {e}");
+            }
+        }
+        Err(e) => eprintln!("[stdlib-cache] serialize failed: {e}"),
+    }
+}
+
+/// Serialize compiled stdlib bytecode into the cache format.
+///
+/// The entry constant pool is scalar by construction; the nested-lambda
+/// blueprints (`child_protos`) may contain live closure constants, LIR, and
+/// region-release tables, so they go through the send module's template
+/// serialization (which deep-copies closures and interns them by pointer).
+/// Serialize compiled stdlib bytecode into the cache format.
+///
+/// The whole `Bytecode` is wrapped as a synthetic entry `ClosureTemplate`
+/// (arity `Exact(0)` — the entry runs as a thunk) and serialized through the
+/// send module's template path. This handles everything uniformly: the entry
+/// constant pool (which may hold live closure instances), the nested-lambda
+/// blueprints, their LIR (so the JIT keeps working after reload), and the
+/// region-release tables.
+pub fn store_bytecode(
+    bytecode: &Bytecode,
+    vm: &mut crate::vm::VM,
+    symbols: &crate::symbol::SymbolTable,
+    cctx: &mut crate::pipeline::CompileCtx,
+) -> Result<StoredBytecode, String> {
+    use crate::value::ClosureTemplate;
+    let (dispatch_wrappers, fn_inline) = cctx.compile_registries_mut();
+    let stored_dispatch = dispatch_wrappers.to_stored(symbols);
+    let stored_fn_inline = fn_inline.to_stored(symbols);
+    let entry = ClosureTemplate {
+        bytecode: Rc::new(bytecode.instructions.clone()),
+        arity: crate::value::Arity::Exact(0),
+        num_locals: 0,
+        num_captures: 0,
+        num_params: 0,
+        constants: Rc::new(bytecode.constants.clone()),
+        signal: bytecode.signal,
+        capture_params_mask: 0,
+        capture_locals_mask: crate::value::CaptureMask::empty(),
+        symbol_names: Rc::new(bytecode.symbol_names.clone()),
+        location_map: Rc::new(bytecode.location_map.clone()),
+        lir_function: None, // the entry thunk is not JIT'd; closures carry their own LIR
+        doc: None,
+        syntax: None,
+        vararg_kind: crate::hir::VarargKind::List,
+        name: None,
+        wasm_func_idx: None,
+        spirv: std::cell::OnceCell::new(),
+        region_table: Vec::new(),
+        merged_slots: bytecode.merged_slots.clone(),
+        frame_release_slots: bytecode.frame_release_slots.clone(),
+        frame_release_regions: bytecode.frame_release_regions.clone(),
+        child_protos: Rc::new(bytecode.child_protos.clone()),
+    };
+    let entry = std::rc::Rc::new(entry);
+    let (templates, intern_table) =
+        crate::value::send::serialize_templates(std::slice::from_ref(&entry), vm.heap(), symbols)?;
+    let entry = templates.into_iter().next().expect("one template");
+    Ok(StoredBytecode {
+        format_version: FORMAT_VERSION,
+        entry,
+        intern_table,
+        signal_projection: bytecode.signal_projection.clone(),
+        dispatch_wrappers: stored_dispatch,
+        fn_inline: stored_fn_inline,
+    })
+}
+
+/// Rebuild a `Bytecode` from the cache format.
+///
+/// Every symbol is re-interned by name into the loading process's table, and
+/// the LIR embedded in the templates has its symbol ids remapped to the new
+/// table (the JIT materializes `LirConst::Symbol` ids directly).
+pub fn load_bytecode(
+    stored: StoredBytecode,
+    vm: &mut crate::vm::VM,
+    symbols: &mut crate::symbol::SymbolTable,
+    cctx: &mut crate::pipeline::CompileCtx,
+) -> Result<Bytecode, String> {
+    if stored.format_version != FORMAT_VERSION {
+        return Err(format!(
+            "stdlib cache format mismatch: {} != {}",
+            stored.format_version, FORMAT_VERSION
+        ));
+    }
+    let t0 = std::time::Instant::now();
+    let mut alloc = crate::primitives::ctx::Alloc::new(vm.heap());
+    let mut templates = crate::value::send::deserialize_templates(
+        vec![stored.entry],
+        stored.intern_table,
+        &mut alloc,
+        symbols,
+    )?;
+    if std::env::var("ELLE_PROFILE").is_ok() {
+        eprintln!("[stdlib-cache] deserialize_templates: {:?}", t0.elapsed());
+    }
+    let t1 = std::time::Instant::now();
+    let entry = templates
+        .pop()
+        .expect("deserialize_templates returns one per input");
+    if std::env::var("ELLE_PROFILE").is_ok() {
+        eprintln!("[stdlib-cache] pop+extract: {:?}", t1.elapsed());
+    }
+    // Restore the cross-unit registries the skipped stdlib compile would have
+    // populated.
+    let (dispatch_wrappers, fn_inline) = cctx.compile_registries_mut();
+    dispatch_wrappers.restore(stored.dispatch_wrappers, symbols);
+    fn_inline.restore(stored.fn_inline, symbols);
+    Ok(Bytecode {
+        instructions: (*entry.bytecode).clone(),
+        constants: (*entry.constants).clone(),
+        symbol_names: (*entry.symbol_names).clone(),
+        location_map: (*entry.location_map).clone(),
+        signal: entry.signal,
+        signal_projection: stored.signal_projection,
+        child_protos: (*entry.child_protos).clone(),
+        merged_slots: entry.merged_slots.clone(),
+        frame_release_slots: entry.frame_release_slots.clone(),
+        frame_release_regions: entry.frame_release_regions.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::compile_file;
+    use crate::runtime::Runtime;
+
+    /// Compile a snippet through the full pipeline, then assert that
+    /// store→load round-trips to an equivalent `Bytecode` (equal instructions
+    /// and constants, closures rebuilt, LIR preserved).
+    #[test]
+    fn bytecode_roundtrip_preserves_lir_and_closures() {
+        let _dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("ELLE_CACHE_DIR", _dir.path());
+        let mut rt = Runtime::new(); // full stdlib: `map` is a stdlib fn
+        let (result, loaded) = {
+            let (vm, symbols, cctx) = rt.parts();
+            let src = r#"
+(defn helper [x] (+ x 1))
+(+ (helper 1) (helper 2))
+"#;
+            let result = compile_file(src, symbols, cctx, "<test>").expect("compiles");
+            let bc = &result.bytecode;
+            assert!(!bc.instructions.is_empty());
+
+            let stored = store_bytecode(bc, vm, symbols, cctx).expect("stores");
+            let bytes = bincode::serialize(&stored).expect("serializes");
+            let decoded: StoredBytecode = bincode::deserialize(&bytes).expect("deserializes");
+            let loaded = load_bytecode(decoded, vm, symbols, cctx).expect("loads");
+            assert_eq!(loaded.instructions, bc.instructions, "instructions equal");
+            assert_eq!(loaded.signal, bc.signal);
+            assert_eq!(loaded.symbol_names.len(), bc.symbol_names.len());
+            assert_eq!(loaded.child_protos.len(), bc.child_protos.len());
+            // The constant pool is byte-identical on the scalar prefix; closure
+            // constants are NEW heap instances after reload (pointer-equal
+            // comparison would spuriously fail), so compare scalar kinds/counts.
+            assert_eq!(
+                bc.constants.len(),
+                loaded.constants.len(),
+                "same number of constants"
+            );
+            for (a, b) in bc.constants.iter().zip(&loaded.constants) {
+                assert_eq!(a.is_closure(), b.is_closure(), "closure-ness preserved");
+                assert_eq!(a.is_heap(), b.is_heap(), "heap-ness preserved");
+            }
+            // LIR must survive (JIT depends on it) and closures must be rebuilt.
+            for (orig, reloaded) in bc.child_protos.iter().zip(&loaded.child_protos) {
+                assert_eq!(
+                    orig.lir_function.is_some(),
+                    reloaded.lir_function.is_some(),
+                    "LIR presence preserved"
+                );
+            }
+            let _ = vm;
+            (result.bytecode, loaded)
+        };
+        // Both bytecodes must execute to the same result.
+        let run = |bc: &crate::compiler::Bytecode| -> i64 {
+            let (vm, symbols, cctx) = rt.parts();
+            vm.execute_scheduled(bc, symbols, cctx)
+                .expect("runs")
+                .as_int()
+                .expect("result is an int")
+        };
+        let mut run = run;
+        let r_orig = run(&result);
+        let r_loaded = run(&loaded);
+        assert_eq!(r_orig, r_loaded, "original and reloaded bytecode agree");
+        eprintln!("roundtrip ok: {r_orig} == {r_loaded}");
+        std::env::remove_var("ELLE_CACHE_DIR");
+    }
+
+    /// Two Runtime instances: the first compiles stdlib and writes the cache,
+    /// the second must hit it (cache-load path) and produce working stdlib.
+    #[test]
+    fn stdlib_cache_hit_produces_working_runtime() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("ELLE_CACHE_DIR", dir.path());
+        let mut a = Runtime::new(); // compiles stdlib, writes cache
+                                    // The second runtime must hit the disk cache (not recompile) and
+                                    // produce a fully working stdlib. Functional check only — timing is
+                                    // asserted in the release-mode boot benchmark instead (debug builds
+                                    // skew it).
+        let mut b = Runtime::new(); // must load from cache
+        let probe = |rt: &mut Runtime| {
+            use crate::pipeline::compile_file_repl;
+            let (vm, symbols, cctx) = rt.parts();
+            let src = "(map (fn [x] (* x 2)) (quote (1 2 3)))";
+            let result = compile_file_repl(src, symbols, cctx, "<probe>").expect("probe compiles");
+            vm.execute_scheduled(&result.0.bytecode, symbols, cctx)
+                .expect("probe runs")
+        };
+        let _ = probe(&mut a);
+        let _ = probe(&mut b);
+        std::env::remove_var("ELLE_CACHE_DIR");
+    }
+}
+
+// =============================================================================
+// SendValue / TableKey serde for the stdlib cache
+// =============================================================================
+//
+// `SendValue` is the owned deep-copy form the send module produces for
+// cross-thread transport, and it is exactly the shape the stdlib cache needs:
+// no Rc, no pointers, symbols by name. We implement serde for it directly
+// rather than storing `Value`s, which carry process-local ids/pointers.
+//
+// Only the pure-data variants are supported; runtime-resource variants
+// (channels, ports, FFI descriptors) return an error, which makes the cache
+// miss and the caller recompile — safe, never wrong.
+
+/// Symmetric serde mirror for `SendValue`. Both directions go through this
+/// enum so the bincode encoding is identical (a hand-written `Serialize` that
+/// emitted tuples would not round-trip against a derived `Deserialize`, which
+/// expects bincode's enum encoding).
+#[derive(serde::Serialize, serde::Deserialize)]
+enum Mirror {
+    Immediate(crate::value::Value),
+    Keyword(String),
+    Symbol {
+        name: String,
+        id: u32,
+    },
+    String(String),
+    Pair(Box<Mirror>, Box<Mirror>, Box<Mirror>),
+    Seq(Vec<Mirror>, Box<Mirror>),
+    Map(
+        std::collections::BTreeMap<crate::value::TableKey, Mirror>,
+        Box<Mirror>,
+    ),
+    Buffer(Vec<u8>, Box<Mirror>),
+    Float(f64),
+    Closure(Box<crate::value::send::SendableClosure>),
+    Ref(usize),
+    CaptureCell(Box<Mirror>, Box<Mirror>),
+}
+
+impl serde::Serialize for crate::value::send::SendValue {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use crate::value::send::SendValue as SV;
+        use serde::ser::Error;
+        fn to_mirror(sv: &SV) -> Result<Mirror, String> {
+            if let SV::Immediate(v) = sv {
+                if v.is_heap() && !v.is_native_fn() {
+                    return Err(format!("Immediate heap value {}", v.type_name()));
+                }
+            }
+            Ok(match sv {
+                SV::Immediate(v) => Mirror::Immediate(*v),
+                SV::Keyword(k) => Mirror::Keyword(k.clone()),
+                SV::Symbol { name, id } => Mirror::Symbol {
+                    name: name.clone(),
+                    id: *id,
+                },
+                SV::String(st) => Mirror::String(st.clone()),
+                SV::Pair(a, b, t) => Mirror::Pair(
+                    Box::new(to_mirror(a)?),
+                    Box::new(to_mirror(b)?),
+                    Box::new(to_mirror(t)?),
+                ),
+                SV::Array(v, t) | SV::Tuple(v, t) | SV::LSet(v, t) | SV::LSetMut(v, t) => {
+                    Mirror::Seq(
+                        v.iter().map(to_mirror).collect::<Result<_, _>>()?,
+                        Box::new(to_mirror(t)?),
+                    )
+                }
+                SV::Struct(m, t) | SV::StructMut(m, t) => Mirror::Map(
+                    m.iter()
+                        .map(|(k, v)| Ok((k.clone(), to_mirror(v)?)))
+                        .collect::<Result<_, String>>()?,
+                    Box::new(to_mirror(t)?),
+                ),
+                SV::Buffer(v, t) | SV::Bytes(v, t) | SV::Blob(v, t) => {
+                    Mirror::Buffer(v.clone(), Box::new(to_mirror(t)?))
+                }
+                SV::LBox(..) => return Err("LBox not needed by stdlib cache".into()),
+                SV::CaptureCell(a, b) => {
+                    Mirror::CaptureCell(Box::new(to_mirror(a)?), Box::new(to_mirror(b)?))
+                }
+                SV::Float(f) => Mirror::Float(*f),
+                SV::Closure(c) => Mirror::Closure(c.clone()),
+                SV::Ref(r) => Mirror::Ref(*r),
+                _ => return Err("SendValue variant not serializable by stdlib cache".into()),
+            })
+        }
+        to_mirror(self).map_err(Error::custom)?.serialize(s)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for crate::value::send::SendValue {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use crate::value::send::SendValue as SV;
+        fn from_mirror(m: Mirror) -> Result<SV, String> {
+            Ok(match m {
+                Mirror::Immediate(v) => SV::Immediate(v),
+                Mirror::Keyword(k) => SV::Keyword(k),
+                Mirror::Symbol { name, id } => SV::Symbol { name, id },
+                Mirror::String(st) => SV::String(st),
+                Mirror::Pair(a, b, t) => SV::Pair(
+                    Box::new(from_mirror(*a)?),
+                    Box::new(from_mirror(*b)?),
+                    Box::new(from_mirror(*t)?),
+                ),
+                Mirror::Seq(v, t) => {
+                    let vals = v
+                        .into_iter()
+                        .map(from_mirror)
+                        .collect::<Result<Vec<_>, _>>()?;
+                    SV::Array(vals, Box::new(from_mirror(*t)?))
+                }
+                Mirror::Map(m, t) => {
+                    let map = m
+                        .into_iter()
+                        .map(|(k, v)| Ok((k, from_mirror(v)?)))
+                        .collect::<Result<_, String>>()?;
+                    SV::Struct(map, Box::new(from_mirror(*t)?))
+                }
+                Mirror::Buffer(v, t) => SV::Bytes(v, Box::new(from_mirror(*t)?)),
+                Mirror::Float(f) => SV::Float(f),
+                Mirror::Closure(c) => SV::Closure(c),
+                Mirror::Ref(r) => SV::Ref(r),
+                Mirror::CaptureCell(a, b) => {
+                    SV::CaptureCell(Box::new(from_mirror(*a)?), Box::new(from_mirror(*b)?))
+                }
+            })
+        }
+        from_mirror(Mirror::deserialize(d)?).map_err(serde::de::Error::custom)
+    }
+}
+
+impl serde::Serialize for crate::value::TableKey {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use crate::value::TableKey as TK;
+        match self {
+            TK::Nil => (0u8, ()).serialize(s),
+            TK::Bool(b) => (1u8, b).serialize(s),
+            TK::Int(i) => (2u8, i).serialize(s),
+            TK::Symbol(sym) => (3u8, sym.0).serialize(s),
+            TK::String(st) => (4u8, st).serialize(s),
+            TK::Keyword(k) => (5u8, k).serialize(s),
+            TK::EmptyList => (6u8, ()).serialize(s),
+            TK::Array(a) => (7u8, a).serialize(s),
+            TK::Heap(_) => Err(serde::ser::Error::custom(
+                "TableKey::Heap not serializable by stdlib cache",
+            )),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for crate::value::TableKey {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use crate::value::TableKey as TK;
+        #[derive(serde::Deserialize)]
+        enum Raw {
+            A(u8, ()),
+            B(u8, bool),
+            C(u8, i64),
+            D(u8, u32),
+            E(u8, String),
+            F(u8, Vec<TK>),
+        }
+        match Raw::deserialize(d)? {
+            Raw::A(0, _) => Ok(TK::Nil),
+            Raw::B(1, b) => Ok(TK::Bool(b)),
+            Raw::C(2, i) => Ok(TK::Int(i)),
+            Raw::D(3, s) => Ok(TK::Symbol(crate::value::SymbolId(s))),
+            Raw::E(4, st) => Ok(TK::String(st)),
+            Raw::E(5, k) => Ok(TK::Keyword(k)),
+            Raw::A(6, _) => Ok(TK::EmptyList),
+            Raw::F(7, a) => Ok(TK::Array(a)),
+            _ => Err(serde::de::Error::custom("unsupported TableKey variant")),
+        }
+    }
+}

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -392,4 +392,42 @@ mod tests {
         let _ = probe(&mut a);
         let _ = probe(&mut b);
     }
+
+    /// A `sys/spawn` worker runs `init_stdlib` on its own thread, so it reads
+    /// and writes a cache of its own. It must use the directory its parent was
+    /// given: a worker that falls back to the process-wide one writes megabytes
+    /// into a place nobody named, which is the leak the construction parameter
+    /// exists to close.
+    #[test]
+    fn a_spawned_worker_caches_where_its_parent_was_told_to() {
+        use crate::pipeline::compile_file_repl;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut rt = Runtime::with_stdlib_cache(StdlibCache::Dir(dir.path().to_path_buf()));
+
+        // The parent's own store already filled the directory, and the worker
+        // writes the same key. Clear it, so anything present afterwards can
+        // only have been written by the worker.
+        let entries = |p: &std::path::Path| -> usize {
+            std::fs::read_dir(p).expect("read cache dir").count()
+        };
+        for entry in std::fs::read_dir(dir.path()).expect("read cache dir") {
+            std::fs::remove_file(entry.expect("entry").path()).expect("clear");
+        }
+        assert_eq!(entries(dir.path()), 0, "cleared");
+
+        let (vm, symbols, cctx) = rt.parts();
+        let result =
+            compile_file_repl("(sys/join (sys/spawn (fn [] 1)))", symbols, cctx, "<spawn>")
+                .expect("spawn form compiles");
+        vm.execute_scheduled(&result.0.bytecode, symbols, cctx)
+            .expect("spawn runs");
+
+        assert_eq!(
+            entries(dir.path()),
+            1,
+            "the worker must cache into the directory its parent was given, \
+             not the process-wide one"
+        );
+    }
 }

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -253,16 +253,13 @@ pub fn load_bytecode(
         &mut alloc,
         symbols,
     )?;
-    if std::env::var("ELLE_PROFILE").is_ok() {
-        eprintln!("[stdlib-cache] deserialize_templates: {:?}", t0.elapsed());
-    }
+    let tracing = crate::trace::compile();
+    crate::trace::phase(tracing, "compile", "stdlib deserialize_templates", t0);
     let t1 = std::time::Instant::now();
     let entry = templates
         .pop()
         .expect("deserialize_templates returns one per input");
-    if std::env::var("ELLE_PROFILE").is_ok() {
-        eprintln!("[stdlib-cache] pop+extract: {:?}", t1.elapsed());
-    }
+    crate::trace::phase(tracing, "compile", "stdlib pop+extract", t1);
     // Restore the cross-unit registries the skipped stdlib compile would have
     // populated.
     let (dispatch_wrappers, fn_inline) = cctx.compile_registries_mut();

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -32,7 +32,27 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 /// Version tag: bump when the serialized layout changes in an incompatible way.
-const FORMAT_VERSION: u32 = 2;
+const FORMAT_VERSION: u32 = 3;
+
+/// Bytes of payload hash a cache file carries ahead of its `StoredBytecode`.
+const PAYLOAD_HASH_BYTES: usize = 8;
+
+/// Hash of a cache file's payload, stored in its prefix and re-checked on load.
+///
+/// `bincode` reports that bytes *decoded*, never that they are the bytes this
+/// binary wrote: eight flipped bytes decode "successfully" and arrive at the VM
+/// as instructions, and a flip deeper in a payload is absorbed into stdlib and
+/// reported as a hit. The prefix is what distinguishes the two.
+///
+/// This detects corruption and truncation, not forgery. A writable cache
+/// directory is a code-execution surface like any other loadable artifact; the
+/// hash is not a defence against someone who can write there.
+fn payload_hash(bytes: &[u8]) -> u64 {
+    use std::hash::Hasher;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    hasher.write(bytes);
+    hasher.finish()
+}
 
 /// The on-disk form of a compiled module's entry `Bytecode`.
 ///
@@ -157,7 +177,15 @@ pub fn try_load(
 ) -> Option<Result<Bytecode, String>> {
     let path = cache.dir()?.join(cache_key(stdlib_source)?);
     let bytes = std::fs::read(&path).ok()?;
-    let stored: StoredBytecode = match bincode::deserialize(&bytes) {
+    if bytes.len() < PAYLOAD_HASH_BYTES {
+        return Some(Err("cache file shorter than its hash prefix".into()));
+    }
+    let (prefix, payload) = bytes.split_at(PAYLOAD_HASH_BYTES);
+    let recorded = u64::from_le_bytes(prefix.try_into().expect("split at 8"));
+    if recorded != payload_hash(payload) {
+        return Some(Err("cache payload does not match its recorded hash".into()));
+    }
+    let stored: StoredBytecode = match bincode::deserialize(payload) {
         Ok(s) => s,
         Err(e) => return Some(Err(format!("cache decode: {e}"))),
     };
@@ -192,7 +220,9 @@ pub fn try_store(
                 return;
             };
             let path = dir.join(key);
-            if let Err(e) = std::fs::write(&path, bytes) {
+            let mut file = payload_hash(&bytes).to_le_bytes().to_vec();
+            file.extend_from_slice(&bytes);
+            if let Err(e) = std::fs::write(&path, file) {
                 eprintln!("[stdlib-cache] write failed: {e}");
             }
         }
@@ -476,5 +506,51 @@ mod tests {
             "the worker must cache into the directory its parent was given, \
              not the process-wide one"
         );
+    }
+
+    /// A cache file is bytes on a disk any process can write. `bincode` reports
+    /// only that the bytes *decoded*, never that they are the bytes this binary
+    /// wrote — so a flipped byte reaches the VM as instructions, and a deeper
+    /// one is absorbed into stdlib and reported as a hit. Every corruption must
+    /// come out as a miss: the cache is an optimization, and a full compile is
+    /// always available.
+    #[test]
+    fn a_corrupt_cache_file_is_a_miss_not_a_panic_or_a_silent_edit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = StdlibCache::Dir(dir.path().to_path_buf());
+
+        // Seed a good cache, then keep its bytes to restore between rounds.
+        drop(Runtime::with_stdlib_cache(cache.clone()));
+        let path = std::fs::read_dir(dir.path())
+            .expect("read cache dir")
+            .next()
+            .expect("the seeding runtime wrote a cache file")
+            .expect("entry")
+            .path();
+        let good = std::fs::read(&path).expect("read cache file");
+        assert!(
+            good.len() > 8192,
+            "cache file too small to corrupt meaningfully"
+        );
+
+        // Two offsets, because there are two failure modes: a shallow one
+        // lands in the decoded structure and reaches the VM as instructions, a
+        // deep one lands in a payload and passes unnoticed. More offsets in the
+        // shallow band would repeat a mode rather than add one, and each round
+        // costs a runtime boot.
+        for offset in [64usize, good.len() / 2] {
+            let mut bad = good.clone();
+            for byte in &mut bad[offset..offset + 8] {
+                *byte = 0xFF;
+            }
+            std::fs::write(&path, &bad).expect("write corrupt cache");
+
+            let rt = Runtime::with_stdlib_cache(cache.clone());
+            assert_eq!(
+                rt.stdlib_source(),
+                StdlibSource::Compiled,
+                "eight corrupt bytes at offset {offset} must be a miss"
+            );
+        }
     }
 }

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -32,7 +32,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 /// Version tag: bump when the serialized layout changes in an incompatible way.
-const FORMAT_VERSION: u32 = 1;
+const FORMAT_VERSION: u32 = 2;
 
 /// The on-disk form of a compiled module's entry `Bytecode`.
 ///
@@ -151,12 +151,6 @@ pub fn try_store(
     }
 }
 
-/// Serialize compiled stdlib bytecode into the cache format.
-///
-/// The entry constant pool is scalar by construction; the nested-lambda
-/// blueprints (`child_protos`) may contain live closure constants, LIR, and
-/// region-release tables, so they go through the send module's template
-/// serialization (which deep-copies closures and interns them by pointer).
 /// Serialize compiled stdlib bytecode into the cache format.
 ///
 /// The whole `Bytecode` is wrapped as a synthetic entry `ClosureTemplate`
@@ -362,182 +356,5 @@ mod tests {
         let _ = probe(&mut a);
         let _ = probe(&mut b);
         std::env::remove_var("ELLE_CACHE_DIR");
-    }
-}
-
-// =============================================================================
-// SendValue / TableKey serde for the stdlib cache
-// =============================================================================
-//
-// `SendValue` is the owned deep-copy form the send module produces for
-// cross-thread transport, and it is exactly the shape the stdlib cache needs:
-// no Rc, no pointers, symbols by name. We implement serde for it directly
-// rather than storing `Value`s, which carry process-local ids/pointers.
-//
-// Only the pure-data variants are supported; runtime-resource variants
-// (channels, ports, FFI descriptors) return an error, which makes the cache
-// miss and the caller recompile — safe, never wrong.
-
-/// Symmetric serde mirror for `SendValue`. Both directions go through this
-/// enum so the bincode encoding is identical (a hand-written `Serialize` that
-/// emitted tuples would not round-trip against a derived `Deserialize`, which
-/// expects bincode's enum encoding).
-#[derive(serde::Serialize, serde::Deserialize)]
-enum Mirror {
-    Immediate(crate::value::Value),
-    Keyword(String),
-    Symbol {
-        name: String,
-        id: u32,
-    },
-    String(String),
-    Pair(Box<Mirror>, Box<Mirror>, Box<Mirror>),
-    Seq(Vec<Mirror>, Box<Mirror>),
-    Map(
-        std::collections::BTreeMap<crate::value::TableKey, Mirror>,
-        Box<Mirror>,
-    ),
-    Buffer(Vec<u8>, Box<Mirror>),
-    Float(f64),
-    Closure(Box<crate::value::send::SendableClosure>),
-    Ref(usize),
-    CaptureCell(Box<Mirror>, Box<Mirror>),
-}
-
-impl serde::Serialize for crate::value::send::SendValue {
-    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        use crate::value::send::SendValue as SV;
-        use serde::ser::Error;
-        fn to_mirror(sv: &SV) -> Result<Mirror, String> {
-            if let SV::Immediate(v) = sv {
-                if v.is_heap() && !v.is_native_fn() {
-                    return Err(format!("Immediate heap value {}", v.type_name()));
-                }
-            }
-            Ok(match sv {
-                SV::Immediate(v) => Mirror::Immediate(*v),
-                SV::Keyword(k) => Mirror::Keyword(k.clone()),
-                SV::Symbol { name, id } => Mirror::Symbol {
-                    name: name.clone(),
-                    id: *id,
-                },
-                SV::String(st) => Mirror::String(st.clone()),
-                SV::Pair(a, b, t) => Mirror::Pair(
-                    Box::new(to_mirror(a)?),
-                    Box::new(to_mirror(b)?),
-                    Box::new(to_mirror(t)?),
-                ),
-                SV::Array(v, t) | SV::Tuple(v, t) | SV::LSet(v, t) | SV::LSetMut(v, t) => {
-                    Mirror::Seq(
-                        v.iter().map(to_mirror).collect::<Result<_, _>>()?,
-                        Box::new(to_mirror(t)?),
-                    )
-                }
-                SV::Struct(m, t) | SV::StructMut(m, t) => Mirror::Map(
-                    m.iter()
-                        .map(|(k, v)| Ok((k.clone(), to_mirror(v)?)))
-                        .collect::<Result<_, String>>()?,
-                    Box::new(to_mirror(t)?),
-                ),
-                SV::Buffer(v, t) | SV::Bytes(v, t) | SV::Blob(v, t) => {
-                    Mirror::Buffer(v.clone(), Box::new(to_mirror(t)?))
-                }
-                SV::LBox(..) => return Err("LBox not needed by stdlib cache".into()),
-                SV::CaptureCell(a, b) => {
-                    Mirror::CaptureCell(Box::new(to_mirror(a)?), Box::new(to_mirror(b)?))
-                }
-                SV::Float(f) => Mirror::Float(*f),
-                SV::Closure(c) => Mirror::Closure(c.clone()),
-                SV::Ref(r) => Mirror::Ref(*r),
-                _ => return Err("SendValue variant not serializable by stdlib cache".into()),
-            })
-        }
-        to_mirror(self).map_err(Error::custom)?.serialize(s)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for crate::value::send::SendValue {
-    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        use crate::value::send::SendValue as SV;
-        fn from_mirror(m: Mirror) -> Result<SV, String> {
-            Ok(match m {
-                Mirror::Immediate(v) => SV::Immediate(v),
-                Mirror::Keyword(k) => SV::Keyword(k),
-                Mirror::Symbol { name, id } => SV::Symbol { name, id },
-                Mirror::String(st) => SV::String(st),
-                Mirror::Pair(a, b, t) => SV::Pair(
-                    Box::new(from_mirror(*a)?),
-                    Box::new(from_mirror(*b)?),
-                    Box::new(from_mirror(*t)?),
-                ),
-                Mirror::Seq(v, t) => {
-                    let vals = v
-                        .into_iter()
-                        .map(from_mirror)
-                        .collect::<Result<Vec<_>, _>>()?;
-                    SV::Array(vals, Box::new(from_mirror(*t)?))
-                }
-                Mirror::Map(m, t) => {
-                    let map = m
-                        .into_iter()
-                        .map(|(k, v)| Ok((k, from_mirror(v)?)))
-                        .collect::<Result<_, String>>()?;
-                    SV::Struct(map, Box::new(from_mirror(*t)?))
-                }
-                Mirror::Buffer(v, t) => SV::Bytes(v, Box::new(from_mirror(*t)?)),
-                Mirror::Float(f) => SV::Float(f),
-                Mirror::Closure(c) => SV::Closure(c),
-                Mirror::Ref(r) => SV::Ref(r),
-                Mirror::CaptureCell(a, b) => {
-                    SV::CaptureCell(Box::new(from_mirror(*a)?), Box::new(from_mirror(*b)?))
-                }
-            })
-        }
-        from_mirror(Mirror::deserialize(d)?).map_err(serde::de::Error::custom)
-    }
-}
-
-impl serde::Serialize for crate::value::TableKey {
-    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        use crate::value::TableKey as TK;
-        match self {
-            TK::Nil => (0u8, ()).serialize(s),
-            TK::Bool(b) => (1u8, b).serialize(s),
-            TK::Int(i) => (2u8, i).serialize(s),
-            TK::Symbol(sym) => (3u8, sym.0).serialize(s),
-            TK::String(st) => (4u8, st).serialize(s),
-            TK::Keyword(k) => (5u8, k).serialize(s),
-            TK::EmptyList => (6u8, ()).serialize(s),
-            TK::Array(a) => (7u8, a).serialize(s),
-            TK::Heap(_) => Err(serde::ser::Error::custom(
-                "TableKey::Heap not serializable by stdlib cache",
-            )),
-        }
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for crate::value::TableKey {
-    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        use crate::value::TableKey as TK;
-        #[derive(serde::Deserialize)]
-        enum Raw {
-            A(u8, ()),
-            B(u8, bool),
-            C(u8, i64),
-            D(u8, u32),
-            E(u8, String),
-            F(u8, Vec<TK>),
-        }
-        match Raw::deserialize(d)? {
-            Raw::A(0, _) => Ok(TK::Nil),
-            Raw::B(1, b) => Ok(TK::Bool(b)),
-            Raw::C(2, i) => Ok(TK::Int(i)),
-            Raw::D(3, s) => Ok(TK::Symbol(crate::value::SymbolId(s))),
-            Raw::E(4, st) => Ok(TK::String(st)),
-            Raw::E(5, k) => Ok(TK::Keyword(k)),
-            Raw::A(6, _) => Ok(TK::EmptyList),
-            Raw::F(7, a) => Ok(TK::Array(a)),
-            _ => Err(serde::de::Error::custom("unsupported TableKey variant")),
-        }
     }
 }

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -166,8 +166,10 @@ fn cache_key(stdlib_source: &str) -> Option<String> {
 /// Try to load the compiled stdlib from the disk cache.
 ///
 /// Returns `None` when no cache is enabled or the file is absent; `Some(Err)`
-/// when the cache file exists but fails to parse (corrupt / version drift) —
-/// the caller recompiles, and the next store overwrites the bad file.
+/// when the file exists but is rejected (hash mismatch, truncation, format
+/// drift), naming the reason. `init_stdlib` treats a rejection exactly like an
+/// absence — it compiles *and stores* — so the rejected file is replaced rather
+/// than rejected again by every later start.
 pub fn try_load(
     stdlib_source: &str,
     cache: &StdlibCache,
@@ -552,5 +554,40 @@ mod tests {
                 "eight corrupt bytes at offset {offset} must be a miss"
             );
         }
+    }
+
+    /// Falling back is half the job. A rejected file that stays on disk is
+    /// rejected again by every later start, so one bad write costs the cache
+    /// permanently — the recompile it forces is invisible, because a working
+    /// runtime is what a miss produces too.
+    #[test]
+    fn a_rejected_cache_file_is_replaced_not_left_to_win() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = StdlibCache::Dir(dir.path().to_path_buf());
+
+        drop(Runtime::with_stdlib_cache(cache.clone()));
+        let path = std::fs::read_dir(dir.path())
+            .expect("read cache dir")
+            .next()
+            .expect("the seeding runtime wrote a cache file")
+            .expect("entry")
+            .path();
+        std::fs::write(&path, b"not a cache file").expect("plant a rejected file");
+
+        let first = Runtime::with_stdlib_cache(cache.clone());
+        assert_eq!(
+            first.stdlib_source(),
+            StdlibSource::Compiled,
+            "the planted file must be rejected"
+        );
+        drop(first);
+
+        let second = Runtime::with_stdlib_cache(cache);
+        assert_eq!(
+            second.stdlib_source(),
+            StdlibSource::Cache,
+            "the runtime that rejected the file must also replace it, or every \
+             later start pays the full compile again"
+        );
     }
 }

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -231,7 +231,9 @@ pub fn try_store(
             // directory, so the name refers to a complete file or the old one.
             if let Err(e) = store_atomically(&dir, &path, &file) {
                 eprintln!("[stdlib-cache] write failed: {e}");
+                return;
             }
+            prune_superseded(&dir, &path);
         }
         Err(e) => eprintln!("[stdlib-cache] serialize failed: {e}"),
     }
@@ -255,6 +257,28 @@ fn store_atomically(
     tmp.persist(path)
         .map(|_| ())
         .map_err(|e| std::io::Error::other(e.to_string()))
+}
+
+/// Remove every cache file in `dir` except `keep`.
+///
+/// The key follows the binary, so every rebuild mints a new one and orphans
+/// the file the last one wrote. At ~16 MB each, a day of rebuilds fills a
+/// directory nobody thinks to look at. Run after the rename, never before: a
+/// store that fails must leave the directory as it found it, still holding a
+/// file some other process may be about to read.
+///
+/// A removal that fails is ignored. It is disk hygiene, not correctness, and
+/// the next store tries again.
+fn prune_superseded(dir: &std::path::Path, keep: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path != keep && path.extension().is_some_and(|e| e == "bin") {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
 }
 
 /// Serialize compiled stdlib bytecode into the cache format.
@@ -657,6 +681,33 @@ mod tests {
              held descriptor saw {} bytes, not the {}-byte sentinel",
             seen.len(),
             SENTINEL.len()
+        );
+    }
+
+    /// Every key that stops being current orphans a file, and the key follows
+    /// the binary — so an ordinary day of rebuilds leaves one 16 MB file per
+    /// build, forever, in a directory nobody thinks to look at.
+    #[test]
+    fn a_store_prunes_the_files_its_key_supersedes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = StdlibCache::Dir(dir.path().to_path_buf());
+
+        // Two files under keys this binary will never mint again.
+        for name in ["deadbeefdeadbeef.bin", "0123456789abcdef.bin"] {
+            std::fs::write(dir.path().join(name), b"an earlier build's cache")
+                .expect("plant a superseded file");
+        }
+
+        drop(Runtime::with_stdlib_cache(cache));
+
+        let left: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read cache dir")
+            .map(|e| e.expect("entry").file_name())
+            .collect();
+        assert_eq!(
+            left.len(),
+            1,
+            "a store must leave only the file it just wrote; found {left:?}"
         );
     }
 }

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -6,7 +6,9 @@
 //! same stdlib source, same elle binary → same bytecode. This module turns that
 //! work into a one-time cost by serializing the compiled `Bytecode` (plus the
 //! per-closure `ClosureTemplate`s and their LIR, so the JIT keeps working) to a
-//! content-addressed cache file, keyed by elle version + stdlib source hash.
+//! content-addressed cache file, keyed by elle version + stdlib source hash +
+//! the canonical primitive-table identity (the last because serialized
+//! native-fn immediates carry process-local `prim_id`s).
 //!
 //! Serialization strategy: the cache format is a plain `StoredBytecode` struct
 //! that is 100% owned data — no `Rc`, no pointers, no symbol-table ids. Symbols
@@ -76,7 +78,8 @@ fn cache_dir() -> std::path::PathBuf {
     base.join("elle").join("stdlib-cache")
 }
 
-/// Content hash of the stdlib source + elle version, forming the cache key.
+/// Content hash of the stdlib source + elle version + primitive-table
+/// identity, forming the cache key.
 fn cache_key(stdlib_source: &str) -> String {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -87,6 +90,12 @@ fn cache_key(stdlib_source: &str) -> String {
         .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string())
         .hash(&mut hasher);
     FORMAT_VERSION.hash(&mut hasher);
+    // A serialized native-fn immediate carries a `prim_id`, which is only
+    // valid against the exact primitive table that minted it. Mix the table
+    // identity in so a prim addition/removal/reorder (a different elle
+    // binary) invalidates the cache instead of deserializing a foreign id
+    // into `panic!("unknown prim id")`.
+    crate::primitives::registration::hash_prim_table_identity(&mut hasher);
     format!("{:016x}.bin", hasher.finish())
 }
 

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -6,9 +6,9 @@
 //! same stdlib source, same elle binary → same bytecode. This module turns that
 //! work into a one-time cost by serializing the compiled `Bytecode` (plus the
 //! per-closure `ClosureTemplate`s and their LIR, so the JIT keeps working) to a
-//! content-addressed cache file, keyed by elle version + stdlib source hash +
-//! the canonical primitive-table identity (the last because serialized
-//! native-fn immediates carry process-local `prim_id`s).
+//! content-addressed cache file, keyed by the running binary's identity +
+//! stdlib source hash + the canonical primitive-table identity (the last
+//! because serialized native-fn immediates carry process-local `prim_id`s).
 //!
 //! Serialization strategy: the cache format is a plain `StoredBytecode` struct
 //! that is 100% owned data — no `Rc`, no pointers, no symbol-table ids. Symbols
@@ -96,17 +96,43 @@ impl StdlibCache {
     }
 }
 
-/// Content hash of the stdlib source + elle version + primitive-table
-/// identity, forming the cache key.
-fn cache_key(stdlib_source: &str) -> String {
+/// Identity of the running binary — its length and modification time.
+///
+/// Returns `None` when the executable cannot be located or measured. A binary
+/// that cannot identify itself must not share a cache with one that can, and
+/// falling back to the version string would restore the very confusion this
+/// exists to prevent, so the caller declines to cache instead.
+fn build_identity() -> Option<(u64, u128)> {
+    let exe = std::env::current_exe().ok()?;
+    let meta = std::fs::metadata(exe).ok()?;
+    let mtime = meta
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_nanos();
+    Some((meta.len(), mtime))
+}
+
+/// Content hash of the stdlib source, the running binary's identity,
+/// `FORMAT_VERSION`, and the primitive-table identity — the cache key.
+///
+/// `None` when the binary cannot be identified; the caller then neither reads
+/// nor writes a cache file.
+fn cache_key(stdlib_source: &str) -> Option<String> {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     stdlib_source.hash(&mut hasher);
-    // Include the binary/format identity so a changed elle (e.g. a compiler
-    // change that alters emitted bytecode) naturally invalidates the cache.
-    std::env::var("ELLE_CACHE_VERSION")
-        .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string())
-        .hash(&mut hasher);
+    // The binary itself, not its version string. Two builds of one version
+    // compile stdlib differently the moment the emitter or a pass changes, and
+    // a key that cannot see the rebuild hands every `Runtime::new()` — the one
+    // in each test included — bytecode the previous binary produced. A test
+    // failure would then stop implicating the branch that caused it.
+    //
+    // It also covers what the primitive-table identity below cannot see: the
+    // ids `prim_id_of` appends outside the canonical tables (trait methods,
+    // FFI callbacks) are minted by the running binary, not listed in it.
+    build_identity()?.hash(&mut hasher);
     FORMAT_VERSION.hash(&mut hasher);
     // A serialized native-fn immediate carries a `prim_id`, which is only
     // valid against the exact primitive table that minted it. Mix the table
@@ -114,7 +140,7 @@ fn cache_key(stdlib_source: &str) -> String {
     // binary) invalidates the cache instead of deserializing a foreign id
     // into `panic!("unknown prim id")`.
     crate::primitives::registration::hash_prim_table_identity(&mut hasher);
-    format!("{:016x}.bin", hasher.finish())
+    Some(format!("{:016x}.bin", hasher.finish()))
 }
 
 /// Try to load the compiled stdlib from the disk cache.
@@ -129,7 +155,7 @@ pub fn try_load(
     symbols: &mut crate::symbol::SymbolTable,
     cctx: &mut crate::pipeline::CompileCtx,
 ) -> Option<Result<Bytecode, String>> {
-    let path = cache.dir()?.join(cache_key(stdlib_source));
+    let path = cache.dir()?.join(cache_key(stdlib_source)?);
     let bytes = std::fs::read(&path).ok()?;
     let stored: StoredBytecode = match bincode::deserialize(&bytes) {
         Ok(s) => s,
@@ -162,7 +188,10 @@ pub fn try_store(
     };
     match bincode::serialize(&stored) {
         Ok(bytes) => {
-            let path = dir.join(cache_key(stdlib_source));
+            let Some(key) = cache_key(stdlib_source) else {
+                return;
+            };
+            let path = dir.join(key);
             if let Err(e) = std::fs::write(&path, bytes) {
                 eprintln!("[stdlib-cache] write failed: {e}");
             }
@@ -349,6 +378,27 @@ mod tests {
         let r_loaded = run(&loaded);
         assert_eq!(r_orig, r_loaded, "original and reloaded bytecode agree");
         eprintln!("roundtrip ok: {r_orig} == {r_loaded}");
+    }
+
+    /// The key must follow the binary, not its version string: two builds of
+    /// one version compile stdlib differently the moment a pass changes. This
+    /// pins that the identity is read from the executable — an edit that put a
+    /// constant back would leave every rebuild sharing one key, and every test
+    /// that boots a runtime reading bytecode the previous binary produced.
+    ///
+    /// Characterization, not a failing-first regression: "a different build
+    /// yields a different key" is observable only across builds.
+    #[test]
+    fn the_build_identity_is_read_from_the_running_executable() {
+        let (len, _mtime) = build_identity().expect("the test binary can identify itself");
+        let exe = std::env::current_exe().expect("current_exe");
+        let meta = std::fs::metadata(&exe).expect("exe metadata");
+        assert_eq!(
+            len,
+            meta.len(),
+            "the identity must be the binary's own size"
+        );
+        assert!(len > 0, "a zero-length identity separates nothing");
     }
 
     /// Two runtimes over one cache directory: the first compiles stdlib and

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -739,4 +739,49 @@ mod tests {
             "a store must leave only the file it just wrote; found {left:?}"
         );
     }
+
+    /// `ClosureTemplate.syntax` does not cross the cache, and `(meta/origin f)`
+    /// — its only reader — reports a closure's source location from it. So a
+    /// stdlib closure has an origin on the compiled path and none on the cached
+    /// one. Nothing in the tree depends on that; it is pinned here rather than
+    /// left to be rediscovered as a surprise.
+    ///
+    /// The second half is what bounds it: a closure the hit runtime compiles
+    /// itself still knows where it came from, so the loss stays with the values
+    /// the cache restored and does not reach user code.
+    #[test]
+    fn a_cached_stdlib_closure_has_no_origin_but_user_code_keeps_its_own() {
+        fn origin_is_nil(rt: &mut Runtime, src: &str) -> bool {
+            use crate::pipeline::compile_file_repl;
+            let (vm, symbols, cctx) = rt.parts();
+            let result = compile_file_repl(src, symbols, cctx, "<origin>").expect("compiles");
+            vm.execute_scheduled(&result.0.bytecode, symbols, cctx)
+                .expect("runs")
+                .is_nil()
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = StdlibCache::Dir(dir.path().to_path_buf());
+
+        let mut compiled = Runtime::with_stdlib_cache(cache.clone());
+        assert_eq!(compiled.stdlib_source(), StdlibSource::Compiled);
+        assert!(
+            !origin_is_nil(&mut compiled, "(meta/origin map)"),
+            "a compiled stdlib closure carries its syntax, so it has an origin"
+        );
+        drop(compiled);
+
+        let mut hit = Runtime::with_stdlib_cache(cache);
+        assert_eq!(hit.stdlib_source(), StdlibSource::Cache);
+        assert!(
+            origin_is_nil(&mut hit, "(meta/origin map)"),
+            "the cache does not carry syntax, so a restored closure has no \
+             origin — a known difference between the two paths"
+        );
+        assert!(
+            !origin_is_nil(&mut hit, "(meta/origin (fn [] nil))"),
+            "the loss must stay with the restored values: a closure this \
+             runtime compiled itself still knows where it came from"
+        );
+    }
 }

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -11,9 +11,11 @@
 //! because serialized native-fn immediates carry process-local `prim_id`s).
 //!
 //! Serialization strategy: the cache format is a plain `StoredBytecode` struct
-//! that is 100% owned data — no `Rc`, no pointers, no symbol-table ids. Symbols
-//! and keywords are carried *by name* (their ids are per-process), and are
-//! re-interned on load. `Value`s that appear in the constant pool are scalars
+//! that is 100% owned data — no `Rc`, no pointers. A symbol or keyword id is
+//! its name's hash (docs/impl/symbol.md), the same number in every process, so
+//! the ids travel as they stand; only the spellings ride alongside, in the
+//! `names` table, and replay into the loading instance's display memo.
+//! `Value`s that appear in the constant pool are scalars
 //! (int/float/bool/nil/keyword/symbol) by construction — string and compound
 //! literals lower to `MaterializeConst` templates, not pool constants — so the
 //! pool serializes cheaply. Closures recurse via `child_protos`.
@@ -32,7 +34,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 /// Version tag: bump when the serialized layout changes in an incompatible way.
-const FORMAT_VERSION: u32 = 4;
+const FORMAT_VERSION: u32 = 5;
 
 /// Bytes of payload hash a cache file carries ahead of its `StoredBytecode`.
 const PAYLOAD_HASH_BYTES: usize = 8;
@@ -67,11 +69,16 @@ fn payload_hash(bytes: &[u8]) -> u64 {
 pub struct StoredBytecode {
     pub format_version: u32,
     /// The entry template: `instructions` → bytecode, `constants` → entry
-    /// pool, `child_protos` → nested lambdas. Symbols by name; LIR preserved.
+    /// pool, `child_protos` → nested lambdas. LIR preserved.
     pub entry: crate::value::send::SendableClosure,
     /// Intern table of closure constants reachable from the entry's pool and
     /// its child templates, referenced by `Ref(idx)`.
     pub intern_table: Vec<crate::value::send::SendableClosure>,
+    /// Spelling table for every symbol and keyword the entry and its templates
+    /// name, replayed into the loading instance's display memo. The ids are
+    /// name hashes and cross unchanged; without this table they would still
+    /// compare correctly but print as `#<symbol:hash>`.
+    pub names: Vec<(u64, Box<str>)>,
     pub signal_projection: Option<HashMap<String, Signal>>,
     /// Cross-unit dispatch-wrapper registry (stdlib `push`/`put`/`add`
     /// monomorphization), snapshotted because the disk cache skips the stdlib
@@ -259,26 +266,6 @@ fn store_atomically(
         .map_err(|e| std::io::Error::other(e.to_string()))
 }
 
-/// Refuse a `SendableClosure` whose LIR names a symbol its `symbol_names`
-/// cannot translate. Recurses through `child_protos`.
-fn check_lir_symbols_are_translatable(
-    sc: &crate::value::send::SendableClosure,
-) -> Result<(), String> {
-    if let Some(lir) = sc.lir_function.as_ref() {
-        let missing = crate::value::send::untranslatable_lir_symbols(lir, &sc.symbol_names);
-        if !missing.is_empty() {
-            return Err(format!(
-                "LIR of {} names symbol ids absent from its symbol_names: {missing:?}",
-                sc.name.as_deref().unwrap_or("<anonymous>")
-            ));
-        }
-    }
-    for child in &sc.child_protos {
-        check_lir_symbols_are_translatable(child)?;
-    }
-    Ok(())
-}
-
 /// Remove every cache file in `dir` except `keep`.
 ///
 /// The key follows the binary, so every rebuild mints a new one and orphans
@@ -329,7 +316,6 @@ pub fn store_bytecode(
         signal: bytecode.signal,
         capture_params_mask: 0,
         capture_locals_mask: crate::value::CaptureMask::empty(),
-        symbol_names: Rc::new(bytecode.symbol_names.clone()),
         location_map: Rc::new(bytecode.location_map.clone()),
         lir_function: None, // the entry thunk is not JIT'd; closures carry their own LIR
         doc: None,
@@ -345,22 +331,18 @@ pub fn store_bytecode(
         child_protos: Rc::new(bytecode.child_protos.clone()),
     };
     let entry = std::rc::Rc::new(entry);
-    let (templates, intern_table) =
+    let sent =
         crate::value::send::serialize_templates(std::slice::from_ref(&entry), vm.heap(), symbols)?;
-    let entry = templates.into_iter().next().expect("one template");
-    // Every LIR symbol must be translatable on load. The load-path remap is a
-    // lookup: an id absent from `symbol_names` survives untouched into the
-    // loading process, where the JIT materializes it as whatever symbol happens
-    // to hold that id. Refuse to write a file that would do that — a missing
-    // cache costs a compile, a wrong symbol costs a wrong program.
-    check_lir_symbols_are_translatable(&entry)?;
-    for sc in &intern_table {
-        check_lir_symbols_are_translatable(sc)?;
-    }
+    let entry = sent
+        .templates
+        .into_iter()
+        .next()
+        .expect("one template in, one template out");
     Ok(StoredBytecode {
         format_version: FORMAT_VERSION,
         entry,
-        intern_table,
+        intern_table: sent.intern_table,
+        names: sent.names,
         signal_projection: bytecode.signal_projection.clone(),
         dispatch_wrappers: stored_dispatch,
         fn_inline: stored_fn_inline,
@@ -369,9 +351,9 @@ pub fn store_bytecode(
 
 /// Rebuild a `Bytecode` from the cache format.
 ///
-/// Every symbol is re-interned by name into the loading process's table, and
-/// the LIR embedded in the templates has its symbol ids remapped to the new
-/// table (the JIT materializes `LirConst::Symbol` ids directly).
+/// Symbol ids cross unchanged — an id is its name's hash — and the stored
+/// spelling table replays into the loading instance's display memo so the
+/// names it now holds can be printed.
 pub fn load_bytecode(
     stored: StoredBytecode,
     vm: &mut crate::vm::VM,
@@ -387,8 +369,11 @@ pub fn load_bytecode(
     let t0 = std::time::Instant::now();
     let mut alloc = crate::primitives::ctx::Alloc::new(vm.heap());
     let mut templates = crate::value::send::deserialize_templates(
-        vec![stored.entry],
-        stored.intern_table,
+        crate::value::send::SendTemplates {
+            templates: vec![stored.entry],
+            intern_table: stored.intern_table,
+            names: stored.names,
+        },
         &mut alloc,
         symbols,
     )?;
@@ -407,7 +392,6 @@ pub fn load_bytecode(
     Ok(Bytecode {
         instructions: (*entry.bytecode).clone(),
         constants: (*entry.constants).clone(),
-        symbol_names: (*entry.symbol_names).clone(),
         location_map: (*entry.location_map).clone(),
         signal: entry.signal,
         signal_projection: stored.signal_projection,
@@ -445,12 +429,18 @@ mod tests {
             assert!(!bc.instructions.is_empty());
 
             let stored = store_bytecode(bc, vm, symbols, cctx).expect("stores");
+            let stored_names = stored.names.len();
             let bytes = bincode::serialize(&stored).expect("serializes");
             let decoded: StoredBytecode = bincode::deserialize(&bytes).expect("deserializes");
+            assert_eq!(
+                decoded.names.len(),
+                stored_names,
+                "the spelling table survives bincode; without it every reloaded \
+                 symbol prints as #<symbol:hash>"
+            );
             let loaded = load_bytecode(decoded, vm, symbols, cctx).expect("loads");
             assert_eq!(loaded.instructions, bc.instructions, "instructions equal");
             assert_eq!(loaded.signal, bc.signal);
-            assert_eq!(loaded.symbol_names.len(), bc.symbol_names.len());
             assert_eq!(loaded.child_protos.len(), bc.child_protos.len());
             // The constant pool is byte-identical on the scalar prefix; closure
             // constants are NEW heap instances after reload (pointer-equal
@@ -477,8 +467,8 @@ mod tests {
         };
         // Both bytecodes must execute to the same result.
         let run = |bc: &crate::compiler::Bytecode| -> i64 {
-            let (vm, symbols, cctx) = rt.parts();
-            vm.execute_scheduled(bc, symbols, cctx)
+            let (vm, _symbols, cctx) = rt.parts();
+            vm.execute_scheduled(bc, cctx)
                 .expect("runs")
                 .as_int()
                 .expect("result is an int")
@@ -543,7 +533,7 @@ mod tests {
             let (vm, symbols, cctx) = rt.parts();
             let src = "(map (fn [x] (* x 2)) (quote (1 2 3)))";
             let result = compile_file_repl(src, symbols, cctx, "<probe>").expect("probe compiles");
-            vm.execute_scheduled(&result.0.bytecode, symbols, cctx)
+            vm.execute_scheduled(&result.0.bytecode, cctx)
                 .expect("probe runs")
         };
         let _ = probe(&mut a);
@@ -577,7 +567,7 @@ mod tests {
         let result =
             compile_file_repl("(sys/join (sys/spawn (fn [] 1)))", symbols, cctx, "<spawn>")
                 .expect("spawn form compiles");
-        vm.execute_scheduled(&result.0.bytecode, symbols, cctx)
+        vm.execute_scheduled(&result.0.bytecode, cctx)
             .expect("spawn runs");
 
         assert_eq!(
@@ -755,7 +745,7 @@ mod tests {
             use crate::pipeline::compile_file_repl;
             let (vm, symbols, cctx) = rt.parts();
             let result = compile_file_repl(src, symbols, cctx, "<origin>").expect("compiles");
-            vm.execute_scheduled(&result.0.bytecode, symbols, cctx)
+            vm.execute_scheduled(&result.0.bytecode, cctx)
                 .expect("runs")
                 .is_nil()
         }

--- a/src/hir/binding.rs
+++ b/src/hir/binding.rs
@@ -11,7 +11,9 @@ use std::fmt;
 
 /// A compile-time binding handle. Index into a `BindingArena`.
 /// 4 bytes, Copy, no heap allocation.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub struct Binding(pub(crate) u32);
 
 impl fmt::Debug for Binding {
@@ -33,7 +35,7 @@ impl Binding {
 }
 
 /// Information about a captured variable in a closure
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CaptureInfo {
     /// The binding being captured
     pub binding: Binding,
@@ -42,7 +44,7 @@ pub struct CaptureInfo {
 }
 
 /// How a capture is accessed from the enclosing scope
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum CaptureKind {
     /// Capture from parent's local slot (resolved by lowerer via binding_to_slot)
     Local,

--- a/src/hir/expr.rs
+++ b/src/hir/expr.rs
@@ -23,7 +23,7 @@ mod traverse;
 /// was the source of a phantom-region class. Code that needs program
 /// order must use the explicit index from
 /// `crate::hir::liveness::compute_order` instead.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct HirId(pub u32);
 
 /// Global monotonic counter for HirId assignment.
@@ -39,14 +39,14 @@ fn fresh_hir_id() -> HirId {
 }
 
 /// A declared signal bound on a function parameter.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ParamBound {
     pub binding: Binding,
     pub signal: Signal,
 }
 
 /// HIR expression with source location, signal, and unique ID.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Hir {
     pub kind: HirKind,
     pub span: Span,
@@ -77,7 +77,7 @@ impl Hir {
 }
 
 /// A function call argument, which may be spliced (spread).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CallArg {
     pub expr: Hir,
     pub spliced: bool,
@@ -85,12 +85,12 @@ pub struct CallArg {
 
 /// Unique identifier for a named/anonymous block, used by `break` to target
 /// the correct block at compile time.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BlockId(pub u32);
 
 /// How extra arguments beyond fixed params are collected.
 /// Only meaningful when `rest_param` is `Some`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum VarargKind {
     /// Collect into a list (existing `&` behavior)
     List,
@@ -102,7 +102,7 @@ pub enum VarargKind {
 }
 
 /// HIR expression kinds - fully analyzed forms
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum HirKind {
     // === Literals ===
     Nil,
@@ -164,8 +164,10 @@ pub enum HirKind {
         /// string data (`Rc<str>`), NOT a heap `Value`. It rides the closure
         /// template (held alive by RC with it) and is materialized as a fresh
         /// ordinary (reclaimable) allocation when `(doc f)` reads it.
+        #[serde(skip)]
         doc: Option<std::rc::Rc<str>>,
         /// Original lambda Syntax node for eval environment reconstruction
+        #[serde(skip)]
         syntax: Option<Rc<crate::syntax::Syntax>>,
         /// True if the function body contains `(numeric!)` assertion.
         /// The lowerer checks `is_gpu_eligible()` after lowering.

--- a/src/hir/expr/op.rs
+++ b/src/hir/expr/op.rs
@@ -1,5 +1,5 @@
 /// Known %-intrinsic operations with fixed type/alloc/escape behavior.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum IntrinsicOp {
     // Arithmetic
     Add,

--- a/src/hir/pattern.rs
+++ b/src/hir/pattern.rs
@@ -5,7 +5,7 @@ use crate::hir::arena::BindingArena;
 use crate::value::SymbolId;
 
 /// HIR pattern for match expressions
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum HirPattern {
     /// Match anything, don't bind
     Wildcard,
@@ -77,7 +77,7 @@ pub enum HirPattern {
 }
 
 /// Literal values that can appear in patterns
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum PatternLiteral {
     Bool(bool),
     Int(i64),
@@ -102,7 +102,7 @@ impl std::hash::Hash for PatternLiteral {
 }
 
 /// Key type in struct/table patterns: keyword (:foo) or symbol ('foo)
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum PatternKey {
     Keyword(String),
     Symbol(SymbolId),

--- a/src/hir/region/id.rs
+++ b/src/hir/region/id.rs
@@ -21,7 +21,10 @@ use std::num::NonZeroU32;
 /// `StaticRegion` lives in the typed LIR layer only. Serialized into bytecode it
 /// becomes a raw `u32`, and the VM decodes that `u32` slot and resolves it to a
 /// `RuntimeRegion` — the two never meet as the same type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(transparent)]
 pub struct StaticRegion(NonZeroU32);
 
 impl StaticRegion {
@@ -61,7 +64,10 @@ impl std::fmt::Display for StaticRegion {
 /// Region ids are minted fresh per allocation *execution* (not per static
 /// site), so a long-running program churns through many ids even though the
 /// *live* count stays bounded by recycling. `u32` gives ample headroom.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(transparent)]
 pub struct RuntimeRegion(NonZeroU32);
 
 impl RuntimeRegion {
@@ -113,7 +119,7 @@ impl std::fmt::Display for RuntimeRegion {
 /// an entry whose region has since moved on (`gen != current`) is recognized as
 /// a dead leftover and skipped, while a genuine borrow freed *while parked* still
 /// trips the check (docs/impl/region/generations.md § "Uncounted-borrow check").
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct MappedRegion {
     /// The physical region the slot resolves to.
     pub region: RuntimeRegion,

--- a/src/hir/typeinfer.rs
+++ b/src/hir/typeinfer.rs
@@ -26,12 +26,13 @@ use std::collections::HashMap;
 mod contract;
 mod fuse;
 pub(crate) use fuse::fuse_map_chains;
-pub(crate) use fuse::FnInlineRegistry;
+pub(crate) use fuse::{FnInlineRegistry, StoredFnInlineRegistry};
 mod guard;
 mod infer;
 use infer::*;
 mod monomorphize;
 pub use monomorphize::DispatchWrapperRegistry;
+pub(crate) use monomorphize::StoredDispatchRegistry;
 mod prune;
 pub(crate) use prune::prune_typeof_match_arms;
 

--- a/src/hir/typeinfer.rs
+++ b/src/hir/typeinfer.rs
@@ -189,7 +189,7 @@ fn unwrap_to_call(hir: &Hir) -> Option<usize> {
 ///
 /// Primitives carry their return type in the registry
 /// (`PrimitiveDef::ret`, looked up through `def_by_name` — name and
-/// alias spellings alike), so inference reads the same const tables
+/// alias spellings alike), so inference reads the same static tables
 /// `register_primitives` feeds and cannot drift from them. The only
 /// names matched here are stdlib *closures* (defined in stdlib.lisp,
 /// not in any primitive table) whose pass-through typing inference

--- a/src/hir/typeinfer/fuse.rs
+++ b/src/hir/typeinfer/fuse.rs
@@ -130,7 +130,7 @@ use clone::*;
 use ops::*;
 use registry::*;
 
-pub(crate) use registry::FnInlineRegistry;
+pub(crate) use registry::{FnInlineRegistry, StoredFnInlineRegistry};
 
 /// Fuse every qualifying HOF chain into an inlined index-walk loop. Runs on
 /// surface HIR, before functionalize (see the module doc). `registry` is the

--- a/src/hir/typeinfer/fuse/registry.rs
+++ b/src/hir/typeinfer/fuse/registry.rs
@@ -7,7 +7,7 @@ use super::*;
 /// `let`-bound bindings per call site, and re-resolves every free global by name
 /// against the consuming unit's own primitive bindings (`clone_reg_template`). The
 /// signal feeds the composition-reorder gate exactly as a same-unit template's does.
-pub(super) struct RegFnTemplate {
+pub(crate) struct RegFnTemplate {
     pub(super) arity: usize,
     pub(super) params: Vec<Binding>,
     pub(super) body: Hir,
@@ -18,6 +18,27 @@ pub(super) struct RegFnTemplate {
     /// arenas, so the fact travels here). It is what proves a spliced raw
     /// `%`-intrinsic in the body — see `BindingInner::declared_numeric`.
     pub(super) declared_numeric: bool,
+}
+impl RegFnTemplate {
+    /// `clone_fresh` re-mints `let`-bound bindings by reading their metadata off
+    /// the defining arena (`arena.get`); a template restored from the stdlib
+    /// disk cache has no such arena, so templates whose body contains a `let`
+    /// are not serialized (they stay un-inlined on the cached path — a
+    /// performance-only difference). Pure-expression bodies are safe.
+    pub(super) fn body_has_let(h: &Hir) -> bool {
+        match &h.kind {
+            HirKind::Let { .. } => true,
+            _ => {
+                let mut found = false;
+                h.for_each_child(|c| {
+                    if !found && Self::body_has_let(c) {
+                        found = true;
+                    }
+                });
+                found
+            }
+        }
+    }
 }
 
 /// Per-instance persistent map of cross-unit-inlineable function templates, keyed
@@ -35,7 +56,7 @@ pub(super) struct RegFnTemplate {
 /// pattern mirrors `monomorphize::DispatchWrapperRegistry`.
 #[derive(Default)]
 pub struct FnInlineRegistry {
-    by_name: FxHashMap<SymbolId, RegFnTemplate>,
+    pub(crate) by_name: FxHashMap<SymbolId, RegFnTemplate>,
 }
 
 impl FnInlineRegistry {
@@ -44,6 +65,62 @@ impl FnInlineRegistry {
     /// binding, and re-recording across compiles is a cheap no-op.
     pub(super) fn record(&mut self, name: SymbolId, t: RegFnTemplate) {
         self.by_name.entry(name).or_insert(t);
+    }
+    /// Snapshot the registry for the stdlib disk cache. Templates whose body
+    /// contains a `let` are skipped (`clone_fresh` re-mints their bindings off
+    /// the defining arena, which a reloaded template cannot provide). Names
+    /// travel instead of per-process `SymbolId`s.
+    pub(crate) fn to_stored(&self, symbols: &crate::symbol::SymbolTable) -> StoredFnInlineRegistry {
+        StoredFnInlineRegistry {
+            by_name: self
+                .by_name
+                .iter()
+                .filter(|(_, t)| !RegFnTemplate::body_has_let(&t.body))
+                .map(|(name, t)| {
+                    (
+                        symbols.name(*name).unwrap_or("").to_string(),
+                        StoredFnTemplate {
+                            arity: t.arity,
+                            params: t.params.iter().map(|b| b.0).collect(),
+                            body: t.body.clone(),
+                            globals: t
+                                .globals
+                                .iter()
+                                .map(|(b, s)| (b.0, symbols.name(*s).unwrap_or("").to_string()))
+                                .collect(),
+                            signal: t.signal,
+                            declared_numeric: t.declared_numeric,
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+    /// Restore a snapshot into this registry (stdlib disk cache load path);
+    /// re-interns names in the loading process's table.
+    pub(crate) fn restore(
+        &mut self,
+        stored: StoredFnInlineRegistry,
+        symbols: &mut crate::symbol::SymbolTable,
+    ) {
+        self.by_name.clear();
+        for (name, t) in stored.by_name {
+            self.by_name.insert(
+                symbols.intern(&name),
+                RegFnTemplate {
+                    arity: t.arity,
+                    params: t.params.iter().map(|&i| Binding(i)).collect(),
+                    body: t.body,
+                    globals: t
+                        .globals
+                        .iter()
+                        .map(|(i, n)| (Binding(*i), symbols.intern(n)))
+                        .collect(),
+                    signal: t.signal,
+                    declared_numeric: t.declared_numeric,
+                },
+            );
+        }
     }
 }
 
@@ -309,4 +386,19 @@ impl FnResolver<'_> {
             _ => unreachable!("validate_chain proved a lambda or a template Var"),
         }
     }
+}
+
+/// Serializable snapshot of [`FnInlineRegistry`] for the stdlib disk cache.
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+pub(crate) struct StoredFnInlineRegistry {
+    pub(crate) by_name: Vec<(String, StoredFnTemplate)>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct StoredFnTemplate {
+    pub(crate) arity: usize,
+    pub(crate) params: Vec<u32>,
+    pub(crate) body: Hir,
+    pub(crate) globals: Vec<(u32, String)>,
+    pub(crate) signal: Signal,
+    pub(crate) declared_numeric: bool,
 }

--- a/src/hir/typeinfer/monomorphize.rs
+++ b/src/hir/typeinfer/monomorphize.rs
@@ -99,9 +99,9 @@ struct Wrapper {
 /// bindings. The operand map (`Arm::arg_src`) is not carried — it was already proven
 /// to be the identity `0..arity` when the wrapper was collected, so the rewrite reuses
 /// the call's args in order.
-struct RegArm {
-    ty: TyId,
-    native_name: SymbolId,
+pub(crate) struct RegArm {
+    pub(crate) ty: TyId,
+    pub(crate) native_name: SymbolId,
     /// This arm does not monomorphize cross-unit — it is a mutable in-place `del`
     /// and stays on the wrapper's container compensation (see
     /// `is_mutable_container`). Decided at record time because an arm's `ty` is
@@ -110,9 +110,9 @@ struct RegArm {
 }
 
 /// A wrapper summarized by name for cross-unit reuse (see `RegArm`).
-struct RegWrapper {
-    arity: usize,
-    arms: Vec<RegArm>,
+pub(crate) struct RegWrapper {
+    pub(crate) arity: usize,
+    pub(crate) arms: Vec<RegArm>,
 }
 
 /// Per-instance persistent map of dispatch wrappers, keyed by wrapper NAME. Each
@@ -127,7 +127,7 @@ struct RegWrapper {
 /// compile that defined the wrapper — never on any VM/region structure.
 #[derive(Default)]
 pub struct DispatchWrapperRegistry {
-    by_name: HashMap<SymbolId, RegWrapper>,
+    pub(crate) by_name: HashMap<SymbolId, RegWrapper>,
 }
 
 impl DispatchWrapperRegistry {
@@ -152,6 +152,63 @@ impl DispatchWrapperRegistry {
                 })
                 .collect(),
         });
+    }
+    /// Snapshot this registry for the stdlib disk cache. SymbolIds are
+    /// per-process; names travel instead, re-interned on load. `TyId` is a
+    /// well-known `TypeInterner` constant (stable across processes).
+    pub(crate) fn to_stored(&self, symbols: &crate::symbol::SymbolTable) -> StoredDispatchRegistry {
+        StoredDispatchRegistry {
+            by_name: self
+                .by_name
+                .iter()
+                .map(|(name, rw)| {
+                    (
+                        symbols.name(*name).unwrap_or("").to_string(),
+                        StoredRegWrapper {
+                            arity: rw.arity,
+                            arms: rw
+                                .arms
+                                .iter()
+                                .map(|a| StoredRegArm {
+                                    ty: a.ty.0,
+                                    native_name: symbols
+                                        .name(a.native_name)
+                                        .unwrap_or("")
+                                        .to_string(),
+                                    skip: a.skip,
+                                })
+                                .collect(),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+    /// Restore a registry snapshot into this one (used by the stdlib disk
+    /// cache load path; re-interns names in the loading process's table).
+    pub(crate) fn restore(
+        &mut self,
+        stored: StoredDispatchRegistry,
+        symbols: &mut crate::symbol::SymbolTable,
+    ) {
+        self.by_name.clear();
+        for (name, rw) in stored.by_name {
+            self.by_name.insert(
+                symbols.intern(&name),
+                RegWrapper {
+                    arity: rw.arity,
+                    arms: rw
+                        .arms
+                        .into_iter()
+                        .map(|a| RegArm {
+                            ty: TyId(a.ty),
+                            native_name: symbols.intern(&a.native_name),
+                            skip: a.skip,
+                        })
+                        .collect(),
+                },
+            );
+        }
     }
 }
 
@@ -578,4 +635,22 @@ mod tests {
             );
         }
     }
+}
+
+/// Serializable snapshot of [`DispatchWrapperRegistry`] for the stdlib disk
+/// cache. Names (not per-process `SymbolId`s) travel; re-interned on load.
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+pub(crate) struct StoredDispatchRegistry {
+    pub(crate) by_name: Vec<(String, StoredRegWrapper)>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct StoredRegWrapper {
+    pub(crate) arity: usize,
+    pub(crate) arms: Vec<StoredRegArm>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct StoredRegArm {
+    pub(crate) ty: u32,
+    pub(crate) native_name: String,
+    pub(crate) skip: bool,
 }

--- a/src/jit/mod.rs
+++ b/src/jit/mod.rs
@@ -51,6 +51,7 @@ pub use code::JitCode;
 pub use compiler::{BatchMember, JitCompiler};
 pub use dispatch::{TAIL_CALL_SENTINEL, YIELD_SENTINEL};
 pub use value::JitValue;
+pub use worker::{JIT_COMPILE_NS, JIT_COMPILE_TASKS};
 
 use std::fmt;
 

--- a/src/jit/worker.rs
+++ b/src/jit/worker.rs
@@ -11,7 +11,7 @@ use crate::jit::{JitCode, JitCompiler, JitError};
 use crate::lir::LirFunction;
 use crate::value::SymbolId;
 /// Cumulative Cranelift compilation time (ns) and task count across the
-/// process, readable by embedders for profiling (`ELLE_PROFILE=1`).
+/// process, readable by embedders for profiling.
 pub static JIT_COMPILE_NS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 pub static JIT_COMPILE_TASKS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 

--- a/src/jit/worker.rs
+++ b/src/jit/worker.rs
@@ -10,6 +10,10 @@
 use crate::jit::{JitCode, JitCompiler, JitError};
 use crate::lir::LirFunction;
 use crate::value::SymbolId;
+/// Cumulative Cranelift compilation time (ns) and task count across the
+/// process, readable by embedders for profiling (`ELLE_PROFILE=1`).
+pub static JIT_COMPILE_NS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+pub static JIT_COMPILE_TASKS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Compilation request sent to the background JIT thread.
 pub(crate) struct JitTask {
@@ -64,10 +68,16 @@ impl JitWorker {
 
                 while let Ok(task) = task_rx.recv() {
                     let key = task.bytecode_key;
+                    let t0 = std::time::Instant::now();
                     let result = match JitCompiler::new() {
                         Ok(compiler) => compiler.compile(&task.lir, task.self_sym, Vec::new()),
                         Err(e) => Err(e),
                     };
+                    JIT_COMPILE_NS.fetch_add(
+                        t0.elapsed().as_nanos() as u64,
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                    JIT_COMPILE_TASKS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     let _ = result_tx.send(JitResult {
                         bytecode_key: key,
                         result,

--- a/src/lir/types/func.rs
+++ b/src/lir/types/func.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// A LIR function (compilation unit)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LirFunction {
     /// This closure's identity in the module's closure list.
     /// `None` for the entry function and standalone tests.
@@ -38,8 +38,10 @@ pub struct LirFunction {
     /// Optional docstring from the source lambda. Plain `Rc<str>` compile-time
     /// data, never a heap `Value` — materialized as a fresh ordinary
     /// (reclaimable) allocation on `(doc f)`.
+    #[serde(skip)]
     pub doc: Option<std::rc::Rc<str>>,
     /// Original lambda Syntax node for eval environment reconstruction
+    #[serde(skip)]
     pub syntax: Option<std::rc::Rc<crate::syntax::Syntax>>,
     /// How varargs are collected: List (pair chain) or Struct (immutable struct).
     /// Only meaningful when arity is AtLeast.
@@ -91,7 +93,7 @@ pub struct LirFunction {
 /// Metadata about a yield point, collected during bytecode emission.
 /// The JIT reads this to know how to spill registers and where to
 /// resume in the interpreter.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct YieldPointInfo {
     /// Bytecode IP to resume at (the instruction after the Yield opcode).
     /// This is the IP stored in the SuspendedFrame so the interpreter
@@ -113,7 +115,7 @@ pub struct YieldPointInfo {
 /// which is needed to build SuspendedFrames for yield-through-call.
 ///
 /// Only populated for functions where `signal.may_suspend()`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CallSiteInfo {
     /// Bytecode IP after the Call instruction and its operands.
     /// This is the IP the interpreter would store in SuspendedFrame.ip

--- a/src/lir/types/instr.rs
+++ b/src/lir/types/instr.rs
@@ -3,7 +3,7 @@ use super::*;
 mod region;
 
 /// LIR instruction (SSA form - each register assigned exactly once)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum LirInstr {
     // === Constants ===
     /// Load a constant into a register

--- a/src/lir/types/instr.rs
+++ b/src/lir/types/instr.rs
@@ -588,3 +588,107 @@ pub enum LirInstr {
     /// Bitwise tag+payload equality
     Identical { dst: Reg, lhs: Reg, rhs: Reg },
 }
+
+impl LirInstr {
+    /// Visit every `LirConst` this instruction carries.
+    ///
+    /// Exhaustive on purpose. The `send` path rewrites `LirConst::Symbol` ids
+    /// into the loading process's table, and an instruction it fails to visit
+    /// keeps the storing process's id — a silently wrong symbol, not an error.
+    /// A new variant that carries a constant cannot be added without choosing
+    /// its arm here.
+    pub fn for_each_const_mut(&mut self, mut f: impl FnMut(&mut LirConst)) {
+        use LirInstr::*;
+        match self {
+            Const { value, .. } => f(value),
+            StructGetOrNil { key, .. } => f(key),
+            StructGetDestructure { key, .. } => f(key),
+            StructRest { exclude_keys, .. } => exclude_keys.iter_mut().for_each(f),
+            // Carries no `LirConst`.
+            ValueConst { .. }
+            | MaterializeConst { .. }
+            | LoadLocal { .. }
+            | StoreLocal { .. }
+            | StoreLocalRefcounted { .. }
+            | LoadCapture { .. }
+            | LoadCaptureRaw { .. }
+            | StoreCapture { .. }
+            | MakeClosure { .. }
+            | LoadSelf { .. }
+            | Call { .. }
+            | SuspendingCall { .. }
+            | TailCall { .. }
+            | List { .. }
+            | MakeArrayMut { .. }
+            | First { .. }
+            | Rest { .. }
+            | BinOp { .. }
+            | UnaryOp { .. }
+            | Convert { .. }
+            | Compare { .. }
+            | IsNil { .. }
+            | IsPair { .. }
+            | IsArray { .. }
+            | IsArrayMut { .. }
+            | IsStruct { .. }
+            | IsStructMut { .. }
+            | IsSet { .. }
+            | IsSetMut { .. }
+            | ArrayMutLen { .. }
+            | MakeCaptureCell { .. }
+            | LoadCaptureCell { .. }
+            | StoreCaptureCell { .. }
+            | MatchFail { .. }
+            | FirstDestructure { .. }
+            | RestDestructure { .. }
+            | ArrayMutRefDestructure { .. }
+            | ArrayMutSliceFrom { .. }
+            | FirstOrNil { .. }
+            | RestOrNil { .. }
+            | ArrayMutRefOrNil { .. }
+            | LoadResumeValue { .. }
+            | Eval { .. }
+            | ArrayMutExtend { .. }
+            | ArrayMutPush { .. }
+            | CallArrayMut { .. }
+            | TailCallArrayMut { .. }
+            | IncrefRegion { .. }
+            | DecrefRegion { .. }
+            | DecrefValueRegion { .. }
+            | DecrefCellRegion { .. }
+            | IncrefValueRegion { .. }
+            | AdoptRegion { .. }
+            | AdoptCellRegion { .. }
+            | FreeRegionGroup { .. }
+            | AdoptIntoActivation { .. }
+            | AssertRegionMatches { .. }
+            | PushParamFrame { .. }
+            | PopParamFrame { .. }
+            | CheckSignalBound { .. }
+            | IsEmpty { .. }
+            | IsBool { .. }
+            | IsInt { .. }
+            | IsFloat { .. }
+            | IsString { .. }
+            | IsKeyword { .. }
+            | IsSymbolCheck { .. }
+            | IsBytes { .. }
+            | IsBox { .. }
+            | IsClosure { .. }
+            | IsFiber { .. }
+            | TypeOf { .. }
+            | Length { .. }
+            | Get { .. }
+            | Put { .. }
+            | Del { .. }
+            | Has { .. }
+            | IntrPush { .. }
+            | IntrStringPush { .. }
+            | IntrBytesPush { .. }
+            | Pop { .. }
+            | Freeze { .. }
+            | Thaw { .. }
+            | Identical { .. } => {}
+        }
+    }
+}

--- a/src/lir/types/instr.rs
+++ b/src/lir/types/instr.rs
@@ -663,7 +663,7 @@ impl LirInstr {
             | AdoptIntoActivation { .. }
             | AssertRegionMatches { .. }
             | PushParamFrame { .. }
-            | PopParamFrame { .. }
+            | PopParamFrame
             | CheckSignalBound { .. }
             | IsEmpty { .. }
             | IsBool { .. }

--- a/src/lir/types/mod.rs
+++ b/src/lir/types/mod.rs
@@ -32,14 +32,14 @@ pub fn closure_value_const_count() -> usize {
 }
 
 /// Virtual register
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Reg(pub u32);
 
 /// Index into an `LirModule`'s closure list.
 ///
 /// `MakeClosure` references closures by ID rather than owning them,
 /// so each closure is an independent compilation unit.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ClosureId(pub u32);
 
 /// A module: an entry function plus independently compiled closures.
@@ -60,7 +60,7 @@ impl Reg {
 }
 
 /// Basic block label
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Label(pub u32);
 
 impl Label {
@@ -77,7 +77,7 @@ impl Label {
 /// the absence of the field — never by a sentinel 0 or an `Option` that every
 /// instruction must drag along (which would let an allocation be built with no
 /// region, the exact invalid state the newtype exists to forbid).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SpannedInstr {
     pub instr: LirInstr,
     pub span: Span,
@@ -90,7 +90,7 @@ impl SpannedInstr {
 }
 
 /// A terminator with source location
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SpannedTerminator {
     pub terminator: Terminator,
     pub span: Span,
@@ -103,7 +103,7 @@ impl SpannedTerminator {
 }
 
 /// A basic block - sequence of instructions ending in a terminator
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BasicBlock {
     pub label: Label,
     pub instructions: Vec<SpannedInstr>,
@@ -121,7 +121,7 @@ impl BasicBlock {
 }
 
 /// Binary operations
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BinOp {
     Add,
     Sub,
@@ -136,7 +136,7 @@ pub enum BinOp {
 }
 
 /// Unary operations
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum UnaryOp {
     Neg,
     Not,
@@ -144,14 +144,14 @@ pub enum UnaryOp {
 }
 
 /// Conversion operations (type coercion intrinsics)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ConvOp {
     IntToFloat,
     FloatToInt,
 }
 
 /// Comparison operations
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum CmpOp {
     Eq,
     Ne,
@@ -162,7 +162,7 @@ pub enum CmpOp {
 }
 
 /// Block terminator - how control leaves a block
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum Terminator {
     /// Return from function
     Return(Reg),
@@ -188,7 +188,7 @@ pub enum Terminator {
 }
 
 /// Constant values in LIR
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum LirConst {
     Nil,
     EmptyList,

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -86,7 +86,12 @@ impl CompilerState {
         vm.set_symbols(&mut *symbol_table as *mut SymbolTable);
         let mut compile = Box::new(CompileCtx::new());
         vm.set_compile_ctx(&mut *compile as *mut CompileCtx);
-        init_stdlib(&mut vm, &mut symbol_table, &mut compile);
+        init_stdlib(
+            &mut vm,
+            &mut symbol_table,
+            &mut compile,
+            &crate::compiler::stdlib_cache::StdlibCache::Process,
+        );
 
         Self {
             documents: HashMap::new(),

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -283,7 +283,9 @@ impl CompileCtx {
         // here would drop every name the module's quoted data carries, and a
         // transformer cached on the shared expander during this compile would
         // outlive the table it learned into. The `each` and probe tests in
-        // tests/integration/projection.rs pin both halves.
+        // tests/integration/projection.rs pin both halves. A cache hit skips
+        // the stdlib compile that would otherwise warm every transformer, so
+        // the probe is often the first expansion on that path too.
         let projection = super::compile::compile_file(&source, symbols, self, resolved_path)
             .ok()
             .and_then(|result| result.bytecode.signal_projection);

--- a/src/primitives/arithmetic.rs
+++ b/src/primitives/arithmetic.rs
@@ -1,3 +1,3 @@
 use crate::primitives::def::PrimitiveDef;
 
-pub(crate) const PRIMITIVES: &[PrimitiveDef] = &[];
+pub(crate) static PRIMITIVES: &[PrimitiveDef] = &[];

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -115,6 +115,9 @@ fn spawn_closure_impl(
     // The worker inherits the spawning VM's Unicode generation: a program is
     // one set of string semantics, whichever VM computes a length.
     let unicode_generation = ctx.unicode_generation();
+    // Moved into the worker thread beside the generation: a worker's stdlib is a
+    // stdlib, so it caches too, and it must cache where its parent was told to.
+    let stdlib_cache = ctx.stdlib_cache();
     // Capabilities flow down across a thread, as they do across a fiber
     // (docs/signals/capabilities.md § Transitivity). The worker runs in a fresh
     // VM whose root fiber is what the capability gate reads, so without this the
@@ -194,11 +197,12 @@ fn spawn_closure_impl(
                 // above are in place, which init_stdlib needs (gensym during load).
                 // The light worker (`sys/spawn-vm`) skips this — primitives only.
                 if load_stdlib {
+                    vm.set_stdlib_cache(stdlib_cache.clone());
                     crate::primitives::module_init::init_stdlib(
                         &mut vm,
                         &mut symbols,
                         &mut compile,
-                        &crate::compiler::stdlib_cache::StdlibCache::Process,
+                        &stdlib_cache,
                     );
                 }
 

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -198,6 +198,7 @@ fn spawn_closure_impl(
                         &mut vm,
                         &mut symbols,
                         &mut compile,
+                        &crate::compiler::stdlib_cache::StdlibCache::Process,
                     );
                 }
 

--- a/src/primitives/ctx.rs
+++ b/src/primitives/ctx.rs
@@ -234,6 +234,12 @@ impl<'h> NativeCtx<'h> {
     pub fn unicode_generation(&self) -> crate::segment::Generation {
         self.vm().unicode_generation()
     }
+
+    /// Where this instance caches its compiled stdlib — what a worker spawned
+    /// from here inherits.
+    pub fn stdlib_cache(&self) -> crate::compiler::stdlib_cache::StdlibCache {
+        self.vm().stdlib_cache().clone()
+    }
 }
 
 /// Generate the ergonomic `ctx.*` constructors (docs/impl/region/ctx.md

--- a/src/primitives/def.rs
+++ b/src/primitives/def.rs
@@ -324,19 +324,23 @@ const fn _default_prim(
 ///   ```
 ///
 /// - **Single static** — one `static`, for the trait-method handles and the
-///   ad-hoc no-op def:
+///   ad-hoc no-op def. Requires an explicit type annotation so the arm
+///   cannot be confused with a single-entry *table* (a bare
+///   `static NAME = "x" => f { .. }` with one entry is always a table):
 ///
 ///   ```ignore
-///   primitive!(static SEQ_FIRST = "trait:Sequence:first" => trait_seq_first {
+///   primitive!(static SEQ_FIRST: PrimitiveDef = "trait:Sequence:first" => trait_seq_first {
 ///       signal: Signal::errors(), arity: Arity::Exact(1), effect: RegionEffect::Mixed
 ///   });
 ///   ```
 macro_rules! primitive {
     // Single static def. Forwards outer attributes (doc comments, `#[cfg]`).
-    ( $(#[$meta:meta])* $vis:vis static $id:ident = $name:literal => $func:ident { $( $key:ident : $val:expr ),* $(,)? } ) => {
+    // The explicit `: Type` marks this as one def, not a single-entry table;
+    // without it the named-table arm below wins and emits `&[PrimitiveDef]`.
+    ( $(#[$meta:meta])* $vis:vis static $id:ident : $ty:ty = $name:literal => $func:ident { $( $key:ident : $val:expr ),* $(,)? } ) => {
         $(#[$meta])*
         #[allow(clippy::needless_update)]
-        $vis static $id: crate::primitives::def::PrimitiveDef = crate::primitives::def::PrimitiveDef {
+        $vis static $id: $ty = crate::primitives::def::PrimitiveDef {
             name: $name,
             func: $func,
             $( $key : $val, )*
@@ -391,7 +395,7 @@ fn _noop_prim(
 primitive!(
     /// A silent, no-op PrimitiveDef for ad-hoc `Value::native_fn` creation.
     /// Used by tests and FFI wrappers that need a `&'static PrimitiveDef`.
-    pub static NOOP_PRIM = "<noop>" => _noop_prim {
+    pub static NOOP_PRIM: PrimitiveDef = "<noop>" => _noop_prim {
         signal: Signal::silent(),
         arity: Arity::AtLeast(0),
     }

--- a/src/primitives/def.rs
+++ b/src/primitives/def.rs
@@ -1,6 +1,6 @@
 //! Primitive definition type for declarative registration.
 //!
-//! Each primitive module exports a `const PRIMITIVES: &[PrimitiveDef]`
+//! Each primitive module exports a `static PRIMITIVES: &[PrimitiveDef]`
 //! table. `register_primitives` iterates all tables to register
 //! primitives with the VM and build the metadata maps.
 
@@ -182,7 +182,7 @@ pub enum RegionEffect {
 /// Declarative definition of a primitive function.
 ///
 /// All metadata for a primitive lives here. Each primitive module
-/// exports a const array of these. Adding a new metadata field
+/// exports a static array of these. Adding a new metadata field
 /// means adding it here with a default; existing tables use
 /// `..PrimitiveDef::DEFAULT`.
 pub struct PrimitiveDef {
@@ -299,7 +299,7 @@ const fn _default_prim(
 ///
 /// Three forms:
 ///
-/// - **Anonymous table** — emits `pub(crate) const PRIMITIVES: &[PrimitiveDef]`,
+/// - **Anonymous table** — emits `pub(crate) static PRIMITIVES: &[PrimitiveDef]`,
 ///   the per-module registration table:
 ///
 ///   ```ignore
@@ -314,11 +314,11 @@ const fn _default_prim(
 ///   }
 ///   ```
 ///
-/// - **Named table** — same, but a caller-chosen const name and visibility,
+/// - **Named table** — same, but a caller-chosen static name and visibility,
 ///   for the feature-gated side tables:
 ///
 ///   ```ignore
-///   primitive!(pub(crate) const CALLBACK_PRIMITIVES =
+///   primitive!(pub(crate) static CALLBACK_PRIMITIVES =
 ///       "ffi/call" => prim_ffi_call { arity: Arity::AtLeast(2) }
 ///   );
 ///   ```
@@ -344,10 +344,10 @@ macro_rules! primitive {
         };
     };
 
-    // Named const table. Forwards outer attributes (doc comments, `#[cfg]`).
-    ( $(#[$meta:meta])* $vis:vis const $tbl:ident = $( $name:literal => $func:ident { $( $key:ident : $val:expr ),* $(,)? } )* ) => {
+    // Named static table. Forwards outer attributes (doc comments, `#[cfg]`).
+    ( $(#[$meta:meta])* $vis:vis static $tbl:ident = $( $name:literal => $func:ident { $( $key:ident : $val:expr ),* $(,)? } )* ) => {
         $(#[$meta])*
-        $vis const $tbl: &[crate::primitives::def::PrimitiveDef] = &[
+        $vis static $tbl: &[crate::primitives::def::PrimitiveDef] = &[
             $(
                 #[allow(clippy::needless_update)]
                 crate::primitives::def::PrimitiveDef {
@@ -360,9 +360,9 @@ macro_rules! primitive {
         ];
     };
 
-    // Anonymous `pub(crate) const PRIMITIVES` table.
+    // Anonymous `pub(crate) static PRIMITIVES` table.
     ( $( $name:literal => $func:ident { $( $key:ident : $val:expr ),* $(,)? } )* ) => {
-        pub(crate) const PRIMITIVES: &[crate::primitives::def::PrimitiveDef] = &[
+        pub(crate) static PRIMITIVES: &[crate::primitives::def::PrimitiveDef] = &[
             $(
                 #[allow(clippy::needless_update)]
                 crate::primitives::def::PrimitiveDef {

--- a/src/primitives/introspection.rs
+++ b/src/primitives/introspection.rs
@@ -453,7 +453,7 @@ primitive! {
 
 #[cfg(feature = "mlir")]
 primitive!(
-    pub(crate) const MLIR_PRIMITIVES =
+    pub(crate) static MLIR_PRIMITIVES =
         "mlir/compile-spirv" => prim_compile_spirv {
             signal: Signal::query_errors(),
             arity: Arity::Range(1, 2),

--- a/src/primitives/loading.rs
+++ b/src/primitives/loading.rs
@@ -353,7 +353,7 @@ primitive! {
 #[cfg(feature = "ffi")]
 primitive!(
     /// FFI call and callback primitives (require libffi).
-    pub(crate) const CALLBACK_PRIMITIVES =
+    pub(crate) static CALLBACK_PRIMITIVES =
         "ffi/call" => prim_ffi_call {
             signal: Signal::ffi_errors(),
             arity: Arity::AtLeast(2),

--- a/src/primitives/module_init.rs
+++ b/src/primitives/module_init.rs
@@ -17,7 +17,12 @@ const STDLIB: &str = include_str!("../stdlib.lisp");
 /// We call that closure, iterate the exports struct, and register each
 /// export into the compilation cache's PrimitiveMeta so that
 /// `bind_primitives` pre-binds them for all subsequent compilations.
-pub fn init_stdlib(vm: &mut VM, symbols: &mut SymbolTable, cctx: &mut CompileCtx) {
+pub fn init_stdlib(
+    vm: &mut VM,
+    symbols: &mut SymbolTable,
+    cctx: &mut CompileCtx,
+    cache: &crate::compiler::stdlib_cache::StdlibCache,
+) -> StdlibSource {
     let boot = crate::trace::boot();
     let t = std::time::Instant::now();
     // Try the disk cache first: same stdlib source + same elle binary → same
@@ -27,13 +32,16 @@ pub fn init_stdlib(vm: &mut VM, symbols: &mut SymbolTable, cctx: &mut CompileCtx
     // OBTAINING the compiled stdlib, and a run that loads it has to be
     // comparable with a run that compiles it. `tests/integration/trace_boot.rs`
     // pins the mark, and it must not disappear the moment the cache warms.
-    if let Some(cached) = crate::compiler::stdlib_cache::try_load(STDLIB, vm, symbols, cctx) {
+    if let Some(cached) = crate::compiler::stdlib_cache::try_load(STDLIB, cache, vm, symbols, cctx)
+    {
+        let mut source = StdlibSource::Cache;
         let bytecode = match cached {
             Ok(bc) => {
                 crate::trace::phase(boot, "boot", "stdlib-compile (cache hit)", t);
                 bc
             }
             Err(e) => {
+                source = StdlibSource::Compiled;
                 crate::trace::phase(
                     boot,
                     "boot",
@@ -59,7 +67,7 @@ pub fn init_stdlib(vm: &mut VM, symbols: &mut SymbolTable, cctx: &mut CompileCtx
         // Call the returned closure to get the exports struct.
         let exports_val = call_closure(vm, closure_val);
         register_exports(vm, symbols, cctx, closure_val, exports_val);
-        return;
+        return source;
     }
     let result = match compile_file(STDLIB, symbols, cctx, "<stdlib>") {
         Ok(r) => r,
@@ -70,7 +78,7 @@ pub fn init_stdlib(vm: &mut VM, symbols: &mut SymbolTable, cctx: &mut CompileCtx
     // Persist the compiled bytecode so the next process start skips the front
     // end entirely. A write failure is not fatal — the cache is a speedup, and
     // a fresh compile is always the fallback.
-    crate::compiler::stdlib_cache::try_store(STDLIB, &result.bytecode, vm, symbols, cctx);
+    crate::compiler::stdlib_cache::try_store(STDLIB, cache, &result.bytecode, vm, symbols, cctx);
     crate::trace::phase(boot, "boot", "stdlib-cache-store", t);
     let t = std::time::Instant::now();
     // Execute stdlib — returns the last expression (a closure).
@@ -82,6 +90,19 @@ pub fn init_stdlib(vm: &mut VM, symbols: &mut SymbolTable, cctx: &mut CompileCtx
     // Call the returned closure to get the exports struct.
     let exports_val = call_closure(vm, closure_val);
     register_exports(vm, symbols, cctx, closure_val, exports_val);
+    StdlibSource::Compiled
+}
+
+/// Where a runtime's stdlib bytecode came from. Returned by `init_stdlib` so a
+/// caller — a test above all — can tell a cache hit from a recompile; without
+/// it a cache that silently never hits is indistinguishable from one that
+/// always does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StdlibSource {
+    /// Loaded from the disk cache.
+    Cache,
+    /// Compiled from `stdlib.lisp`.
+    Compiled,
 }
 
 /// Register each stdlib export into the compilation cache (the tail of the

--- a/src/primitives/module_init.rs
+++ b/src/primitives/module_init.rs
@@ -28,61 +28,54 @@ pub fn init_stdlib(
     // Try the disk cache first: same stdlib source + same elle binary → same
     // compiled bytecode. On hit we skip the entire ~2.4s front end.
     //
-    // Both arms report `stdlib-compile`: the boot mark attributes the cost of
-    // OBTAINING the compiled stdlib, and a run that loads it has to be
-    // comparable with a run that compiles it. `tests/integration/trace_boot.rs`
-    // pins the mark, and it must not disappear the moment the cache warms.
-    if let Some(cached) = crate::compiler::stdlib_cache::try_load(STDLIB, cache, vm, symbols, cctx)
-    {
-        let mut source = StdlibSource::Cache;
-        let bytecode = match cached {
-            Ok(bc) => {
+    // One fork, two arms, one tail. A rejected file falls into the compiling
+    // arm along with a plain absence, so it is *replaced* rather than left to
+    // be rejected again by every later start; and the execute → exports tail
+    // exists once, so the two paths cannot drift apart.
+    //
+    // Both arms mark `stdlib-compile`: the boot mark attributes the cost of
+    // OBTAINING the compiled stdlib, so a run that loads it stays comparable
+    // with a run that compiles it.
+    let (bytecode, source) =
+        match crate::compiler::stdlib_cache::try_load(STDLIB, cache, vm, symbols, cctx) {
+            Some(Ok(bc)) => {
                 crate::trace::phase(boot, "boot", "stdlib-compile (cache hit)", t);
-                bc
+                (bc, StdlibSource::Cache)
             }
-            Err(e) => {
-                source = StdlibSource::Compiled;
-                crate::trace::phase(
-                    boot,
-                    "boot",
-                    &format!("stdlib-cache-miss ({e}); recompiling"),
-                    t,
-                );
+            absent_or_rejected => {
+                if let Some(Err(e)) = absent_or_rejected {
+                    crate::trace::phase(
+                        boot,
+                        "boot",
+                        &format!("stdlib-cache-rejected ({e}); recompiling"),
+                        t,
+                    );
+                }
                 let t = std::time::Instant::now();
-                let bc = match compile_file(STDLIB, symbols, cctx, "<stdlib>") {
-                    Ok(r) => r.bytecode,
+                let result = match compile_file(STDLIB, symbols, cctx, "<stdlib>") {
+                    Ok(r) => r,
                     Err(e) => panic!("stdlib compilation failed: {}", e),
                 };
                 crate::trace::phase(boot, "boot", "stdlib-compile", t);
-                bc
+                let t = std::time::Instant::now();
+                // Persist so the next process start skips the front end. A write
+                // failure is not fatal — the cache is a speedup, and a fresh
+                // compile is always the fallback.
+                crate::compiler::stdlib_cache::try_store(
+                    STDLIB,
+                    cache,
+                    &result.bytecode,
+                    vm,
+                    symbols,
+                    cctx,
+                );
+                crate::trace::phase(boot, "boot", "stdlib-cache-store", t);
+                (result.bytecode, StdlibSource::Compiled)
             }
         };
-        let t = std::time::Instant::now();
-        // Execute stdlib — returns the last expression (a closure).
-        let closure_val = match vm.execute(&bytecode) {
-            Ok(v) => v,
-            Err(e) => panic!("stdlib execution failed: {}", e),
-        };
-        crate::trace::phase(boot, "boot", "stdlib-execute", t);
-        // Call the returned closure to get the exports struct.
-        let exports_val = call_closure(vm, closure_val);
-        register_exports(vm, symbols, cctx, closure_val, exports_val);
-        return source;
-    }
-    let result = match compile_file(STDLIB, symbols, cctx, "<stdlib>") {
-        Ok(r) => r,
-        Err(e) => panic!("stdlib compilation failed: {}", e),
-    };
-    crate::trace::phase(boot, "boot", "stdlib-compile", t);
-    let t = std::time::Instant::now();
-    // Persist the compiled bytecode so the next process start skips the front
-    // end entirely. A write failure is not fatal — the cache is a speedup, and
-    // a fresh compile is always the fallback.
-    crate::compiler::stdlib_cache::try_store(STDLIB, cache, &result.bytecode, vm, symbols, cctx);
-    crate::trace::phase(boot, "boot", "stdlib-cache-store", t);
     let t = std::time::Instant::now();
     // Execute stdlib — returns the last expression (a closure).
-    let closure_val = match vm.execute(&result.bytecode) {
+    let closure_val = match vm.execute(&bytecode) {
         Ok(v) => v,
         Err(e) => panic!("stdlib execution failed: {}", e),
     };
@@ -90,7 +83,7 @@ pub fn init_stdlib(
     // Call the returned closure to get the exports struct.
     let exports_val = call_closure(vm, closure_val);
     register_exports(vm, symbols, cctx, closure_val, exports_val);
-    StdlibSource::Compiled
+    source
 }
 
 /// Where a runtime's stdlib bytecode came from. Returned by `init_stdlib` so a

--- a/src/primitives/module_init.rs
+++ b/src/primitives/module_init.rs
@@ -20,20 +20,81 @@ const STDLIB: &str = include_str!("../stdlib.lisp");
 pub fn init_stdlib(vm: &mut VM, symbols: &mut SymbolTable, cctx: &mut CompileCtx) {
     let boot = crate::trace::boot();
     let t = std::time::Instant::now();
+    // Try the disk cache first: same stdlib source + same elle binary → same
+    // compiled bytecode. On hit we skip the entire ~2.4s front end.
+    //
+    // Both arms report `stdlib-compile`: the boot mark attributes the cost of
+    // OBTAINING the compiled stdlib, and a run that loads it has to be
+    // comparable with a run that compiles it. `tests/integration/trace_boot.rs`
+    // pins the mark, and it must not disappear the moment the cache warms.
+    if let Some(cached) = crate::compiler::stdlib_cache::try_load(STDLIB, vm, symbols, cctx) {
+        let bytecode = match cached {
+            Ok(bc) => {
+                crate::trace::phase(boot, "boot", "stdlib-compile (cache hit)", t);
+                bc
+            }
+            Err(e) => {
+                crate::trace::phase(
+                    boot,
+                    "boot",
+                    &format!("stdlib-cache-miss ({e}); recompiling"),
+                    t,
+                );
+                let t = std::time::Instant::now();
+                let bc = match compile_file(STDLIB, symbols, cctx, "<stdlib>") {
+                    Ok(r) => r.bytecode,
+                    Err(e) => panic!("stdlib compilation failed: {}", e),
+                };
+                crate::trace::phase(boot, "boot", "stdlib-compile", t);
+                bc
+            }
+        };
+        let t = std::time::Instant::now();
+        // Execute stdlib — returns the last expression (a closure).
+        let closure_val = match vm.execute(&bytecode) {
+            Ok(v) => v,
+            Err(e) => panic!("stdlib execution failed: {}", e),
+        };
+        crate::trace::phase(boot, "boot", "stdlib-execute", t);
+        // Call the returned closure to get the exports struct.
+        let exports_val = call_closure(vm, closure_val);
+        register_exports(vm, symbols, cctx, closure_val, exports_val);
+        return;
+    }
     let result = match compile_file(STDLIB, symbols, cctx, "<stdlib>") {
         Ok(r) => r,
         Err(e) => panic!("stdlib compilation failed: {}", e),
     };
     crate::trace::phase(boot, "boot", "stdlib-compile", t);
     let t = std::time::Instant::now();
+    // Persist the compiled bytecode so the next process start skips the front
+    // end entirely. A write failure is not fatal — the cache is a speedup, and
+    // a fresh compile is always the fallback.
+    crate::compiler::stdlib_cache::try_store(STDLIB, &result.bytecode, vm, symbols, cctx);
+    crate::trace::phase(boot, "boot", "stdlib-cache-store", t);
+    let t = std::time::Instant::now();
     // Execute stdlib — returns the last expression (a closure).
     let closure_val = match vm.execute(&result.bytecode) {
         Ok(v) => v,
         Err(e) => panic!("stdlib execution failed: {}", e),
     };
+    crate::trace::phase(boot, "boot", "stdlib-execute", t);
     // Call the returned closure to get the exports struct.
     let exports_val = call_closure(vm, closure_val);
-    crate::trace::phase(boot, "boot", "stdlib-execute", t);
+    register_exports(vm, symbols, cctx, closure_val, exports_val);
+}
+
+/// Register each stdlib export into the compilation cache (the tail of the
+/// original `init_stdlib`, split out so both the cached and compiled paths
+/// share it).
+fn register_exports(
+    vm: &mut VM,
+    symbols: &mut SymbolTable,
+    cctx: &mut CompileCtx,
+    closure_val: Value,
+    exports_val: Value,
+) {
+    let boot = crate::trace::boot();
     let t = std::time::Instant::now();
     // Root the stdlib export aggregate (the struct + its module closure), not
     // each export. `exports_val` references every stdlib export, and the `Value`s

--- a/src/primitives/registration.rs
+++ b/src/primitives/registration.rs
@@ -11,12 +11,12 @@ use super::{
     structs, subprocess, time, traits, types, unix, watch,
 };
 
-/// All primitive tables. Each module exports a `const PRIMITIVES`
+/// All primitive tables. Each module exports a `static PRIMITIVES`
 /// array; this list is the single place that enumerates them.
 ///
 /// Tables gated behind `ffi` are appended via `ffi_tables()` below
-/// because `const` arrays cannot contain conditional entries.
-pub(crate) const ALL_TABLES: &[&[PrimitiveDef]] = &[
+/// because `static` arrays cannot contain conditional entries.
+pub(crate) static ALL_TABLES: &[&[PrimitiveDef]] = &[
     allocator::PRIMITIVES,
     arena::PRIMITIVES,
     arithmetic::PRIMITIVES,
@@ -74,7 +74,8 @@ pub(crate) const ALL_TABLES: &[&[PrimitiveDef]] = &[
 /// Primitive tables that require the `ffi` feature (libffi).
 #[cfg(feature = "ffi")]
 fn ffi_tables() -> &'static [&'static [PrimitiveDef]] {
-    &[loading::CALLBACK_PRIMITIVES]
+    static TABLES: &[&[PrimitiveDef]] = &[loading::CALLBACK_PRIMITIVES];
+    TABLES
 }
 
 #[cfg(not(feature = "ffi"))]
@@ -86,7 +87,7 @@ fn ffi_tables() -> &'static [&'static [PrimitiveDef]] {
 ///
 /// Compile-time consumers (type inference reading `PrimitiveDef::ret`)
 /// use this to look up primitive metadata by source name without a VM —
-/// the same const tables `register_primitives` feeds, so the data cannot
+/// the same static tables `register_primitives` feeds, so the data cannot
 /// drift from what runs.
 pub(crate) fn def_by_name(name: &str) -> Option<&'static PrimitiveDef> {
     use std::collections::HashMap;
@@ -154,8 +155,8 @@ pub(crate) fn def_by_symbol(id: crate::value::SymbolId) -> Option<&'static Primi
 /// small, deterministic ids; any other native-fn def (the trait-method handlers
 /// in `traitregistry`, ffi callbacks) is appended on first `prim_id_of` — in a
 /// deterministic startup order, so the ids are stable across runs of one binary.
-/// Keyed by the def's `&'static` address (every table is a `const PRIMITIVES`
-/// reference into promoted static memory, so addresses are stable).
+/// Keyed by the def's `&'static` address (every table is a `static PRIMITIVES`
+/// item, so addresses are stable across every reference site).
 struct PrimRegistry {
     defs: Vec<&'static PrimitiveDef>,
     by_ptr: std::collections::HashMap<usize, u32>,

--- a/src/primitives/registration.rs
+++ b/src/primitives/registration.rs
@@ -180,6 +180,30 @@ static PRIM_REGISTRY: std::sync::LazyLock<std::sync::Mutex<PrimRegistry>> =
         std::sync::Mutex::new(reg)
     });
 
+/// Visit the ordered canonical primitive-table identity (`name` + `aliases`)
+/// into a hasher.
+///
+/// A native-fn immediate's whole payload is its `prim_id`, which is the def's
+/// index in the canonical `ALL_TABLES`+`ffi_tables` enumeration. That id is
+/// only meaningful against the exact table that minted it, so consumers that
+/// persist native-fn values (the stdlib disk cache) must mix this identity
+/// into their key: any addition, removal, rename, or reorder of a canonical
+/// primitive changes the hash and invalidates the persisted payload.
+pub(crate) fn hash_prim_table_identity<H: std::hash::Hasher>(hasher: &mut H) {
+    for table in ALL_TABLES.iter().chain(ffi_tables().iter()) {
+        for def in *table {
+            hash_def_identity(def, hasher);
+        }
+    }
+}
+
+/// Hash one def's identity fields (see [`hash_prim_table_identity`]).
+fn hash_def_identity<H: std::hash::Hasher>(def: &PrimitiveDef, hasher: &mut H) {
+    use std::hash::Hash;
+    def.name.hash(hasher);
+    def.aliases.hash(hasher);
+}
+
 /// The `prim_id` of a primitive definition — how `Value::native_fn` finds the id
 /// to store as the immediate payload. Returns the existing id, or appends the def
 /// and assigns the next one (for defs minted outside the canonical tables, e.g.

--- a/src/primitives/registration/tests.rs
+++ b/src/primitives/registration/tests.rs
@@ -117,8 +117,16 @@ fn prim_identity_hash_sensitive_to_name_and_aliases() {
         aliases: &["a2"],
         ..PrimitiveDef::DEFAULT
     };
-    assert_ne!(hash(&base), hash(&renamed), "rename must change the identity");
-    assert_ne!(hash(&base), hash(&aliased), "alias change must change the identity");
+    assert_ne!(
+        hash(&base),
+        hash(&renamed),
+        "rename must change the identity"
+    );
+    assert_ne!(
+        hash(&base),
+        hash(&aliased),
+        "alias change must change the identity"
+    );
     assert_eq!(hash(&base), hash(&base), "identity hash is deterministic");
 }
 

--- a/src/primitives/registration/tests.rs
+++ b/src/primitives/registration/tests.rs
@@ -86,3 +86,52 @@ fn every_primitive_declares_an_examined_region_effect() {
         undeclared,
     );
 }
+
+/// The stdlib disk cache mixes `hash_prim_table_identity` into its key: a
+/// serialized native-fn immediate carries a `prim_id` that is only valid
+/// against the exact canonical table that minted it. The per-def hash must be
+/// sensitive to a rename or alias change (over-conservative is fine — a miss
+/// just recompiles; a false hit panics on `unknown prim id`).
+#[test]
+fn prim_identity_hash_sensitive_to_name_and_aliases() {
+    use super::super::def::PrimitiveDef;
+    use super::hash_def_identity;
+    use std::hash::{DefaultHasher, Hasher};
+
+    let hash = |def: &PrimitiveDef| {
+        let mut h = DefaultHasher::new();
+        hash_def_identity(def, &mut h);
+        h.finish()
+    };
+
+    let base = PrimitiveDef {
+        name: "a",
+        ..PrimitiveDef::DEFAULT
+    };
+    let renamed = PrimitiveDef {
+        name: "b",
+        ..PrimitiveDef::DEFAULT
+    };
+    let aliased = PrimitiveDef {
+        name: "a",
+        aliases: &["a2"],
+        ..PrimitiveDef::DEFAULT
+    };
+    assert_ne!(hash(&base), hash(&renamed), "rename must change the identity");
+    assert_ne!(hash(&base), hash(&aliased), "alias change must change the identity");
+    assert_eq!(hash(&base), hash(&base), "identity hash is deterministic");
+}
+
+/// The canonical table's identity is what the cache key reads, so it must be
+/// deterministic across calls within a process (stable startup ordering).
+#[test]
+fn prim_table_identity_deterministic() {
+    use super::hash_prim_table_identity;
+    use std::hash::{DefaultHasher, Hasher};
+    let fingerprint = || {
+        let mut h = DefaultHasher::new();
+        hash_prim_table_identity(&mut h);
+        h.finish()
+    };
+    assert_eq!(fingerprint(), fingerprint());
+}

--- a/src/primitives/traitregistry/methods.rs
+++ b/src/primitives/traitregistry/methods.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::primitives::def::RegionEffect;
+use crate::primitives::def::{PrimitiveDef, RegionEffect};
 
 /// Build the :Sequence method struct (immutable) into `heap`'s root region.
 pub(super) fn build_sequence_methods(heap: &mut FiberHeap) -> Value {
@@ -9,27 +9,27 @@ pub(super) fn build_sequence_methods(heap: &mut FiberHeap) -> Value {
 
     // Native function definitions for sequence methods — `&'static`
     // native-fn handles, carried as immediate `prim_id` values (no region).
-    primitive!(static SEQ_FIRST = "trait:Sequence:first" => trait_seq_first {
+    primitive!(static SEQ_FIRST: PrimitiveDef = "trait:Sequence:first" => trait_seq_first {
         signal: Signal::errors(), arity: Arity::Exact(1),
         doc: "Sequence trait: first element", params: &["self"],
         category: "trait", effect: RegionEffect::Funnel,
     });
-    primitive!(static SEQ_REST = "trait:Sequence:rest" => trait_seq_rest {
+    primitive!(static SEQ_REST: PrimitiveDef = "trait:Sequence:rest" => trait_seq_rest {
         signal: Signal::errors(), arity: Arity::Exact(1),
         doc: "Sequence trait: rest of sequence", params: &["self"],
         category: "trait", effect: RegionEffect::Funnel,
     });
-    primitive!(static SEQ_LAST = "trait:Sequence:last" => trait_seq_last {
+    primitive!(static SEQ_LAST: PrimitiveDef = "trait:Sequence:last" => trait_seq_last {
         signal: Signal::errors(), arity: Arity::Exact(1),
         doc: "Sequence trait: last element", params: &["self"],
         category: "trait", effect: RegionEffect::Funnel,
     });
-    primitive!(static SEQ_NTH = "trait:Sequence:nth" => trait_seq_nth {
+    primitive!(static SEQ_NTH: PrimitiveDef = "trait:Sequence:nth" => trait_seq_nth {
         signal: Signal::errors(), arity: Arity::Exact(2),
         doc: "Sequence trait: nth element", params: &["self", "n"],
         category: "trait", effect: RegionEffect::Funnel,
     });
-    primitive!(static SEQ_ITER = "trait:Sequence:iter" => trait_seq_iter {
+    primitive!(static SEQ_ITER: PrimitiveDef = "trait:Sequence:iter" => trait_seq_iter {
         signal: Signal::errors(), arity: Arity::Exact(1),
         doc: "Sequence trait: fiber iterator", params: &["self"],
         category: "trait", effect: RegionEffect::Fresh,
@@ -55,27 +55,27 @@ pub(super) fn build_collection_methods(heap: &mut FiberHeap) -> Value {
     use crate::signals::Signal;
     use crate::value::types::Arity;
 
-    primitive!(static COLL_LENGTH = "trait:Collection:length" => trait_coll_length {
+    primitive!(static COLL_LENGTH: PrimitiveDef = "trait:Collection:length" => trait_coll_length {
         signal: Signal::errors(), arity: Arity::Exact(1),
         doc: "Collection trait: element count", params: &["self"],
         category: "trait", effect: RegionEffect::Immediate,
     });
-    primitive!(static COLL_EMPTY = "trait:Collection:empty?" => trait_coll_empty {
+    primitive!(static COLL_EMPTY: PrimitiveDef = "trait:Collection:empty?" => trait_coll_empty {
         signal: Signal::errors(), arity: Arity::Exact(1),
         doc: "Collection trait: is empty?", params: &["self"],
         category: "trait", effect: RegionEffect::Immediate,
     });
-    primitive!(static COLL_HAS = "trait:Collection:has?" => trait_coll_has {
+    primitive!(static COLL_HAS: PrimitiveDef = "trait:Collection:has?" => trait_coll_has {
         signal: Signal::errors(), arity: Arity::Exact(2),
         doc: "Collection trait: membership test", params: &["self", "needle"],
         category: "trait", effect: RegionEffect::Immediate,
     });
-    primitive!(static COLL_CONJ = "trait:Collection:conj" => trait_coll_conj {
+    primitive!(static COLL_CONJ: PrimitiveDef = "trait:Collection:conj" => trait_coll_conj {
         signal: Signal::errors(), arity: Arity::Exact(2),
         doc: "Collection trait: add element", params: &["self", "item"],
         category: "trait", effect: RegionEffect::Funnel,
     });
-    primitive!(static COLL_EMPTY_NEW = "trait:Collection:empty" => trait_coll_empty_new {
+    primitive!(static COLL_EMPTY_NEW: PrimitiveDef = "trait:Collection:empty" => trait_coll_empty_new {
         signal: Signal::errors(), arity: Arity::Exact(1),
         doc: "Collection trait: empty container of same type", params: &["self"],
         category: "trait", effect: RegionEffect::Fresh,

--- a/src/reader/token.rs
+++ b/src/reader/token.rs
@@ -9,7 +9,7 @@ use std::fmt;
 /// three places here plus the lexer, free to drift).
 pub const UNKNOWN_FILE: &str = "<unknown>";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SourceLoc {
     pub file: String,
     pub line: usize,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -125,6 +125,10 @@ impl RuntimeCore {
         &mut self,
         cache: &crate::compiler::stdlib_cache::StdlibCache,
     ) -> crate::primitives::module_init::StdlibSource {
+        // Record it on the VM so a `sys/spawn` worker, which reaches the
+        // spawning instance only through `ctx.vm()`, inherits this directory
+        // instead of falling back to the process-wide one.
+        self.vm.set_stdlib_cache(cache.clone());
         let (vm, symbols, compile) = self.parts();
         init_stdlib(vm, symbols, compile, cache)
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -21,6 +21,7 @@
 //! world returns to its pre-`main` state — only the native-fn primitives persist
 //! (immediates, occupying no region).
 
+use crate::compiler::stdlib_cache::StdlibCache;
 use crate::pipeline::CompileCtx;
 use crate::symbol::SymbolTable;
 use crate::vm::VM;
@@ -120,9 +121,12 @@ impl RuntimeCore {
 
     /// Compile and execute stdlib.lisp into this core's `CompileCtx`. The caller
     /// must have installed the symbol-table context first (stdlib macros gensym).
-    pub fn load_stdlib(&mut self) {
+    pub fn load_stdlib(
+        &mut self,
+        cache: &crate::compiler::stdlib_cache::StdlibCache,
+    ) -> crate::primitives::module_init::StdlibSource {
         let (vm, symbols, compile) = self.parts();
-        init_stdlib(vm, symbols, compile);
+        init_stdlib(vm, symbols, compile, cache)
     }
 
     /// Mutable access to the VM.
@@ -174,6 +178,7 @@ impl RuntimeCore {
 pub struct Runtime {
     core: RuntimeCore,
     torn_down: bool,
+    stdlib_source: crate::primitives::module_init::StdlibSource,
 }
 
 impl Runtime {
@@ -193,22 +198,36 @@ impl Runtime {
     /// given Unicode generation for its whole life. `Runtime::new()` uses
     /// the newest vendored generation (or the process `--unicode=` choice).
     pub fn with_unicode(gen: crate::segment::Generation) -> Self {
-        Self::build_with(true, gen)
+        Self::build_with(true, gen, StdlibCache::Process)
+    }
+
+    /// Build a stdlib-loaded runtime that caches its compiled stdlib under
+    /// `cache` rather than the process-wide directory. Two instances given the
+    /// same directory share a cache; two given different ones cannot see each
+    /// other's, which is what lets tests run beside each other.
+    pub fn with_stdlib_cache(cache: StdlibCache) -> Self {
+        Self::build_with(true, crate::config::get().unicode_generation(), cache)
     }
 
     fn build(load_stdlib: bool) -> Self {
-        Self::build_with(load_stdlib, crate::config::get().unicode_generation())
+        Self::build_with(
+            load_stdlib,
+            crate::config::get().unicode_generation(),
+            StdlibCache::Process,
+        )
     }
 
-    fn build_with(load_stdlib: bool, gen: crate::segment::Generation) -> Self {
+    fn build_with(load_stdlib: bool, gen: crate::segment::Generation, cache: StdlibCache) -> Self {
         let mut core = RuntimeCore::bare_with_unicode(gen);
 
         // `RuntimeCore::bare` already pointed the VM at this instance's symbol
         // table, so stdlib-load gensym (and all runtime name resolution) resolve
         // through `ctx.vm().symbols()` — this instance's own table.
-        if load_stdlib {
-            core.load_stdlib();
-        }
+        let stdlib_source = if load_stdlib {
+            core.load_stdlib(&cache)
+        } else {
+            crate::primitives::module_init::StdlibSource::Compiled
+        };
 
         // The post-boot heap census (docs/impl/image.md § "Open risks and
         // dispatch experiments", item 2): at this point every live object is
@@ -222,7 +241,15 @@ impl Runtime {
         Runtime {
             core,
             torn_down: false,
+            stdlib_source,
         }
+    }
+
+    /// Where this instance's stdlib came from. A cache that silently never hits
+    /// still yields a working runtime, so a test that only checks behaviour
+    /// cannot tell the two apart — this is what it asserts on instead.
+    pub fn stdlib_source(&self) -> crate::primitives::module_init::StdlibSource {
+        self.stdlib_source
     }
 
     /// Mutable access to the VM.

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -152,7 +152,7 @@ pub const CAP_MASK: SignalBits = SignalBits::new(VM_INTERNAL.raw() ^ 0xFFFF_FFFF
 ///   function propagates (bit i set = parameter i's signals flow through)
 ///
 /// `Copy` and `const fn` constructors — no allocation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Signal {
     /// Signal bits this function itself might emit.
     pub bits: SignalBits,

--- a/src/syntax/span.rs
+++ b/src/syntax/span.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 /// A span in source code (byte offsets plus line/column for errors)
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Span {
     pub start: usize,
     pub end: usize,

--- a/src/value/capturemask.rs
+++ b/src/value/capturemask.rs
@@ -24,7 +24,7 @@
 
 /// A capture bitmask over a function's locally-defined slots, unbounded in
 /// width. Bit `i` set means slot `i` needs a capture cell.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct CaptureMask {
     words: Vec<u64>,
 }

--- a/src/value/fiber/signalbits.rs
+++ b/src/value/fiber/signalbits.rs
@@ -7,7 +7,7 @@
 /// The inner representation is an implementation detail. All code outside
 /// this impl block should use the provided methods instead of accessing
 /// the raw field.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SignalBits(u64);
 
 impl SignalBits {

--- a/src/value/repr/mod.rs
+++ b/src/value/repr/mod.rs
@@ -303,3 +303,123 @@ impl Value {
         }
     }
 }
+
+// =============================================================================
+// Scalar serialization (used by the stdlib compilation cache)
+// =============================================================================
+//
+// The cache serializes `Value` constants in `Bytecode`/`ClosureTemplate` pools.
+// Those pools hold only scalars (int/float/bool/nil/keyword/symbol) by
+// construction — string and compound literals lower to `MaterializeConst`
+// templates, not pool constants. Symbols and keywords are process-local
+// (their payload is a per-process table id / intern hash), so we serialize
+// them by NAME (which the loader re-interns), and the heap-pointer tags are
+// never representable here.
+impl serde::Serialize for Value {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::Error;
+        if self.is_heap() {
+            return Err(Error::custom("cannot serialize heap Value"));
+        }
+        let kind = if self.as_symbol().is_some() {
+            ScalarKind::Symbol
+        } else if self.as_keyword_name().is_some() {
+            ScalarKind::Keyword
+        } else if self.as_bool().is_some() {
+            ScalarKind::Bool
+        } else if self.is_native_fn() {
+            ScalarKind::NativeFn
+        } else if self.is_nil() {
+            ScalarKind::Nil
+        } else if self.as_int().is_some() {
+            ScalarKind::Int
+        } else if self.as_float().is_some() {
+            ScalarKind::Float
+        } else {
+            return Err(Error::custom("unsupported scalar Value"));
+        };
+        let payload = match kind {
+            ScalarKind::Symbol => ScalarPayload::Symbol(self.as_symbol().unwrap()),
+            ScalarKind::Keyword => ScalarPayload::Keyword(self.as_keyword_name().unwrap()),
+            ScalarKind::Bool => ScalarPayload::Bool(self.as_bool().unwrap()),
+            // Native-fn payload is a prim_id, stable across processes.
+            ScalarKind::NativeFn => ScalarPayload::NativeFn(self.payload as u32),
+            ScalarKind::Nil => ScalarPayload::Nil,
+            ScalarKind::Int => ScalarPayload::Int(self.as_int().unwrap()),
+            ScalarKind::Float => ScalarPayload::Float(self.as_float().unwrap()),
+        };
+        (u8::from(kind), payload).serialize(s)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Value {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let (kind, payload): (u8, ScalarPayload) = serde::Deserialize::deserialize(d)?;
+        Ok(match (ScalarKind::from(kind), payload) {
+            (ScalarKind::Symbol, ScalarPayload::Symbol(id)) => Value::symbol(id),
+            (ScalarKind::Keyword, ScalarPayload::Keyword(name)) => Value::keyword(&name),
+            (ScalarKind::Bool, ScalarPayload::Bool(b)) => Value::bool(b),
+            (ScalarKind::NativeFn, ScalarPayload::NativeFn(id)) => {
+                match crate::primitives::prim_def(id) {
+                    Some(def) => Value::native_fn(def),
+                    None => panic!("unknown prim id {id}"),
+                }
+            }
+            (ScalarKind::Nil, ScalarPayload::Nil) => Value::NIL,
+            (ScalarKind::Int, ScalarPayload::Int(n)) => Value::int(n),
+            (ScalarKind::Float, ScalarPayload::Float(f)) => Value::float(f),
+            _ => panic!("scalar kind/payload mismatch"),
+        })
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+enum ScalarPayload {
+    Nil,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Symbol(u32),
+    Keyword(String),
+    NativeFn(u32),
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum ScalarKind {
+    Nil,
+    Bool,
+    Int,
+    Float,
+    Symbol,
+    Keyword,
+    NativeFn,
+}
+
+impl From<ScalarKind> for u8 {
+    fn from(k: ScalarKind) -> u8 {
+        match k {
+            ScalarKind::Nil => 0,
+            ScalarKind::Bool => 1,
+            ScalarKind::Int => 2,
+            ScalarKind::Float => 3,
+            ScalarKind::Symbol => 4,
+            ScalarKind::Keyword => 5,
+            ScalarKind::NativeFn => 6,
+        }
+    }
+}
+
+impl From<u8> for ScalarKind {
+    fn from(v: u8) -> ScalarKind {
+        match v {
+            0 => ScalarKind::Nil,
+            1 => ScalarKind::Bool,
+            2 => ScalarKind::Int,
+            3 => ScalarKind::Float,
+            4 => ScalarKind::Symbol,
+            5 => ScalarKind::Keyword,
+            6 => ScalarKind::NativeFn,
+            _ => panic!("invalid scalar kind {v}"),
+        }
+    }
+}

--- a/src/value/repr/mod.rs
+++ b/src/value/repr/mod.rs
@@ -362,7 +362,12 @@ impl<'de> serde::Deserialize<'de> for Value {
             (ScalarKind::NativeFn, ScalarPayload::NativeFn(id)) => {
                 match crate::primitives::prim_def(id) {
                     Some(def) => Value::native_fn(def),
-                    None => panic!("unknown prim id {id}"),
+                    // The stdlib disk cache persists native-fn immediates by
+                    // prim_id; a cache written by a process whose registry
+                    // differs (different feature set, different prim tables)
+                    // is a stale file, not a reason to crash. Report the error
+                    // so the cache layer treats it as a miss and recompiles.
+                    None => return Err(serde::de::Error::custom(format!("unknown prim id {id}"))),
                 }
             }
             (ScalarKind::Nil, ScalarPayload::Nil) => Value::NIL,

--- a/src/value/repr/mod.rs
+++ b/src/value/repr/mod.rs
@@ -308,123 +308,74 @@ impl Value {
 // Scalar serialization (used by the stdlib compilation cache)
 // =============================================================================
 //
-// The cache serializes `Value` constants in `Bytecode`/`ClosureTemplate` pools.
-// Those pools hold only scalars (int/float/bool/nil/keyword/symbol) by
-// construction — string and compound literals lower to `MaterializeConst`
-// templates, not pool constants. Symbols and keywords are process-local
-// (their payload is a per-process table id / intern hash), so we serialize
-// them by NAME (which the loader re-interns), and the heap-pointer tags are
-// never representable here.
+// The cache serializes `Value` constants in `Bytecode`/`ClosureTemplate` pools
+// and in LIR `ValueConst` operands. After `convert_lir_for_send`, the values
+// that reach this path are non-heap scalars (int/float/bool/nil/keyword) and
+// native-fn immediates. A symbol refuses to serialize: its payload is a
+// process-local table id and no name travels with it, so a loader could not
+// re-intern it — symbols cross by name as `SendValue::Symbol` or
+// `LirConst::Symbol` (which the loader remaps). Every malformed input must
+// come back as a serde error, never a panic: the cache layer converts errors
+// into a miss and recompiles, and `ScalarPayload`'s single derived enum tag
+// makes an out-of-range discriminant a native bincode error.
 impl serde::Serialize for Value {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         use serde::ser::Error;
         if self.is_heap() {
             return Err(Error::custom("cannot serialize heap Value"));
         }
-        let kind = if self.as_symbol().is_some() {
-            ScalarKind::Symbol
-        } else if self.as_keyword_name().is_some() {
-            ScalarKind::Keyword
-        } else if self.as_bool().is_some() {
-            ScalarKind::Bool
+        let payload = if self.as_symbol().is_some() {
+            return Err(Error::custom("symbol Value has no name to re-intern"));
+        } else if let Some(name) = self.as_keyword_name() {
+            ScalarPayload::Keyword(name)
+        } else if let Some(b) = self.as_bool() {
+            ScalarPayload::Bool(b)
         } else if self.is_native_fn() {
-            ScalarKind::NativeFn
+            // Native-fn payload is a prim_id, stable across processes as long
+            // as the cache key mixes in the primitive-table identity.
+            ScalarPayload::NativeFn(self.payload as u32)
         } else if self.is_nil() {
-            ScalarKind::Nil
-        } else if self.as_int().is_some() {
-            ScalarKind::Int
-        } else if self.as_float().is_some() {
-            ScalarKind::Float
+            ScalarPayload::Nil
+        } else if let Some(n) = self.as_int() {
+            ScalarPayload::Int(n)
+        } else if let Some(f) = self.as_float() {
+            ScalarPayload::Float(f)
         } else {
             return Err(Error::custom("unsupported scalar Value"));
         };
-        let payload = match kind {
-            ScalarKind::Symbol => ScalarPayload::Symbol(self.as_symbol().unwrap()),
-            ScalarKind::Keyword => ScalarPayload::Keyword(self.as_keyword_name().unwrap()),
-            ScalarKind::Bool => ScalarPayload::Bool(self.as_bool().unwrap()),
-            // Native-fn payload is a prim_id, stable across processes.
-            ScalarKind::NativeFn => ScalarPayload::NativeFn(self.payload as u32),
-            ScalarKind::Nil => ScalarPayload::Nil,
-            ScalarKind::Int => ScalarPayload::Int(self.as_int().unwrap()),
-            ScalarKind::Float => ScalarPayload::Float(self.as_float().unwrap()),
-        };
-        (u8::from(kind), payload).serialize(s)
+        payload.serialize(s)
     }
 }
 
 impl<'de> serde::Deserialize<'de> for Value {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let (kind, payload): (u8, ScalarPayload) = serde::Deserialize::deserialize(d)?;
-        Ok(match (ScalarKind::from(kind), payload) {
-            (ScalarKind::Symbol, ScalarPayload::Symbol(id)) => Value::symbol(id),
-            (ScalarKind::Keyword, ScalarPayload::Keyword(name)) => Value::keyword(&name),
-            (ScalarKind::Bool, ScalarPayload::Bool(b)) => Value::bool(b),
-            (ScalarKind::NativeFn, ScalarPayload::NativeFn(id)) => {
-                match crate::primitives::prim_def(id) {
-                    Some(def) => Value::native_fn(def),
-                    // The stdlib disk cache persists native-fn immediates by
-                    // prim_id; a cache written by a process whose registry
-                    // differs (different feature set, different prim tables)
-                    // is a stale file, not a reason to crash. Report the error
-                    // so the cache layer treats it as a miss and recompiles.
-                    None => return Err(serde::de::Error::custom(format!("unknown prim id {id}"))),
-                }
-            }
-            (ScalarKind::Nil, ScalarPayload::Nil) => Value::NIL,
-            (ScalarKind::Int, ScalarPayload::Int(n)) => Value::int(n),
-            (ScalarKind::Float, ScalarPayload::Float(f)) => Value::float(f),
-            _ => panic!("scalar kind/payload mismatch"),
+        Ok(match ScalarPayload::deserialize(d)? {
+            ScalarPayload::Nil => Value::NIL,
+            ScalarPayload::Bool(b) => Value::bool(b),
+            ScalarPayload::Int(n) => Value::int(n),
+            ScalarPayload::Float(f) => Value::float(f),
+            ScalarPayload::Keyword(name) => Value::keyword(&name),
+            ScalarPayload::NativeFn(id) => match crate::primitives::prim_def(id) {
+                Some(def) => Value::native_fn(def),
+                // A cache written by a process whose primitive registry
+                // differs (feature set, prim tables) is a stale file, not a
+                // reason to crash. Report the error so the cache layer treats
+                // it as a miss and recompiles.
+                None => return Err(serde::de::Error::custom(format!("unknown prim id {id}"))),
+            },
         })
     }
 }
 
+/// The single wire form of a scalar `Value`. Its derived enum tag is the only
+/// discriminant — both serde directions share it, so the encoding cannot
+/// drift and an invalid tag is a bincode error, not a panic.
 #[derive(serde::Serialize, serde::Deserialize)]
 enum ScalarPayload {
     Nil,
     Bool(bool),
     Int(i64),
     Float(f64),
-    Symbol(u32),
     Keyword(String),
     NativeFn(u32),
-}
-
-#[derive(Clone, Copy, PartialEq)]
-enum ScalarKind {
-    Nil,
-    Bool,
-    Int,
-    Float,
-    Symbol,
-    Keyword,
-    NativeFn,
-}
-
-impl From<ScalarKind> for u8 {
-    fn from(k: ScalarKind) -> u8 {
-        match k {
-            ScalarKind::Nil => 0,
-            ScalarKind::Bool => 1,
-            ScalarKind::Int => 2,
-            ScalarKind::Float => 3,
-            ScalarKind::Symbol => 4,
-            ScalarKind::Keyword => 5,
-            ScalarKind::NativeFn => 6,
-        }
-    }
-}
-
-impl From<u8> for ScalarKind {
-    fn from(v: u8) -> ScalarKind {
-        match v {
-            0 => ScalarKind::Nil,
-            1 => ScalarKind::Bool,
-            2 => ScalarKind::Int,
-            3 => ScalarKind::Float,
-            4 => ScalarKind::Symbol,
-            5 => ScalarKind::Keyword,
-            6 => ScalarKind::NativeFn,
-            _ => panic!("invalid scalar kind {v}"),
-        }
-    }
 }

--- a/src/value/repr/mod.rs
+++ b/src/value/repr/mod.rs
@@ -310,24 +310,24 @@ impl Value {
 //
 // The cache serializes `Value` constants in `Bytecode`/`ClosureTemplate` pools
 // and in LIR `ValueConst` operands. After `convert_lir_for_send`, the values
-// that reach this path are non-heap scalars (int/float/bool/nil/keyword) and
-// native-fn immediates. A symbol refuses to serialize: its payload is a
-// process-local table id and no name travels with it, so a loader could not
-// re-intern it — symbols cross by name as `SendValue::Symbol` or
-// `LirConst::Symbol` (which the loader remaps). Every malformed input must
-// come back as a serde error, never a panic: the cache layer converts errors
-// into a miss and recompiles, and `ScalarPayload`'s single derived enum tag
-// makes an out-of-range discriminant a native bincode error.
+// that reach this path are non-heap scalars (int/float/bool/nil/symbol/keyword)
+// and native-fn immediates. A symbol and a keyword carry their name's hash
+// (docs/impl/symbol.md), which is the same in every process, so the payload
+// travels as it stands; only the spelling needs the bundle's name table. Every
+// malformed input must come back as a serde error, never a panic: the cache
+// layer converts errors into a miss and recompiles, and `ScalarPayload`'s
+// single derived enum tag makes an out-of-range discriminant a native bincode
+// error.
 impl serde::Serialize for Value {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         use serde::ser::Error;
         if self.is_heap() {
             return Err(Error::custom("cannot serialize heap Value"));
         }
-        let payload = if self.as_symbol().is_some() {
-            return Err(Error::custom("symbol Value has no name to re-intern"));
-        } else if let Some(name) = self.as_keyword_name() {
-            ScalarPayload::Keyword(name)
+        let payload = if let Some(id) = self.as_symbol() {
+            ScalarPayload::Symbol(id.0)
+        } else if let Some(hash) = self.keyword_hash() {
+            ScalarPayload::Keyword(hash)
         } else if let Some(b) = self.as_bool() {
             ScalarPayload::Bool(b)
         } else if self.is_native_fn() {
@@ -354,7 +354,8 @@ impl<'de> serde::Deserialize<'de> for Value {
             ScalarPayload::Bool(b) => Value::bool(b),
             ScalarPayload::Int(n) => Value::int(n),
             ScalarPayload::Float(f) => Value::float(f),
-            ScalarPayload::Keyword(name) => Value::keyword(&name),
+            ScalarPayload::Symbol(hash) => Value::symbol(crate::value::SymbolId(hash)),
+            ScalarPayload::Keyword(hash) => Value::keyword_from_hash(hash),
             ScalarPayload::NativeFn(id) => match crate::primitives::prim_def(id) {
                 Some(def) => Value::native_fn(def),
                 // A cache written by a process whose primitive registry
@@ -376,6 +377,7 @@ enum ScalarPayload {
     Bool(bool),
     Int(i64),
     Float(f64),
-    Keyword(String),
+    Symbol(u64),
+    Keyword(u64),
     NativeFn(u32),
 }

--- a/src/value/repr/tests.rs
+++ b/src/value/repr/tests.rs
@@ -1,1 +1,23 @@
 // Tests migrated to tests/elle/value-repr.lisp
+
+use super::*;
+
+/// A corrupt cache file must surface as a decode error the cache layer can
+/// turn into a miss. The trap: routing the discriminant through a plain
+/// `From<u8>` panics on an invalid tag, so one flipped byte crashes startup
+/// instead of falling back to a recompile.
+#[test]
+fn invalid_scalar_tag_is_an_error_not_a_panic() {
+    let bytes = [200u8, 0, 0, 0, 0, 0, 0, 0];
+    assert!(bincode::deserialize::<Value>(&bytes).is_err());
+}
+
+/// A symbol `Value` carries only a process-local id; no name travels with it,
+/// so a loader could not re-intern it. Pool symbols cross via
+/// `SendValue::Symbol { name, .. }` instead — this path must refuse, not
+/// persist a raw id that binds to an arbitrary symbol on load.
+#[test]
+fn symbol_value_refuses_scalar_serialization() {
+    let sym = Value::symbol(7);
+    assert!(bincode::serialize(&sym).is_err());
+}

--- a/src/value/repr/tests.rs
+++ b/src/value/repr/tests.rs
@@ -12,12 +12,18 @@ fn invalid_scalar_tag_is_an_error_not_a_panic() {
     assert!(bincode::deserialize::<Value>(&bytes).is_err());
 }
 
-/// A symbol `Value` carries only a process-local id; no name travels with it,
-/// so a loader could not re-intern it. Pool symbols cross via
-/// `SendValue::Symbol { name, .. }` instead — this path must refuse, not
-/// persist a raw id that binds to an arbitrary symbol on load.
+/// A symbol `Value`'s payload is its name's hash, the same number in every
+/// process, so the scalar wire form carries it as it stands.
+///
+/// The trap this replaced: while the payload was a per-process table index,
+/// persisting it bound the constant to whatever symbol held that index in the
+/// loading process, so this path had to refuse. The counter-factual now is a
+/// round-trip that returns a *different* symbol — and it would be silent,
+/// because both sides are only integers.
 #[test]
-fn symbol_value_refuses_scalar_serialization() {
-    let sym = Value::symbol(7);
-    assert!(bincode::serialize(&sym).is_err());
+fn symbol_value_round_trips_as_its_name_hash() {
+    let id = crate::value::SymbolId::of("a-pool-symbol");
+    let bytes = bincode::serialize(&Value::symbol(id)).expect("a symbol scalar serializes");
+    let back: Value = bincode::deserialize(&bytes).expect("deserializes");
+    assert_eq!(back.as_symbol(), Some(id));
 }

--- a/src/value/send/de.rs
+++ b/src/value/send/de.rs
@@ -92,7 +92,7 @@ impl<'a, 'h> DeserContext<'a, 'h> {
 /// `env`/`squelch_mask` (a blueprint is a pure template). Used to rebuild a
 /// reconstructed template's `child_protos` so the worker's `MakeClosure`
 /// resolves by index.
-fn template_from_sendable(
+pub(in crate::value::send) fn template_from_sendable(
     sc: SendableClosure,
     ctx: &mut DeserContext<'_, '_>,
 ) -> std::rc::Rc<crate::value::ClosureTemplate> {

--- a/src/value/send/mirror.rs
+++ b/src/value/send/mirror.rs
@@ -1,0 +1,262 @@
+//! Bincode serde for [`SendValue`] and [`TableKey`], used by the stdlib disk
+//! cache (`crate::compiler::stdlib_cache`).
+//!
+//! `SendValue` is the owned deep-copy form the send module produces for
+//! cross-thread transport, and it is exactly the shape a disk format needs:
+//! no `Rc`, no pointers, symbols by name. Serde is implemented for it
+//! directly rather than for `Value`, which carries process-local
+//! ids/pointers.
+//!
+//! Only the pure-data variants are supported; runtime-resource variants
+//! (channels, ports, FFI descriptors) return an error, which makes the cache
+//! miss and the caller recompile — safe, never wrong.
+//!
+//! Both directions of each impl go through one derived mirror enum so the
+//! bincode encoding cannot drift: a hand-written `Serialize` that emits
+//! `(u8, payload)` tuples does not round-trip against a derived
+//! `Deserialize`, which reads bincode's enum tag
+//! (`tablekey_map_roundtrips_through_bincode` pins this).
+
+use super::SendValue;
+use super::SendableClosure;
+use crate::value::{TableKey, Value};
+
+/// Symmetric serde mirror for `SendValue`. Both directions go through this
+/// enum so the bincode encoding is identical (a hand-written `Serialize` that
+/// emitted tuples would not round-trip against a derived `Deserialize`, which
+/// expects bincode's enum encoding).
+#[derive(serde::Serialize, serde::Deserialize)]
+enum Mirror {
+    Immediate(Value),
+    Keyword(String),
+    Symbol { name: String, id: u32 },
+    String(String),
+    Pair(Box<Mirror>, Box<Mirror>, Box<Mirror>),
+    Seq(Vec<Mirror>, Box<Mirror>),
+    Map(std::collections::BTreeMap<TableKey, Mirror>, Box<Mirror>),
+    Buffer(Vec<u8>, Box<Mirror>),
+    Float(f64),
+    Closure(Box<SendableClosure>),
+    Ref(usize),
+    CaptureCell(Box<Mirror>, Box<Mirror>),
+}
+
+impl serde::Serialize for SendValue {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use super::SendValue as SV;
+        use serde::ser::Error;
+        fn to_mirror(sv: &SV) -> Result<Mirror, String> {
+            if let SV::Immediate(v) = sv {
+                if v.is_heap() && !v.is_native_fn() {
+                    return Err(format!("Immediate heap value {}", v.type_name()));
+                }
+            }
+            Ok(match sv {
+                SV::Immediate(v) => Mirror::Immediate(*v),
+                SV::Keyword(k) => Mirror::Keyword(k.clone()),
+                SV::Symbol { name, id } => Mirror::Symbol {
+                    name: name.clone(),
+                    id: *id,
+                },
+                SV::String(st) => Mirror::String(st.clone()),
+                SV::Pair(a, b, t) => Mirror::Pair(
+                    Box::new(to_mirror(a)?),
+                    Box::new(to_mirror(b)?),
+                    Box::new(to_mirror(t)?),
+                ),
+                SV::Array(v, t) | SV::Tuple(v, t) | SV::LSet(v, t) | SV::LSetMut(v, t) => {
+                    Mirror::Seq(
+                        v.iter().map(to_mirror).collect::<Result<_, _>>()?,
+                        Box::new(to_mirror(t)?),
+                    )
+                }
+                SV::Struct(m, t) | SV::StructMut(m, t) => Mirror::Map(
+                    m.iter()
+                        .map(|(k, v)| Ok((k.clone(), to_mirror(v)?)))
+                        .collect::<Result<_, String>>()?,
+                    Box::new(to_mirror(t)?),
+                ),
+                SV::Buffer(v, t) | SV::Bytes(v, t) | SV::Blob(v, t) => {
+                    Mirror::Buffer(v.clone(), Box::new(to_mirror(t)?))
+                }
+                SV::LBox(..) => return Err("LBox not needed by stdlib cache".into()),
+                SV::CaptureCell(a, b) => {
+                    Mirror::CaptureCell(Box::new(to_mirror(a)?), Box::new(to_mirror(b)?))
+                }
+                SV::Float(f) => Mirror::Float(*f),
+                SV::Closure(c) => Mirror::Closure(c.clone()),
+                SV::Ref(r) => Mirror::Ref(*r),
+                _ => return Err("SendValue variant not serializable by stdlib cache".into()),
+            })
+        }
+        to_mirror(self).map_err(Error::custom)?.serialize(s)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SendValue {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use super::SendValue as SV;
+        fn from_mirror(m: Mirror) -> Result<SV, String> {
+            Ok(match m {
+                Mirror::Immediate(v) => SV::Immediate(v),
+                Mirror::Keyword(k) => SV::Keyword(k),
+                Mirror::Symbol { name, id } => SV::Symbol { name, id },
+                Mirror::String(st) => SV::String(st),
+                Mirror::Pair(a, b, t) => SV::Pair(
+                    Box::new(from_mirror(*a)?),
+                    Box::new(from_mirror(*b)?),
+                    Box::new(from_mirror(*t)?),
+                ),
+                Mirror::Seq(v, t) => {
+                    let vals = v
+                        .into_iter()
+                        .map(from_mirror)
+                        .collect::<Result<Vec<_>, _>>()?;
+                    SV::Array(vals, Box::new(from_mirror(*t)?))
+                }
+                Mirror::Map(m, t) => {
+                    let map = m
+                        .into_iter()
+                        .map(|(k, v)| Ok((k, from_mirror(v)?)))
+                        .collect::<Result<_, String>>()?;
+                    SV::Struct(map, Box::new(from_mirror(*t)?))
+                }
+                Mirror::Buffer(v, t) => SV::Bytes(v, Box::new(from_mirror(*t)?)),
+                Mirror::Float(f) => SV::Float(f),
+                Mirror::Closure(c) => SV::Closure(c),
+                Mirror::Ref(r) => SV::Ref(r),
+                Mirror::CaptureCell(a, b) => {
+                    SV::CaptureCell(Box::new(from_mirror(*a)?), Box::new(from_mirror(*b)?))
+                }
+            })
+        }
+        from_mirror(Mirror::deserialize(d)?).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Symmetric serde mirror for `TableKey`, for the same reason as [`Mirror`]:
+/// both directions must share one bincode encoding. `Symbol` has no variant —
+/// a symbol key carries only a process-local id, no name the loader could
+/// re-intern, so it is rejected at serialize time (a cache miss, never a key
+/// silently bound to an arbitrary symbol). `Heap` likewise.
+#[derive(serde::Serialize, serde::Deserialize)]
+enum KeyMirror {
+    Nil,
+    Bool(bool),
+    Int(i64),
+    String(String),
+    Keyword(String),
+    EmptyList,
+    Array(Vec<KeyMirror>),
+}
+
+impl serde::Serialize for TableKey {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use crate::value::TableKey as TK;
+        use serde::ser::Error;
+        fn to_mirror(k: &TK) -> Result<KeyMirror, String> {
+            Ok(match k {
+                TK::Nil => KeyMirror::Nil,
+                TK::Bool(b) => KeyMirror::Bool(*b),
+                TK::Int(i) => KeyMirror::Int(*i),
+                TK::String(st) => KeyMirror::String(st.clone()),
+                TK::Keyword(kw) => KeyMirror::Keyword(kw.clone()),
+                TK::EmptyList => KeyMirror::EmptyList,
+                TK::Array(a) => {
+                    KeyMirror::Array(a.iter().map(to_mirror).collect::<Result<_, _>>()?)
+                }
+                TK::Symbol(_) => {
+                    return Err("TableKey::Symbol has no name to re-intern".into());
+                }
+                TK::Heap(_) => {
+                    return Err("TableKey::Heap not serializable by stdlib cache".into());
+                }
+            })
+        }
+        to_mirror(self).map_err(Error::custom)?.serialize(s)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for TableKey {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use crate::value::TableKey as TK;
+        fn from_mirror(m: KeyMirror) -> TK {
+            match m {
+                KeyMirror::Nil => TK::Nil,
+                KeyMirror::Bool(b) => TK::Bool(b),
+                KeyMirror::Int(i) => TK::Int(i),
+                KeyMirror::String(st) => TK::String(st),
+                KeyMirror::Keyword(kw) => TK::Keyword(kw),
+                KeyMirror::EmptyList => TK::EmptyList,
+                KeyMirror::Array(a) => TK::Array(a.into_iter().map(from_mirror).collect()),
+            }
+        }
+        Ok(from_mirror(KeyMirror::deserialize(d)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// A struct constant's `TableKey`s must survive bincode. The trap: a
+    /// hand-written `Serialize` that emits `(u8, payload)` tuples against a
+    /// derived `Deserialize` that reads bincode's enum tag decodes garbage —
+    /// every struct-bearing cache entry would fail to load (and the failure
+    /// is silent: the caller just recompiles, forever).
+    #[test]
+    fn tablekey_map_roundtrips_through_bincode() {
+        use super::SendValue as SV;
+
+        let mut map: BTreeMap<TableKey, SV> = BTreeMap::new();
+        map.insert(TableKey::Int(7), SV::Immediate(Value::int(1)));
+        map.insert(TableKey::String("s".into()), SV::Immediate(Value::int(2)));
+        map.insert(TableKey::Keyword("k".into()), SV::Immediate(Value::int(3)));
+        map.insert(
+            TableKey::Array(vec![TableKey::Bool(true), TableKey::EmptyList]),
+            SV::Immediate(Value::int(4)),
+        );
+        let sv = SV::Struct(map, Box::new(SV::Immediate(Value::NIL)));
+
+        let bytes = bincode::serialize(&sv).expect("serializes");
+        let back: SV = bincode::deserialize(&bytes).expect("deserializes");
+        let SV::Struct(m, _) = back else {
+            panic!("round-trip changed the container kind");
+        };
+        assert_eq!(m.len(), 4, "all keys survive");
+        for (k, want) in [
+            (TableKey::Int(7), 1),
+            (TableKey::String("s".into()), 2),
+            (TableKey::Keyword("k".into()), 3),
+            (
+                TableKey::Array(vec![TableKey::Bool(true), TableKey::EmptyList]),
+                4,
+            ),
+        ] {
+            let Some(SV::Immediate(v)) = m.get(&k) else {
+                panic!("key {k:?} lost or value kind changed");
+            };
+            assert_eq!(v.as_int(), Some(want), "value under {k:?}");
+        }
+    }
+
+    /// A symbol `TableKey` carries only a process-local id — no name travels
+    /// with it, so a loader cannot re-intern it. Storing it raw would attach
+    /// the entry to an arbitrary symbol in the loading process; the only safe
+    /// treatment is a serialize error, which the cache layer turns into a
+    /// plain miss.
+    #[test]
+    fn tablekey_symbol_key_is_rejected_not_mistranslated() {
+        use super::SendValue as SV;
+        use crate::value::SymbolId;
+
+        let mut map: BTreeMap<TableKey, SV> = BTreeMap::new();
+        map.insert(TableKey::Symbol(SymbolId(42)), SV::Immediate(Value::int(1)));
+        let sv = SV::Struct(map, Box::new(SV::Immediate(Value::NIL)));
+        assert!(
+            bincode::serialize(&sv).is_err(),
+            "symbol keys must fail to serialize, not carry a raw id"
+        );
+    }
+}

--- a/src/value/send/mirror.rs
+++ b/src/value/send/mirror.rs
@@ -25,16 +25,51 @@ use crate::value::{TableKey, Value};
 /// enum so the bincode encoding is identical (a hand-written `Serialize` that
 /// emitted tuples would not round-trip against a derived `Deserialize`, which
 /// expects bincode's enum encoding).
+/// Which sequence a `Mirror::Seq` came from. Eight `SendValue` variants share
+/// three shapes — a sequence, a map, a byte run — and the shape alone does not
+/// say which. Derived, not hand-written, so both directions read one encoding.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy)]
+enum SeqKind {
+    Array,
+    Tuple,
+    LSet,
+    LSetMut,
+}
+
+/// Which map a `Mirror::Map` came from: mutability is the difference.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy)]
+enum MapKind {
+    Struct,
+    StructMut,
+}
+
+/// Which byte run a `Mirror::Buffer` came from. `Buffer` is a mutable
+/// `@string` and `Bytes` an immutable one, so dropping the tag turns a mutable
+/// value immutable on reload.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy)]
+enum BytesKind {
+    Buffer,
+    Bytes,
+    Blob,
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 enum Mirror {
     Immediate(Value),
     Keyword(String),
-    Symbol { name: String, id: u32 },
+    Symbol {
+        name: String,
+        id: u32,
+    },
     String(String),
     Pair(Box<Mirror>, Box<Mirror>, Box<Mirror>),
-    Seq(Vec<Mirror>, Box<Mirror>),
-    Map(std::collections::BTreeMap<TableKey, Mirror>, Box<Mirror>),
-    Buffer(Vec<u8>, Box<Mirror>),
+    Seq(SeqKind, Vec<Mirror>, Box<Mirror>),
+    Map(
+        MapKind,
+        std::collections::BTreeMap<TableKey, Mirror>,
+        Box<Mirror>,
+    ),
+    Buffer(BytesKind, Vec<u8>, Box<Mirror>),
     Float(f64),
     Closure(Box<SendableClosure>),
     Ref(usize),
@@ -65,19 +100,36 @@ impl serde::Serialize for SendValue {
                     Box::new(to_mirror(t)?),
                 ),
                 SV::Array(v, t) | SV::Tuple(v, t) | SV::LSet(v, t) | SV::LSetMut(v, t) => {
+                    let kind = match sv {
+                        SV::Array(..) => SeqKind::Array,
+                        SV::Tuple(..) => SeqKind::Tuple,
+                        SV::LSet(..) => SeqKind::LSet,
+                        _ => SeqKind::LSetMut,
+                    };
                     Mirror::Seq(
+                        kind,
                         v.iter().map(to_mirror).collect::<Result<_, _>>()?,
                         Box::new(to_mirror(t)?),
                     )
                 }
                 SV::Struct(m, t) | SV::StructMut(m, t) => Mirror::Map(
+                    if matches!(sv, SV::Struct(..)) {
+                        MapKind::Struct
+                    } else {
+                        MapKind::StructMut
+                    },
                     m.iter()
                         .map(|(k, v)| Ok((k.clone(), to_mirror(v)?)))
                         .collect::<Result<_, String>>()?,
                     Box::new(to_mirror(t)?),
                 ),
                 SV::Buffer(v, t) | SV::Bytes(v, t) | SV::Blob(v, t) => {
-                    Mirror::Buffer(v.clone(), Box::new(to_mirror(t)?))
+                    let kind = match sv {
+                        SV::Buffer(..) => BytesKind::Buffer,
+                        SV::Bytes(..) => BytesKind::Bytes,
+                        _ => BytesKind::Blob,
+                    };
+                    Mirror::Buffer(kind, v.clone(), Box::new(to_mirror(t)?))
                 }
                 SV::LBox(..) => return Err("LBox not needed by stdlib cache".into()),
                 SV::CaptureCell(a, b) => {
@@ -107,21 +159,38 @@ impl<'de> serde::Deserialize<'de> for SendValue {
                     Box::new(from_mirror(*b)?),
                     Box::new(from_mirror(*t)?),
                 ),
-                Mirror::Seq(v, t) => {
+                Mirror::Seq(kind, v, t) => {
                     let vals = v
                         .into_iter()
                         .map(from_mirror)
                         .collect::<Result<Vec<_>, _>>()?;
-                    SV::Array(vals, Box::new(from_mirror(*t)?))
+                    let traits = Box::new(from_mirror(*t)?);
+                    match kind {
+                        SeqKind::Array => SV::Array(vals, traits),
+                        SeqKind::Tuple => SV::Tuple(vals, traits),
+                        SeqKind::LSet => SV::LSet(vals, traits),
+                        SeqKind::LSetMut => SV::LSetMut(vals, traits),
+                    }
                 }
-                Mirror::Map(m, t) => {
+                Mirror::Map(kind, m, t) => {
                     let map = m
                         .into_iter()
                         .map(|(k, v)| Ok((k, from_mirror(v)?)))
                         .collect::<Result<_, String>>()?;
-                    SV::Struct(map, Box::new(from_mirror(*t)?))
+                    let traits = Box::new(from_mirror(*t)?);
+                    match kind {
+                        MapKind::Struct => SV::Struct(map, traits),
+                        MapKind::StructMut => SV::StructMut(map, traits),
+                    }
                 }
-                Mirror::Buffer(v, t) => SV::Bytes(v, Box::new(from_mirror(*t)?)),
+                Mirror::Buffer(kind, v, t) => {
+                    let traits = Box::new(from_mirror(*t)?);
+                    match kind {
+                        BytesKind::Buffer => SV::Buffer(v, traits),
+                        BytesKind::Bytes => SV::Bytes(v, traits),
+                        BytesKind::Blob => SV::Blob(v, traits),
+                    }
+                }
                 Mirror::Float(f) => SV::Float(f),
                 Mirror::Closure(c) => SV::Closure(c),
                 Mirror::Ref(r) => SV::Ref(r),

--- a/src/value/send/mirror.rs
+++ b/src/value/send/mirror.rs
@@ -3,9 +3,9 @@
 //!
 //! `SendValue` is the owned deep-copy form the send module produces for
 //! cross-thread transport, and it is exactly the shape a disk format needs:
-//! no `Rc`, no pointers, symbols by name. Serde is implemented for it
-//! directly rather than for `Value`, which carries process-local
-//! ids/pointers.
+//! no `Rc`, no pointers, symbol and keyword ids that are their name's hash.
+//! Serde is implemented for it directly rather than for `Value`, which also
+//! carries heap pointers.
 //!
 //! Only the pure-data variants are supported; runtime-resource variants
 //! (channels, ports, FFI descriptors) return an error, which makes the cache
@@ -56,11 +56,6 @@ enum BytesKind {
 #[derive(serde::Serialize, serde::Deserialize)]
 enum Mirror {
     Immediate(Value),
-    Keyword(String),
-    Symbol {
-        name: String,
-        id: u32,
-    },
     String(String),
     Pair(Box<Mirror>, Box<Mirror>, Box<Mirror>),
     Seq(SeqKind, Vec<Mirror>, Box<Mirror>),
@@ -88,11 +83,6 @@ impl serde::Serialize for SendValue {
             }
             Ok(match sv {
                 SV::Immediate(v) => Mirror::Immediate(*v),
-                SV::Keyword(k) => Mirror::Keyword(k.clone()),
-                SV::Symbol { name, id } => Mirror::Symbol {
-                    name: name.clone(),
-                    id: *id,
-                },
                 SV::String(st) => Mirror::String(st.clone()),
                 SV::Pair(a, b, t) => Mirror::Pair(
                     Box::new(to_mirror(a)?),
@@ -151,8 +141,6 @@ impl<'de> serde::Deserialize<'de> for SendValue {
         fn from_mirror(m: Mirror) -> Result<SV, String> {
             Ok(match m {
                 Mirror::Immediate(v) => SV::Immediate(v),
-                Mirror::Keyword(k) => SV::Keyword(k),
-                Mirror::Symbol { name, id } => SV::Symbol { name, id },
                 Mirror::String(st) => SV::String(st),
                 Mirror::Pair(a, b, t) => SV::Pair(
                     Box::new(from_mirror(*a)?),
@@ -204,17 +192,18 @@ impl<'de> serde::Deserialize<'de> for SendValue {
 }
 
 /// Symmetric serde mirror for `TableKey`, for the same reason as [`Mirror`]:
-/// both directions must share one bincode encoding. `Symbol` has no variant —
-/// a symbol key carries only a process-local id, no name the loader could
-/// re-intern, so it is rejected at serialize time (a cache miss, never a key
-/// silently bound to an arbitrary symbol). `Heap` likewise.
+/// both directions must share one bincode encoding. A symbol or keyword key
+/// travels as its name's hash, which names the same symbol in the loading
+/// process. `Heap` has no variant — it holds a live `Value` — so it is
+/// rejected at serialize time, which the cache layer turns into a miss.
 #[derive(serde::Serialize, serde::Deserialize)]
 enum KeyMirror {
     Nil,
     Bool(bool),
     Int(i64),
     String(String),
-    Keyword(String),
+    Symbol(u64),
+    Keyword(u64),
     EmptyList,
     Array(Vec<KeyMirror>),
 }
@@ -229,13 +218,11 @@ impl serde::Serialize for TableKey {
                 TK::Bool(b) => KeyMirror::Bool(*b),
                 TK::Int(i) => KeyMirror::Int(*i),
                 TK::String(st) => KeyMirror::String(st.clone()),
-                TK::Keyword(kw) => KeyMirror::Keyword(kw.clone()),
+                TK::Symbol(id) => KeyMirror::Symbol(id.0),
+                TK::Keyword(hash) => KeyMirror::Keyword(*hash),
                 TK::EmptyList => KeyMirror::EmptyList,
                 TK::Array(a) => {
                     KeyMirror::Array(a.iter().map(to_mirror).collect::<Result<_, _>>()?)
-                }
-                TK::Symbol(_) => {
-                    return Err("TableKey::Symbol has no name to re-intern".into());
                 }
                 TK::Heap(_) => {
                     return Err("TableKey::Heap not serializable by stdlib cache".into());
@@ -255,7 +242,8 @@ impl<'de> serde::Deserialize<'de> for TableKey {
                 KeyMirror::Bool(b) => TK::Bool(b),
                 KeyMirror::Int(i) => TK::Int(i),
                 KeyMirror::String(st) => TK::String(st),
-                KeyMirror::Keyword(kw) => TK::Keyword(kw),
+                KeyMirror::Symbol(id) => TK::Symbol(crate::value::SymbolId(id)),
+                KeyMirror::Keyword(hash) => TK::Keyword(hash),
                 KeyMirror::EmptyList => TK::EmptyList,
                 KeyMirror::Array(a) => TK::Array(a.into_iter().map(from_mirror).collect()),
             }
@@ -281,7 +269,10 @@ mod tests {
         let mut map: BTreeMap<TableKey, SV> = BTreeMap::new();
         map.insert(TableKey::Int(7), SV::Immediate(Value::int(1)));
         map.insert(TableKey::String("s".into()), SV::Immediate(Value::int(2)));
-        map.insert(TableKey::Keyword("k".into()), SV::Immediate(Value::int(3)));
+        map.insert(
+            TableKey::Keyword(crate::value::keyword::keyword_hash("k")),
+            SV::Immediate(Value::int(3)),
+        );
         map.insert(
             TableKey::Array(vec![TableKey::Bool(true), TableKey::EmptyList]),
             SV::Immediate(Value::int(4)),
@@ -297,7 +288,10 @@ mod tests {
         for (k, want) in [
             (TableKey::Int(7), 1),
             (TableKey::String("s".into()), 2),
-            (TableKey::Keyword("k".into()), 3),
+            (
+                TableKey::Keyword(crate::value::keyword::keyword_hash("k")),
+                3,
+            ),
             (
                 TableKey::Array(vec![TableKey::Bool(true), TableKey::EmptyList]),
                 4,
@@ -310,22 +304,31 @@ mod tests {
         }
     }
 
-    /// A symbol `TableKey` carries only a process-local id — no name travels
-    /// with it, so a loader cannot re-intern it. Storing it raw would attach
-    /// the entry to an arbitrary symbol in the loading process; the only safe
-    /// treatment is a serialize error, which the cache layer turns into a
-    /// plain miss.
+    /// A symbol `TableKey` travels as the id it holds, because that id is the
+    /// name's hash and names the same symbol in the loading process. The trap
+    /// this guards: writing the key through any name-shaped detour (intern on
+    /// load, a remap table) reintroduces a step that can disagree with the
+    /// hash the rest of the bundle carries. The counter-factual is a key that
+    /// deserializes to a *different* `SymbolId` than it was stored with — the
+    /// struct then answers to a symbol no source text spells.
     #[test]
-    fn tablekey_symbol_key_is_rejected_not_mistranslated() {
+    fn tablekey_symbol_key_round_trips_as_its_name_hash() {
         use super::SendValue as SV;
         use crate::value::SymbolId;
 
+        let id = SymbolId::of("a-symbol-key");
         let mut map: BTreeMap<TableKey, SV> = BTreeMap::new();
-        map.insert(TableKey::Symbol(SymbolId(42)), SV::Immediate(Value::int(1)));
+        map.insert(TableKey::Symbol(id), SV::Immediate(Value::int(1)));
         let sv = SV::Struct(map, Box::new(SV::Immediate(Value::NIL)));
-        assert!(
-            bincode::serialize(&sv).is_err(),
-            "symbol keys must fail to serialize, not carry a raw id"
-        );
+
+        let bytes = bincode::serialize(&sv).expect("a symbol key serializes");
+        let back: SV = bincode::deserialize(&bytes).expect("deserializes");
+        let SV::Struct(m, _) = back else {
+            panic!("round-trip changed the container kind");
+        };
+        let Some(SV::Immediate(v)) = m.get(&TableKey::Symbol(id)) else {
+            panic!("the symbol key did not come back as the same id");
+        };
+        assert_eq!(v.as_int(), Some(1));
     }
 }

--- a/src/value/send/mod.rs
+++ b/src/value/send/mod.rs
@@ -19,6 +19,7 @@ use crate::value::types::Arity;
 use std::collections::{BTreeMap, HashMap};
 
 mod de;
+mod mirror;
 mod ser;
 mod syntax;
 

--- a/src/value/send/mod.rs
+++ b/src/value/send/mod.rs
@@ -417,29 +417,51 @@ fn remap_sendable_symbols(
 /// `name` has in the *loading* process's symbol table. Symbol ids are
 /// per-process: the JIT materializes them into `Value::symbol(id)` directly.
 fn remap_lir_symbols(lir: &mut crate::lir::LirFunction, old_to_new: &HashMap<u32, u32>) {
-    use crate::lir::{LirConst, LirInstr};
+    use crate::lir::LirConst;
     for block in &mut lir.blocks {
         for si in &mut block.instructions {
-            let fix = |c: &mut LirConst| {
+            // Through the visitor rather than a list of instruction shapes: a
+            // shape this missed would keep the storing process's id, and the
+            // JIT materializes that id straight into a `Value::symbol`.
+            si.instr.for_each_const_mut(|c| {
                 if let LirConst::Symbol(sid) = c {
                     if let Some(&new_id) = old_to_new.get(&sid.0) {
                         *sid = crate::value::SymbolId(new_id);
                     }
                 }
-            };
-            match &mut si.instr {
-                LirInstr::Const { value, .. } => fix(value),
-                LirInstr::StructGetOrNil { key, .. } => fix(key),
-                LirInstr::StructGetDestructure { key, .. } => fix(key),
-                LirInstr::StructRest { exclude_keys, .. } => {
-                    for k in exclude_keys.iter_mut() {
-                        fix(k);
-                    }
-                }
-                _ => {}
-            }
+            });
         }
     }
+}
+
+/// The `LirConst::Symbol` ids in `lir` that `names` cannot translate.
+///
+/// The remap above is a lookup, so an id absent from `symbol_names` survives
+/// untouched into the loading process — where it names whatever symbol happens
+/// to hold that id, silently. A storer that would produce one refuses instead.
+pub(crate) fn untranslatable_lir_symbols(
+    lir: &crate::lir::LirFunction,
+    names: &HashMap<u32, String>,
+) -> Vec<u32> {
+    use crate::lir::LirConst;
+    let mut missing = Vec::new();
+    // `for_each_const_mut` needs `&mut`, and this reads; clone the block's
+    // instruction to inspect it rather than duplicate the exhaustive match.
+    for block in &lir.blocks {
+        for si in &block.instructions {
+            let mut probe = si.instr.clone();
+            probe.for_each_const_mut(|c| {
+                if let LirConst::Symbol(sid) = c {
+                    if !names.contains_key(&sid.0) {
+                        missing.push(sid.0);
+                    }
+                }
+            });
+        }
+    }
+    missing.sort_unstable();
+    missing.dedup();
+    missing
 }
 
 #[cfg(test)]

--- a/src/value/send/mod.rs
+++ b/src/value/send/mod.rs
@@ -22,8 +22,8 @@ mod de;
 mod ser;
 mod syntax;
 
-use de::{into_value_inner, DeserContext, ReconState};
-use ser::{from_value_inner, SerContext};
+use de::{into_value_inner, template_from_sendable, DeserContext, ReconState};
+use ser::{from_value_inner, sendable_from_template, SerContext};
 use syntax::{send_to_syntax, SendSyntax};
 
 /// Sendable snapshot of a closure.
@@ -38,7 +38,7 @@ use syntax::{send_to_syntax, SendSyntax};
 ///
 /// This struct is `pub(crate)` — it is part of the public interface of
 /// `SendBundle` but not independently useful outside `send.rs`.
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct SendableClosure {
     pub bytecode: Vec<u8>,
     pub arity: Arity,
@@ -327,6 +327,117 @@ impl SendBundle {
         }
 
         result
+    }
+}
+
+/// Serialize a list of closure templates (e.g. a module's `child_protos`) into
+/// owned `SendableClosure`s, for the stdlib compilation cache.
+///
+/// Each template is a blueprint: `env`/`squelch_mask` are empty. Templates have
+/// no heap identity to intern, so they are emitted inline; their own
+/// `child_protos` recurse. Closure constants *inside* a template's constant
+/// pool are live heap instances and intern into `ctx.closures`, which is
+/// returned as the second element — the reconstructed templates reference it
+/// by `Ref(idx)`.
+pub(crate) fn serialize_templates(
+    protos: &[std::rc::Rc<crate::value::ClosureTemplate>],
+    heap: &crate::value::fiberheap::FiberHeap,
+    symbols: &crate::symbol::SymbolTable,
+) -> Result<(Vec<SendableClosure>, Vec<SendableClosure>), String> {
+    let mut ctx = SerContext::new(heap, symbols);
+    let mut out = Vec::with_capacity(protos.len());
+    for t in protos {
+        out.push(sendable_from_template(t, &mut ctx)?);
+    }
+    Ok((out, ctx.closures))
+}
+
+/// Reconstruct closure templates from owned `SendableClosure`s (the `(templates,
+/// intern_table)` pair from `serialize_templates`). The intern table is shared
+/// across all templates so `Ref(idx)` entries (closure constants) resolve.
+///
+/// `Alloc` is the receiving context's allocation capability (every
+/// reconstructed heap object is born in its region); symbols re-intern names.
+///
+/// The stored `symbol_names` maps and LIR `LirConst::Symbol` ids carry the
+/// *storing* process's ids; both are remapped to this process's table before
+/// reconstruction (constants themselves re-intern by name in
+/// `template_from_sendable`).
+pub(crate) fn deserialize_templates(
+    templates: Vec<SendableClosure>,
+    mut intern_table: Vec<SendableClosure>,
+    alloc: &mut crate::primitives::ctx::Alloc<'_>,
+    symbols: &mut crate::symbol::SymbolTable,
+) -> Result<Vec<std::rc::Rc<crate::value::ClosureTemplate>>, String> {
+    remap_sendable_symbols(&mut intern_table, symbols);
+    let mut templates = templates;
+    remap_sendable_symbols(&mut templates, symbols);
+    let mut dctx = DeserContext::new(intern_table, alloc, symbols);
+    let mut out = Vec::with_capacity(templates.len());
+    for sc in templates {
+        out.push(template_from_sendable(sc, &mut dctx));
+    }
+    Ok(out)
+}
+
+/// Rewrite a `SendableClosure`'s `symbol_names` map and LIR symbol ids from the
+/// storing process's table to this one. Recurses through `child_protos`.
+fn remap_sendable_symbols(
+    protos: &mut [SendableClosure],
+    symbols: &mut crate::symbol::SymbolTable,
+) {
+    fn fix_one(sc: &mut SendableClosure, symbols: &mut crate::symbol::SymbolTable) {
+        let old_names: Vec<(u32, String)> = sc
+            .symbol_names
+            .iter()
+            .map(|(&id, name)| (id, name.clone()))
+            .collect();
+        let mut old_to_new = HashMap::new();
+        let mut new_names = HashMap::new();
+        for (old_id, name) in &old_names {
+            let new_id = symbols.intern(name).0;
+            old_to_new.insert(*old_id, new_id);
+            new_names.entry(new_id).or_insert_with(|| name.clone());
+        }
+        if let Some(lir) = sc.lir_function.as_mut() {
+            remap_lir_symbols(lir, &old_to_new);
+        }
+        sc.symbol_names = new_names;
+        for child in sc.child_protos.iter_mut() {
+            fix_one(child, symbols);
+        }
+    }
+    for p in protos.iter_mut() {
+        fix_one(p, symbols);
+    }
+}
+
+/// Re-map every `LirConst::Symbol(old_id)` in a LIR function to the id that
+/// `name` has in the *loading* process's symbol table. Symbol ids are
+/// per-process: the JIT materializes them into `Value::symbol(id)` directly.
+fn remap_lir_symbols(lir: &mut crate::lir::LirFunction, old_to_new: &HashMap<u32, u32>) {
+    use crate::lir::{LirConst, LirInstr};
+    for block in &mut lir.blocks {
+        for si in &mut block.instructions {
+            let fix = |c: &mut LirConst| {
+                if let LirConst::Symbol(sid) = c {
+                    if let Some(&new_id) = old_to_new.get(&sid.0) {
+                        *sid = crate::value::SymbolId(new_id);
+                    }
+                }
+            };
+            match &mut si.instr {
+                LirInstr::Const { value, .. } => fix(value),
+                LirInstr::StructGetOrNil { key, .. } => fix(key),
+                LirInstr::StructGetDestructure { key, .. } => fix(key),
+                LirInstr::StructRest { exclude_keys, .. } => {
+                    for k in exclude_keys.iter_mut() {
+                        fix(k);
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 }
 

--- a/src/value/send/mod.rs
+++ b/src/value/send/mod.rs
@@ -331,137 +331,76 @@ impl SendBundle {
     }
 }
 
+/// A serialized set of closure templates — what `SendBundle` is to a value,
+/// this is to a module's blueprints (the stdlib compilation cache stores one).
+///
+/// A struct rather than a tuple because `templates` and `intern_table` have the
+/// same type: as positional arguments they are swappable at every call site
+/// with no compile error, and a swap would resolve every `Ref(idx)` against the
+/// wrong table.
+pub(crate) struct SendTemplates {
+    /// The blueprints themselves, in the order they were serialized.
+    pub(crate) templates: Vec<SendableClosure>,
+    /// Live closure instances lifted out of the templates' constant pools,
+    /// referenced from the templates by `SendValue::Ref(idx)`.
+    pub(crate) intern_table: Vec<SendableClosure>,
+    /// Spelling table, the same one a `SendBundle` carries. Ids are name
+    /// hashes and need no translation; the names are what the loading instance
+    /// must learn in order to print them.
+    pub(crate) names: Vec<(u64, Box<str>)>,
+}
+
 /// Serialize a list of closure templates (e.g. a module's `child_protos`) into
 /// owned `SendableClosure`s, for the stdlib compilation cache.
 ///
 /// Each template is a blueprint: `env`/`squelch_mask` are empty. Templates have
 /// no heap identity to intern, so they are emitted inline; their own
 /// `child_protos` recurse. Closure constants *inside* a template's constant
-/// pool are live heap instances and intern into `ctx.closures`, which is
-/// returned as the second element — the reconstructed templates reference it
-/// by `Ref(idx)`.
+/// pool are live heap instances and intern into the returned `intern_table` —
+/// the reconstructed templates reference it by `Ref(idx)`.
 pub(crate) fn serialize_templates(
     protos: &[std::rc::Rc<crate::value::ClosureTemplate>],
     heap: &crate::value::fiberheap::FiberHeap,
     symbols: &crate::symbol::SymbolTable,
-) -> Result<(Vec<SendableClosure>, Vec<SendableClosure>), String> {
-    let mut ctx = SerContext::new(heap, symbols);
-    let mut out = Vec::with_capacity(protos.len());
+) -> Result<SendTemplates, String> {
+    let mut ctx = SerContext::new(heap, Some(symbols));
+    let mut templates = Vec::with_capacity(protos.len());
     for t in protos {
-        out.push(sendable_from_template(t, &mut ctx)?);
+        templates.push(sendable_from_template(t, &mut ctx)?);
     }
-    Ok((out, ctx.closures))
+    let names = ctx.take_names();
+    Ok(SendTemplates {
+        templates,
+        intern_table: ctx.closures,
+        names,
+    })
 }
 
-/// Reconstruct closure templates from owned `SendableClosure`s (the `(templates,
-/// intern_table)` pair from `serialize_templates`). The intern table is shared
-/// across all templates so `Ref(idx)` entries (closure constants) resolve.
+/// Reconstruct closure templates from a [`SendTemplates`]. The intern table is
+/// shared across all templates so `Ref(idx)` entries (closure constants)
+/// resolve.
 ///
 /// `Alloc` is the receiving context's allocation capability (every
-/// reconstructed heap object is born in its region); symbols re-intern names.
+/// reconstructed heap object is born in its region).
 ///
-/// The stored `symbol_names` maps and LIR `LirConst::Symbol` ids carry the
-/// *storing* process's ids; both are remapped to this process's table before
-/// reconstruction (constants themselves re-intern by name in
-/// `template_from_sendable`).
+/// The name table replays into `symbols`, the receiving instance's display
+/// memo, exactly as `SendBundle::into_value` does. Nothing else about a symbol
+/// needs carrying: an id is its name's hash, so a `LirConst::Symbol` or a pool
+/// constant means the same symbol here as where it was stored.
 pub(crate) fn deserialize_templates(
-    templates: Vec<SendableClosure>,
-    mut intern_table: Vec<SendableClosure>,
+    stored: SendTemplates,
     alloc: &mut crate::primitives::ctx::Alloc<'_>,
     symbols: &mut crate::symbol::SymbolTable,
 ) -> Result<Vec<std::rc::Rc<crate::value::ClosureTemplate>>, String> {
-    remap_sendable_symbols(&mut intern_table, symbols);
-    let mut templates = templates;
-    remap_sendable_symbols(&mut templates, symbols);
-    let mut dctx = DeserContext::new(intern_table, alloc, symbols);
-    let mut out = Vec::with_capacity(templates.len());
-    for sc in templates {
+    for (hash, name) in &stored.names {
+        symbols.record_spelling(*hash, name);
+    }
+    let mut dctx = DeserContext::new(stored.intern_table, alloc);
+    let mut out = Vec::with_capacity(stored.templates.len());
+    for sc in stored.templates {
         out.push(template_from_sendable(sc, &mut dctx));
     }
     Ok(out)
-}
-
-/// Rewrite a `SendableClosure`'s `symbol_names` map and LIR symbol ids from the
-/// storing process's table to this one. Recurses through `child_protos`.
-fn remap_sendable_symbols(
-    protos: &mut [SendableClosure],
-    symbols: &mut crate::symbol::SymbolTable,
-) {
-    fn fix_one(sc: &mut SendableClosure, symbols: &mut crate::symbol::SymbolTable) {
-        let old_names: Vec<(u32, String)> = sc
-            .symbol_names
-            .iter()
-            .map(|(&id, name)| (id, name.clone()))
-            .collect();
-        let mut old_to_new = HashMap::new();
-        let mut new_names = HashMap::new();
-        for (old_id, name) in &old_names {
-            let new_id = symbols.intern(name).0;
-            old_to_new.insert(*old_id, new_id);
-            new_names.entry(new_id).or_insert_with(|| name.clone());
-        }
-        if let Some(lir) = sc.lir_function.as_mut() {
-            remap_lir_symbols(lir, &old_to_new);
-        }
-        sc.symbol_names = new_names;
-        for child in sc.child_protos.iter_mut() {
-            fix_one(child, symbols);
-        }
-    }
-    for p in protos.iter_mut() {
-        fix_one(p, symbols);
-    }
-}
-
-/// Re-map every `LirConst::Symbol(old_id)` in a LIR function to the id that
-/// `name` has in the *loading* process's symbol table. Symbol ids are
-/// per-process: the JIT materializes them into `Value::symbol(id)` directly.
-fn remap_lir_symbols(lir: &mut crate::lir::LirFunction, old_to_new: &HashMap<u32, u32>) {
-    use crate::lir::LirConst;
-    for block in &mut lir.blocks {
-        for si in &mut block.instructions {
-            // Through the visitor rather than a list of instruction shapes: a
-            // shape this missed would keep the storing process's id, and the
-            // JIT materializes that id straight into a `Value::symbol`.
-            si.instr.for_each_const_mut(|c| {
-                if let LirConst::Symbol(sid) = c {
-                    if let Some(&new_id) = old_to_new.get(&sid.0) {
-                        *sid = crate::value::SymbolId(new_id);
-                    }
-                }
-            });
-        }
-    }
-}
-
-/// The `LirConst::Symbol` ids in `lir` that `names` cannot translate.
-///
-/// The remap above is a lookup, so an id absent from `symbol_names` survives
-/// untouched into the loading process — where it names whatever symbol happens
-/// to hold that id, silently. A storer that would produce one refuses instead.
-pub(crate) fn untranslatable_lir_symbols(
-    lir: &crate::lir::LirFunction,
-    names: &HashMap<u32, String>,
-) -> Vec<u32> {
-    use crate::lir::LirConst;
-    let mut missing = Vec::new();
-    // `for_each_const_mut` needs `&mut`, and this reads; clone the block's
-    // instruction to inspect it rather than duplicate the exhaustive match.
-    for block in &lir.blocks {
-        for si in &block.instructions {
-            let mut probe = si.instr.clone();
-            probe.for_each_const_mut(|c| {
-                if let LirConst::Symbol(sid) = c {
-                    if !names.contains_key(&sid.0) {
-                        missing.push(sid.0);
-                    }
-                }
-            });
-        }
-    }
-    missing.sort_unstable();
-    missing.dedup();
-    missing
 }
 
 #[cfg(test)]

--- a/src/value/send/ser.rs
+++ b/src/value/send/ser.rs
@@ -16,6 +16,7 @@ mod lir;
 mod template;
 
 pub(super) use ctx::SerContext;
+pub(super) use template::sendable_from_template;
 
 use closure::send_closure;
 

--- a/src/value/send/ser/template.rs
+++ b/src/value/send/ser/template.rs
@@ -14,7 +14,7 @@ use super::lir::convert_lir_for_send;
 /// so they are emitted inline; `env`/`squelch_mask` are empty (a blueprint is a
 /// pure template). Recurses on the template's own `child_protos` so a worker
 /// rebuilds the full nested-lambda tree and every `MakeClosure` resolves.
-pub(super) fn sendable_from_template(
+pub(in crate::value::send) fn sendable_from_template(
     t: &crate::value::ClosureTemplate,
     ctx: &mut SerContext<'_>,
 ) -> Result<SendableClosure, String> {

--- a/src/value/send/tests.rs
+++ b/src/value/send/tests.rs
@@ -510,3 +510,43 @@ fn serde_round_trip_keeps_each_container_kind_distinct() {
         );
     }
 }
+
+// ── every LIR symbol must be translatable on load ───────────────────
+
+/// The load-path remap is a lookup, so an id absent from `symbol_names`
+/// survives into the loading process untouched and names whatever symbol holds
+/// that id there. The storer refuses rather than write such a file; this pins
+/// that the check sees a missing id and passes a present one.
+///
+/// Characterization, not a failing-first regression: today's four
+/// `LirConst`-bearing instructions are all reachable by the remap, so nothing
+/// currently produces an untranslatable id. The guard is for the next one.
+#[test]
+fn an_untranslatable_lir_symbol_is_reported() {
+    use crate::lir::{LirConst, LirInstr, Reg, Terminator};
+    use crate::value::SymbolId;
+
+    let lir = LirFixture::new(Arity::Exact(0))
+        .block(
+            0,
+            vec![LirInstr::Const {
+                dst: Reg(0),
+                value: LirConst::Symbol(SymbolId(4242)),
+            }],
+            Terminator::Return(Reg(0)),
+        )
+        .build();
+
+    let mut names = HashMap::new();
+    assert_eq!(
+        super::untranslatable_lir_symbols(&lir, &names),
+        vec![4242],
+        "an id with no name cannot be remapped, and must be reported"
+    );
+
+    names.insert(4242u32, "answerish".to_string());
+    assert!(
+        super::untranslatable_lir_symbols(&lir, &names).is_empty(),
+        "an id its closure can name is translatable"
+    );
+}

--- a/src/value/send/tests.rs
+++ b/src/value/send/tests.rs
@@ -511,18 +511,19 @@ fn serde_round_trip_keeps_each_container_kind_distinct() {
     }
 }
 
-// ── every LIR symbol must be translatable on load ───────────────────
+// ── a LIR symbol constant crosses unchanged ─────────────────────────
 
-/// The load-path remap is a lookup, so an id absent from `symbol_names`
-/// survives into the loading process untouched and names whatever symbol holds
-/// that id there. The storer refuses rather than write such a file; this pins
-/// that the check sees a missing id and passes a present one.
+/// The JIT materializes a `LirConst::Symbol` straight into a `Value::symbol`,
+/// so the id that crosses the boundary must name the same symbol on the other
+/// side. It does, with no translation step: the id is the name's hash.
 ///
-/// Characterization, not a failing-first regression: today's four
-/// `LirConst`-bearing instructions are all reachable by the remap, so nothing
-/// currently produces an untranslatable id. The guard is for the next one.
+/// The trap this replaced: while ids were per-process table indices, the
+/// loading side remapped them against a stored name map, and an id the map
+/// missed silently became whatever symbol held that index there. The
+/// counter-factual is a round-trip that yields a different `SymbolId` — the
+/// JIT then compiles a comparison against a symbol no source text spells.
 #[test]
-fn an_untranslatable_lir_symbol_is_reported() {
+fn a_lir_symbol_constant_survives_serialization_as_the_name_hash() {
     use crate::lir::{LirConst, LirInstr, Reg, Terminator};
     use crate::value::SymbolId;
 
@@ -531,22 +532,29 @@ fn an_untranslatable_lir_symbol_is_reported() {
             0,
             vec![LirInstr::Const {
                 dst: Reg(0),
-                value: LirConst::Symbol(SymbolId(4242)),
+                value: LirConst::Symbol(SymbolId::of("answerish")),
             }],
             Terminator::Return(Reg(0)),
         )
         .build();
 
-    let mut names = HashMap::new();
-    assert_eq!(
-        super::untranslatable_lir_symbols(&lir, &names),
-        vec![4242],
-        "an id with no name cannot be remapped, and must be reported"
-    );
+    let bytes = bincode::serialize(&lir).expect("LIR serializes");
+    let back: crate::lir::LirFunction = bincode::deserialize(&bytes).expect("deserializes");
 
-    names.insert(4242u32, "answerish".to_string());
-    assert!(
-        super::untranslatable_lir_symbols(&lir, &names).is_empty(),
-        "an id its closure can name is translatable"
+    let mut ids = Vec::new();
+    for block in &back.blocks {
+        for si in &block.instructions {
+            let mut probe = si.instr.clone();
+            probe.for_each_const_mut(|c| {
+                if let LirConst::Symbol(sid) = c {
+                    ids.push(*sid);
+                }
+            });
+        }
+    }
+    assert_eq!(
+        ids,
+        vec![SymbolId::of("answerish")],
+        "the stored id must still be the hash of `answerish`"
     );
 }

--- a/src/value/send/tests.rs
+++ b/src/value/send/tests.rs
@@ -454,3 +454,59 @@ fn a_keyword_names_the_same_keyword_on_both_sides() {
         assert_eq!(receiver.keyword_name(kw_hash), Some("kw-send-xt"));
     });
 }
+
+// ── the serde mirror keeps container kinds apart ────────────────────
+
+/// `SendValue`'s serde is the stdlib cache's wire format, and eight variants
+/// share three shapes: a sequence, a map, a byte run. Collapsing them loses
+/// which one it was, so a `Tuple` returns as an `Array`, an `LSet` as an
+/// `Array`, and a `Buffer` — a *mutable* @string — as immutable `Bytes`. The
+/// value would be silently the wrong type on every reload.
+#[test]
+fn serde_round_trip_keeps_each_container_kind_distinct() {
+    use super::SendValue as SV;
+
+    fn nil() -> Box<SV> {
+        Box::new(SV::Immediate(Value::NIL))
+    }
+    fn name(sv: &SV) -> &'static str {
+        match sv {
+            SV::Array(..) => "Array",
+            SV::Tuple(..) => "Tuple",
+            SV::LSet(..) => "LSet",
+            SV::LSetMut(..) => "LSetMut",
+            SV::Struct(..) => "Struct",
+            SV::StructMut(..) => "StructMut",
+            SV::Buffer(..) => "Buffer",
+            SV::Bytes(..) => "Bytes",
+            SV::Blob(..) => "Blob",
+            _ => panic!("unexpected variant in this test"),
+        }
+    }
+
+    let empty = std::collections::BTreeMap::new();
+    let cases = vec![
+        SV::Array(vec![], nil()),
+        SV::Tuple(vec![], nil()),
+        SV::LSet(vec![], nil()),
+        SV::LSetMut(vec![], nil()),
+        SV::Struct(empty.clone(), nil()),
+        SV::StructMut(empty, nil()),
+        SV::Buffer(vec![1, 2, 3], nil()),
+        SV::Bytes(vec![1, 2, 3], nil()),
+        SV::Blob(vec![1, 2, 3], nil()),
+    ];
+
+    for case in cases {
+        let bytes = bincode::serialize(&case).expect("serializes");
+        let back: SV = bincode::deserialize(&bytes).expect("deserializes");
+        assert_eq!(
+            name(&back),
+            name(&case),
+            "a {} must not come back as a {} — the cache would hand the runtime \
+             a value of the wrong type on every reload",
+            name(&case),
+            name(&back)
+        );
+    }
+}

--- a/src/value/template.rs
+++ b/src/value/template.rs
@@ -21,7 +21,7 @@ use crate::value::Value;
 /// data mirroring the quoted datum. Leaves that are immediates (`Symbol`,
 /// `Int`, …) materialize to immediate `Value`s with no allocation; heap nodes
 /// (`String`, `Pair`, `Array`, …) allocate into the literal's region.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ConstTemplate {
     // Immediate leaves — no allocation.
     Nil,

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -33,7 +33,9 @@ use std::fmt;
 /// integer compare, and a symbol value is portable by construction. Ordering
 /// follows the hash, which is deterministic but carries no alphabetical
 /// meaning; see [docs/impl/symbol.md](../../docs/impl/symbol.md).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub struct SymbolId(pub u64);
 
 impl SymbolId {
@@ -67,7 +69,7 @@ impl fmt::Display for SymbolId {
 /// assert!(Arity::Exact(2).matches(2));
 /// assert!(!Arity::Exact(2).matches(1));
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Arity {
     /// Exact number of arguments required
     Exact(usize),

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -131,6 +131,12 @@ pub struct VM {
     /// split at cluster boundaries, so a mid-run change would corrupt
     /// their framing.
     pub(crate) unicode_generation: crate::segment::Generation,
+    /// Where this instance caches its compiled stdlib. Recorded by
+    /// `RuntimeCore::load_stdlib`, and read by `sys/spawn`: a worker builds its
+    /// own runtime on a new thread and reaches the spawning instance only
+    /// through `ctx.vm()`, so this is how it inherits the directory its parent
+    /// was given instead of falling back to the process-wide one.
+    pub(crate) stdlib_cache: crate::compiler::stdlib_cache::StdlibCache,
     /// Pointer to this instance's heap. The VM does not own it: a `RuntimeCore`
     /// owns it as a sibling `Box<FiberHeap>` (`VM::new_with_heap`), or — for a bare
     /// VM with no `RuntimeCore` — it is a privately leaked heap (`VM::new`). Either

--- a/src/vm/core/lifecycle.rs
+++ b/src/vm/core/lifecycle.rs
@@ -46,6 +46,17 @@ impl VM {
         self.unicode_generation = gen;
     }
 
+    /// Where this VM's instance caches its compiled stdlib — what a `sys/spawn`
+    /// worker inherits.
+    pub fn stdlib_cache(&self) -> &crate::compiler::stdlib_cache::StdlibCache {
+        &self.stdlib_cache
+    }
+
+    /// Record it. Construction-time only, from `RuntimeCore::load_stdlib`.
+    pub(crate) fn set_stdlib_cache(&mut self, cache: crate::compiler::stdlib_cache::StdlibCache) {
+        self.stdlib_cache = cache;
+    }
+
     /// Build a VM pointing at an externally-owned heap (`RuntimeCore`'s
     /// `Box<FiberHeap>`), the coexistence-correct constructor: the program VM and
     /// its instance's macro-expansion VM share this one heap, so core.lisp and
@@ -86,6 +97,7 @@ impl VM {
         VM {
             runtime_config: rc,
             unicode_generation: crate::config::get().unicode_generation(),
+            stdlib_cache: crate::compiler::stdlib_cache::StdlibCache::default(),
             heap_ptr,
             compile_ctx_ptr: std::ptr::null_mut(),
             symbols_ptr: std::ptr::null_mut(),

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -303,7 +303,12 @@ fn eval_wasm_raw(source: &str, source_name: &str, with_stdlib: bool) -> Result<S
     // spliced letrec definitions (lexical scope shadows the registered exports),
     // so the emitted WASM calls the compiled stdlib, not the macro-VM closures.
     if with_stdlib {
-        crate::primitives::init_stdlib(&mut vm, &mut symbols, &mut compile);
+        crate::primitives::init_stdlib(
+            &mut vm,
+            &mut symbols,
+            &mut compile,
+            &crate::compiler::stdlib_cache::StdlibCache::Process,
+        );
     }
 
     let full_source;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -153,7 +153,7 @@ fn eval_with_cache(
                 // `RuntimeCore::bare` already points the VM at this instance's own
                 // symbol table, so stdlib-load gensym (and all name resolution)
                 // resolves through it.
-                core.load_stdlib();
+                core.load_stdlib(&elle::compiler::stdlib_cache::StdlibCache::Off);
             }
             core
         });

--- a/tests/integration/jit.rs
+++ b/tests/integration/jit.rs
@@ -53,7 +53,7 @@ fn stdlib_cctx(
 ) -> elle::pipeline::CompileCtx {
     let mut cctx = elle::pipeline::CompileCtx::new();
     vm.set_symbols(symbols as *mut elle::symbol::SymbolTable);
-    elle::init_stdlib(vm, symbols, &mut cctx);
+    elle::init_stdlib(vm, symbols, &mut cctx, &elle::compiler::stdlib_cache::StdlibCache::Off);
     cctx
 }
 

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -118,6 +118,9 @@ mod elle_scripts {
 mod dump_cli {
     include!("dump_cli.rs");
 }
+mod trace_compile {
+    include!("trace_compile.rs");
+}
 mod flip_cli {
     include!("flip_cli.rs");
 }

--- a/tests/integration/signal_enforcement.rs
+++ b/tests/integration/signal_enforcement.rs
@@ -56,7 +56,7 @@ fn analyze_with_stdlib(
 ) -> Result<elle::pipeline::AnalyzeResult, String> {
     let mut cctx = elle::pipeline::CompileCtx::new();
     vm.set_symbols(symbols as *mut SymbolTable);
-    elle::init_stdlib(vm, symbols, &mut cctx);
+    elle::init_stdlib(vm, symbols, &mut cctx, &elle::compiler::stdlib_cache::StdlibCache::Off);
     elle::pipeline::analyze(source, symbols, vm, &mut cctx, source_name)
 }
 

--- a/tests/integration/trace_compile.rs
+++ b/tests/integration/trace_compile.rs
@@ -1,0 +1,75 @@
+// `--trace` phase marks around the stdlib disk cache.
+//
+// The cache and the boot marks meet in `init_stdlib`: the cache exists to skip
+// the stdlib compile, the marks exist to attribute it. Loading the stdlib is
+// still the phase, so it is still marked.
+
+use std::process::Command;
+
+fn elle_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_elle")
+}
+
+fn run(args: &[&str], script: &std::path::Path) -> (bool, String) {
+    let out = Command::new(elle_binary())
+        .args(args)
+        .arg(script)
+        .output()
+        .expect("run elle");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn script_in(dir: &crate::common::ScratchDir) -> std::path::PathBuf {
+    let script = dir.join("script.lisp");
+    std::fs::write(&script, "(+ 1 2)\n").expect("write script");
+    script
+}
+
+#[test]
+fn a_cache_hit_still_reports_the_stdlib_boot_phase() {
+    let dir = crate::common::ScratchDir::new("trace-stdlib-cache");
+    let script = script_in(&dir);
+    let cache = format!("--cache={}", dir.join("cache").display());
+
+    // The first run compiles and stores; the second loads what the first wrote.
+    let (ok, first) = run(&[&cache, "--trace=boot"], &script);
+    assert!(ok, "first run failed:\n{first}");
+    let (ok, second) = run(&[&cache, "--trace=boot"], &script);
+    assert!(ok, "second run failed:\n{second}");
+
+    // The trap: the cache-hit path returns early, so a mark placed only on the
+    // compile arm vanishes the moment the cache starts working. The
+    // counter-factual is a second run whose stderr names no stdlib phase at
+    // all — boot attribution quietly stops covering the slowest boot step, and
+    // the only symptom is a shorter trace nobody reads twice.
+    for (which, err) in [("first", &first), ("second", &second)] {
+        assert!(
+            err.lines()
+                .any(|l| l.starts_with("[trace:boot]") && l.contains("stdlib-compile")),
+            "{which} run reports no stdlib-compile boot mark:\n{err}"
+        );
+    }
+    assert!(
+        second.contains("stdlib-compile (cache hit)"),
+        "the second run must load the stdlib the first one stored:\n{second}"
+    );
+}
+
+#[test]
+fn phase_marks_stay_quiet_without_the_keyword() {
+    // A diagnostic that prints when nobody asked is a diagnostic that gets
+    // filtered out and then ignored.
+    let dir = crate::common::ScratchDir::new("trace-quiet");
+    let script = script_in(&dir);
+    let (ok, err) = run(&[], &script);
+    assert!(ok, "elle exited non-zero:\n{err}");
+    for subsystem in ["[trace:boot]", "[trace:compile]"] {
+        assert!(
+            !err.contains(subsystem),
+            "no {subsystem} phase mark may appear without --trace:\n{err}"
+        );
+    }
+}

--- a/tests/region_cell_borrow.rs
+++ b/tests/region_cell_borrow.rs
@@ -37,7 +37,12 @@ fn run(source: &str) -> String {
     let mut cctx = elle::pipeline::CompileCtx::new();
     vm.set_compile_ctx(&mut cctx as *mut elle::pipeline::CompileCtx);
     vm.set_symbols(&mut symbols as *mut SymbolTable);
-    init_stdlib(&mut vm, &mut symbols, &mut cctx);
+    init_stdlib(
+        &mut vm,
+        &mut symbols,
+        &mut cctx,
+        &elle::compiler::stdlib_cache::StdlibCache::Off,
+    );
     match elle::eval_all(source, &mut symbols, &mut vm, &mut cctx, "<cell-borrow>") {
         Ok(v) => format!("{}", v.display_with(Some(&symbols))),
         Err(e) => format!("error: {e}"),

--- a/tests/region_cell_release_order.rs
+++ b/tests/region_cell_release_order.rs
@@ -35,7 +35,12 @@ fn run(source: &str) -> String {
     let mut cctx = elle::pipeline::CompileCtx::new();
     vm.set_compile_ctx(&mut cctx as *mut elle::pipeline::CompileCtx);
     vm.set_symbols(&mut symbols as *mut SymbolTable);
-    init_stdlib(&mut vm, &mut symbols, &mut cctx);
+    init_stdlib(
+        &mut vm,
+        &mut symbols,
+        &mut cctx,
+        &elle::compiler::stdlib_cache::StdlibCache::Off,
+    );
     match elle::eval_all(source, &mut symbols, &mut vm, &mut cctx, "<cell-release>") {
         Ok(v) => format!("{}", v.display_with(Some(&symbols))),
         Err(e) => format!("error: {e}"),

--- a/tests/region_lsp_resident.rs
+++ b/tests/region_lsp_resident.rs
@@ -39,7 +39,12 @@ fn lsp_resident_analyze_is_region_clean_under_guardfree() {
     let mut cctx = elle::pipeline::CompileCtx::new();
     vm.set_compile_ctx(&mut cctx as *mut elle::pipeline::CompileCtx);
     vm.set_symbols(&mut symbols as *mut SymbolTable);
-    init_stdlib(&mut vm, &mut symbols, &mut cctx);
+    init_stdlib(
+        &mut vm,
+        &mut symbols,
+        &mut cctx,
+        &elle::compiler::stdlib_cache::StdlibCache::Off,
+    );
 
     // Mirror compile_document(): re-analyze on every "change", reusing the
     // resident VM and its per-instance compile context across iterations.

--- a/tests/region_scrub.rs
+++ b/tests/region_scrub.rs
@@ -30,7 +30,12 @@ fn run(source: &str) -> String {
     let mut cctx = elle::pipeline::CompileCtx::new();
     vm.set_compile_ctx(&mut cctx as *mut elle::pipeline::CompileCtx);
     vm.set_symbols(&mut symbols as *mut SymbolTable);
-    init_stdlib(&mut vm, &mut symbols, &mut cctx);
+    init_stdlib(
+        &mut vm,
+        &mut symbols,
+        &mut cctx,
+        &elle::compiler::stdlib_cache::StdlibCache::Off,
+    );
     match elle::eval_all(source, &mut symbols, &mut vm, &mut cctx, "<scrub>") {
         Ok(v) => format!("{}", v.display_with(Some(&symbols))),
         Err(e) => format!("error: {e}"),

--- a/tests/unittests/bytecode_debug.rs
+++ b/tests/unittests/bytecode_debug.rs
@@ -14,7 +14,7 @@ fn compile(
     let _ = elle::register_primitives(&mut vm, symbols);
     let mut cctx = elle::pipeline::CompileCtx::new();
     vm.set_symbols(symbols as *mut SymbolTable);
-    elle::init_stdlib(&mut vm, symbols, &mut cctx);
+    elle::init_stdlib(&mut vm, symbols, &mut cctx, &elle::compiler::stdlib_cache::StdlibCache::Off);
     elle::pipeline::compile(source, symbols, &mut cctx, source_name)
 }
 


### PR DESCRIPTION
## Motivation

`init_stdlib` runs the whole front end over stdlib.lisp on every process start —
expand → analyze → regions → lower → emit — before a line of user code compiles.
Executing the result costs a fraction of that. The compile is deterministic:
same source, same binary → same bytecode, so it is work that need happen once.

## What this does

The compiled `Bytecode` is serialized to a content-addressed cache file and
loaded on later starts instead of recompiled.

- **The key is the binary**, not its version string — its length and mtime, plus
  the stdlib source hash, `FORMAT_VERSION`, and the primitive-table identity. A
  version string cannot see a rebuild, and a key that misses one hands every
  `Runtime::new()` bytecode the previous binary compiled.
- **The directory is a construction parameter**, `StdlibCache`, passed to
  `Runtime::with_stdlib_cache` and inherited by `sys/spawn` workers. Not an
  environment variable and not a global: the suite builds many runtimes across
  threads, and the directory has to travel with the instance that uses it.
  `Process` takes `stdlib-cache` beneath the existing `--cache=<dir>`, whose
  empty form already means off.
- **Every failure is a miss.** An unidentifiable binary, a payload hash
  mismatch, a truncated file, a format bump — each falls back to a compile, and
  a rejected file is *replaced* rather than left to be rejected again.
  `Runtime::stdlib_source()` reports which path an instance took.
- **A store lands whole or not at all**: a temp file in the same directory,
  renamed over the target, then the superseded files are pruned.
- **LIR is preserved**, so the JIT keeps compiling stdlib functions after a
  reload — dropping it would send every stdlib function to the interpreter
  forever.
- **Symbols cross by name** and re-intern on load; LIR symbol ids are remapped
  through an exhaustive `LirInstr::for_each_const_mut`, and a store refuses to
  write a file whose LIR names a symbol its `symbol_names` cannot translate.
- The `SendValue`/`TableKey` serde lives in `src/value/send/mirror.rs` and keeps
  each container kind distinct — a `Tuple`, an `LSet`, a `Buffer` all return as
  themselves.
- Phase timings report on the existing `--trace=compile`.
- Adds `serde` + `bincode` as dependencies.

## Performance

Release build, `elle -e '(+ 1 1)'`, this machine. A trivial script, so this is
the boot floor rather than any particular workload:

| | stdlib phase | total |
|---|---|---|
| `--cache=` (off) | 249 ms | 0.26 s |
| cache hit | 70 ms | 0.08 s |

Of the 70 ms, **45 ms is `deserialize_templates`** — deserialization dominates
what remains, which is the ceiling of this approach and the case for the page
mapping in docs/impl/image.md. The cache file is 15.8 MB. Writing it costs
~50 ms on the run that compiles.

Breakdown from `--trace=compile`, which this PR routes the marks through.

## Tests

`src/compiler/stdlib_cache.rs`:

- `bytecode_roundtrip_preserves_lir_and_closures` — store → load produces
  equivalent bytecode that executes to the same result
- `second_runtime_on_a_shared_cache_dir_loads_stdlib_from_it` — the first
  runtime compiles, the second loads what it wrote
- `a_spawned_worker_caches_where_its_parent_was_told_to`
- `a_corrupt_cache_file_is_a_miss_not_a_panic_or_a_silent_edit` — both failure
  modes: a shallow offset that reaches the VM, a deep one that passes unnoticed
- `a_rejected_cache_file_is_replaced_not_left_to_win`
- `a_store_replaces_the_cache_file_instead_of_rewriting_it` — a held descriptor
  still sees the old bytes
- `a_store_prunes_the_files_its_key_supersedes`
- `the_build_identity_is_read_from_the_running_executable`
- `a_cached_stdlib_closure_has_no_origin_but_user_code_keeps_its_own`

`src/value/send/tests.rs`: `serde_round_trip_keeps_each_container_kind_distinct`,
`an_untranslatable_lir_symbol_is_reported`.
`src/value/repr/tests.rs`: `invalid_scalar_tag_is_an_error_not_a_panic`,
`symbol_value_refuses_scalar_serialization`.

Each was written against the code before its fix and failed there, except the
two characterization tests named as such in their doc comments — a build
identity and an untranslatable symbol are observable only across builds and in
future code respectively.

## One difference between the two paths

`ClosureTemplate.syntax` does not cross the cache, and `(meta/origin f)` — its
only reader — reports a closure's location from it. So `(meta/origin map)`
answers with a location after a compile and `nil` after a hit. Nothing in the
tree depends on it, and the loss is bounded to values the cache restored: a
closure a cache-hit runtime compiles still carries its syntax. Both halves are
pinned.

## Depends on

#988 and #989 carry the `SendableClosure` release-table fix and the
`get_or_compile_projection` fix. This branch needs both — the cache skips the
stdlib compile that would otherwise warm every transformer, and it round-trips
through `SendableClosure` — so the hunks remain here until those land and this
rebases onto them.

Design notes: `docs/impl/stdlib-cache.md`.
