### PR TITLE
bytecode: an Emit operand is wide enough for a user signal's bit

### DIFF
--- a/docs/impl/bytecode.md
+++ b/docs/impl/bytecode.md
@@ -54,7 +54,7 @@ MakeStruct n       construct struct from n key-value pairs
 ### Fiber operations
 ```text
 Yield              yield current fiber
-Emit signal val    emit a signal
+Emit bits          emit a signal; value comes off the stack
 ```
 
 ### Self-reference
@@ -81,6 +81,20 @@ Instructions are encoded as a byte stream. The opcode byte is followed
 by zero or more operand bytes (typically u16 or u32 indices). The
 `LocationMap` maps bytecode offsets to source locations for error
 reporting.
+
+### Signal-bits operands
+
+`SignalBits` is a 64-bit mask, and every bit of it is meaningful in
+bytecode: built-in signals sit at bits 0–17, the runtime reserves bits
+18–31, and `(signal :keyword)` allocates user signals from bit 32 upward
+(`docs/signals/protocol.md`). An operand that holds fewer than 64 bits
+therefore cannot name a user signal at all.
+
+Two instructions carry such an operand — `Emit` and `CheckSignalBound` —
+and both encode it the same way: eight bytes, big-endian, written by
+`Bytecode::emit_signal_bits` and read by `VM::read_signal_bits`. Use that
+pair rather than an open-coded byte sequence; a hand-written operand is
+how a mask silently loses its high half.
 
 ## Files
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -18,9 +18,14 @@ Signal     Bit   Purpose
 :fuel      12    Instruction budget exhaustion
 :switch    13    Context switch
 :wait      14    Blocking wait
+:gpu       15    GPU hardware dispatch
+:os-signal 16    POSIX signal send/raise
+:fs        17    Filesystem access
 ```
 
-User-defined signals (via `(signal :keyword)`) get bits 16–31.
+Bits 18–31 are reserved for future runtime signals. User-defined signals
+(via `(signal :keyword)`) get bits 32–63 — see
+[signals/protocol.md](signals/protocol.md).
 
 ## Fuel budgets
 

--- a/docs/signals/emit.md
+++ b/docs/signals/emit.md
@@ -79,11 +79,11 @@ overlap the fiber's mask:
 
 ## User-defined signals
 
-Any keyword can be a signal. Register it with `signal/register` and
+Any keyword can be a signal. Declare it with `(signal :keyword)` and
 use it with `emit`:
 
 ```text
-(signal/register :heartbeat)
+(signal :heartbeat)
 (emit :heartbeat {:timestamp (clock/monotonic)})
 ```
 
@@ -92,6 +92,12 @@ The parent catches it through the mask like any other signal:
 ```text
 (fiber/new body |:heartbeat|)
 ```
+
+A user signal is allocated a bit in the 32–63 range
+([protocol.md](protocol.md)), and the literal `emit` above carries that
+bit into the bytecode whole — a user signal suspends, routes, and gets
+squelched exactly as `:yield` does. The `Emit` operand is 64 bits wide
+for this reason ([impl/bytecode.md](../impl/bytecode.md)).
 
 ## Dynamic emit (primitive fallback)
 

--- a/docs/signals/fibers.md
+++ b/docs/signals/fibers.md
@@ -57,7 +57,7 @@ back-pointers, avoiding Rc cycles.
 ## Signals
 
 
-Signal types are bit positions in a `u32` bitmask. User-facing signals
+Signal types are bit positions in a 64-bit mask. User-facing signals
 use keywords in set literals for fiber masks:
 
 | Keyword | Bit | Purpose |
@@ -71,8 +71,11 @@ use keywords in set literals for fiber masks:
 | `:exec` | 11 | Subprocess completion |
 | `:fuel` | 12 | Instruction budget exhaustion |
 
-Bits 3, 5–7, 10, 13–15 are VM-internal. Bits 16–31 are for
-user-defined signals (via `(signal :keyword)`).
+Bits 3, 5–7, 10, 13–14 are VM-internal. Bits 15–17 name capabilities
+(`:gpu`, `:os-signal`, `:fs`) and bits 18–31 are reserved for future
+runtime signals — see [runtime.md](../runtime.md) for the full table.
+Bits 32–63 are for user-defined signals (via `(signal :keyword)`) — see
+[protocol.md](protocol.md).
 
 The terminal signal (bit 10) is **uncatchable** — it passes through all
 mask checks. `fiber/cancel` uses this to ensure the fiber dies immediately.

--- a/docs/signals/protocol.md
+++ b/docs/signals/protocol.md
@@ -7,7 +7,7 @@
 Signal types are bit positions in a 64-bit bitfield (`SignalBits` is `u64`).
 The lower 32 bits are reserved for the runtime; the upper 32 bits are
 available for user-defined signals. Within the runtime's 32 bits, the
-first 16 are compiler-known:
+first 18 are allocated:
 
 | Bit | Name | Value | Meaning |
 |-----|------|-------|---------|
@@ -23,8 +23,8 @@ first 16 are compiler-known:
 | 8 | halt | 256 | Graceful VM termination |
 | 9 | io | 512 | I/O request to scheduler |
 | 10 | terminal | 1024 | Uncatchable — passes through mask checks |
-| 11–15 | reserved | — | Future compiler-known signals |
-| 16–31 | runtime | — | Runtime-reserved signals |
+| 11–17 | runtime | — | Runtime signals and capability bits ([runtime.md](../runtime.md)) |
+| 18–31 | reserved | — | Future runtime signals |
 | 32–63 | user | — | User-defined signal types |
 
 Bit 0 is special: "ok" means no bits are set. A normal return has an empty
@@ -362,7 +362,7 @@ the scheduler, not by the language.
 
 ## Signal Registry
 
-The signal registry maps signal keywords to bit positions. Built-in signals occupy bits 0–15; bits 16–31 are runtime-reserved; user-defined signals use bits 32–63.
+The signal registry maps signal keywords to bit positions. Built-in signals occupy bits 0–17; bits 18–31 are runtime-reserved; user-defined signals use bits 32–63.
 
 ### Built-in Signals
 
@@ -376,7 +376,9 @@ The signal registry maps signal keywords to bit positions. Built-in signals occu
 | `:io` | 9 | I/O request to scheduler |
 
 Bits 3, 5–7 are VM-internal (resume, propagate, query). Bits 10–14 are
-VM-internal (terminal, exec, fuel, switch, wait). Bit 15 is reserved.
+VM-internal (terminal, exec, fuel, switch, wait). Bits 15–17 name
+capabilities (gpu, os-signal, fs) and bits 18–31 are reserved for future
+runtime signals — see [../runtime.md](../runtime.md).
 
 ### User-Defined Signals
 
@@ -387,7 +389,7 @@ supported. Registration happens at analysis time.
 ```lisp
 (signal :heartbeat)
 (signal :rate-limit)
-# :heartbeat gets bit 16, :rate-limit gets bit 17
+# :heartbeat gets bit 32, :rate-limit gets bit 33
 
 # Expression position — returns the keyword
 (def my-signal (signal :custom))

--- a/docs/signals/questions.md
+++ b/docs/signals/questions.md
@@ -4,7 +4,7 @@
 
 ### Signal bit allocation
 
-64 bits (SignalBits is u64): bits 0–15 compiler-known, bits 16–31
+64 bits (SignalBits is u64): bits 0–17 built-in, bits 18–31
 runtime-reserved, bits 32–63 user-defined (up to 32 user signals).
 
 ### Interaction with the type system

--- a/src/compiler/bytecode.rs
+++ b/src/compiler/bytecode.rs
@@ -144,6 +144,16 @@ impl Bytecode {
         self.instructions.push((value & 0xff) as u8);
     }
 
+    /// Emit a `SignalBits` operand: eight bytes, big-endian.
+    ///
+    /// Every bit of the mask is meaningful — user signals live at bits 32-63 —
+    /// so this is the only way to write one. See `docs/impl/bytecode.md`
+    /// § "Signal-bits operands"; [`crate::vm::VM::read_signal_bits`] reads it.
+    pub fn emit_signal_bits(&mut self, bits: crate::value::fiber::SignalBits) {
+        self.instructions
+            .extend_from_slice(&bits.raw().to_be_bytes());
+    }
+
     /// Emit an i16 (big-endian)
     pub fn emit_i16(&mut self, value: i16) {
         self.emit_u16(value as u16);

--- a/src/compiler/bytecode/disasm.rs
+++ b/src/compiler/bytecode/disasm.rs
@@ -190,18 +190,16 @@ pub fn disassemble_lines(instructions: &[u8]) -> Vec<String> {
                 line.push_str(&format!(" (region={})", region_id));
                 i += 4;
             }
-            Instruction::Emit if i + 1 < instructions.len() => {
-                let signal_bits = ((instructions[i] as u16) << 8) | (instructions[i + 1] as u16);
-                line.push_str(&format!(" (signal_bits=0x{:04x})", signal_bits));
-                i += 2;
+            // Both signal-bits operands are eight bytes, big-endian —
+            // `Bytecode::emit_signal_bits` writes them (docs/impl/bytecode.md
+            // § "Signal-bits operands").
+            Instruction::Emit if i + 7 < instructions.len() => {
+                let raw = u64::from_be_bytes(instructions[i..i + 8].try_into().expect("8 bytes"));
+                line.push_str(&format!(" (signal_bits=0x{:016x})", raw));
+                i += 8;
             }
             Instruction::CheckSignalBound if i + 7 < instructions.len() => {
-                let mut raw: u64 = 0;
-                for word in 0..4 {
-                    let w = ((instructions[i + word * 2] as u16) << 8)
-                        | (instructions[i + word * 2 + 1] as u16);
-                    raw |= (w as u64) << (word * 16);
-                }
+                let raw = u64::from_be_bytes(instructions[i..i + 8].try_into().expect("8 bytes"));
                 line.push_str(&format!(" (allowed_bits=0x{:016x})", raw));
                 i += 8;
             }

--- a/src/compiler/bytecode/tests.rs
+++ b/src/compiler/bytecode/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::fiber::SignalBits;
 
 #[test]
 fn test_bytecode_emission() {
@@ -113,30 +114,36 @@ fn adopt_into_activation_is_operandless() {
 
 #[test]
 fn disassemble_skips_emit_operand() {
-    // Emit carries a 2-byte signal-bits operand.
+    // Emit carries an 8-byte signal-bits operand, wide enough for a user
+    // signal's bit (32-63). The disassembler must skip all eight and report
+    // the whole mask; a narrower skip decodes the operand's tail as opcodes.
     let mut bc = Bytecode::new();
     bc.emit(Instruction::Emit);
-    bc.emit_u16(0xb600);
+    bc.emit_signal_bits(SignalBits::from_bit(40).union(SignalBits::from_bit(1)));
     bc.emit(Instruction::Return);
     let lines = disassemble_lines(&bc.instructions);
     assert_eq!(lines.len(), 2, "got: {lines:?}");
-    assert!(lines[0].contains("Emit"), "got: {lines:?}");
+    assert!(
+        lines[0].contains("Emit") && lines[0].contains("signal_bits=0x0000010000000002"),
+        "got: {lines:?}"
+    );
     assert!(lines[1].contains("Return"), "got: {lines:?}");
 }
 
 #[test]
 fn disassemble_skips_check_signal_bound_operand() {
-    // CheckSignalBound carries an 8-byte (4 × u16) operand.
+    // CheckSignalBound carries the same 8-byte signal-bits operand as Emit.
     let mut bc = Bytecode::new();
     bc.emit(Instruction::CheckSignalBound);
-    bc.emit_u16(0xb600);
-    bc.emit_u16(0xb601);
-    bc.emit_u16(0xb602);
-    bc.emit_u16(0xb603);
+    bc.emit_signal_bits(SignalBits::from_bit(63).union(SignalBits::from_bit(0)));
     bc.emit(Instruction::Return);
     let lines = disassemble_lines(&bc.instructions);
     assert_eq!(lines.len(), 2, "got: {lines:?}");
-    assert!(lines[0].contains("CheckSignalBound"), "got: {lines:?}");
+    assert!(
+        lines[0].contains("CheckSignalBound")
+            && lines[0].contains("allowed_bits=0x8000000000000001"),
+        "got: {lines:?}"
+    );
     assert!(lines[1].contains("Return"), "got: {lines:?}");
 }
 

--- a/src/lir/emit/instr/ops.rs
+++ b/src/lir/emit/instr/ops.rs
@@ -523,12 +523,7 @@ impl Emitter {
             LirInstr::CheckSignalBound { src, allowed_bits } => {
                 self.ensure_on_top(*src);
                 self.bytecode.emit(Instruction::CheckSignalBound);
-                // Emit SignalBits raw value as four u16s (least-significant first)
-                let raw = allowed_bits.raw();
-                self.bytecode.emit_u16(raw as u16);
-                self.bytecode.emit_u16((raw >> 16) as u16);
-                self.bytecode.emit_u16((raw >> 32) as u16);
-                self.bytecode.emit_u16((raw >> 48) as u16);
+                self.bytecode.emit_signal_bits(*allowed_bits);
                 // Value consumed by the check
                 self.pop();
             }

--- a/src/lir/emit/mod.rs
+++ b/src/lir/emit/mod.rs
@@ -411,12 +411,12 @@ impl Emitter {
                 resume_label,
             } => {
                 self.ensure_on_top(*value);
-                // Emit instruction with signal bits as u16 operand.
-                // Only bits 0-15 (built-in) are encoded here; user-defined
-                // signals (bits 32-63) are resolved at runtime via the
-                // signal registry, not baked into bytecode.
+                // The whole mask is baked in: `(signal :keyword)` resolves to a
+                // bit at analysis time, so nothing at runtime re-reads the
+                // registry for a literal `emit`, and the operand is the only
+                // place a user signal's bit (32-63) can live.
                 self.bytecode.emit(Instruction::Emit);
-                self.bytecode.emit_u16(signal.raw() as u16);
+                self.bytecode.emit_signal_bits(*signal);
                 self.pop();
 
                 let resume_ip = self.bytecode.current_pos();

--- a/src/lir/emit/tests.rs
+++ b/src/lir/emit/tests.rs
@@ -294,3 +294,50 @@ fn test_yield_sentinel_distinct() {
     assert_ne!(YIELD_SENTINEL, JitValue::nil());
     assert_ne!(TAIL_CALL_SENTINEL, JitValue::nil());
 }
+
+#[test]
+fn emit_terminator_carries_a_user_signal_bit_whole() {
+    // `(signal :keyword)` allocates bits 32-63, and the emitter bakes the mask
+    // of a literal `emit` into the `Emit` operand. The whole mask must survive:
+    // an emit of empty bits builds a suspension nothing can route, and the VM
+    // tears the fiber down as if its body had returned.
+    //
+    // The trap: `:yield` and every other built-in sits in bits 0-15, so a
+    // narrow operand carries them fine and only user signals disappear. This
+    // asserts over a mask with a bit in each half for that reason.
+    use crate::compiler::bytecode::disassemble_lines;
+    use crate::value::fiber::SignalBits;
+
+    let signal = SignalBits::from_bit(32).union(crate::value::fiber::SIG_YIELD);
+    let func = LirFixture::new(Arity::Exact(0))
+        .signal(crate::signals::Signal::of(signal))
+        .block(
+            0,
+            vec![LirInstr::Const {
+                dst: Reg(0),
+                value: LirConst::Int(42),
+            }],
+            Terminator::Emit {
+                signal,
+                value: Reg(0),
+                resume_label: Label(1),
+            },
+        )
+        .block(
+            1,
+            vec![LirInstr::LoadResumeValue { dst: Reg(1) }],
+            Terminator::Return(Reg(1)),
+        )
+        .build();
+
+    let (bytecode, _, _) = Emitter::new().emit(&func);
+    let lines = disassemble_lines(&bytecode.instructions);
+    let emit_line = lines
+        .iter()
+        .find(|l| l.contains("Emit "))
+        .unwrap_or_else(|| panic!("no Emit line in: {lines:?}"));
+    assert!(
+        emit_line.contains(&format!("signal_bits=0x{:016x}", signal.raw())),
+        "got: {emit_line}"
+    );
+}

--- a/src/runtime/tests/ownership/anode.rs
+++ b/src/runtime/tests/ownership/anode.rs
@@ -95,7 +95,7 @@ fn activation_owner_node_survives_yield_resume_completion() {
         bc.emit(Instruction::AdoptIntoActivation);
         bc.emit(Instruction::Nil);
         bc.emit(Instruction::Emit);
-        bc.emit_u16(crate::value::fiber::SIG_YIELD.raw() as u16);
+        bc.emit_signal_bits(crate::value::fiber::SIG_YIELD);
         bc.emit(Instruction::Return);
         let code = crate::value::Code::new(
             Rc::new(bc.instructions),
@@ -168,11 +168,11 @@ fn activation_owner_node_survives_repeated_parks() {
         bc.emit(Instruction::AdoptIntoActivation);
         bc.emit(Instruction::Nil);
         bc.emit(Instruction::Emit);
-        bc.emit_u16(crate::value::fiber::SIG_YIELD.raw() as u16);
+        bc.emit_signal_bits(crate::value::fiber::SIG_YIELD);
         bc.emit(Instruction::Pop);
         bc.emit(Instruction::Nil);
         bc.emit(Instruction::Emit);
-        bc.emit_u16(crate::value::fiber::SIG_YIELD.raw() as u16);
+        bc.emit_signal_bits(crate::value::fiber::SIG_YIELD);
         bc.emit(Instruction::Return);
         let code = crate::value::Code::new(
             Rc::new(bc.instructions),

--- a/src/runtime/tests/ownership/fnode.rs
+++ b/src/runtime/tests/ownership/fnode.rs
@@ -101,7 +101,7 @@ fn fiber_owner_node_survives_parks_and_frees_at_completion() {
         bc.emit(Instruction::AdoptIntoActivation);
         bc.emit(Instruction::Nil);
         bc.emit(Instruction::Emit);
-        bc.emit_u16(crate::value::fiber::SIG_YIELD.raw() as u16);
+        bc.emit_signal_bits(crate::value::fiber::SIG_YIELD);
         bc.emit(Instruction::Return);
         let (handle, fiber_value) = child_fiber(heap, fiber_body_closure(bc));
 
@@ -221,7 +221,7 @@ fn fiber_kill_frees_parked_and_fiber_owned() {
         bc.emit(Instruction::AdoptIntoActivation);
         bc.emit(Instruction::Nil);
         bc.emit(Instruction::Emit);
-        bc.emit_u16(crate::value::fiber::SIG_YIELD.raw() as u16);
+        bc.emit_signal_bits(crate::value::fiber::SIG_YIELD);
         bc.emit(Instruction::Return);
         let (handle, fiber_value) = child_fiber(heap, fiber_body_closure(bc));
 
@@ -324,7 +324,7 @@ fn fiber_kill_park_retains_terminal_payload() {
     let mut bc = Bytecode::new();
     bc.emit(Instruction::Nil);
     bc.emit(Instruction::Emit);
-    bc.emit_u16(crate::value::fiber::SIG_YIELD.raw() as u16);
+    bc.emit_signal_bits(crate::value::fiber::SIG_YIELD);
     bc.emit(Instruction::Return);
     let (handle, fiber_value) = child_fiber(unsafe { &mut *heap_ptr }, fiber_body_closure(bc));
 
@@ -418,7 +418,7 @@ fn discard_frees_parked_activation_owner_node() {
         bc.emit(Instruction::AdoptIntoActivation);
         bc.emit(Instruction::Nil);
         bc.emit(Instruction::Emit);
-        bc.emit_u16(crate::value::fiber::SIG_YIELD.raw() as u16);
+        bc.emit_signal_bits(crate::value::fiber::SIG_YIELD);
         bc.emit(Instruction::Return);
         crate::value::Code::new(
             Rc::new(bc.instructions),
@@ -525,7 +525,7 @@ fn dropped_parked_fiber_discharges_owned_state() {
         bc.emit(Instruction::AdoptIntoActivation);
         bc.emit(Instruction::Nil);
         bc.emit(Instruction::Emit);
-        bc.emit_u16(crate::value::fiber::SIG_YIELD.raw() as u16);
+        bc.emit_signal_bits(crate::value::fiber::SIG_YIELD);
         bc.emit(Instruction::Return);
         let (handle, fiber_value) = child_fiber(heap, fiber_body_closure(bc));
 
@@ -599,7 +599,7 @@ fn dropped_parked_fiber_releases_signal_escape_retain() {
         bc.emit(Instruction::LoadConst);
         bc.emit_u16(idx);
         bc.emit(Instruction::Emit);
-        bc.emit_u16(crate::value::fiber::SIG_YIELD.raw() as u16);
+        bc.emit_signal_bits(crate::value::fiber::SIG_YIELD);
         bc.emit(Instruction::Return);
         let (handle, fiber_value) = child_fiber(heap, fiber_body_closure(bc));
 
@@ -699,7 +699,7 @@ fn payload_regions_stranded_over(n: usize, bits: crate::value::SignalBits) -> i6
         bc.emit_u16(idx);
         if !bits.is_empty() {
             bc.emit(Instruction::Emit);
-            bc.emit_u16(bits.raw() as u16);
+            bc.emit_signal_bits(bits);
         }
         bc.emit(Instruction::Return);
         let (handle, fiber_value) = child_fiber(heap, fiber_body_closure(bc));
@@ -775,7 +775,7 @@ fn a_parked_terminal_payload_is_worth_one_retain_at_every_stage() {
         bc.emit_u16(idx);
         if !bits.is_empty() {
             bc.emit(Instruction::Emit);
-            bc.emit_u16(bits.raw() as u16);
+            bc.emit_signal_bits(bits);
         }
         bc.emit(Instruction::Return);
         let (handle, fiber_value) = child_fiber(unsafe { &mut *heap_ptr }, fiber_body_closure(bc));

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -126,7 +126,7 @@ pub fn squelched_bits(bits: SignalBits, mask: SignalBits) -> SignalBits {
 /// Capability mask: all signals that user code can produce.
 ///
 /// Defined as the complement of VM-internal bits within the 64-bit signal
-/// space (bits 0-15 compiler-reserved, bits 16-31 runtime-reserved,
+/// space (bits 0-17 built-in, bits 18-31 runtime-reserved,
 /// bits 32-63 user-defined). Used for capability enforcement (which
 /// operations a fiber can be denied) and for static analysis (what an
 /// unknown callee might emit).

--- a/src/vm/core/decode.rs
+++ b/src/vm/core/decode.rs
@@ -50,6 +50,19 @@ impl VM {
             .expect("region operand is nonzero — emitter writes StaticRegion::get()")
     }
 
+    /// Read a `SignalBits` operand: eight bytes, big-endian.
+    ///
+    /// The counterpart of [`crate::compiler::bytecode::Bytecode::emit_signal_bits`].
+    /// The full width is load-bearing: a `(signal :keyword)` declaration
+    /// allocates bits 32-63, so a mask read at any narrower width names no
+    /// user signal at all. See `docs/impl/bytecode.md` § "Signal-bits operands".
+    #[inline(always)]
+    pub fn read_signal_bits(&self, bytecode: &[u8], ip: &mut usize) -> SignalBits {
+        let raw = u64::from_be_bytes(bytecode[*ip..*ip + 8].try_into().expect("8 bytes"));
+        *ip += 8;
+        SignalBits::new(raw)
+    }
+
     #[inline(always)]
     pub fn read_i32(&self, bytecode: &[u8], ip: &mut usize) -> i32 {
         let b0 = bytecode[*ip] as u32;

--- a/src/vm/core/tests.rs
+++ b/src/vm/core/tests.rs
@@ -58,3 +58,28 @@ fn test_wrap_error_empty_stack() {
 
     assert_eq!(wrapped, error_msg);
 }
+
+#[test]
+fn signal_bits_operand_round_trips_the_user_range() {
+    // A `(signal :keyword)` declaration allocates a bit in 32-63, so the
+    // operand the emitter writes and the operand the VM reads must agree over
+    // the whole 64-bit width (docs/impl/bytecode.md § "Signal-bits operands").
+    //
+    // The counter-factual: a narrower operand decodes this mask to SIG_OK,
+    // which is exactly what a fiber returning normally looks like — the emit
+    // then reads as a return, and nothing downstream reports an error.
+    use crate::compiler::bytecode::Bytecode;
+    use crate::value::fiber::SignalBits;
+
+    let bits = SignalBits::from_bit(32)
+        .union(SignalBits::from_bit(63))
+        .union(crate::value::SIG_YIELD);
+    let mut bc = Bytecode::new();
+    bc.emit_signal_bits(bits);
+    assert_eq!(bc.instructions.len(), 8, "a signal-bits operand is 8 bytes");
+
+    let vm = VM::new();
+    let mut ip = 0;
+    assert_eq!(vm.read_signal_bits(&bc.instructions, &mut ip), bits);
+    assert_eq!(ip, 8, "reading a signal-bits operand advances 8 bytes");
+}

--- a/src/vm/dispatch/interp/opcodes.rs
+++ b/src/vm/dispatch/interp/opcodes.rs
@@ -380,8 +380,7 @@ impl VM {
             // SIG_ERROR: store error, no SuspendedFrame (error propagation).
             // Other signals: create SuspendedFrame (cooperative suspension).
             Instruction::Emit => {
-                let bits_raw = self.read_u16(bc, ip) as u64;
-                let signal_bits = crate::value::fiber::SignalBits::new(bits_raw);
+                let signal_bits = self.read_signal_bits(bc, ip);
                 return Some(self.handle_emit(signal_bits, code, closure_env, *ip));
             }
 

--- a/src/vm/dispatch/interp/signals.rs
+++ b/src/vm/dispatch/interp/signals.rs
@@ -1,8 +1,7 @@
 //! `CheckSignalBound` opcode body.
 //!
-//! Split out of the dispatch match: decoding a four-word `SignalBits` mask and
-//! formatting a `restrict` violation is verbose enough to crowd the routing.
-//! Behavior is unchanged.
+//! Split out of the dispatch match: formatting a `restrict` violation from the
+//! global registry is verbose enough to crowd the routing.
 
 use super::*;
 
@@ -10,18 +9,12 @@ impl VM {
     /// `CheckSignalBound`: verify the closure on the stack cannot emit any
     /// signal outside `allowed_bits`.
     ///
-    /// The mask is encoded as four `u16` words (least-significant first).
     /// Non-closure operands carry no signal metadata and silently pass — only
     /// closures are checked. A violation sets `SIG_ERROR` with the excess and
     /// allowed signals formatted from the global registry.
     #[inline]
     pub(super) fn handle_check_signal_bound(&mut self, bc: &[u8], ip: &mut usize) {
-        // Read SignalBits as four u16s (least-significant first)
-        let w0 = self.read_u16(bc, ip) as u64;
-        let w1 = self.read_u16(bc, ip) as u64;
-        let w2 = self.read_u16(bc, ip) as u64;
-        let w3 = self.read_u16(bc, ip) as u64;
-        let allowed_bits = SignalBits::new(w0 | (w1 << 16) | (w2 << 32) | (w3 << 48));
+        let allowed_bits = self.read_signal_bits(bc, ip);
         let val = self.fiber.stack.pop().unwrap_or(Value::NIL);
         if let Some(closure) = val.as_closure() {
             let signal_bits = closure.signal().bits;

--- a/tests/elle/emit-user-signal.lisp
+++ b/tests/elle/emit-user-signal.lisp
@@ -1,0 +1,103 @@
+(elle/epoch 12)
+# ── A literal emit carries a user signal's bit whole ──────────────────
+#
+# `(emit :keyword payload)` with a literal keyword compiles to the `Emit`
+# instruction, which encodes the signal bits as an operand. User signals
+# live at bits 32-63 (docs/signals/protocol.md), so the operand must be
+# 64 bits wide. A narrower operand truncates every user bit to zero, and
+# an emit of empty bits is indistinguishable from a normal return.
+#
+# The trap: nothing about a truncated emit looks like a failure at the
+# emit site. The payload still reaches the parent, so a test that only
+# checks the payload passes on both the correct and the broken encoding.
+# The status, the bits, and the resumed body are what tell them apart.
+
+(signal :user_sig_893)
+(def user-bit (get (signals) :user_sig_893))
+(def user-bits (bit/shift-left 1 user-bit))
+
+# The registry allocates user signals from bit 32 upward. Below 32 the
+# assertions further down would still hold under a 32-bit operand, so
+# this is what makes them a test of the wide encoding.
+(assert (>= user-bit 32) "a user signal is allocated at bit 32 or above")
+
+# ── A literal emit suspends and resumes ──────────────────────────────
+
+(let [f (fiber/new (fn []
+                     (let [r (emit :user_sig_893 {:p 2})]
+                       [:resumed r])) |:user_sig_893|)]
+  (assert (= (fiber/resume f) {:p 2}) "literal emit delivers its payload")
+  (assert (= (fiber/status f) :paused)
+          "literal emit of a user signal suspends the fiber")
+  (assert (= (fiber/bits f) user-bits)
+          "literal emit reports the user signal's bit")
+  (assert (= (fiber/resume f "MEDIATED") [:resumed "MEDIATED"])
+          "the resume value is the result of the literal emit"))
+
+# ── The literal path agrees with the dynamic path ────────────────────
+#
+# A non-literal first argument falls through to the runtime primitive,
+# which reads the registry and keeps all 64 bits. Both paths emit the
+# same signal, so both must report the same bits and the same status.
+#
+# This stops at the first resume. A second one — resuming a fiber parked
+# through the dynamic path, whatever the signal — reads the fiber's freed
+# activation region; see issue #915.
+
+(let [s :user_sig_893
+      f (fiber/new (fn []
+                     (let [r (emit s {:p 1})]
+                       [:resumed r])) |:user_sig_893|)]
+  (assert (= (fiber/resume f) {:p 1}) "dynamic emit delivers its payload")
+  (assert (= (fiber/status f) :paused) "dynamic emit suspends the fiber")
+  (assert (= (fiber/bits f) user-bits)
+          "dynamic emit reports the same bit as the literal emit"))
+
+# ── A compound literal emit keeps both halves ────────────────────────
+#
+# `:yield` survives any truncation on its own, so a compound signal
+# suspends either way. The user bit is what a mediator needs to tell
+# `|:yield :user_sig_893|` from a bare `(yield)`.
+
+(let [f (fiber/new (fn [] (emit |:yield :user_sig_893| :data))
+                   |:yield :user_sig_893|)]
+  (assert (= (fiber/resume f) :data)
+          "compound literal emit delivers its payload")
+  (assert (= (bit/and (fiber/bits f) 2) 2) "compound literal emit keeps :yield")
+  (assert (= (bit/and (fiber/bits f) user-bits) user-bits)
+          "compound literal emit keeps the user signal's bit"))
+
+# ── A mask that does not name the signal does not catch it ───────────
+#
+# Routing reads the emitted bits. With the bits truncated away there is
+# nothing left to decide against, and the payload reaches a parent whose
+# mask never named the signal.
+
+(signal :user_sig_893b)
+(def user-bits-b (bit/shift-left 1 (get (signals) :user_sig_893b)))
+(let [inner (fiber/new (fn []
+                         (let [r (emit :user_sig_893b :escaped)]
+                           [:resumed r])) |:yield|)
+      outer (fiber/new (fn [] (fiber/resume inner)) |:user_sig_893b|)]
+  (assert (= (fiber/resume outer) :escaped)
+          "a mask that does not name the signal propagates it to the parent")
+  (assert (= (fiber/status inner) :paused)
+          "the fiber whose signal propagated is suspended, not finished")
+  (assert (= (fiber/bits inner) user-bits-b)
+          "the propagated signal keeps the user signal's bit"))
+
+# ── A squelch boundary naming the signal holds ───────────────────────
+#
+# `squelch` enforces against the bits the closure actually produces. A
+# literal emit of a squelched signal must be converted into a
+# `signal-violation`, exactly as the dynamic emit of the same signal is.
+
+(signal :user_sig_893c)
+(let [g (squelch (fn [] (emit :user_sig_893c {:p 1})) |:user_sig_893c|)
+      [ok? _] (protect (g))]
+  (assert (not ok?) "a squelch boundary catches a literal emit of the signal"))
+
+(let [s :user_sig_893c
+      h (squelch (fn [] (emit s {:p 2})) |:user_sig_893c|)
+      [ok? _] (protect (h))]
+  (assert (not ok?) "a squelch boundary catches a dynamic emit of the signal"))

--- a/tests/elle/signals.lisp
+++ b/tests/elle/signals.lisp
@@ -118,8 +118,8 @@
 (begin
   (signal :intro_c6a)
   (def reg2 (signals))  # bit position depends on how many user signals were registered before this one
-  (assert (>= (get reg2 :intro_c6a) 16)
-          "signals contains user-defined signal at bit >= 16"))
+  (assert (>= (get reg2 :intro_c6a) 32)
+          "signals contains user-defined signal at bit >= 32"))
 
 # ============================================================================
 # squelch runtime checks — passing cases


### PR DESCRIPTION
Closes #893.

## The defect

`Emit` encoded its signal bits as a `u16`. `SignalRegistry::register`
allocates user signals from bit 32 upward, so `as u16` dropped every one
of them and a literal `(emit :mine payload)` emitted `SIG_OK`.

An emit of empty bits still builds a `SuspendedFrame`, but
`with_child_fiber` sees no bits, marks the child `Dead`, and frees what
the fiber owns. The visible result: the fiber did not suspend, the rest
of its body never ran, `fiber/status` reported `:dead`, and `fiber/bits`
was `0`.

Two consequences the issue names, both reproduced and both now pinned by
tests:

- A compound `|:yield :mine|` suspended on the surviving `:yield` bit, so
  a mediator could not tell it from a bare `(yield)`.
- A `squelch` boundary naming the signal was handed zero bits and found
  nothing to enforce.

The dynamic path — a non-literal first argument, which reads the registry
at runtime — was already correct, and is the counter-factual the tests
compare against.

## The fix

The operand is now the full 64 bits. `Bytecode::emit_signal_bits` and
`VM::read_signal_bits` are the one pair that writes and reads a signal
mask; `CheckSignalBound`, which open-coded four `u16` words in a mixed
endianness, uses them too. The disassembler decodes both the same way.

The JIT and the WASM backend already passed `signal.raw()` whole, so no
change was needed there; the eager-JIT reproduction in the issue came
through the interpreter.

## Docs

Three files stated the user range as bits 16–31 and the registry agreed
with none of them. They now say 32–63. The built-in table in
`docs/runtime.md` gains `:gpu` (15), `:os-signal` (16), and `:fs` (17),
and `docs/impl/bytecode.md` gets a section on the signal-bits operand.

## Tests

- `tests/elle/emit-user-signal.lisp` — a literal emit suspends, reports
  the user bit, and returns the resume value; the literal and dynamic
  paths agree; a compound emit keeps both halves; propagation past a mask
  that does not name the signal leaves the fiber suspended with its bit
  intact; a squelch boundary catches both forms.
- `lir::emit::tests::emit_terminator_carries_a_user_signal_bit_whole` —
  the emitter bakes a mask with a bit in each half into the operand.
- `vm::core::tests::signal_bits_operand_round_trips_the_user_range` —
  emit and read agree over the whole width.
- The two disassembler operand-skip tests now assert the decoded mask,
  not just that the stream stays aligned.

Each fails on the pre-fix encoding.

## Verification

`cargo test -p elle --lib` (2181 pass), `cargo test --test lib --release`
(1209 pass), `make smoke-elle` over the full corpus on both tiers,
`cargo clippy --all-targets`, `cargo fmt --check`, `make fmt-check`,
`make crosscheck`.