### PR TITLE
regions: a call that allocates nothing gives its physical id back

### DIFF
--- a/docs/impl/region/diagnostics.md
+++ b/docs/impl/region/diagnostics.md
@@ -55,6 +55,25 @@ the region rules ([rules.md](rules.md)) honest.
   variadic stdlib operator allocates"). `tests/elle/region-page-recycle.lisp`
   reads it. Immediate, so sampling it allocates nothing and does not perturb
   the measurement.
+- `(arena/region-ids)` and `(arena/region-table)`: the *id* dimension, which no
+  other gauge can show. A minted id that never allocates holds no object, no
+  page, and no reference count, so `arena/count`, `arena/bytes`,
+  `arena/page-claims`, and `arena/region-count` all read flat while it strands
+  ([model.md](model.md) § "Physical id recycling"). Reach for `region-ids` to
+  *detect* the leak and `region-table` to size it:
+  - `arena/region-ids` is `next_physical`, one past the largest id ever minted
+    from scratch. A mint that finds an id on the free list leaves it alone, so a
+    steady-state loop holds it flat and every unit of growth is an id that did
+    not come back. A delta across a fixed window of such a loop must be zero.
+  - `arena/region-table` is `regions.len()`, one past the largest id ever made
+    *live*, which times the slot size is what the table costs resident. It
+    **lags**: a stranded id is never materialized, so it inflates the table only
+    once some later mint reaches its range. A loop whose calls allocate nothing
+    can leak ids at full rate and leave this gauge flat, which is why it is the
+    wrong one to assert on.
+
+  `tests/elle/region-id-recycle.lisp` reads both. Both are Immediate, so
+  sampling allocates nothing.
 - **Direct vs cascade free** — the two have different fixes. A *direct* free of a
   still-live value is a liveness bug: a `decref_point` fired while the value was still
   reachable. A *cascade* free of a still-referenced region is a missing incref on

--- a/docs/impl/region/generations.md
+++ b/docs/impl/region/generations.md
@@ -75,16 +75,27 @@ approaches the bound. It is a backstop, not a detector: it makes the failure
 *loud* instead of an opaque OOM — the deref site and the freeing region still
 come from the generation check (debug) and `--trace=guardfree` / `--trace=free`.
 
-The bound has a ceiling of its own, and it is the reason the constant is not
-simply set as high as the id space allows. The panic can only fire if the table
-at that id is **allocatable**: the check runs before `resize_with`, but a bound
-whose table exceeds what the machine can supply lets the allocator abort one id
-below it instead, at which point the program dies with a byte count and no
-diagnosis. So `MAX_PLAUSIBLE_REGION_ID` is `1 << 24`: a table of ~3.5 GB, which
-an allocator can still satisfy, while a program with 2^24 concurrently-live
-regions would need at least 64 GiB of region pages to hold them (Rule 6 — a live
-region owns at least one page). The bound sits between what a real program
-reaches and what the allocator can build.
+The bound has a ceiling of its own. The panic can only fire if the table at that
+id is **allocatable**: the check runs before `resize_with`, so a bound whose
+table exceeds what the machine can supply lets the allocator abort one id below
+it instead, and the program dies with a byte count and no diagnosis.
+
+Those two requirements pull in opposite directions, and what leaves room between
+them is a ratio rather than any absolute size. A live region owns at least one
+4 KiB page (Rule 6), so a program holding N regions at once already holds at
+least 4N KiB of pages, while the table for those ids costs
+N × `size_of::<Option<RegionEntry>>()` — about a twentieth as much. Set
+`MAX_PLAUSIBLE_REGION_ID` past the live-region count a machine's memory permits,
+and the table at that bound stays within what the same machine can allocate. At
+`1 << 28` that is 1 TiB of pages against a ~56 GB table.
+
+Do not read the bound as "no program can want this much memory". A machine large
+enough to host such a program is the same machine that can allocate the table, so
+the bound tracks the hardware; picking a smaller constant to make the table
+cheaper only moves the tripwire into the range where real programs live. On a
+machine too small for the table the allocator still aborts first — which is why
+the assertion message names id exhaustion beside corruption rather than
+asserting the second.
 
 The free-time cascade scan (`find_object_cross_refs`) deliberately does NOT
 check generations: teardown legitimately scans objects whose contained

--- a/docs/impl/region/generations.md
+++ b/docs/impl/region/generations.md
@@ -69,11 +69,22 @@ principle, hand it a garbage id from a stale or foreign read): an id past
 `regions.resize_with(id + 1, …)` would grow the table to that id — hundreds of GB
 — and abort on allocation failure far from the deref. It panics there, naming the
 hazard, in every build. The region table is bounded by the max *concurrently-live*
-regions (freed ids recycle through `free_physical`), so a real id never approaches
-the bound; the backstop only ever fires on corruption. It is a backstop, not a
-detector: it makes the failure *loud* instead of an opaque OOM — the deref site
-and the freeing region still come from the generation check (debug) and
-`--trace=guardfree` / `--trace=free`.
+regions — every id reaches `free_physical` again, freed and never-materialized
+alike ([model.md](model.md) § "Physical id recycling") — so a real id never
+approaches the bound. It is a backstop, not a detector: it makes the failure
+*loud* instead of an opaque OOM — the deref site and the freeing region still
+come from the generation check (debug) and `--trace=guardfree` / `--trace=free`.
+
+The bound has a ceiling of its own, and it is the reason the constant is not
+simply set as high as the id space allows. The panic can only fire if the table
+at that id is **allocatable**: the check runs before `resize_with`, but a bound
+whose table exceeds what the machine can supply lets the allocator abort one id
+below it instead, at which point the program dies with a byte count and no
+diagnosis. So `MAX_PLAUSIBLE_REGION_ID` is `1 << 24`: a table of ~3.5 GB, which
+an allocator can still satisfy, while a program with 2^24 concurrently-live
+regions would need at least 64 GiB of region pages to hold them (Rule 6 — a live
+region owns at least one page). The bound sits between what a real program
+reaches and what the allocator can build.
 
 The free-time cascade scan (`find_object_cross_refs`) deliberately does NOT
 check generations: teardown legitimately scans objects whose contained

--- a/docs/impl/region/model.md
+++ b/docs/impl/region/model.md
@@ -175,6 +175,61 @@ scrubbed — an unmapped address faults on its own.
 call from Elle, through the `arena/page-claims` gauge; `pagepool::tests` pins
 the untouched-recycle contract and the scrub's spans.
 
+## Physical id recycling: reserved, live, free
+
+A physical region id has three states, and every id must reach `free` again.
+
+- **Reserved.** `new_runtime_region` takes an id off `free_physical`, or bumps
+  `next_physical` when that list is empty. The id names no region yet: it has no
+  entry and no pages. Its generation slot, if it has one, still holds the value
+  its previous incarnation's teardown left.
+- **Live.** `ensure_raw` builds the id's `RegionEntry` on first touch. It also
+  sizes `regions` and `generations` to the id, so **the table is as long as the
+  largest id ever made live**, whatever the count of live regions is. (Static
+  slot ids reach `ensure_raw` too and size the table the same way; they come
+  from the compiler's own bounded counter — see § "Two id-spaces".)
+- **Free.** A teardown returns the id's pages, bumps its generation, and pushes
+  the id onto `free_physical`, where the next mint finds it.
+
+The reserved state has a second exit: a caller can mint an id and never allocate
+into it. The **per-call result region** is that case, on the hottest path in the
+runtime. `dispatch_native_call` and `dispatch_collection_call` each mint one
+region per call, before the call runs, because the callee may allocate its
+result into it. A primitive that returns an
+immediate (`(< a b)`), or one that returns a value borrowed from an argument
+(`first`, `rest`, `get`), allocates nothing into it. That id never reaches
+`ensure_raw`, so no teardown can ever return it.
+
+An id stranded that way costs no heap object, no page, and no reference count,
+which is why the object and region gauges cannot see it. It costs the region
+**table**: it raises the largest id a later mint hands out, and `regions` is a
+`Vec<Option<RegionEntry>>` indexed by id, so a stranded id is one
+`size_of::<Option<RegionEntry>>()` slot of resident memory that nothing frees.
+Resident memory then grows with total work while `arena/count`,
+`arena/region-count`, and `arena/bytes` all stay flat.
+
+So both dispatchers close the reserved state themselves: after the call,
+`recycle_unmaterialized` pushes the result region back onto `free_physical` when
+the call left it unmaterialized. Unmaterialized means two things together —
+`regions[id]` is empty **and** the id's generation still equals the generation
+read at the mint.
+
+The generation half is what makes the test exact, and it is not optional. A
+region that materialized and was freed inside the call (a native that re-enters
+the VM) also leaves `regions[id]` empty — but its teardown already pushed that
+id, so pushing it again would put a **duplicate** in `free_physical`. Two mints
+could then take the same id before either materialized, and `new_runtime_region`
+could not tell them apart: its skip loop only rejects an id that is already
+*live*. Two logical regions on one physical id is the aliasing UAF the mint loop
+exists to prevent. A teardown bumps the generation, so the generation check
+rejects exactly that id and admits only a mint that nothing has touched since.
+
+`arena/region-ids` reads `next_physical` from Elle — the gauge that moves the
+moment an id fails to come back — and `arena/region-table` reads what the table
+costs. `tests/elle/region-id-recycle.lisp` uses them to pin the bound: a loop of
+calls that allocate nothing issues no new id. `regionstore::tests::recycle` pins
+the store-level contract, the duplicate the generation check refuses included.
+
 ## RegionSlice contents share their object's region
 
 Non-obvious and load-bearing: immutable aggregates (string, array, struct, and a

--- a/src/primitives/arena.rs
+++ b/src/primitives/arena.rs
@@ -162,6 +162,33 @@ pub(crate) fn prim_arena_region_count(
     (SIG_OK, Value::int(count as i64))
 }
 
+/// (arena/region-ids) — physical region ids issued, one past the largest id ever
+/// minted from scratch.
+///
+/// The *id* dimension the object, byte, and page gauges cannot show: a minted id
+/// that never allocates holds no object, no page, and no reference count, yet
+/// never returns to the free list (docs/impl/region/model.md § "Physical id
+/// recycling"). A mint that recycles leaves this alone, so a delta across a fixed
+/// window of a steady-state loop must be zero.
+pub(crate) fn prim_arena_region_ids(
+    ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
+    _args: &[Value],
+) -> (SignalBits, Value) {
+    let issued = ctx.heap_mut().region_ids_issued();
+    (SIG_OK, Value::int(i64::from(issued)))
+}
+
+/// (arena/region-table) — entries in the region table, one past the largest
+/// physical region id ever made live. What the table costs resident, in slots;
+/// `arena/region-ids` is the gauge that detects an id leak.
+pub(crate) fn prim_arena_region_table(
+    ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
+    _args: &[Value],
+) -> (SignalBits, Value) {
+    let len = ctx.heap_mut().region_table_len();
+    (SIG_OK, Value::int(len as i64))
+}
+
 /// (arena/region-info) — return array of {:id N :rc N :objects N} per region.
 pub(crate) fn prim_arena_region_info(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
@@ -305,6 +332,24 @@ primitive! {
         category: "debug",
         example: "(debug/arena-region-count)",
         aliases: &["arena/region-count"],
+        effect: RegionEffect::Immediate,
+    }
+    "debug/arena-region-ids" => prim_arena_region_ids {
+        ret: RetType::Int,
+        signal: Signal::errors(),
+        doc: "Return physical region ids issued (one past the largest id ever minted from scratch).",
+        category: "debug",
+        example: "(debug/arena-region-ids)",
+        aliases: &["arena/region-ids"],
+        effect: RegionEffect::Immediate,
+    }
+    "debug/arena-region-table" => prim_arena_region_table {
+        ret: RetType::Int,
+        signal: Signal::errors(),
+        doc: "Return entries in the region table (one past the largest physical region id ever made live).",
+        category: "debug",
+        example: "(debug/arena-region-table)",
+        aliases: &["arena/region-table"],
         effect: RegionEffect::Immediate,
     }
     "debug/arena-region-info" => prim_arena_region_info {

--- a/src/value/fiberheap/region.rs
+++ b/src/value/fiberheap/region.rs
@@ -9,6 +9,7 @@ use crate::hir::region::RuntimeRegion;
 use crate::value::heap::HeapObject;
 use crate::value::Value;
 
+use super::regionstore::RegionMint;
 use super::FiberHeap;
 
 impl FiberHeap {
@@ -63,6 +64,21 @@ impl FiberHeap {
     /// slot; the two id-spaces are distinct (see docs/impl/region/model.md § id-spaces).
     pub fn new_runtime_region(&mut self) -> RuntimeRegion {
         self.region_store.new_runtime_region()
+    }
+
+    /// Mint a fresh runtime region id together with the receipt that returns it
+    /// if nothing allocates into it — the mint for a caller that may end without
+    /// materializing its region (docs/impl/region/model.md § "Physical id
+    /// recycling"). Pair with [`Self::recycle_unmaterialized_region`].
+    pub(crate) fn new_runtime_region_tracked(&mut self) -> RegionMint {
+        self.region_store.new_runtime_region_tracked()
+    }
+
+    /// Return a minted id to the free list if the mint never materialized it.
+    /// A no-op when the id names a live region, or when it lived and died since
+    /// the mint (docs/impl/region/model.md § "Physical id recycling").
+    pub(crate) fn recycle_unmaterialized_region(&mut self, mint: RegionMint) {
+        self.region_store.recycle_unmaterialized(mint);
     }
 
     /// Increment the reference count for a region.
@@ -212,6 +228,20 @@ impl FiberHeap {
     /// Number of active regions.
     pub fn active_region_count(&self) -> usize {
         self.region_store.active_region_count()
+    }
+
+    /// Physical region ids this heap has issued — the backend of the
+    /// `arena/region-ids` gauge (docs/impl/region/diagnostics.md). Flat in a
+    /// steady-state loop; every unit of growth is an id that never returned to
+    /// the free list.
+    pub fn region_ids_issued(&self) -> u32 {
+        self.region_store.region_ids_issued()
+    }
+
+    /// Entries in this heap's region table — what the table costs resident, in
+    /// slots (docs/impl/region/model.md § "Physical id recycling").
+    pub fn region_table_len(&self) -> usize {
+        self.region_store.region_table_len()
     }
 
     /// Per-region info: (region_id, rc, object_count) for every active region.

--- a/src/value/fiberheap/regionstore.rs
+++ b/src/value/fiberheap/regionstore.rs
@@ -95,6 +95,32 @@ impl RegionEntry {
     }
 }
 
+/// A mint receipt: the physical id a mint handed out, plus the generation that
+/// id carried at that moment (docs/impl/region/model.md § "Physical id
+/// recycling").
+///
+/// It is the only key [`RegionStore::recycle_unmaterialized`] accepts, and its
+/// fields are private to this module, so a caller cannot ask the store to
+/// recycle an id no mint produced — injecting an id `next_physical` has not
+/// passed would let a later mint issue it a second time, and that is
+/// unrepresentable here rather than guarded against at the use site.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RegionMint {
+    region: RuntimeRegion,
+    /// The id's generation at the mint. A teardown bumps it, so an id that
+    /// lived and died since the mint no longer matches — which is what keeps the
+    /// recycle from putting a second copy of that id in the free list.
+    gen: u32,
+}
+
+impl RegionMint {
+    /// The physical region this mint handed out.
+    #[inline]
+    pub(crate) fn region(self) -> RuntimeRegion {
+        self.region
+    }
+}
+
 /// Region table on FiberHeap.
 pub(crate) struct RegionStore {
     /// Indexed by physical region id (mortal `RuntimeRegion`s, id ≥ 2).
@@ -105,9 +131,17 @@ pub(crate) struct RegionStore {
     /// Next never-used physical region id (monotonic). Id 0 is the
     /// unassigned/immediate sentinel and id 1 is reserved, so minting starts at 2.
     next_physical: u32,
-    /// Recycled physical ids returned by `free_runtime_region_pages`. Reusing freed ids keeps
-    /// the `regions` Vec bounded by the max *concurrently-live* region count
-    /// even though allocation mints a fresh region per execution.
+    /// Physical ids available for reissue. Two paths return an id here, and
+    /// between them every minted id comes back (docs/impl/region/model.md
+    /// § "Physical id recycling"): `free_runtime_region_pages`, when a region's
+    /// pages are torn down, and `recycle_unmaterialized`, when a mint ends
+    /// without ever allocating into its id. Reusing them keeps the `regions` Vec
+    /// bounded by the max *concurrently-live* region count even though
+    /// allocation mints a fresh region per execution.
+    ///
+    /// An id appears here at most once. A duplicate would be handed to two mints
+    /// before either materialized — `new_runtime_region` rejects only an id that
+    /// is already *live* — aliasing two logical regions onto one physical id.
     free_physical: Vec<u32>,
     /// Per-physical-id generation counter (docs/impl/region/generations.md § "Region
     /// generations"), indexed like `regions`. Bumped on every path that
@@ -153,16 +187,23 @@ static NEXT_STORE_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU3
 /// Upper bound on a physically-plausible region id, the `ensure_raw` backstop's
 /// tripwire (docs/impl/region/generations.md § "Region generations"). The region
 /// table is indexed by id and bounded by the max *concurrently-live* regions —
-/// freed ids recycle through `free_physical`, and static-slot ids are bounded by
+/// every minted id returns to `free_physical`, and static-slot ids are bounded by
 /// the compiler's region-slot count — so a real id stays far below this. An id
 /// above it reaching `ensure_raw` is a corrupt page-header read handed back as a
 /// region id — a misidentified page base (the `region_of_ptr` walk's ownership
 /// validation and the page-header magic close the known cause) or a stale/foreign
-/// read — not a region to lazily create: resizing the table to it commits
-/// hundreds of GB and OOM-aborts far from the deref. 2^28 ids is a ~36 GB table —
-/// already impossible for a real program (each live region owns at least one
-/// 4 KiB page) — while leaving headroom below the garbage range.
-const MAX_PLAUSIBLE_REGION_ID: u32 = 1 << 28;
+/// read — not a region to lazily create.
+///
+/// The bound sits between what a real program reaches and what the allocator can
+/// build, and it needs both sides. Below: 2^24 concurrently-live regions would
+/// own at least 64 GiB of pages (Rule 6 — a live region owns at least one 4 KiB
+/// page), so no real program comes near. Above: the panic fires only if the
+/// table at that id is still *allocatable*, since the check runs before
+/// `regions.resize_with`. At 2^24 that table is ~3.5 GB, which an allocator can
+/// satisfy; set the bound where the table itself exceeds what the machine can
+/// supply and the allocator aborts one id below the tripwire instead, killing
+/// the program with a byte count and no diagnosis.
+const MAX_PLAUSIBLE_REGION_ID: u32 = 1 << 24;
 
 impl RegionStore {
     pub fn new(

--- a/src/value/fiberheap/regionstore.rs
+++ b/src/value/fiberheap/regionstore.rs
@@ -194,16 +194,20 @@ static NEXT_STORE_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU3
 /// validation and the page-header magic close the known cause) or a stale/foreign
 /// read — not a region to lazily create.
 ///
-/// The bound sits between what a real program reaches and what the allocator can
-/// build, and it needs both sides. Below: 2^24 concurrently-live regions would
-/// own at least 64 GiB of pages (Rule 6 — a live region owns at least one 4 KiB
-/// page), so no real program comes near. Above: the panic fires only if the
-/// table at that id is still *allocatable*, since the check runs before
-/// `regions.resize_with`. At 2^24 that table is ~3.5 GB, which an allocator can
-/// satisfy; set the bound where the table itself exceeds what the machine can
-/// supply and the allocator aborts one id below the tripwire instead, killing
-/// the program with a byte count and no diagnosis.
-const MAX_PLAUSIBLE_REGION_ID: u32 = 1 << 24;
+/// The bound has to clear two things at once, and it is the *ratio* between them
+/// that leaves room to do so — not any absolute figure, which only tracks the
+/// machine. A live region owns at least one 4 KiB page (Rule 6), so holding 2^28
+/// regions at once means holding at least 1 TiB of region pages, while the table
+/// for those ids is 2^28 × `size_of::<Option<RegionEntry>>()`, about 56 GB. The
+/// table is always ~1/20th of the pages a program at that id is already holding.
+/// Set the bound past what a machine's memory lets a program hold live, and the
+/// table at that bound is something the same machine can still allocate — which
+/// it must, because the check runs before `regions.resize_with`: a table the
+/// allocator cannot build aborts one id *below* the tripwire, killing the program
+/// with a byte count and no diagnosis. That failure is still reachable on a
+/// machine too small to allocate the 56 GB table, which is why the assertion
+/// message names id exhaustion beside corruption instead of asserting the latter.
+const MAX_PLAUSIBLE_REGION_ID: u32 = 1 << 28;
 
 impl RegionStore {
     pub fn new(

--- a/src/value/fiberheap/regionstore/alloc.rs
+++ b/src/value/fiberheap/regionstore/alloc.rs
@@ -47,6 +47,44 @@ impl RegionStore {
         }
     }
 
+    /// Mint a physical region id together with the receipt that can return it —
+    /// the mint used where the caller may end without allocating into the id
+    /// (docs/impl/region/model.md § "Physical id recycling"). The per-call result
+    /// region is that case: it is minted before the callee runs, because the
+    /// callee may allocate its result into it, and a callee that returns an
+    /// immediate or a borrowed value allocates nothing.
+    pub fn new_runtime_region_tracked(&mut self) -> RegionMint {
+        let region = self.new_runtime_region();
+        RegionMint {
+            region,
+            gen: self.generation_raw(region.get()),
+        }
+    }
+
+    /// Return a minted id to the free list when the mint never materialized it —
+    /// the reserved → free exit of the id lifecycle (docs/impl/region/model.md
+    /// § "Physical id recycling"). Without it an id that no allocation touched is
+    /// stranded forever, and since `regions` is indexed by id, each stranded id
+    /// is a table slot of resident memory that no heap gauge accounts for.
+    ///
+    /// Unmaterialized means two conditions together. `regions[id]` empty alone
+    /// is also true of a region that materialized and was *freed* since the
+    /// mint — whose teardown already pushed that id, so pushing it again would
+    /// duplicate it in `free_physical`. A teardown bumps the id's generation, so
+    /// requiring the generation to still equal the mint's admits only an id
+    /// nothing has touched. Neither condition is redundant; `tests::recycle`
+    /// pins what each one catches.
+    pub fn recycle_unmaterialized(&mut self, mint: RegionMint) {
+        let idx = mint.region().get() as usize;
+        if idx < self.regions.len() && self.regions[idx].is_some() {
+            return;
+        }
+        if self.generation_raw(mint.region().get()) != mint.gen {
+            return;
+        }
+        self.free_physical.push(mint.region().get());
+    }
+
     /// Ensure a region entry exists for `id`, creating it lazily.
     pub(super) fn ensure(&mut self, id: RuntimeRegion) {
         self.ensure_raw(id.get());
@@ -59,21 +97,30 @@ impl RegionStore {
         let idx = id as usize;
         if idx >= self.regions.len() {
             // Backstop (always on, release included — the generation check in
-            // `region_of_ptr` is debug-only): an id this large is never a real
-            // region (see `MAX_PLAUSIBLE_REGION_ID`). It is a corrupt page-header
-            // read handed back as a region id — a misidentified page base or a
-            // stale/foreign read — so detonate here, naming it, instead of
-            // resizing the table to ~584 GB and OOM-aborting far from the deref
+            // `region_of_ptr` is debug-only): an id this large names no region a
+            // real program can hold (see `MAX_PLAUSIBLE_REGION_ID`), so detonate
+            // here, naming it, instead of resizing the table to hundreds of GB
+            // and OOM-aborting far from the deref
             // (docs/impl/region/generations.md § "Region generations").
+            //
+            // The message names both admissible causes rather than asserting
+            // one. The expected cause is a corrupt page-header read; the other
+            // is a heap whose ids stopped recycling, which reaches this check
+            // with ids that are sequential and a table that grew honestly. The
+            // two are indistinguishable at this point, and naming only the first
+            // sends a reader hunting corruption that is not there.
             assert!(
                 id <= MAX_PLAUSIBLE_REGION_ID,
                 "region id {id} (0x{id:08x}) reaching ensure_raw would grow the \
-                 region table to {} entries — physically implausible; this is a \
+                 region table to {} entries — physically implausible. Either a \
                  corrupt page-header read (a misidentified page base, or a \
-                 stale/foreign read) handed back as a region id. The in-situ \
-                 detectors are the ownership-validated walk and generation check \
-                 in region_of_ptr and --trace=guardfree \
-                 (docs/impl/region/generations.md)",
+                 stale/foreign read) was handed back as a region id, or this \
+                 heap's physical ids stopped returning to the free list \
+                 (docs/impl/region/model.md § 'Physical id recycling'). Sequential \
+                 ids and a live-region count far below this id point at the \
+                 second. For the first, the in-situ detectors are the \
+                 ownership-validated walk and generation check in region_of_ptr \
+                 and --trace=guardfree (docs/impl/region/generations.md)",
                 idx + 1,
             );
             self.regions.resize_with(idx + 1, || None);

--- a/src/value/fiberheap/regionstore/introspect.rs
+++ b/src/value/fiberheap/regionstore/introspect.rs
@@ -104,6 +104,33 @@ impl RegionStore {
         self.regions.iter().filter(|r| r.is_some()).count()
     }
 
+    /// Physical region ids issued — one past the largest id ever minted from
+    /// scratch, so it is the high-water mark of ids in simultaneous circulation.
+    /// The backend of the `arena/region-ids` gauge
+    /// (docs/impl/region/diagnostics.md).
+    ///
+    /// The *id* dimension, which the object, byte, and page gauges cannot show: a
+    /// minted id that never allocates holds none of what they count, yet keeps
+    /// its id out of circulation forever (docs/impl/region/model.md § "Physical
+    /// id recycling"). A mint that finds `free_physical` empty raises this;
+    /// a mint that recycles leaves it alone. So a steady-state loop holds it
+    /// flat, and every unit of growth is an id that did not come back.
+    ///
+    /// This leads [`Self::region_table_len`], which only moves when an id is made
+    /// *live*: stranded ids are never materialized, so they inflate the table
+    /// only once some later mint reaches their range. Read this one to detect an
+    /// id leak, and the table length for what it costs in resident memory.
+    pub fn region_ids_issued(&self) -> u32 {
+        self.next_physical
+    }
+
+    /// Entries in the region table — one past the largest physical id ever made
+    /// live, since `ensure_raw` sizes the table to the id it materializes. Its
+    /// slot size times this is what the table costs resident.
+    pub fn region_table_len(&self) -> usize {
+        self.regions.len()
+    }
+
     /// Object tags currently live in a region (the `arena/dump` diagnostic).
     pub fn region_tags(&self, id: u32) -> Vec<crate::value::heap::HeapTag> {
         self.regions

--- a/src/value/fiberheap/regionstore/tests/mod.rs
+++ b/src/value/fiberheap/regionstore/tests/mod.rs
@@ -16,4 +16,5 @@ pub(super) fn cons_obj() -> HeapObject {
 mod edges;
 mod forest;
 mod generations;
+mod recycle;
 mod refcount;

--- a/src/value/fiberheap/regionstore/tests/recycle.rs
+++ b/src/value/fiberheap/regionstore/tests/recycle.rs
@@ -1,0 +1,188 @@
+use super::*;
+
+// ── Physical id recycling (docs/impl/region/model.md § "Physical id recycling") ─
+//
+// Written from the spec: every physical id returns to `free_physical`, whether a
+// teardown freed it or a mint never materialized it.
+
+#[test]
+fn an_unmaterialized_mint_returns_its_id_to_the_free_list() {
+    // The reserved → free exit. A minted id that nothing allocates into names no
+    // region at all: no entry, no pages, no count. Recycling it must make the
+    // next mint hand it straight back.
+    //
+    // Counter-factual: without the recycle the second mint takes a fresh id off
+    // `next_physical`, and every such mint raises the largest id forever.
+    let mut store = RegionStore::default();
+    let mint = store.new_runtime_region_tracked();
+
+    store.recycle_unmaterialized(mint);
+
+    assert_eq!(
+        store.new_runtime_region(),
+        mint.region(),
+        "an id no allocation materialized must be reissued, not stranded",
+    );
+}
+
+#[test]
+fn recycle_leaves_a_materialized_id_alone() {
+    // A mint that DID allocate holds a live region, and the recycle must pass
+    // over it: the id is not reissued and the region keeps its count.
+    let mut store = RegionStore::default();
+    let mint = store.new_runtime_region_tracked();
+    store.alloc_obj(mint.region(), cons_obj());
+
+    store.recycle_unmaterialized(mint);
+
+    assert_ne!(
+        store.new_runtime_region(),
+        mint.region(),
+        "a live region's id must not be reissued",
+    );
+    assert_eq!(
+        store.rc(mint.region()),
+        1,
+        "the live region is untouched by the recycle",
+    );
+}
+
+#[test]
+fn recycling_a_live_id_does_not_double_book_it_for_its_later_free() {
+    // Why the liveness check is not redundant with the mint loop's skip. Push a
+    // still-live id and the immediate damage is hidden: the next mint pops it,
+    // sees it live, and skips it. The damage lands later — when the region is
+    // genuinely freed, its teardown pushes the same id a SECOND time, and now
+    // neither copy is live. Two mints take it, and the first to allocate has its
+    // pages freed under the second.
+    //
+    // Counter-factual: with the liveness check removed, the two mints below
+    // return the same id. The `assert_ne!` in
+    // `recycle_leaves_a_materialized_id_alone` does not catch that on its own —
+    // the skip loop masks it until the free.
+    let mut store = RegionStore::default();
+    let mint = store.new_runtime_region_tracked();
+    let r = mint.region();
+    store.alloc_obj(r, cons_obj());
+
+    store.recycle_unmaterialized(mint); // live: must push nothing
+    store.decref(r); // freed: the teardown pushes the id, once
+
+    let first = store.new_runtime_region();
+    let second = store.new_runtime_region();
+    assert_eq!(first, r, "the teardown's recycle reissues the id");
+    assert_ne!(
+        second, first,
+        "the id reached the free list twice — two logical regions on one id",
+    );
+}
+
+#[test]
+fn recycle_refuses_an_id_freed_since_the_mint() {
+    // The trap the generation check exists for. A region that materialized and
+    // was freed between the mint and the recycle ALSO leaves `regions[id]`
+    // empty — but its teardown already pushed that id, so pushing it again puts
+    // a duplicate in `free_physical`.
+    //
+    // A duplicate is not caught downstream: `new_runtime_region` skips an id
+    // that is already LIVE, and neither of two mints taking the same
+    // still-unmaterialized id is live yet. Both would get the id, and the first
+    // to allocate would have its pages freed under the second.
+    //
+    // Counter-factual: an emptiness-only check (no generation comparison) makes
+    // the two mints below return the same id.
+    let mut store = RegionStore::default();
+    let mint = store.new_runtime_region_tracked();
+    let r = mint.region();
+    store.alloc_obj(r, cons_obj());
+    store.decref(r); // freed: pages returned, generation bumped, id recycled once
+
+    store.recycle_unmaterialized(mint);
+
+    let first = store.new_runtime_region();
+    let second = store.new_runtime_region();
+    assert_eq!(first, r, "the teardown's own recycle still reissues the id");
+    assert_ne!(
+        second, first,
+        "the id must appear in the free list once, not twice",
+    );
+}
+
+#[test]
+fn recycle_refuses_an_id_that_lived_and_died_twice_since_the_mint() {
+    // The same trap one incarnation deeper, where comparing only "has the
+    // generation moved by exactly one" could still be fooled: the id is freed,
+    // reminted, and freed again. Its generation is two past the mint and it sits
+    // in the free list once. The recycle must still refuse it.
+    let mut store = RegionStore::default();
+    let mint = store.new_runtime_region_tracked();
+    let r = mint.region();
+    store.alloc_obj(r, cons_obj());
+    store.decref(r);
+    let again = store.new_runtime_region();
+    assert_eq!(again, r, "the freed id is reissued");
+    store.alloc_obj(again, cons_obj());
+    store.decref(again);
+
+    store.recycle_unmaterialized(mint);
+
+    let first = store.new_runtime_region();
+    let second = store.new_runtime_region();
+    assert_eq!(first, r);
+    assert_ne!(second, first, "no duplicate reached the free list");
+}
+
+#[test]
+fn a_run_of_unmaterialized_mints_does_not_grow_the_region_table() {
+    // The resident-memory claim itself, at the store level. The table is
+    // `Vec<Option<RegionEntry>>` indexed by id, so its length is one past the
+    // largest id ever made live. Mints that allocate nothing must not move it.
+    //
+    // Counter-factual: unrecycled, each iteration strands one id, and the table
+    // jumps to the iteration count the moment any later mint materializes.
+    let mut store = RegionStore::default();
+    // A live region, so the table has a length to hold steady.
+    let keep = store.new_runtime_region();
+    store.alloc_obj(keep, cons_obj());
+    let before = store.region_table_len();
+
+    for _ in 0..10_000 {
+        let mint = store.new_runtime_region_tracked();
+        store.recycle_unmaterialized(mint);
+    }
+    // Materialize one region afterwards: the table grows only when an id is made
+    // live, so a stranded id shows up here rather than inside the loop.
+    let after_loop = store.new_runtime_region();
+    store.alloc_obj(after_loop, cons_obj());
+
+    let len = store.region_table_len();
+    assert!(
+        len <= before + 1,
+        "10000 mints that allocated nothing grew the region table from {before} \
+         to {len} entries — their ids never returned to the free list",
+    );
+}
+
+#[test]
+fn a_recycled_id_mints_a_sound_region_afterwards() {
+    // The recycled id is an ordinary free id, not a special one: the next mint
+    // takes it, allocates into it, and the value resolves back to that region
+    // through the page header. A recycle that left stale generation or table
+    // state behind would trip the stale-deref check here instead.
+    let mut store = RegionStore::default();
+    let mint = store.new_runtime_region_tracked();
+    store.recycle_unmaterialized(mint);
+
+    let r = store.new_runtime_region();
+    assert_eq!(r, mint.region());
+    let v = store.alloc_obj(r, cons_obj());
+    assert_eq!(store.region_of_ptr(v.as_heap_ptr().unwrap()), r.get());
+    assert_eq!(store.rc(r), 1);
+
+    store.decref(r);
+    assert_eq!(
+        store.rc(r),
+        0,
+        "the region frees normally after the recycle"
+    );
+}

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -268,7 +268,8 @@ impl VM {
         args: &[Value],
         region_id: StaticRegion,
     ) -> Option<Result<Value, (&'static str, String)>> {
-        let alloc_region = self.new_runtime_region_for_call_slot(region_id);
+        let mint = self.new_runtime_region_for_call_slot(region_id);
+        let alloc_region = mint.region();
         let result = {
             // The ctx is the explicit capability `call_collection` allocates
             // through, minted from this call's fresh region exactly as
@@ -289,6 +290,10 @@ impl VM {
                 );
             }
         }
+        // A borrowed element or an immediate result left this call's region
+        // unallocated, so its id goes back to the free list — the same close-out
+        // `dispatch_native_call` makes.
+        self.release_unused_call_region(mint);
         result
     }
 

--- a/src/vm/core/region.rs
+++ b/src/vm/core/region.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::fiberheap::regionstore::RegionMint;
 
 impl VM {
     /// Resolve a static region slot to a **fresh** physical region for an
@@ -110,12 +111,26 @@ impl VM {
     /// instead of always minting fresh. Keep it wired; the `StaticRegion`
     /// newtype already guards the static-vs-runtime confusion bug
     /// (`dispatch_native_call`'s doc). Do not "scrub" it as vestigial.
+    ///
+    /// The mint is **tracked**: the region is minted before the callee runs,
+    /// because the callee may allocate its result into it, and a callee that
+    /// returns an immediate or a value borrowed from an argument allocates
+    /// nothing. The receipt lets the dispatcher return that id to the free list
+    /// (docs/impl/region/model.md § "Physical id recycling"); a call that does
+    /// allocate leaves the id live and the recycle no-ops.
     #[inline]
     pub(crate) fn new_runtime_region_for_call_slot(
         &mut self,
         _static_id: StaticRegion,
-    ) -> RuntimeRegion {
-        self.heap().new_runtime_region()
+    ) -> RegionMint {
+        self.heap().new_runtime_region_tracked()
+    }
+    /// Close out a call-result mint: return its id to the free list unless the
+    /// call materialized the region (docs/impl/region/model.md § "Physical id
+    /// recycling"). The shared tail of both call dispatchers.
+    #[inline]
+    pub(crate) fn release_unused_call_region(&mut self, mint: RegionMint) {
+        self.heap().recycle_unmaterialized_region(mint);
     }
     /// Dispatch a native primitive call with per-execution region routing and
     /// the "pass-through retain", shared verbatim by the interpreter
@@ -148,7 +163,8 @@ impl VM {
         args: &[Value],
         region_id: StaticRegion,
     ) -> (SignalBits, Value) {
-        let alloc_region = self.new_runtime_region_for_call_slot(region_id);
+        let mint = self.new_runtime_region_for_call_slot(region_id);
+        let alloc_region = mint.region();
         let (bits, value) = {
             // The native-call capability: this call's fresh result region, the
             // VM's heap, and the driving VM itself, so the primitive can reach
@@ -292,6 +308,11 @@ impl VM {
                 alloc_region,
             );
         }
+        // A primitive that returned an immediate or a borrowed value never
+        // allocated into this call's region, so its id names nothing and goes
+        // back to the free list. Runs after the pass-through retain, which reads
+        // `alloc_region` to decide whether the result is fresh.
+        self.release_unused_call_region(mint);
         (bits, value)
     }
     /// Resolve a static slot to the physical region it currently maps to in this

--- a/tests/elle/region-id-recycle.lisp
+++ b/tests/elle/region-id-recycle.lisp
@@ -1,0 +1,114 @@
+(elle/epoch 12)
+# What a call costs in region IDS — the dimension no other gauge sees
+# (docs/impl/region/model.md § "Physical id recycling").
+#
+# Every native call mints a physical region for its result, before the callee
+# runs, because the callee may allocate the result into it. A primitive that
+# returns an immediate, or one that returns a value borrowed from an argument,
+# allocates nothing into that region — so the id never becomes a live region.
+#
+# Such an id holds no object, no page, and no reference count. `arena/count`,
+# `arena/region-count`, `arena/bytes`, and `arena/page-claims` are therefore all
+# blind to it: they read perfectly flat while the id is stranded.
+#
+# `arena/region-ids` is the gauge that sees it — `next_physical`, one past the
+# largest id ever minted from scratch. A mint that finds an id on the free list
+# leaves it alone, so a steady-state loop holds it flat and every unit of growth
+# is an id that did not come back.
+#
+# `arena/region-table` is NOT the gauge to assert on, and the difference is the
+# trap this file exists to avoid. The table only grows when an id is made LIVE,
+# and a stranded id never is: a loop of calls that allocate nothing can leak an
+# id per call and leave the table flat for the whole run. Measured here as a
+# second reading, never as a ceiling.
+#
+# Every bound below is a CEILING, so the file is shrink-only.
+
+(def window 4000)
+
+(defn ids-issued [thunk warm window]
+  "Physical region ids issued over WINDOW calls of THUNK, after WARM untimed calls."
+  (var i 0)
+  (while (%lt i warm)
+    (thunk)
+    (assign i (%add i 1)))
+  (def before (arena/region-ids))
+  (var j 0)
+  (while (%lt j window)
+    (thunk)
+    (assign j (%add j 1)))
+  (%sub (arena/region-ids) before))
+
+# the gauge-live discriminator ─────────────────────────────────────────────────
+# A ceiling reads green against a dead gauge too, and a gauge frozen at whatever
+# the stdlib load left behind would pass every assertion below. So make the
+# counter MOVE first, and read the move.
+#
+# It only rises when a program holds more ids at once than it ever has, so hold
+# a margin past the current reading: every cons in the array is a live region
+# holding a live id, and the counter cannot answer the same number afterwards.
+
+(def base (arena/region-ids))
+(def hold (@array))
+(var k 0)
+(while (%lt k (%add base 5000))
+  (push hold (pair k k))
+  (assign k (%add k 1)))
+(def live-ids (arena/region-ids))
+(println "region-id-recycle: " (length hold)
+         " live conses moved region-ids from " base " to " live-ids)
+(assert (%gt live-ids base)
+        (concat "arena/region-ids is dead: holding "
+                (number->string (length hold))
+                " live conses at once left it at " (number->string live-ids)
+                ", where it already was — every ceiling below is void"))
+
+# measurements ─────────────────────────────────────────────────────────────────
+# Each subject is a call whose result is NOT allocated in the call's own region,
+# so the region it mints stays unmaterialized and must come straight back.
+
+(def imm-d (ids-issued (fn [] (< 1 2)) 200 window))
+(def len-d (ids-issued (fn [] (length hold)) 200 window))
+(def get-d (ids-issued (fn [] (get hold 0)) 200 window))
+(def first-d (ids-issued (fn [] (first (pair 1 2))) 200 window))
+(def fresh-d (ids-issued (fn [] (pair 1 2)) 200 window))
+
+(println "  immediate result: (< 1 2) " imm-d "  (length a) " len-d)
+(println "  borrowed result:  (get a 0) " get-d "  (first p) " first-d)
+(println "  fresh result:     (pair 1 2) " fresh-d)
+
+(defn at-most [d ceiling label]
+  (assert (%le d ceiling)
+          (concat label " issued " (number->string d) " new region ids over "
+                  (number->string window) " calls, over the ceiling of "
+                  (number->string ceiling)
+                  " — its minted ids are not returning to the free list")))
+
+# A ceiling of zero admits nothing: a loop of calls that allocate nothing must
+# leave the counter exactly where it found it, at any iteration count.
+(at-most imm-d 0 "(< 1 2), whose result is an immediate")
+(at-most len-d 0 "(length a), whose result is an immediate")
+(at-most get-d 0 "(get a 0), whose result is borrowed from the array")
+(at-most first-d 0 "(first p), whose result is borrowed from the pair")
+
+# A call that DOES allocate its result is bounded the same way, by the other
+# half of the contract: the result region dies at its decref_point and the
+# teardown recycles its id.
+(at-most fresh-d 0 "(pair 1 2), whose result region dies at its decref_point")
+
+# The resident cost of the same contract. The table is indexed by physical id,
+# so it can only stay bounded if the ids do; with the ids flat above, the table
+# must be flat too.
+(def table-before (arena/region-table))
+(var m 0)
+(while (%lt m window)
+  (first (pair 1 2))
+  (assign m (%add m 1)))
+(def table-growth (%sub (arena/region-table) table-before))
+(println "  region table over " window " more calls: " table-growth " entries")
+(assert (%le table-growth 0)
+        (concat "the region table grew by " (number->string table-growth)
+                " entries over " (number->string window)
+                " calls — resident memory per call, invisible to every other gauge"))
+
+(println "region-id-recycle: ok")


### PR DESCRIPTION
Closes #909.

## The stranded id

The report's key observation was that `free_physical` is empty at every sample
while the live-region count stays flat. Both are true, and together they rule
out the free path: the ids were never freed, because they were never live.

`dispatch_native_call` and `dispatch_collection_call` mint a physical region for
the call's result **before** the callee runs, because the callee may allocate the
result into it. A primitive that returns an immediate (`(< a b)`), or one that
returns a value borrowed from an argument (`first`, `rest`, `get`), allocates
nothing into that region. The id never reaches `ensure_raw`, so it never becomes
a live region, so no teardown can return it. Nothing else in the runtime owns it
either — the call's `DecrefValueRegion` releases the *result's* region, which is
a different one.

That id holds no object, no page, and no reference count, which is exactly why
`arena/count`, `arena/region-count`, `arena/bytes`, and `arena/page-claims` all
read flat while resident memory climbed. What it costs is the region table:
`regions` is a `Vec<Option<RegionEntry>>` indexed by physical id, so the largest
id ever made live sets its length. The ~3.8 KB per list element in the report is
about 18 stranded ids × 208 bytes.

## The fix

Both dispatchers close the mint. `recycle_unmaterialized` returns the result
region to the free list when the call left it unmaterialized.

The mint hands back a `RegionMint` receipt carrying the id's generation, and the
recycle admits an id only when **both** hold: the entry is empty, and the
generation still equals the mint's. Neither condition is redundant, and each has
a test that fails when it alone is removed:

- Without the generation check, a region that materialized and was freed *inside*
  the call also reads as empty. Its teardown already pushed that id, so it would
  enter `free_physical` twice. `new_runtime_region` rejects only an id that is
  already *live*, so two mints could take one still-unmaterialized id — the
  aliasing UAF that skip loop exists to prevent.
- Without the liveness check, pushing a live id looks harmless, because the skip
  loop passes over it. The damage lands later, when that region is genuinely
  freed and its teardown pushes the same id a second time.

`RegionMint`'s fields are private to `regionstore`, so an id no mint produced
cannot be handed to the recycle at all.

## The gauge

`arena/region-ids` reads `next_physical` — one past the largest id ever minted
from scratch. A mint that finds an id on the free list leaves it alone, so a
steady-state loop holds it flat and every unit of growth is an id that did not
come back.

`arena/region-table` reads `regions.len()`, which is what the table costs
resident. It is deliberately **not** what the new test asserts on: the table
grows only when an id is made *live*, and a stranded id never is, so a loop
leaking an id per call can leave that gauge flat for the whole run. That trap is
recorded in the test file, because the first version of the test fell into it —
three of its five subjects read clean against the broken build.

## The backstop

`ensure_raw`'s message changes. Its tripwire stays at 2^28.

The message stated a corrupt page-header read as fact. It now names both
admissible causes — corruption, and a heap whose ids stopped recycling — and
says which evidence points at which. That is the report's actual complaint about
the backstop, and it is what this PR fixes.

The threshold is a separate matter, and it should not move. The report notes the
abort landed at id 2^28−1, one below the cap, so the assertion never fired: the
table at 2^28 is ~56 GB, more than that machine could allocate, so the resize
died before the check could speak. Lowering the constant is the wrong reading of
that. The two requirements — sit past what a real program reaches, and stay
allocatable — are reconciled by a ratio, not by any absolute size. A live region
owns at least one 4 KiB page (Rule 6), so a program at the bound already holds
about twenty times what its own table costs, and a machine big enough to host it
is big enough to allocate the table. Walking the constant down to make the table
cheaper only moves the tripwire into the range where real programs live: 2^24
regions is 64 GiB of pages, which an ordinary large machine supplies. On a
machine too small for the table the allocator still aborts first, which is
exactly why the message now names id exhaustion instead of asserting corruption.

The constant's comment carried a stale figure — "~36 GB" for the 2^28 table.
That is corrected to ~56 GB, which is 2^28 × the current
`size_of::<Option<RegionEntry>>()`.

## Measurements

The report's own `fibers.lisp`:

| case | before | after |
| --- | --- | --- |
| `25 50 4` (fibers) | 189 → 4615 MB | flat at 177 MB |
| `500 50 2` | aborted: `memory allocation of 55834574848 bytes failed` | completes, 178 MB |
| region table over 4 waves | → 8.4M entries | flat at 10,602 |

The stdlib load alone issued 54,226 physical ids before this change and issues
476 after.

## Tests

- `tests/elle/region-id-recycle.lisp` — ceilings of zero on five call shapes,
  with a live-gauge discriminator. Against the unfixed build every subject moves
  (28001, 4001, 4001, 4001, 1).
- `regionstore::tests::recycle` — seven tests over the store contract, including
  the two duplicate-in-the-free-list traps above.

`make smoke-elle` is green (20 batches, 0 fail / 0 diverge / 0 timeout,
`oracle: ok`), as are `cargo test --workspace --lib` (2179), the integration
tests (920), clippy, rustdoc, and `cargo fmt --check`.

## Out of scope, found while sweeping for residual id leaks

A raised-and-caught error retains a live region per raise:

```
try/catch error   regions +2002  objects +2003  bytes +8200192   (2000 raises)
try/catch ok      regions +2     objects +3     bytes +0
```

This is a different defect from #909 — every counter moves, so the heap gauges
do see it — and it is pre-existing: the numbers are identical with this PR's
recycle disabled. Not touched here.

