### PR TITLE
jit: pin bytecode allocations in the code cache

### DIFF
--- a/docs/impl/jit.md
+++ b/docs/impl/jit.md
@@ -35,9 +35,9 @@ Not all functions can be JIT-compiled. The JIT rejects functions that:
 **Negative-cache invariant.** A function whose compilation is rejected is
 recorded in `jit_rejections` and **never re-submitted**: every subsequent
 call falls through to the interpreter directly. The rejection is keyed by the
-function's bytecode pointer, which uniquely identifies its (immutable) LIR, so
-a re-submission could only ever reproduce the identical rejection — it is pure
-wasted work.
+function's bytecode pointer (see "Cache identity" for why that key is sound),
+so a re-submission could only ever reproduce the identical rejection — it is
+pure wasted work.
 
 This invariant is load-bearing under eager JIT. With `--jit=eager` the hotness
 threshold is 0, so *every* call is "hot"; absent the negative cache, each call
@@ -49,7 +49,33 @@ dwarfs the program's real work. The `jit/rejections` report exposes a per-
 function `:attempts` count; the negative cache holds `attempts == 1` no matter
 how many times the function is called.
 
-## The code-address registry
+## Cache identity
+
+`jit_cache`, `jit_pending`, and `jit_rejections` key entries by the raw
+address of the template's bytecode allocation (`bytecode.as_ptr()`). A raw
+address identifies a function only while that allocation is alive: templates
+are ordinary reclaimable data (region-allocated per `MakeClosure`, sharing
+one `Rc<Vec<u8>>` bytecode buffer per lambda proto), so a dropped compile
+unit frees its bytecode buffers, and a later compile can allocate a NEW
+function's bytecode at a reused address. A cache entry that outlived its
+template would then serve the old function's code to the new function —
+which runs the wrong body with the new closure's env and args, producing
+healthy-looking wrong values and no memory corruption.
+
+The invariant that makes the address key sound: **every entry pins the
+bytecode `Rc` it was keyed by** (`JitEntryPin`), from submission until the
+entry is removed. A pinned allocation cannot be freed, so its address cannot
+be reused, so a key collision cannot occur. The pin travels: recorded in
+`jit_pending` at submit, moved into `jit_cache` (or `jit_rejections`) when
+the result installs. The cost is that cached/rejected functions' bytecode
+stays resident for the VM's lifetime — bounded by the amount of code the
+program compiles, the same order as the retained native code itself.
+
+An alternative — validating entries at hit time by content — was rejected:
+it puts an O(bytecode) compare (or a hash plus per-template caching) on the
+hot dispatch path to detect a situation the pin makes impossible.
+
+Pinning tests: `src/vm/jit_entry/tests.rs`.
 
 Native samplers (`/usr/bin/sample`, `eu-stack`) cannot name JIT frames: the
 code lives in anonymous Cranelift mappings, so a wedged thread's stack shows

--- a/src/config/keywords.rs
+++ b/src/config/keywords.rs
@@ -40,6 +40,12 @@ pub const TRACE_KEYWORDS: &[&str] = &[
     // helpers) and every frame replay (resume_suspended) with the frame's
     // shape and value types. See src/jit/suspend.rs and src/vm/core/resume.rs.
     "park",
+    // JIT diagnostics: force synchronous Cranelift compilation on the VM
+    // thread instead of the background `elle-jit` worker (see
+    // src/vm/jit_entry.rs `submit_jit_task`). Splits install-race bugs from
+    // codegen bugs: a failure that persists under `syncjit` is in codegen or
+    // its inputs; one that vanishes lives at the worker boundary.
+    "syncjit",
 ];
 
 // ── Dump keywords ─────────────────────────────────────────────────

--- a/src/config/keywords.rs
+++ b/src/config/keywords.rs
@@ -36,6 +36,10 @@ pub const TRACE_KEYWORDS: &[&str] = &[
     "guardfree",
     "freebt",
     "scrub",
+    // Park/resume diagnostics: log every suspended-frame park (JIT side-exit
+    // helpers) and every frame replay (resume_suspended) with the frame's
+    // shape and value types. See src/jit/suspend.rs and src/vm/core/resume.rs.
+    "park",
 ];
 
 // ── Dump keywords ─────────────────────────────────────────────────

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -93,10 +93,12 @@ fn trace_all_covers_every_defined_bit() {
 fn trace_keywords_are_known() {
     // Future GPU backends — accepted without error, no bit yet.
     const FORWARD_COMPAT: &[&str] = &["spirv", "mlir", "gpu"];
-    // Region/free diagnostics: functional today but checked via the
-    // string `has_trace` (cold free paths in fiberheap/freelog.rs),
-    // so they deliberately carry no `trace_bits` entry.
-    const STRING_TRACED: &[&str] = &["free", "guardfree", "freebt", "scrub", "park"];
+    // Region/free diagnostics, the park trace, and the syncjit compile
+    // mode: functional today but checked via the string `has_trace` (cold
+    // free paths in fiberheap/freelog.rs; the park/resume seam; the submit
+    // path in vm/jit_entry.rs), so they deliberately carry no `trace_bits`
+    // entry.
+    const STRING_TRACED: &[&str] = &["free", "guardfree", "freebt", "scrub", "park", "syncjit"];
     for kw in TRACE_KEYWORDS {
         let recognized = trace_bits::from_name(kw) != 0
             || FORWARD_COMPAT.contains(kw)

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -96,7 +96,7 @@ fn trace_keywords_are_known() {
     // Region/free diagnostics: functional today but checked via the
     // string `has_trace` (cold free paths in fiberheap/freelog.rs),
     // so they deliberately carry no `trace_bits` entry.
-    const STRING_TRACED: &[&str] = &["free", "guardfree", "freebt", "scrub"];
+    const STRING_TRACED: &[&str] = &["free", "guardfree", "freebt", "scrub", "park"];
     for kw in TRACE_KEYWORDS {
         let recognized = trace_bits::from_name(kw) != 0
             || FORWARD_COMPAT.contains(kw)

--- a/src/jit/AGENTS.md
+++ b/src/jit/AGENTS.md
@@ -37,6 +37,14 @@ into `jit_cache`; rejections are recorded in `jit_rejections`.
 Diagnostics (`jit/rejections`, `--stats`) call `drain_jit_pending()`
 to block until all pending compilations finish before reporting.
 
+**`--trace=syncjit`** disables the worker entirely: `submit_jit_task`
+compiles on the VM thread and installs into `jit_cache` before returning.
+Codegen inputs are identical (same `prepare_task` output), so this is the
+first lever when chasing a suspected JIT race — a failure that persists
+under `syncjit` is a codegen or input bug; one that vanishes lives at the
+worker boundary (the `Send` claim on `JitTask`, or poll/install racing
+execution). Combine with `--trace=jit` to log each synchronous install.
+
 ## Interface
 
 | Type | Purpose |

--- a/src/jit/AGENTS.md
+++ b/src/jit/AGENTS.md
@@ -32,7 +32,9 @@ through the VM pointer threaded into each call.
 
 On every call to `try_jit_call`, the VM polls for completed
 compilations via non-blocking `try_recv()`. Compiled code is inserted
-into `jit_cache`; rejections are recorded in `jit_rejections`.
+into `jit_cache`; rejections are recorded in `jit_rejections`. All three
+maps key by raw bytecode address, sound only because every entry pins the
+allocation it is keyed by — see docs/impl/jit.md § "Cache identity".
 
 Diagnostics (`jit/rejections`, `--stats`) call `drain_jit_pending()`
 to block until all pending compilations finish before reporting.

--- a/src/jit/AGENTS.md
+++ b/src/jit/AGENTS.md
@@ -368,10 +368,9 @@ No errors are silently swallowed.
 spaces:
 
 - **Stack-relative (LoadLocal/StoreLocal):** The lowerer assigns slots starting
-  at `num_params` (it initializes `num_locals = num_params`). The JIT maps these
-  via `local_slot_to_var()` in `helpers.rs`: slots >= `num_params` are offset
-  into the `local_var_base` region; slots < `num_params` defensively map to
-  `arg_var_base`.
+  at 0 for all non-LBox locals (non-LBox params copied into local slots, plus
+  let bindings). The JIT maps these via `local_slot_to_var()` in `helpers.rs`:
+  every slot offsets into the `local_var_base` region.
 
 - **Env-relative (LoadCapture/StoreCapture):** Indices address the closure
   environment array directly. Captures with index < `num_captures` load from
@@ -445,21 +444,26 @@ resume IP and stack state.
 ### Environment Reconstruction on Side-Exit
 
 When building a `SuspendedFrame` for interpreter resumption, the JIT yield
-helpers (`elle_jit_yield`, `elle_jit_yield_through_call`) reconstruct the full
-interpreter environment from the closure's captures and the spilled locals:
+helpers (`elle_jit_yield`, `elle_jit_yield_through_call`) reconstruct the
+interpreter frame from the closure's captures and the spill buffer. The
+spill buffer layout is `[params(num_params), locals(num_locals),
+operands(num_spilled)]`, with all three counts from the yield-point /
+call-site metadata:
 
 ```
-env = [closure.env[0], ..., closure.env[n-1], local_0, ..., local_{m-1}]
-stack = [operand_0, ..., operand_k]
+env   = [closure.env[0], ..., closure.env[n-1], param_0, ..., param_{p-1}]
+stack = [local_0, ..., local_{m-1}, operand_0, ..., operand_k]
 ```
 
-The interpreter's `LoadUpvalue` accesses `env[idx]` for ALL variables —
-captures, params, and locally-defined vars. The JIT stores captures in
-`closure.env` and params/locals in Cranelift variables. The spill buffer
-layout is `[locals..., operands...]`, where `num_locals` (from yield/call-site
-metadata) gives the split point. The first `num_locals` spilled values are
-appended to `closure.env` to form the full env; the remaining values form
-the operand stack.
+This matches the interpreter's frame shape: `LoadUpvalue` reads captures
+and params from `env`; `LoadLocal` reads locals from the bottom of the
+frame stack. LBox cells are first-class values in JIT registers (no
+auto-unwrap), so spilled cells are the original objects — no re-wrapping.
+Note the env rebuilt here carries captures and params only; an
+interpreter-built frame for the same activation also has one env slot per
+local (`populate_env` pads with nil / CaptureCell). The asymmetry is
+benign because celled locals require `MakeClosure`, which the JIT
+rejects.
 
 ## Roadmap
 

--- a/src/jit/calls/callops.rs
+++ b/src/jit/calls/callops.rs
@@ -98,7 +98,7 @@ pub extern "C" fn elle_jit_call(
 
         // JIT-to-JIT fast path: check if callee has JIT code
         let bytecode_ptr = closure.template.bytecode.as_ptr();
-        if let Some(jit_code) = vm.jit_cache.get(&bytecode_ptr).cloned() {
+        if let Some(jit_code) = vm.jit_code_for(bytecode_ptr) {
             vm.fiber.call_depth += 1;
 
             // Stack overflow guard: resource exhaustion (not signal-theoretic).

--- a/src/jit/compiler/translate.rs
+++ b/src/jit/compiler/translate.rs
@@ -391,6 +391,28 @@ impl JitCompiler {
             }
         }
 
+        // Metadata/translation agreement: the yield helpers index
+        // `JitCode.yield_points` / `JitCode.call_sites` by the translator's
+        // running counters, and the emitter recorded those lists in its own
+        // walk over the same blocks. A count mismatch means some side-exit
+        // would read ANOTHER site's resume_ip and stack shape — a silently
+        // corrupted resume. Reject the compile; the interpreter tier is
+        // always correct.
+        if translator.yield_point_index as usize != lir.yield_points.len() {
+            return Err(JitError::InvalidLir(format!(
+                "yield-point count mismatch: translated {}, emitter recorded {}",
+                translator.yield_point_index,
+                lir.yield_points.len()
+            )));
+        }
+        if lir.signal.may_suspend() && translator.call_site_index as usize != lir.call_sites.len() {
+            return Err(JitError::InvalidLir(format!(
+                "call-site count mismatch: translated {}, emitter recorded {}",
+                translator.call_site_index,
+                lir.call_sites.len()
+            )));
+        }
+
         builder.seal_all_blocks();
         builder.finalize();
 

--- a/src/jit/helpers.rs
+++ b/src/jit/helpers.rs
@@ -483,10 +483,19 @@ impl<'a> FunctionTranslator<'a> {
         builder.switch_to_block(yield_block);
         builder.seal_block(yield_block);
 
-        let call_site = self.lir.call_sites.get(call_site_idx as usize);
-        let stack_regs = match call_site {
+        // Every yield check must have its emitter-recorded call site: the
+        // runtime helper indexes JitCode.call_sites with this same index, so
+        // a missing entry means the counters diverged and the side-exit
+        // would rebuild the frame from another site's stack shape.
+        let stack_regs = match self.lir.call_sites.get(call_site_idx as usize) {
             Some(cs) => cs.stack_regs.as_slice(),
-            None => &[] as &[crate::lir::Reg],
+            None => {
+                return Err(JitError::InvalidLir(format!(
+                    "call site {} has no emitter-recorded metadata ({} recorded)",
+                    call_site_idx,
+                    self.lir.call_sites.len()
+                )))
+            }
         };
 
         let spilled_ptr = self.spill_locals_and_operands(builder, stack_regs)?;

--- a/src/jit/mod.rs
+++ b/src/jit/mod.rs
@@ -139,4 +139,22 @@ pub struct JitRejectionInfo {
     pub name: Option<String>,
     /// Why the JIT rejected this closure.
     pub reason: JitError,
+    /// Pin for the bytecode allocation this rejection is keyed by
+    /// (docs/impl/jit.md § "Cache identity"): while the entry lives, the
+    /// address cannot be reused by a different function, so the negative
+    /// cache can never wrongly block a new function from compiling.
+    _pin: Option<std::rc::Rc<Vec<u8>>>,
+}
+
+impl JitRejectionInfo {
+    /// Build a rejection record pinning the bytecode it is keyed by. `pin`
+    /// is `None` only when the submission's pin was already lost (a worker
+    /// result with no matching pending entry).
+    pub fn new(reason: JitError, pin: Option<std::rc::Rc<Vec<u8>>>) -> Self {
+        JitRejectionInfo {
+            name: None,
+            reason,
+            _pin: pin,
+        }
+    }
 }

--- a/src/jit/suspend.rs
+++ b/src/jit/suspend.rs
@@ -8,6 +8,75 @@ use crate::value::{BytecodeFrame, SuspendedFrame, Value};
 // Yield Side-Exit Helpers
 // =============================================================================
 
+/// `--trace=park`: log a JIT side-exit park with its frame shape. The resume
+/// twin lives in `resume_suspended`; together they show whether a wrong value
+/// was parked wrong or went wrong while parked.
+fn trace_park(
+    helper: &str,
+    closure: &crate::value::Closure,
+    site_index: u64,
+    resume_ip: usize,
+    env: &[Value],
+    stack: &[Value],
+) {
+    if !crate::config::get().has_trace("park") {
+        return;
+    }
+    eprintln!(
+        "[park:{helper}] fn={} site={site_index} resume_ip={resume_ip} \
+         env[{}]=[{}] stack[{}]=[{}]",
+        closure.template.name.as_deref().unwrap_or("<anonymous>"),
+        env.len(),
+        Value::type_name_line(env),
+        stack.len(),
+        Value::type_name_line(stack),
+    );
+}
+
+/// Park-time tripwire (debug builds): every value the side-exit parks must be
+/// structurally sound (`Value::malformed_reason`). A torn or zeroed slot here
+/// means the compiled frame's spill diverged from the interpreter layout the
+/// resume expects; detonating at the park names the function and the slot
+/// instead of leaving a segfault for the resumed reader.
+#[cfg(debug_assertions)]
+fn check_parked_frame(
+    helper: &str,
+    closure: &crate::value::Closure,
+    resume_ip: usize,
+    env: &[Value],
+    stack: &[Value],
+) {
+    let name = closure.template.name.as_deref().unwrap_or("<anonymous>");
+    for (section, values) in [("env", env), ("stack", stack)] {
+        for (i, v) in values.iter().enumerate() {
+            if let Some(reason) = v.malformed_reason() {
+                panic!(
+                    "{helper}: parked a malformed value — {reason}: \
+                     fn={name} resume_ip={resume_ip} {section}[{i}] \
+                     tag=0x{:x} payload=0x{:x} (env_len={} stack_len={} \
+                     num_params={} num_locals={})",
+                    v.tag,
+                    v.payload,
+                    env.len(),
+                    stack.len(),
+                    closure.template.num_params,
+                    closure.template.num_locals,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn check_parked_frame(
+    _helper: &str,
+    _closure: &crate::value::Closure,
+    _resume_ip: usize,
+    _env: &[Value],
+    _stack: &[Value],
+) {
+}
+
 /// JIT yield side-exit: build a SuspendedFrame and set fiber.signal.
 ///
 /// Called from JIT code when a Yield terminator is reached.
@@ -122,6 +191,8 @@ pub extern "C" fn elle_jit_yield(
         // jit-cache borrows so the `&mut self` VM accessors below are free to run.
         let code = closure.template.code();
         let resume_ip = yield_meta.resume_ip;
+        trace_park("jit-yield", closure, yield_index, resume_ip, &env, &stack);
+        check_parked_frame("elle_jit_yield", closure, resume_ip, &env, &stack);
         // MOVE the activation's owner node into the frame (its slot is
         // likewise still on top) so it rides the park to the resumed body's
         // completion — the compiled twin of the interpreter yield park
@@ -230,6 +301,21 @@ pub extern "C" fn elle_jit_yield_through_call(
     // jit-cache borrows so the `&mut self` VM accessors below are free to run.
     let code = closure.template.code();
     let resume_ip = call_meta.resume_ip;
+    trace_park(
+        "jit-yield-through-call",
+        closure,
+        call_site_index,
+        resume_ip,
+        &env,
+        &stack,
+    );
+    check_parked_frame(
+        "elle_jit_yield_through_call",
+        closure,
+        resume_ip,
+        &env,
+        &stack,
+    );
     // MOVE the caller's owner node into its park — this compiled activation
     // unwinds with the callee's suspending signal (see elle_jit_yield).
     let activation_owner_node = vm.take_activation_owner_node();

--- a/src/jit/suspend.rs
+++ b/src/jit/suspend.rs
@@ -121,8 +121,7 @@ pub extern "C" fn elle_jit_yield(
     // Look up yield point metadata from JitCode
     let bytecode_ptr = closure.template.bytecode.as_ptr();
     let jit_code = vm
-        .jit_cache
-        .get(&bytecode_ptr)
+        .jit_code_for(bytecode_ptr)
         .expect("VM bug: elle_jit_yield called but no JitCode in cache");
     let yield_meta = &jit_code.yield_points[yield_index as usize];
     let num_params = yield_meta.num_params as usize;
@@ -256,8 +255,7 @@ pub extern "C" fn elle_jit_yield_through_call(
     // Look up call site metadata from JitCode
     let bytecode_ptr = closure.template.bytecode.as_ptr();
     let jit_code = vm
-        .jit_cache
-        .get(&bytecode_ptr)
+        .jit_code_for(bytecode_ptr)
         .expect("VM bug: elle_jit_yield_through_call called but no JitCode in cache");
     let call_meta = &jit_code.call_sites[call_site_index as usize];
 

--- a/src/jit/suspend/tests/mod.rs
+++ b/src/jit/suspend/tests/mod.rs
@@ -51,7 +51,6 @@ fn setup_yield_test(
         squelch_mask: SignalBits::EMPTY,
     };
 
-    let bytecode_ptr = template.bytecode.as_ptr();
     // The closure header must share `region` with its env slice (see above), so
     // allocate it into `region` explicitly via a NativeCtx over this VM rather
     // than dropping the region argument.
@@ -63,7 +62,7 @@ fn setup_yield_test(
     .closure(closure);
 
     let jit_code = Arc::new(crate::jit::JitCode::test_with_yield_points(yield_points));
-    vm.jit_cache.insert(bytecode_ptr, jit_code);
+    vm.install_jit_code(bytecode, jit_code);
 
     (vm, closure_val)
 }
@@ -114,7 +113,6 @@ fn setup_yield_test_with_lbox(
         squelch_mask: SignalBits::EMPTY,
     };
 
-    let bytecode_ptr = template.bytecode.as_ptr();
     // The closure header must share `region` with its env slice (see above), so
     // allocate it into `region` explicitly via a NativeCtx over this VM rather
     // than dropping the region argument.
@@ -126,7 +124,7 @@ fn setup_yield_test_with_lbox(
     .closure(closure);
 
     let jit_code = Arc::new(crate::jit::JitCode::test_with_yield_points(yield_points));
-    vm.jit_cache.insert(bytecode_ptr, jit_code);
+    vm.install_jit_code(bytecode, jit_code);
 
     (vm, closure_val)
 }

--- a/src/jit/suspend/tests/park.rs
+++ b/src/jit/suspend/tests/park.rs
@@ -107,14 +107,14 @@ fn jit_yield_through_call_parks_owner_node_for_resume_completion() {
     // CALL-SITE helper, so re-key the cache entry with call-site metadata.
     let (mut vm, closure_val) =
         setup_yield_test(vec![Instruction::Return as u8], vec![], vec![], vec![]);
-    let bytecode_ptr = closure_val
+    let bytecode = closure_val
         .as_closure()
         .expect("setup builds a closure")
         .template
         .bytecode
-        .as_ptr();
-    vm.jit_cache.insert(
-        bytecode_ptr,
+        .clone();
+    vm.install_jit_code(
+        bytecode,
         Arc::new(crate::jit::JitCode::test_with_call_sites(vec![
             CallSiteMeta {
                 resume_ip: 0,

--- a/src/jit/translate/terminator.rs
+++ b/src/jit/translate/terminator.rs
@@ -149,12 +149,20 @@ impl<'a> FunctionTranslator<'a> {
                 let yield_index = self.yield_point_index;
                 self.yield_point_index += 1;
 
-                let stack_regs = self
-                    .lir
-                    .yield_points
-                    .get(yield_index as usize)
-                    .map(|yp| yp.stack_regs.as_slice())
-                    .unwrap_or(&[]);
+                // Every Emit terminator must have its emitter-recorded yield
+                // point: elle_jit_yield indexes JitCode.yield_points with this
+                // same index, so a missing entry means the counters diverged
+                // and the side-exit would resume at another point's ip.
+                let stack_regs = match self.lir.yield_points.get(yield_index as usize) {
+                    Some(yp) => yp.stack_regs.as_slice(),
+                    None => {
+                        return Err(JitError::InvalidLir(format!(
+                            "yield point {} has no emitter-recorded metadata ({} recorded)",
+                            yield_index,
+                            self.lir.yield_points.len()
+                        )))
+                    }
+                };
 
                 let spilled_ptr = self.spill_locals_and_operands(builder, stack_regs)?;
                 let yield_idx_val = builder.ins().iconst(I64, yield_index as i64);

--- a/src/value/fiber/frame.rs
+++ b/src/value/fiber/frame.rs
@@ -68,7 +68,8 @@ pub struct BytecodeFrame {
     /// use while the activation's `code`/`env` live on as `Rc`s — so it is never
     /// dereferenced on restore; it is live exactly where it is read (`LoadSelf`,
     /// whose self-recursive body keeps its closure region alive through the
-    /// recursion). `NIL` for an untracked activation (e.g. a JIT-built frame).
+    /// recursion). The JIT side-exit helpers park the executing closure here
+    /// too (`src/jit/suspend.rs`); `NIL` only for an untracked activation.
     pub current_closure: Value,
     /// Debug-only snapshot of the uncounted region borrows `activation_region_map`
     /// holds at suspension: `(slot, region, establish-generation)` per LIVE mapped

--- a/src/value/repr/mod.rs
+++ b/src/value/repr/mod.rs
@@ -196,6 +196,89 @@ impl Value {
         self.tag != TAG_NIL && self.tag != TAG_FALSE
     }
 
+    /// The reason these bits cannot be a live `Value`, or `None` when they can.
+    ///
+    /// A conservative structural check for the park/resume tripwires
+    /// (`elle_jit_yield`, `resume_suspended`): the tag must be a known
+    /// `TAG_*` constant, and a heap tag must carry a non-null, 8-byte-aligned
+    /// payload. A permutation of valid values passes — this catches torn or
+    /// zeroed slots, not misplaced ones.
+    pub fn malformed_reason(&self) -> Option<&'static str> {
+        if self.tag > TAG_CLOSURE_TEMPLATE {
+            return Some("tag out of range");
+        }
+        if self.is_heap() {
+            if self.payload == 0 {
+                return Some("heap tag with null payload");
+            }
+            if !self.payload.is_multiple_of(8) {
+                return Some("heap tag with unaligned payload");
+            }
+        }
+        None
+    }
+
+    /// The static name of this value's TAG — no heap dereference. A parked
+    /// frame may carry values in slots that are past their last use
+    /// (uncounted borrows whose regions are already freed), so a trace over
+    /// a whole frame must never deref; `type_name` would.
+    pub fn tag_name(&self) -> &'static str {
+        match self.tag {
+            TAG_INT => "int",
+            TAG_FLOAT => "float",
+            TAG_NIL => "nil",
+            TAG_TRUE | TAG_FALSE => "bool",
+            TAG_EMPTY_LIST => "empty",
+            TAG_SYMBOL => "sym",
+            TAG_KEYWORD => "kw",
+            TAG_UNDEFINED => "undef",
+            TAG_CPOINTER => "cptr",
+            TAG_NATIVE_FN => "native",
+            TAG_STRING_MUT => "@string",
+            TAG_ARRAY => "array",
+            TAG_ARRAY_MUT => "@array",
+            TAG_STRUCT => "struct",
+            TAG_STRUCT_MUT => "@struct",
+            TAG_CONS => "cons",
+            TAG_CLOSURE => "closure",
+            TAG_BYTES => "bytes",
+            TAG_BYTES_MUT => "@bytes",
+            TAG_SET => "set",
+            TAG_SET_MUT => "@set",
+            TAG_LBOX => "lbox",
+            TAG_FIBER => "fiber",
+            TAG_SYNTAX => "syntax",
+            TAG_STRING => "string",
+            TAG_FFI_SIG => "ffi-sig",
+            TAG_FFI_TYPE => "ffi-type",
+            TAG_LIB_HANDLE => "lib",
+            TAG_MANAGED_PTR => "managed",
+            TAG_EXTERNAL => "external",
+            TAG_PARAMETER => "param",
+            TAG_THREAD => "thread",
+            TAG_CAPTURE_CELL => "cell",
+            TAG_CLOSURE_TEMPLATE => "template",
+            _ => "invalid",
+        }
+    }
+
+    /// Render `values` as a comma-joined tag-name list for trace output
+    /// (`--trace=park`). Tag names only — never dereferences (see
+    /// [`Value::tag_name`]); raw bits are shown for a malformed value.
+    pub fn type_name_line(values: &[Value]) -> String {
+        values
+            .iter()
+            .map(|v| {
+                if v.malformed_reason().is_some() {
+                    format!("bad(0x{:x},0x{:x})", v.tag, v.payload)
+                } else {
+                    v.tag_name().to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
     /// Create a heap pointer value from a raw pointer and an explicit tag.
     ///
     /// # Safety

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -155,7 +155,7 @@ On resume, the VM wires up the parent/child chain (Janet semantics):
 | `heap_ptr` | `*mut FiberHeap` | This instance's single heap, owned by `RuntimeCore` (or privately leaked for a bare VM). All fibers share it; reach it via `heap()` |
 | `current_fiber_handle` | `Option<FiberHandle>` | Handle for current fiber (`None` for root) |
 | `current_fiber_value` | `Option<Value>` | Cached Value for current fiber (`None` for root) |
-| `jit_cache` | `FxHashMap<*const u8, Rc<JitCode>>` | JIT code cache (FxHash for pointer keys) |
+| `jit_cache` | `FxHashMap<*const u8, JitCacheEntry>` | JIT code cache; each entry pins the bytecode allocation its key names (docs/impl/jit.md § "Cache identity"). Write via `install_jit_code`, read via `jit_code_for` |
 | `jit_rejections` | `FxHashMap<*const u8, JitRejectionInfo>` | JIT rejection log: first rejection per closure template |
 | `closure_call_counts` | `FxHashMap<*const u8, usize>` | JIT hotness profiling (FxHash for pointer keys) |
 | `pending_tail_call` | `Option<TailCallInfo>` | Rc-based tail call info (transient) |

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -17,6 +17,29 @@ use std::sync::Arc;
 #[cfg(feature = "jit")]
 use crate::jit::{JitCode, JitRejectionInfo};
 
+/// A `jit_cache` entry: the compiled code plus the pin that keeps the keyed
+/// bytecode allocation alive (docs/impl/jit.md § "Cache identity"). The pin
+/// makes the raw-address key sound: a pinned allocation cannot be freed, so
+/// its address cannot be reused by a different function's bytecode while
+/// this entry lives.
+#[cfg(feature = "jit")]
+pub struct JitCacheEntry {
+    _pin: Rc<Vec<u8>>,
+    pub code: Arc<JitCode>,
+}
+
+#[cfg(feature = "jit")]
+impl JitCacheEntry {
+    /// Build an entry pinning `bytecode` — the same `Rc` the entry's cache
+    /// key is derived from.
+    pub fn new(bytecode: Rc<Vec<u8>>, code: Arc<JitCode>) -> Self {
+        JitCacheEntry {
+            _pin: bytecode,
+            code,
+        }
+    }
+}
+
 /// The releases a frame-replacing tail call leaves behind, one per channel.
 ///
 /// Everything the lowerer emits after a `TailCall` runs only on the native
@@ -215,15 +238,20 @@ pub struct VM {
     /// per-thread, keeping the trap scoped to the calling OS thread (the runner's
     /// own `exit`, on a VM with the trap unset, still terminates the process).
     pub(crate) exit_trapped: bool,
-    /// JIT code cache: bytecode pointer → compiled native code.
+    /// JIT code cache: bytecode pointer → pinned entry (see `JitCacheEntry`
+    /// and docs/impl/jit.md § "Cache identity"). Write through
+    /// `install_jit_code`; read through `jit_code_for`.
     #[cfg(feature = "jit")]
-    pub jit_cache: FxHashMap<*const u8, Arc<JitCode>>,
+    pub jit_cache: FxHashMap<*const u8, JitCacheEntry>,
     /// Background JIT compilation worker (spawned lazily).
     #[cfg(feature = "jit")]
     pub(crate) jit_worker: Option<crate::jit::worker::JitWorker>,
-    /// Bytecode pointers currently being compiled in background.
+    /// Compilations in flight on the worker, keyed by bytecode address. The
+    /// value pins the keyed allocation from submission until the result
+    /// installs (docs/impl/jit.md § "Cache identity"); the pin then moves
+    /// into `jit_cache` or `jit_rejections`.
     #[cfg(feature = "jit")]
-    pub(crate) jit_pending: rustc_hash::FxHashSet<usize>,
+    pub(crate) jit_pending: FxHashMap<usize, Rc<Vec<u8>>>,
     /// Documentation for all named forms (primitives, special forms, macros).
     /// Keyed by name string for direct lookup via `doc` and `vm/primitive-meta`.
     pub docs: HashMap<String, Doc>,

--- a/src/vm/core/lifecycle.rs
+++ b/src/vm/core/lifecycle.rs
@@ -112,7 +112,7 @@ impl VM {
             #[cfg(feature = "jit")]
             jit_worker: None,
             #[cfg(feature = "jit")]
-            jit_pending: rustc_hash::FxHashSet::default(),
+            jit_pending: FxHashMap::default(),
             #[cfg(feature = "jit")]
             jit_rejections: FxHashMap::default(),
             #[cfg(feature = "jit")]

--- a/src/vm/core/resume.rs
+++ b/src/vm/core/resume.rs
@@ -123,6 +123,50 @@ impl VM {
                         }
                     }
 
+                    // `--trace=park`: the replay twin of the park-side log in
+                    // src/jit/suspend.rs — shows the frame's shape as it
+                    // re-enters the interpreter.
+                    if crate::config::get().has_trace("park") {
+                        // `current_closure` is an uncounted borrow that may be
+                        // dead by resume time (see BytecodeFrame) — print its
+                        // bits, never dereference it for a name.
+                        eprintln!(
+                            "[park:resume] frame={i} closure=0x{:x} ip={} push_rv={} \
+                             rv={} env[{}]=[{}] stack[{}]=[{}]",
+                            frame.current_closure.payload,
+                            frame.ip,
+                            frame.push_resume_value,
+                            Value::type_name_line(std::slice::from_ref(&current_value)),
+                            frame.env.len(),
+                            Value::type_name_line(&frame.env),
+                            frame.stack.len(),
+                            Value::type_name_line(&frame.stack),
+                        );
+                    }
+
+                    // Resume-time tripwire (debug builds): every value this frame
+                    // carries back into the interpreter must be structurally
+                    // sound. The park-side twin (`check_parked_frame`,
+                    // src/jit/suspend.rs) validated a JIT-built frame as it was
+                    // built; a value that was sound at park and is malformed
+                    // here was corrupted WHILE the fiber was parked.
+                    #[cfg(debug_assertions)]
+                    for (section, values) in [
+                        ("stack", frame.stack.as_slice()),
+                        ("env", frame.env.as_slice()),
+                    ] {
+                        for (vi, v) in values.iter().enumerate() {
+                            if let Some(reason) = v.malformed_reason() {
+                                panic!(
+                                    "resume_suspended: frame {i} carries a malformed \
+                                     value — {reason}: ip={} {section}[{vi}] \
+                                     tag=0x{:x} payload=0x{:x}",
+                                    frame.ip, v.tag, v.payload,
+                                );
+                            }
+                        }
+                    }
+
                     // Confirm every uncounted region borrow this suspended frame
                     // holds across park/resume is still live (debug builds). The
                     // snapshot (`record_region_borrows`) recorded only the LIVE

--- a/src/vm/jit_entry.rs
+++ b/src/vm/jit_entry.rs
@@ -124,6 +124,43 @@ impl VM {
             Some(&label),
         );
 
+        // `--trace=syncjit`: compile here on the VM thread and install
+        // immediately; the `elle-jit` worker never spawns. Codegen inputs are
+        // identical to the background path (same prepare_task output), so a
+        // failure that persists under syncjit indicts codegen or its inputs,
+        // while one that vanishes lives at the worker boundary — the Send
+        // claim on JitTask, or a poll/install racing execution. Diagnosing a
+        // suspected JIT race starts here; `--trace=jit,syncjit` logs each
+        // synchronous install like the background path logs its own.
+        if crate::config::get().has_trace("syncjit") {
+            let res = crate::jit::JitCompiler::new()
+                .and_then(|c| c.compile(&task.lir, task.self_sym, task.symbol_names, Vec::new()));
+            match res {
+                Ok(jit_code) => {
+                    if self
+                        .runtime_config
+                        .has_trace_bit(crate::config::trace_bits::JIT)
+                    {
+                        eprintln!(
+                            "[jit] synchronous compile (syncjit): bc_ptr={:#x}",
+                            bytecode_ptr as usize,
+                        );
+                    }
+                    self.jit_cache.insert(bytecode_ptr, Arc::new(jit_code));
+                }
+                Err(e) => {
+                    self.jit_rejections
+                        .entry(bytecode_ptr)
+                        .or_insert_with(|| JitRejectionInfo {
+                            name: None,
+                            reason: e,
+                        });
+                }
+            }
+            *self.jit_compile_attempts.entry(bytecode_ptr).or_insert(0) += 1;
+            return;
+        }
+
         // Lazily spawn the worker thread on first use
         let worker = self
             .jit_worker

--- a/src/vm/jit_entry.rs
+++ b/src/vm/jit_entry.rs
@@ -12,7 +12,34 @@ use std::sync::Arc;
 
 use super::core::VM;
 
+#[cfg(test)]
+mod tests;
+
 impl VM {
+    /// Install compiled code for the function whose bytecode is `bytecode`.
+    /// The single write path into `jit_cache`: the key is derived from the
+    /// bytecode here, never passed separately, and the entry pins the
+    /// bytecode so the key stays sound (docs/impl/jit.md § "Cache identity").
+    pub fn install_jit_code(&mut self, bytecode: std::rc::Rc<Vec<u8>>, code: Arc<JitCode>) {
+        self.jit_cache.insert(
+            bytecode.as_ptr(),
+            crate::vm::core::JitCacheEntry::new(bytecode, code),
+        );
+    }
+
+    /// Compiled code for the function at `bytecode_ptr`, if cached.
+    pub fn jit_code_for(&self, bytecode_ptr: *const u8) -> Option<Arc<JitCode>> {
+        self.jit_cache.get(&bytecode_ptr).map(|e| e.code.clone())
+    }
+
+    /// Record that a compile for `bytecode` is in flight on the worker. The
+    /// entry pins `bytecode` until the result installs, so the key the
+    /// worker echoes back still names this function.
+    pub(crate) fn record_jit_pending(&mut self, bytecode: std::rc::Rc<Vec<u8>>) {
+        self.jit_pending
+            .insert(bytecode.as_ptr() as usize, bytecode);
+    }
+
     /// Try JIT compilation/dispatch for a closure call.
     ///
     /// Returns `Some(Option<SignalBits>)` if JIT handled the call (the inner
@@ -40,7 +67,7 @@ impl VM {
         self.poll_jit_completions();
 
         // Check cache (may have been populated by poll above)
-        if let Some(jit_code) = self.jit_cache.get(&bytecode_ptr).cloned() {
+        if let Some(jit_code) = self.jit_code_for(bytecode_ptr) {
             return Some(self.run_jit(&jit_code, closure, args, func));
         }
 
@@ -52,7 +79,7 @@ impl VM {
         // every call "hot") the absence of this check re-submits un-jit'able
         // hot functions on every call and saturates the background worker.
         if is_hot
-            && !self.jit_pending.contains(&(bytecode_ptr as usize))
+            && !self.jit_pending.contains_key(&(bytecode_ptr as usize))
             && !self.jit_rejections.contains_key(&bytecode_ptr)
         {
             if let Some(ref lir_func) = closure.template.lir_function {
@@ -72,10 +99,14 @@ impl VM {
         };
         let results: Vec<_> = worker.poll().collect();
         for result in results {
-            self.jit_pending.remove(&result.bytecode_key);
+            // The pin recorded at submit is what keeps `bytecode_key`
+            // naming this function; without it the address may already
+            // belong to a different function's bytecode, so the result
+            // must not be installed under it.
+            let pin = self.jit_pending.remove(&result.bytecode_key);
             match result.result {
                 Ok(jit_code) => {
-                    let bytecode_ptr = result.bytecode_key as *const u8;
+                    let Some(pin) = pin else { continue };
                     if self
                         .runtime_config
                         .has_trace_bit(crate::config::trace_bits::JIT)
@@ -85,7 +116,7 @@ impl VM {
                             result.bytecode_key,
                         );
                     }
-                    self.jit_cache.insert(bytecode_ptr, Arc::new(jit_code));
+                    self.install_jit_code(pin, Arc::new(jit_code));
                 }
                 Err(e) => match &e {
                     crate::jit::JitError::UnsupportedInstruction(_)
@@ -93,12 +124,9 @@ impl VM {
                     | crate::jit::JitError::Yielding => {
                         // Expected rejection — record for diagnostics.
                         let bytecode_ptr = result.bytecode_key as *const u8;
-                        self.jit_rejections.entry(bytecode_ptr).or_insert_with(|| {
-                            JitRejectionInfo {
-                                name: None,
-                                reason: e,
-                            }
-                        });
+                        self.jit_rejections
+                            .entry(bytecode_ptr)
+                            .or_insert_with(|| JitRejectionInfo::new(e, pin));
                     }
                     _ => {
                         eprintln!("[jit] background compilation failed: {}", e);
@@ -116,6 +144,7 @@ impl VM {
         bytecode_ptr: *const u8,
     ) {
         let label = closure.template.display_label();
+        let bytecode = closure.template.bytecode.clone();
         let task = crate::jit::worker::prepare_task(
             lir_func,
             None,
@@ -146,15 +175,12 @@ impl VM {
                             bytecode_ptr as usize,
                         );
                     }
-                    self.jit_cache.insert(bytecode_ptr, Arc::new(jit_code));
+                    self.install_jit_code(bytecode, Arc::new(jit_code));
                 }
                 Err(e) => {
                     self.jit_rejections
                         .entry(bytecode_ptr)
-                        .or_insert_with(|| JitRejectionInfo {
-                            name: None,
-                            reason: e,
-                        });
+                        .or_insert_with(|| JitRejectionInfo::new(e, Some(bytecode)));
                 }
             }
             *self.jit_compile_attempts.entry(bytecode_ptr).or_insert(0) += 1;
@@ -167,7 +193,7 @@ impl VM {
             .get_or_insert_with(crate::jit::worker::JitWorker::new);
 
         if worker.submit(task) {
-            self.jit_pending.insert(bytecode_ptr as usize);
+            self.record_jit_pending(bytecode);
             *self.jit_compile_attempts.entry(bytecode_ptr).or_insert(0) += 1;
             if self
                 .runtime_config
@@ -194,20 +220,19 @@ impl VM {
             };
             match worker.recv_blocking() {
                 Some(result) => {
-                    self.jit_pending.remove(&result.bytecode_key);
+                    // As in `poll_jit_completions`: no pin, no install — the
+                    // key may already name a different function's bytecode.
+                    let pin = self.jit_pending.remove(&result.bytecode_key);
                     match result.result {
                         Ok(jit_code) => {
-                            let bytecode_ptr = result.bytecode_key as *const u8;
-                            self.jit_cache.insert(bytecode_ptr, Arc::new(jit_code));
+                            let Some(pin) = pin else { continue };
+                            self.install_jit_code(pin, Arc::new(jit_code));
                         }
                         Err(e) => {
                             let bytecode_ptr = result.bytecode_key as *const u8;
-                            self.jit_rejections.entry(bytecode_ptr).or_insert_with(|| {
-                                JitRejectionInfo {
-                                    name: None,
-                                    reason: e,
-                                }
-                            });
+                            self.jit_rejections
+                                .entry(bytecode_ptr)
+                                .or_insert_with(|| JitRejectionInfo::new(e, pin));
                         }
                     }
                 }

--- a/src/vm/jit_entry/tests.rs
+++ b/src/vm/jit_entry/tests.rs
@@ -1,0 +1,83 @@
+//! Cache-identity tests for the JIT entry points.
+//!
+//! `jit_cache` keys entries by the raw address of a template's bytecode
+//! allocation. The invariant under test (docs/impl/jit.md § "Cache
+//! identity"): an entry pins the bytecode allocation it is keyed by, so the
+//! address cannot be freed and reused by a different function while the
+//! entry lives. Without the pin, a template drop plus an address-reusing
+//! allocation hands the new function the old function's compiled code —
+//! wrong body, new env and args, no memory corruption to observe.
+
+use std::rc::Rc;
+use std::sync::Arc;
+
+use crate::jit::JitCode;
+use crate::vm::VM;
+
+/// Distinctive allocation size for the probe: any size works, but an odd
+/// one keeps unrelated runtime allocations from landing in the same
+/// size class mid-test.
+const PROBE_LEN: usize = 371;
+
+/// Try to get the allocator to hand back `target` for a fresh allocation of
+/// the same size. Failed candidates are kept alive so the allocator must
+/// keep producing new addresses instead of recycling the same wrong one.
+/// Returns true if `target` was reissued.
+fn address_reissued(target: *const u8, tries: usize) -> bool {
+    let mut hold = Vec::with_capacity(tries);
+    for _ in 0..tries {
+        let candidate: Vec<u8> = vec![9u8; PROBE_LEN];
+        if candidate.as_ptr() == target {
+            return true;
+        }
+        hold.push(candidate);
+    }
+    false
+}
+
+/// The wrong answer that looked right: keying by address is fine as long as
+/// the allocation is immortal — and templates USED to be process-lifetime
+/// data, so nothing ever checked. Templates are region-reclaimed now; a live
+/// cache entry must therefore keep its keyed allocation alive itself.
+#[test]
+fn jit_cache_entry_pins_its_keyed_bytecode_allocation() {
+    let mut vm = VM::new();
+    let bytecode: Rc<Vec<u8>> = Rc::new(vec![7u8; PROBE_LEN]);
+    let ptr = bytecode.as_ptr();
+
+    vm.install_jit_code(
+        bytecode.clone(),
+        Arc::new(JitCode::test_with_yield_points(Vec::new())),
+    );
+
+    // The template drops; the cache entry survives.
+    drop(bytecode);
+
+    assert!(
+        !address_reissued(ptr, 10_000),
+        "jit_cache key address was reallocated while its entry is live: \
+         a new function's bytecode at this address would dispatch the old \
+         function's compiled code"
+    );
+}
+
+/// Same invariant for the in-flight window: a compile submitted to the
+/// background worker keys its future cache entry by address, so the pin
+/// must start at submission, not at install.
+#[test]
+fn jit_pending_entry_pins_its_keyed_bytecode_allocation() {
+    let mut vm = VM::new();
+    let bytecode: Rc<Vec<u8>> = Rc::new(vec![7u8; PROBE_LEN]);
+    let ptr = bytecode.as_ptr();
+
+    vm.record_jit_pending(bytecode.clone());
+
+    drop(bytecode);
+
+    assert!(
+        !address_reissued(ptr, 10_000),
+        "jit_pending key address was reallocated while its compile is in \
+         flight: the worker's result would install under an address now \
+         owned by a different function"
+    );
+}

--- a/src/vm/run_on/jit.rs
+++ b/src/vm/run_on/jit.rs
@@ -43,7 +43,7 @@ impl VM {
 
         // Use the cached JIT code if available, else force-compile.
         let bytecode_ptr = closure.template.bytecode.as_ptr();
-        let jit_code = match self.jit_cache.get(&bytecode_ptr).cloned() {
+        let jit_code = match self.jit_code_for(bytecode_ptr) {
             Some(jc) => jc,
             None => {
                 let compiler = match crate::jit::JitCompiler::new() {
@@ -63,7 +63,7 @@ impl VM {
                 ) {
                     Ok(jc) => {
                         let jc = Arc::new(jc);
-                        self.jit_cache.insert(bytecode_ptr, jc.clone());
+                        self.install_jit_code(closure.template.bytecode.clone(), jc.clone());
                         jc
                     }
                     Err(e) => {


### PR DESCRIPTION
Fixes #911: the macOS corpus segfaults and the flaky wrong-value errors
were one mechanism — a stale JIT code-cache key, not memory corruption.

## Root cause

`jit_cache`, `jit_pending`, and `jit_rejections` keyed entries by the raw
address of a template's bytecode allocation. Templates are region-reclaimed,
so a dropped compile unit frees its bytecode buffers, and a later compile
can allocate a **different** function's bytecode at a reused address. A
surviving cache entry then dispatches the old function's compiled code with
the new closure's env and args. Nothing in memory is ever corrupt — the
wrong body runs on healthy values — which is why park traces, guardfree,
and scrub all came back clean.

Caught in the act on macOS by a content tripwire: cached code for
portrait.lisp's `false-mutable-advisories [analysis]` dispatched for
rdf/elle.lisp's `emit-signal`, so `(compile/diagnostics analysis)` ran with
`analysis := buf` (an `@string`) — exactly the observed
"compile/diagnostics: expected analysis handle, got @string" at
elle.lisp:100:5. The platform skew was allocator address-reuse timing, not
architecture: Linux x86_64 reproduced it under `--trace=syncjit`.

## Fix

Every cache/pending/rejection entry now pins the bytecode `Rc` it is keyed
by, from submission until the entry is removed. A pinned allocation cannot
be freed, so its keyed address cannot be reused while the entry lives.
Writes go through `install_jit_code` / `record_jit_pending`; reads through
`jit_code_for`. A worker result whose pending pin is gone is dropped
instead of installed. Design notes: docs/impl/jit.md § "Cache identity".

## Also in this PR

- Park/resume tripwires and the `--trace=park` lever (debug builds panic on
  malformed parked/resumed values; compile rejects yield-site metadata
  count mismatches).
- `--trace=syncjit`: compile on the VM thread instead of the worker — the
  first lever for suspected JIT races.
- Stale-doc corrections (JIT spill-buffer layout, `local_slot_to_var`,
  `current_closure` on JIT-built frames).

## Verification

- Counter-factual tests (`src/vm/jit_entry/tests.rs`): both failed before
  the pin, pass after.
- macOS lab, direct `--jit=eager` graph-bench x40: 12/40 failing before,
  0/40 after.
- macOS full lab: phase A (exact `make smoke` replica, previously always
  crashing) exit 0; phase B (whole corpus per-file) exit 0; zero `.ips`
  crash reports.
- `cargo test -p elle --lib`: 2181 pass.
