### PR TITLE
image: the persistence design and its de-risking experiments

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -91,6 +91,7 @@ make smoke                 # run all tests (~30s)
 | [spirv](docs/impl/spirv.md) | SPIR-V emission for GPU compute |
 | [gpu](docs/impl/gpu.md) | End-to-end GPU compute (Vulkan) |
 | [values](docs/impl/values.md) | Value representation, tagged union |
+| [image](docs/impl/image.md) | Image persistence design: boot image, environment save/load |
 
 ## Reference
 

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,18 @@
 fn main() {
+    // The compiling rustc's version string, baked in for the image
+    // fingerprint (docs/impl/image.md § "Fingerprint: regenerate, never
+    // migrate"): `HeapObject` is `repr(Rust)`, so an image is valid only for
+    // a binary whose compiler agrees with the dumper's layout decisions.
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+    let version = std::process::Command::new(&rustc)
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".into());
+    println!("cargo:rustc-env=ELLE_RUSTC={version}");
+
     // libgcc is only needed for libffi on Android (__clear_cache symbol).
     if std::env::var("CARGO_FEATURE_FFI").is_ok()
         && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("android")

--- a/docs/config.md
+++ b/docs/config.md
@@ -43,6 +43,7 @@ Available trace keywords:
 | `:regions` | Region inference and lifetime decisions |
 | `:anf` | A-normal form lift pass |
 | `:pages` | Region page allocation |
+| `:boot` | Boot-sequence timing: primitive registration, core, prelude, stdlib compile/execute (string-traced, no bit) |
 | `:free` | Region free diagnostics (string-traced, no bit) |
 | `:guardfree` | Guarded-free diagnostics (string-traced, no bit) |
 | `:freebt` | Free backtrace diagnostics (string-traced, no bit) |

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,6 +44,7 @@ Available trace keywords:
 | `:anf` | A-normal form lift pass |
 | `:pages` | Region page allocation |
 | `:boot` | Boot-sequence timing: primitive registration, core, prelude, stdlib compile/execute (string-traced, no bit) |
+| `:census` | Post-boot heap census: per-tag object counts and bytes, capture cells, pointer-slot density, unsealed variants (string-traced, no bit; see docs/impl/image.md § Sealing) |
 | `:free` | Region free diagnostics (string-traced, no bit) |
 | `:guardfree` | Guarded-free diagnostics (string-traced, no bit) |
 | `:freebt` | Free backtrace diagnostics (string-traced, no bit) |

--- a/docs/impl/image.md
+++ b/docs/impl/image.md
@@ -52,10 +52,10 @@ accounting, the generation checks, `--trace=scrub`, `--trace=guardfree`, and
 `arena/dump` all see ordinary pages in an ordinary region.
 
 Compaction is where the runtime win comes from. Stdlib boot today produces
-thousands of regions — one per letrec capture cell plus everything they pin.
-The image is **one** region: every internal reference is a self-edge, so its
-edge tables are empty, and all RC traffic against stdlib values lands on a
-single counter.
+hundreds of regions — one per letrec capture cell plus everything they pin
+(405 measured; risk item 2 records the census). The image is **one**
+region: every internal reference is a self-edge, so its edge tables are
+empty, and all RC traffic against stdlib values lands on a single counter.
 
 ## One mechanism, two configurations
 
@@ -101,7 +101,7 @@ environment-over-boot are simply the two depths this design ships.
   path that runs once.
 - **In-place capture of live regions.** Pages of a live heap are entangled
   with Rust-side state (`Rc` payloads, cursors, dtor lists) and fragmented
-  across thousands of regions. Dumping is the rare, slow operation; a
+  across hundreds of regions. Dumping is the rare, slow operation; a
   compacting copy buys a dense, sealed, single-region body.
 - **An immortal image store outside the region system.** Image values as
   permanently region-less foreign pointers would skip even the single
@@ -267,6 +267,16 @@ closures like `println` capture the `Parameter` object itself, so a
 re-evaluated `def` would mint a second parameter the captured references
 never see. Anything the dumper meets that is neither sealed nor
 reconstructible nor side-streamable fails the dump with a named binding.
+
+The **default trait tables** are the second reconstructible class, found by
+the census (risk item 2): every collection's `traits` field points at one of
+the instance's two default traitsets — `@struct`s built by
+`init_default_traits` at VM init, before any stdlib load or hydration. They
+are instance infrastructure, not program state, so the dumper never copies
+them: a `traits` slot aimed at a default traitset becomes a reconstruction
+entry whose constructor resolves the hydrating instance's own table for that
+tag. The tables exist before hydration by construction (VM-init order), so
+the constructor is a lookup, not an allocation.
 
 **Macros persist whole.** A manifest macro entry carries its parameter
 lists, its template syntax (a body value), and its transformer cache's body
@@ -532,12 +542,36 @@ wrong about. Run these before the foundations land, in this order:
    that ~38 ms floor and the 1.4 ms execute — roughly a 10× boot. Region
    inference alone is 44% of the stdlib compile, an independent
    optimization target for the fallback path.
-2. **Post-boot heap census.** The sealed-set and snapping claims describe a
-   graph nobody has enumerated. Walk today's process roots and histogram
-   `HeapObject` variants, count capture cells whose binding is assigned,
-   and measure bytes and pointer-slot density. This decides whether the
-   boot image is dumpable at all, sizes the file, and predicts the dirty
-   set.
+2. **Post-boot heap census — dispatched, sealing confirmed.**
+   `--trace=census` (landed with this experiment; pinned by
+   `tests/integration/census.rs`, whose sealing net fails the moment an
+   unsealed variant enters the boot graph) walks every live object in the
+   instance's region store after boot. A warm release boot leaves **405
+   regions**, **630 objects**, 1.62 MiB of committed region pages, and
+   ~455 KiB of estimated body payload:
+
+   | Tag | Count | Bytes | Heap-ptr slots | Slices |
+   |-----|-------|-------|----------------|--------|
+   | ClosureTemplate | 202 | 317,383 | 24 | 0 |
+   | Closure | 202 | 68,320 | 816 | 142 |
+   | CaptureCell | 210 | 63,840 | 205 | 0 |
+   | LStruct | 4 | 12,490 | 197 | 0 |
+   | Parameter | 7 | 2,016 | 3 | 0 |
+   | External | 3 | 864 | 0 | 0 |
+   | LStructMut | 2 | 748 | 3 | 0 |
+
+   The boot residue is code, not data: no pair, string, or array survives
+   to the post-boot heap. The 210 capture cells are the snapping set — the
+   static scan found zero top-level `assign`s in stdlib.lisp, so every
+   cell snaps. The unsealed leaves are exactly the reconstruction stream's
+   two classes: the three stdio-port `External`s and the two default
+   traitsets (§ "Process-owned resources reconstruct in place"); nothing
+   else in the graph is refused, so the boot image is dumpable. Relocation
+   load: 1,248 heap-pointer slots + 142 `RegionSlice` ptrs + 682
+   primitive slots ≈ 2,100 relocation entries, ~2.7 heap-pointer slots
+   per KiB of payload. `shared-templates 0`: every boot closure already
+   references a region-resident template object, so the template
+   foundation rewrites representation, not sharing structure.
 3. **The store spike** (already in the landing order): mapping, the pool
    flag, relocation, teardown, on data-only graphs.
 4. **Symbol-identity scout.** Audit the ~220 `SymbolId` sites for density

--- a/docs/impl/image.md
+++ b/docs/impl/image.md
@@ -212,9 +212,9 @@ conversion seams, double maintenance, and a standing invitation for the two
 to drift. The performance bar for the migration is **parity**: building and
 mutating syntax trees in regions must be comparably fast to the Rust-heap
 tree they replace, since expansion is compile-path-hot and the fallback
-compile pays it too. The boundary-only split is a last resort, considered
-only if measured parity proves unreachable and the regression is a
-deal-breaker.
+compile pays it too. Risk item 5 measured the bar and retired it: the
+prototype region tree beats the Rust-heap tree on every expansion-hot
+operation by 2–5×, so the boundary-only split is off the table.
 
 Hygiene scope ids minted by the expander remain process-local counters; the
 image records a scope watermark so a fresh expander mints above every scope
@@ -634,11 +634,53 @@ wrong about. Run these before the foundations land, in this order:
    verbatim, so worker-side JIT re-emission pools sender-space ids; and
    `TableKey::Symbol` keys inside sent structs cross untranslated. The
    symbol milestone must land regression tests for both.
-5. **Expander mutation parity.** The region-native syntax migration is
-   whole (see *Region-native syntax*), and its bar is parity with the
-   Rust-heap tree it replaces. Benchmark expansion-heavy compiles on a
-   prototype before committing the full migration; the boundary-only split
-   exists only as a last resort behind a measured deal-breaker.
+5. **Expander mutation parity — dispatched, parity exceeded.** A throwaway
+   prototype node ran the expander's hot operations head to head against
+   the Rust-heap tree, allocating through the real region store
+   (`FiberHeap::alloc_region_slice_in_region`). The node is 56 bytes to
+   `Syntax`'s 112: kind tag, packed span over an interned file id, scope
+   set inline (capacity 4 plus an overflow slice), string payloads and
+   child slices as `RegionSlice`, symbols as stable hashes (the symbol
+   foundation lands first). Corpus: the parsed prelude + stdlib trees
+   (230 forms, 13,332 nodes), 20 rounds per op, in-place walks mutating
+   uniquely owned trees through the child slices:
+
+   | Per node | Rust-heap tree | Region tree |
+   |----------|----------------|-------------|
+   | stamp-copy (macro-arg clone + add-scope walk) | 176 ns | 37 ns |
+   | hygiene flip walk, in place | 40 ns | 17 ns |
+   | file-scope add walk, in place | 31 ns | 13 ns |
+   | build + drop (the `from_value` shape) | 73 ns | 17 ns |
+   | teardown | 31 ns | 7 ns |
+
+   Region mint + free measures ~6 ns, so per-expansion transient regions
+   are noise. The no-inline-capacity fallback — regrow the scope slice on
+   every add — costs 8 ns per visit, so scope storage is not a parity risk
+   in either form. The op mix is measured, not assumed: counters on
+   `Syntax::clone`, the constructors, `map_scope_recursive`, and the
+   converters (dumped at the `--trace=compile` expand/analyze marks)
+   showed the stdlib expand phase (84.5 ms warm release) deep-clones
+   **464,089** nodes against 46,746 built and 24,718 from `from_value`,
+   across 1,532 expansions; analysis clones another 143,298. A 300-defn
+   macro-heavy user file amplified the same shape: 992,170 clones in a
+   206 ms expand, ~254 clones per expansion — a large share being the
+   per-call `MacroDef` template deep clone, which pointer-shared immutable
+   region trees delete outright. perf agrees: `Syntax::clone` +
+   `drop_in_place<Syntax>` is ~10% of the whole boot. Scope sets are tiny
+   everywhere: every one of the ~430k measured scope ops ended with ≤3
+   scopes. Counts × per-op deltas put tree ops near half of an
+   expansion-heavy expand phase and ~4× cheaper in regions, so the
+   migration is projected to make expansion-heavy compiles roughly a
+   third *faster* — and even a fully immutable working tree meets the
+   bar, since a full stamp-copy (37 ns) undercuts the Rust tree's
+   in-place walk (40 ns). The boundary-only split is dead; no measured
+   deal-breaker exists. One condition binds the migration: keep in-place
+   mutation legal on uniquely owned working trees (stamped copies and
+   conversion results — the ownership discipline the hygiene flip already
+   relies on). To redo: counter patch at the sites above, plus a
+   `#[cfg(test)]` bench under `src/syntax/expand/` building the prototype
+   node from `read_syntax_all` output and running stamp/flip/add/build/
+   teardown against `stamp_scope`/`flip_scope_recursive`.
 6. **Fingerprint strength.** Size/align probes do not pin field offsets.
    Record `offset_of!` for every field of every sealed variant, so the
    two-stage embed build cannot pass the fingerprint with a shifted layout.

--- a/docs/impl/image.md
+++ b/docs/impl/image.md
@@ -1,0 +1,626 @@
+# Images — regions hydrated at load
+
+Design for image-style persistence. One mechanism with two shipped
+configurations: the **boot** image (core, prelude, and stdlib pre-compiled
+into the binary) and **environment** images (user `save`/`load`) — the same
+format, dumper, and hydrator throughout, differing only in dependency list
+and dump policy (see *One mechanism, two configurations*). This doc owns the
+design argument. Nothing here is implemented yet; the test plan at the end
+names the pins each milestone must land with.
+
+## The problem
+
+Every process start compiles core.lisp, prelude.lisp, and stdlib.lisp — about
+3700 lines — through the full pipeline: read, expand, letrec analysis,
+regularize, type inference, region inference, lower, emit, execute. Every
+`sys/spawn` worker repeats it on its own heap. The WASM entry repeats it too.
+Nothing persists between runs.
+
+A REPL or embedding session that builds up an environment loses it on exit.
+The only durable stores are files and RDF; there is no way to save compiled
+state.
+
+## The idea: an image is a region, dumped and hydrated
+
+An image is the page-level bytes of one real region — a compacted, sealed
+copy of a value graph — plus a relocation table, name tables, and a manifest.
+*Hydration* (loading) is:
+
+1. map the image's pages privately into an aligned reservation — they become
+   the pages of a freshly minted region,
+2. one linear pass over the relocation table: rewrite each pointer slot to
+   its target's new page address; remap primitive ids by name when the
+   registry differs,
+3. stamp each page header with the minted region id and the store's stamp,
+   and rebuild the region's Rust-side lists (`dtors`, `ref_objs`, cursors)
+   from the object index,
+4. register the region as a process root and install the manifest's bindings
+   into `PrimitiveMeta` and the expander.
+
+No value is deserialized, nothing allocates per object, and untouched pages
+are not even read: cost is O(relocations) + O(objects) pointer pushes +
+O(bindings), with the bulk of the bytes faulting in lazily on first use —
+page speed, not serde speed.
+
+The hydrated region is not a new kind of memory. It is a `Counted` region
+like any other: pinned for the process's life by the same process-root
+registration that pins stdlib's exports today, released by
+`teardown_process_root_regions` at exit, and freed by the ordinary cascade.
+The lifetime guarantee in [regions/lifetime.md](../regions/lifetime.md) —
+after the program ends, everything frees — holds without amendment. Leak
+accounting, the generation checks, `--trace=scrub`, `--trace=guardfree`, and
+`arena/dump` all see ordinary pages in an ordinary region.
+
+Compaction is where the runtime win comes from. Stdlib boot today produces
+thousands of regions — one per letrec capture cell plus everything they pin.
+The image is **one** region: every internal reference is a self-edge, so its
+edge tables are empty, and all RC traffic against stdlib values lands on a
+single counter.
+
+## One mechanism, two configurations
+
+"Boot image" and "environment image" are not two kinds of image. There is
+one format, one dumper, one hydrator, one verifier. Every use of either
+name in this doc means a *configuration* of that one mechanism; an image
+differs from another only in its **dependency list** and its **dump
+policy**:
+
+- Every image declares the fingerprints of the images beneath it. A dump
+  walks its roots and stops at any value a dependency layer already
+  provides, emitting a cross-image reference instead of a copy — the
+  visited map is seeded with the dependency regions' address intervals. The
+  root set of a dump is therefore always the same thing: *the bindings the
+  layers below do not already provide*.
+- The **boot** configuration is the image with an empty dependency list:
+  its roots are the boot bindings (stdlib exports, module closure, core
+  exports, macro definitions, meta tables, inline-fn syntax), its policy is
+  strict — no mutable bindings, in body or side-stream — and it is
+  distributed by the warm cache or the embedded blob, regenerated from
+  sources whenever the fingerprint misses.
+- The **environment** configuration depends on a boot image: its roots are
+  the session's bindings beyond that layer, its policy is user-facing
+  (refuse mutables by default, `&allow-mutable` opt-in), and it is a file
+  the user saves and loads explicitly — binary-locked user data, not a
+  regenerable artifact.
+
+Nothing limits the stack to two layers; an image may depend on any hydrated
+stack whose fingerprints it names. Boot-over-nothing and
+environment-over-boot are simply the two depths this design ships.
+
+## Rejected alternatives
+
+- **CAS cache over a serialized code object** (a byte codec on the `send`
+  types). Load re-allocates every object, re-interns every symbol, and
+  rebuilds every `Rc` — O(objects) allocator and decode work on every start,
+  and the measured shape confirms it: deserialization dominates the cache-hit
+  path. The content-addressed *keying* survives in this design (the
+  warm-cache path below); the per-value decode does not.
+- **Position-independent (offset-based) pointers in the runtime
+  representation.** Zero-fixup load, but every deref pays the add forever.
+  The region system's point is raw-pointer deref; do not tax it for a load
+  path that runs once.
+- **In-place capture of live regions.** Pages of a live heap are entangled
+  with Rust-side state (`Rc` payloads, cursors, dtor lists) and fragmented
+  across thousands of regions. Dumping is the rare, slow operation; a
+  compacting copy buys a dense, sealed, single-region body.
+- **An immortal image store outside the region system.** Image values as
+  permanently region-less foreign pointers would skip even the single
+  counter and would let many stores share one mapping. But it is a second
+  memory class: the leak suite, the freelog guard, the debug asserts, and
+  the lifetime guarantee would each need a carve-out, and reclamation would
+  gain a second mechanism beside region RC. Hydration keeps one mechanism;
+  each store maps the image privately, and the clean pages are shared
+  through the page cache anyway.
+- **A copy-based hydrator** (claim pool pages, `memcpy` the image in). It
+  would work with no pool changes, but it is a second implementation beside
+  the mapped one, and its existence would let unmappable assumptions creep
+  into the format and the runtime unnoticed. Mapping is the only hydrator;
+  its input is a mappable descriptor, and every source provides one — the
+  warm-cache file, an environment-image file, the executable itself for the
+  embedded blob, and an anonymous memory file for an image that arrives as
+  bytes (below). This holds even if relocation dirties enough frames that
+  mapping's cost approaches a copy's: one implementation, kernel-enforced
+  immutability, and a clean set that grows as the layout improves beat a
+  second code path at equal cost.
+- **A constant-pool region owned by the code object** is still rejected for
+  ordinary constants ([region/model.md](region/model.md)); images do not
+  change constant materialization. `MaterializeConst` keeps building fresh
+  values per execution — image templates carry the same encoded
+  `ConstTemplate` bytes, which are already name-stable.
+
+## Foundations
+
+The image effort does not start with images. Four representation fixes come
+first. Each is independently valuable at runtime today, lands green against
+the existing corpus with no image machinery, and **deletes** image machinery
+that would otherwise have to be built and then thrown away. Building the
+image first would mean shipping remap passes, re-sort passes, and a syntax
+codec whose only purpose is to compensate for representations we intend to
+fix anyway.
+
+### Stable symbol identity
+
+`SymbolId` is a dense per-table index minted in first-intern order — a
+process-local accident. Everything downstream compensates: every code object
+carries a `symbol_names` map for cross-table remap, `send` re-interns by
+name, `CompileCtx` leans on a fragile "registration order is deterministic"
+invariant, and — the sharpest edge — immutable structs and sets are *sorted
+arrays* whose order (`TableKey`/`Value` compare symbols by raw id) is
+process-local, so a persisted sorted container is correct only where it was
+built.
+
+The fix is the identity model keywords already use: the id is a 64-bit
+FNV-1a hash of the name, stable across tables, processes, and builds, with a
+global hash→name registry for display and a collision panic. Then symbol
+values are as portable as keyword values; sort orders are stable by
+construction; the image needs no symbol remap pass, no re-sort pass, no
+symbol watermark; templates lose their `symbol_names` maps; `send` stops
+re-interning; the `CompileCtx` ordering invariant dissolves.
+
+Migration notes: `SymbolId(u32)` widens to `u64` (the `Value` payload
+already is one); the `SYNTHETIC` sentinel survives as a reserved hash;
+bytecode operand widths at symbol sites must be audited; struct and set
+iteration order changes from intern-order to hash-order — deterministic, but
+print-order test expectations churn once.
+
+### Region-native immutable structs
+
+`LStruct` holds `Vec<(TableKey, Value)>` and `TableKey::String` owns a
+`String`. Move the payload to `RegionSlice<(TableKey, Value)>` with string
+keys inline in the region, as arrays and strings already do. Payoff now:
+immutable structs stop allocating on the Rust heap. Payoff for images:
+structs become body data.
+
+### Region-native closure templates
+
+`ClosureTemplate` is ~20 `Rc`/`Vec` fields. [region/model.md](region/model.md)
+already specifies the target: a region-resident template whose bytecode is an
+inline `RegionSlice<u8>`. Flatten every field: constants as
+`RegionSlice<Value>`, masks and release tables as inline slices, the location
+map as a sorted `RegionSlice<(u32, PackedLoc)>` over an interned file table,
+`child_protos` as `RegionSlice<Value>` of sibling templates, name and doc as
+region strings (`symbol_names` is gone per the above). Payoff now:
+`MakeClosure` clones the blueprint — ~20 `Rc` bumps per closure creation —
+into the instance region; a flattened template is referenced, not cloned.
+Payoff for images: code objects become body data.
+
+### Region-native syntax
+
+Syntax is load-bearing for images, not a reconstruction nicety: a macro *is*
+its template (`MacroDef.template: Syntax` plus parameter lists; the compiled
+transformer is a lazily filled cache), so the expander cannot be rebuilt
+without syntax. Today `Syntax` is a Rust-heap `Box` tree, which would force a
+side-stream codec (an extended `SendSyntax`) and a lazy-decode seam — a
+serializer whose entire job is to work around the representation.
+
+Make syntax a region-native immutable tree instead: nodes and child slices
+inline in region pages, spans and hygiene scopes as plain fields. This is
+the largest foundation — it touches the expander's core type — but it pays
+three times: syntax objects become ordinary sealed values (macro templates,
+closure syntax, and inline-fn syntax are just body data, demand-paged like
+everything else); `send` gets real syntax support, fixing its
+syntax-dropping defect at the root rather than at a boundary; and the
+`SyntaxLiteral` case (post-expansion syntax embedding a value) becomes an
+ordinary child `Value` instead of an unencodable special case.
+
+The migration is whole, not boundary-only: the expander's working tree
+moves too. Keeping a mutable Rust tree in the compiler and a region-native
+form at the value boundary would mean two representations of one datum —
+conversion seams, double maintenance, and a standing invitation for the two
+to drift. The performance bar for the migration is **parity**: building and
+mutating syntax trees in regions must be comparably fast to the Rust-heap
+tree they replace, since expansion is compile-path-hot and the fallback
+compile pays it too. The boundary-only split is a last resort, considered
+only if measured parity proves unreachable and the regression is a
+deal-breaker.
+
+Hygiene scope ids minted by the expander remain process-local counters; the
+image records a scope watermark so a fresh expander mints above every scope
+baked into persisted syntax.
+
+## Sealing
+
+After the foundations, the body may contain only *sealed* heap objects:
+byte-self-contained, pointing only into this image (or an image it depends
+on), and free of Rust heap ownership (no `Rc`, `Vec`, `Box`, or `RefCell`
+inside) — page bytes must *be* the object. Sealed objects have no real
+destructors, so the hydrated region's teardown drops are no-ops by
+construction.
+
+Sealed and portable after the foundations: `Pair`, `LString`, `LArray`,
+`LBytes`, `LSet`, `LStruct`, `Syntax`, closure templates, closure instances
+(env is an inline `RegionSlice<Value>`), keywords and symbols (payloads are
+stable name hashes), native-fns (dense `prim_id`, remapped by name), ints
+and floats, `Parameter`.
+
+**Capture cells are snapped, not persisted.** The stdlib file-letrec
+allocates one `CaptureCell` (`Rc<RefCell<Value>>`) per captured top-level
+binding. After the letrec fixpoint completes, a cell whose binding is never
+`assign`ed again holds its final value; the dumper rewrites each closure env
+to reference that value directly. The compiler knows which top-level
+bindings are assigned anywhere in the file; the dumper refuses to snap
+those. The boot image requires stdlib to have no post-boot-mutable
+top-levels — a property the dump step enforces, and a reasonable one to
+demand of a standard library.
+
+Refused from the body outright: every mutable variant, `LBox`, `Fiber`,
+thread and library handles, ports, externals, FFI signatures, managed
+pointers. Mutable *bindings* may still be persisted through the side-stream
+(below) where the image's dump policy permits it — the environment policy
+does, opt-in; the strict boot policy does not. The `spirv` kernel cache is
+the one true drop: the GPU path recompiles.
+
+**Process-owned resources reconstruct in place.** The boot graph is not
+fully pure: stdlib defines `*stdin*`/`*stdout*`/`*stderr*` as dynamic
+parameters, and a `Parameter` heap object — itself sealed POD
+(`{id, default, traits}`) — holds as its *default* an `External` wrapping
+the stdio port. `send` already made the semantic call for this case: a
+stdio port is reconstructed fresh on the receiving side, never carried.
+The image does the same via the **reconstruction stream**: (slot location,
+constructor tag) entries emitted by the dumper wherever it meets a
+reconstructible resource. Hydration runs each constructor, allocates the
+fresh value into a companion region (an ordinary region whose edge from the
+hydrated region is recorded, so the teardown cascade releases it), and
+writes the pointer into the listed slot — a handful of dirtied frames.
+Reconstruction must be in place, not re-evaluation of the defining forms:
+closures like `println` capture the `Parameter` object itself, so a
+re-evaluated `def` would mint a second parameter the captured references
+never see. Anything the dumper meets that is neither sealed nor
+reconstructible nor side-streamable fails the dump with a named binding.
+
+**Macros persist whole.** A manifest macro entry carries its parameter
+lists, its template syntax (a body value), and its transformer cache's body
+location. The filled caches — ordinary closures — hydrate without
+recompiling, preserving the hygiene property the lazy fill exists for: the
+persisted transformer is the one compiled in a real expansion context,
+which is exactly what later compiles reuse in a source boot. A cache the
+boot never filled stays empty and fills lazily as today.
+
+## Compiler state is part of the environment
+
+The heap is not the whole boot product. Compiling stdlib also fills
+compile-side registries on `CompileCtx` that later user compiles read:
+
+- `FnInlineRegistry` — per-name HIR templates of cross-unit-inlineable
+  stdlib functions; user code inlines through it.
+- `DispatchWrapperRegistry` and the signal-projection memo.
+
+An image boot that leaves these empty compiles user code *differently* from
+a source boot — silently worse code, and divergent artifacts for anything
+keyed on compiler output. That is not acceptable: the two boot modes must
+produce identical user-code compiles.
+
+With region-native syntax the fix is small: the manifest records each
+inlineable function's *syntax* as a body value, and the registry re-derives
+the HIR template lazily (expand + analyze of one small form) the first time
+a user compile asks for that name. The parity test below is the acceptance
+gate, and it belongs to the **boot** milestone, not a follow-up.
+
+## File format
+
+One image is one file (or one embedded blob):
+
+| Section | Content |
+|---------|---------|
+| header | magic, format version, fingerprint, section offsets, page count |
+| pages | the dumped region's pages in order: size class + body bytes per page; each page's bytes start at a 4 KiB-aligned file offset (padding between pages), so the section is mappable |
+| relocations | pointer stream: (slot page, slot offset, target segment, target page, target offset); primitive stream: (slot page, slot offset); reconstruction stream: (slot page, slot offset, constructor tag) |
+| object index | (page, offset, tag) per heap object, sorted — rebuilds `dtors`/`ref_objs`/cursors and drives the verifier |
+| primitive table | primitive names in dump-time `prim_id` order |
+| name table | symbol and keyword names in the body — hashes are stable, but the process-global hash→name display registries must learn them |
+| signal table | user-defined signal names in dump-time bit order |
+| watermarks | dump-time counters: parameter id, static-region mint, hygiene scope id, next signal bit |
+| manifest | bindings: name, kind (function / macro / core), value location, signal, arity, doc location; macro entries add parameter lists, template-syntax and transformer-cache locations; inline-fn syntax locations; plus root locations and dependency fingerprints |
+| side-stream | typed streams, present in any image: encoded `LirFunction`s keyed by template location (the boot configuration requires this stream — see *JIT*); `SendValue`-encoded mutable bindings (present only where the dump policy permits mutables) |
+
+**Relocation slots.** A pointer slot is any 8-byte field holding an absolute
+address: a heap-tagged `Value`'s payload, a `RegionSlice`'s ptr. A primitive
+slot is a `Value` with `TAG_NATIVE_FN`, remapped by name — and a name
+missing from the live registry is minted on the spot from its static def
+(trait-method handlers are appended to the registry on first use, so a dump
+can hold ids the fresh process has not minted yet). Symbol and keyword
+payloads are stable hashes and need no relocation. The dumper emits each
+entry as it copies the object — it knows every variant's layout, so there is
+no post-hoc discovery, and targets are (page, offset) pairs so hydration
+rewrites each slot in O(1) with no address search.
+
+**Static region slots** baked into bytecode operands are opaque per-function
+keys; they collide harmlessly across functions. The loader bumps the global
+mint counter past the image watermark anyway, so uniqueness diagnostics stay
+truthful. Parameter ids, hygiene scopes, and signal bits get the same
+watermark treatment.
+
+## Fingerprint: regenerate, never migrate
+
+`HeapObject` is `repr(Rust)`; opcode discriminants and `prim_id`s are
+source-order-dependent. An image is therefore valid only for a binary whose
+layout agrees with the dumper's. The fingerprint records: format version,
+rustc version and target triple, `size_of`/`align_of` for `Value`,
+`HeapObject`, `RegionSlice`, `Closure`, `ClosureTemplate`, and `TableKey`, the
+instruction-set high-water mark, `CURRENT_EPOCH`, the feature set, a hash of
+the primitive name list in registration order, and (for the boot
+configuration) the hashes of the three sources.
+
+On mismatch the loader falls back — the `include_str!` sources never go away,
+so the image is an optimization, not a correctness dependency. Images are
+regenerated, not migrated; epochs stay a source-level concept. An environment
+image is binary-locked: durable cross-version data belongs in files or RDF,
+and the manifest is designed so a tool running the *old* binary can export
+bindings as source. State that limit to users rather than promising
+migration.
+
+## Hydration
+
+1. Validate the fingerprint; on failure, fall back (boot: compile sources;
+   environment: report the mismatch).
+2. Register the name table in the symbol and keyword display registries.
+   Replay the signal table so user signal bits land where the dump minted
+   them. Check the primitive table against the live registry.
+3. Mint a region and map the page section: reserve an aligned `PROT_NONE`
+   range, then `MAP_FIXED` + `MAP_PRIVATE` each dumped page from the file
+   into its slot. The section's 4 KiB file alignment makes the offsets
+   legal; the reservation gives each page the self-alignment the
+   masked-header walk requires. The pages enter the region flagged
+   **file-backed**: the pool neither caches nor recycles such a page, and
+   its release is `munmap`. Generations, scrub's `memset`, and guardfree's
+   `mprotect` operate on mappings unchanged.
+4. Run the relocation passes: rewrite pointer slots to
+   `new_page_base + offset`; remap primitive payloads when the registry
+   differs; run the reconstruction stream's constructors and write the
+   fresh values' addresses into their slots. One linear pass; each write
+   copy-on-write faults its 4 KiB frame private.
+5. Stamp each page header; rebuild `dtors`, `ref_objs`, cursors, and
+   `obj_count` from the object index.
+6. Register the region as a process root; bump the watermark counters.
+7. Rebuild `PrimitiveMeta` maps, expander macros, and `core_env` from the
+   manifest — hundreds of entries, microseconds.
+8. Decode side-stream mutable bindings (present only when the dump policy
+   permitted them) through the existing `SendValue` deserializer into
+   ordinary regions, rooted like REPL bindings. The LIR stream is not
+   decoded here at all — it decodes lazily, per function, on JIT promotion.
+
+An environment image hydrates on top of a boot image and relocates its
+cross-image slots against the boot region's hydrated pages. References
+between the two hydrated regions are ordinary counted cross-region edges,
+recorded during relocation; the environment region's `outgoing` table names
+the boot region, nothing else.
+
+Workers hydrate their own mapping: a region belongs to one `RegionStore`,
+so each `sys/spawn` worker runs steps 3–8 against the same image file
+instead of `init_stdlib` — a private mapping per worker, not a compile,
+with the clean pages shared between them in the page cache. The WASM
+entry's *host-side* runtime hydrates the same way, but the WASM module
+itself still splices stdlib source into the compiled unit; fixing that tier
+is the separate stdlib-module work described in [wasm.md](wasm.md), not
+this design.
+
+**The hydrator's input is `(fd, offset)`,** never a path. A path source is
+opened first; the embedded blob maps from the executable's descriptor; an
+image that arrives as bytes — over the network, from Redis, from a channel —
+is written into an anonymous memory file (`memfd_create`; `shm_open` on
+macOS) and hydrated from that descriptor without touching a filesystem. On
+Linux the memfd is write-sealed (`F_SEAL_WRITE | F_SEAL_SHRINK`) before
+mapping, so the immutability the mapping relies on is kernel-enforced.
+
+**Never rewrite an image file in place.** The atomic temp-file-and-rename
+discipline is what keeps a mapped old inode stable while a new image
+replaces the path; `MAP_PRIVATE` over a file mutated in place is
+unspecified. A sealed memfd is immune by construction.
+
+**An image is code — trust it like a shared library.** Hydration installs
+raw memory and executes whatever the templates say; the verifier
+bounds-checks pointers and tags, but it is a drift detector, not a sandbox.
+Hydrate only images from sources you would `dlopen`. A network-retrieved
+image deserves the same policy as a network-retrieved `.so`.
+
+**Pointer resolution must not regress.** Resolving a pointer to its region
+(`region_of_ptr`) is a probe ladder — mask the address to each size-class
+base, test the 16-byte header, then confirm with `RegionPool::owns`, a
+linear scan of the region's page list. Today's regions are one or two
+pages, so both steps are cheap. A single region holding all of stdlib
+breaks both assumptions: a pointer into a large page fails every smaller
+class's header probe first (each a likely cache miss into arbitrary image
+bytes), and the owns scan walks the whole page list. Since resolution runs
+on the RC hot path — every escape incref and edge record of a stdlib value
+— that is a per-operation regression, not a curiosity.
+
+The mapped layout dissolves it: a hydrated region is **one contiguous
+address interval by construction** (the aligned reservation of step 3).
+`region_of_ptr` consults a per-store table of hydrated-region intervals —
+one or two entries, two compares each — before the probe ladder, and
+`owns` for a hydrated region is the same range check. Image pointers never
+enter the ladder at all. Page headers stay, stamped for uniformity and
+diagnostics, but resolution does not depend on them — which also argues for
+large image pages: each stamped header copy-on-write dirties its 4 KiB
+frame, so fewer, larger pages keep the clean set large.
+
+**The clean set is the currency.** Relocation copy-on-write dirties every
+4 KiB frame that holds a pointer slot or a page-header stamp; those frames
+pay a fault and a private copy. Frames with no relocations — bytecode,
+strings, syntax, docs, name tables — stay clean: they fault in lazily
+(functions never executed are never read from disk), every process mapping
+the image shares them, and under memory pressure they are evictable rather
+than swappable. The dumper therefore routes byte payloads
+(`RegionSlice<u8>`) to dedicated data pages and keeps object shells and
+`Value` slices on separate pages, maximizing the clean set.
+
+## Dumping
+
+The dumper is a compacting copy into a real region. It allocates a fresh
+scratch region and walks the root set with a visited map keyed on payload
+address (cycles and sharing preserved — unlike `send`, which copies shared
+plain data per edge), building sealed forms through the ordinary arena API:
+cells snapped, strings and file names interned. Every internal reference is
+a self-edge by construction. It records a relocation entry per pointer slot
+as it writes, then dumps the scratch region's pages verbatim and drops the
+region. Unsupported values fail the dump with an error naming the binding.
+
+The root set is defined once, in *One mechanism, two configurations*: the
+bindings the dependency stack does not already provide. For the boot
+configuration that is everything boot pins as process roots today; for an
+environment dump it is the session's delta.
+
+Dump determinism is engineered, not assumed: the walk visits roots and
+children in sorted order and never iterates a hash map, so the same graph
+always yields byte-identical output. That is what lets the warm-cache path
+key the artifact content-addressably and lets concurrent dumpers race
+harmlessly through the atomic rename.
+
+Mutable bindings are the dump-policy fork. The strict policy (boot) fails
+the dump, naming the binding. The environment policy defaults to the same
+refusal with a `deep-freeze` suggestion, and `&allow-mutable` opts into
+encoding via the side-stream, rebuilt as fresh mutables at load. The
+manifest's per-binding kind field makes the opt-in mode additive.
+
+## JIT
+
+The JIT compiles from `lir_function`, which is Rust-heap LIR and cannot live
+in the body. Every image stores an encoded `LirFunction` per template in the
+side-stream, decoded lazily the first time the hotness counter promotes that
+function — so decode fees are paid once, only for hot code. `jit_cache` keys
+on the bytecode address, which is stable for the hydrated region's life.
+Machine code itself is never persisted: Cranelift output bakes absolute
+addresses and is not relocatable.
+
+The LIR stream is not optional for the boot configuration. An image boot
+whose stdlib cannot reach the JIT tier trades startup for steady-state
+throughput — a deal-breaker, and a violation of the parity principle: the
+two boot modes must be indistinguishable to running code, tiers included.
+The stream ships inside the **boot** milestone, and tier parity is part of
+its acceptance gate.
+
+## Build integration
+
+- **Warm cache (default, no build changes):** when no valid boot image is
+  available, boot compiles from source as today, then dumps
+  `$ELLE_CACHE/boot/<fingerprint>.image` (written atomically: temp file,
+  rename). Subsequent starts hydrate it. Development builds get fast starts
+  from the second run onward.
+- **Embedded (release):** a Makefile stage builds `elle`, runs
+  `elle image dump-boot`, and rebuilds with the blob embedded (path passed
+  by env var; `build.rs` declares the rerun-if). The blob is embedded
+  4 KiB-aligned — an `include_bytes!` behind a `#[repr(align(4096))]`
+  wrapper keeps its virtual address aligned, and load-segment congruence
+  makes its file offset aligned too — so hydration maps it straight from
+  the executable's own file, with the offset recovered from the static's
+  address and the segment table (`dl_iterate_phdr`; the Mach-O load
+  commands on macOS). Embedding changes the binary but not the fingerprint
+  — every fingerprint input is computed from layout probes and sources, not
+  from the binary hash — so the two-stage build converges in one iteration.
+
+## Verifier
+
+A debug verifier walks the object index after hydration and asserts sealing:
+every tag is in the sealed set, every pointer slot targets this image or a
+declared dependency, every `RegionSlice` is in bounds, and the rebuilt
+cursors agree with the index. Format drift then fails loudly at load, not as
+a torn read later.
+
+## Open risks and dispatch experiments
+
+The design rests on assumptions that are cheap to test and expensive to be
+wrong about. Run these before the foundations land, in this order:
+
+1. **Boot-time attribution — dispatched, value proposition confirmed.**
+   `--trace=boot,compile` (landed with this design; pinned by
+   `tests/integration/trace_boot.rs`) attributes a warm release-build boot
+   of a trivial script (~545 ms total): stdlib frontend compile ~494 ms
+   (91%), of which region inference ~216 ms, expand ~95 ms, analyze
+   ~75 ms, emit ~74 ms, lower ~18 ms; core ~8 ms; prelude, registration,
+   and meta build ~2 ms combined; stdlib *execute* ~1.4 ms; ~38 ms of
+   process/VM setup and teardown remain. The image removes everything but
+   that ~38 ms floor and the 1.4 ms execute — roughly a 10× boot. Region
+   inference alone is 44% of the stdlib compile, an independent
+   optimization target for the fallback path.
+2. **Post-boot heap census.** The sealed-set and snapping claims describe a
+   graph nobody has enumerated. Walk today's process roots and histogram
+   `HeapObject` variants, count capture cells whose binding is assigned,
+   and measure bytes and pointer-slot density. This decides whether the
+   boot image is dumpable at all, sizes the file, and predicts the dirty
+   set.
+3. **The store spike** (already in the landing order): mapping, the pool
+   flag, relocation, teardown, on data-only graphs.
+4. **Symbol-identity scout.** Audit the ~220 `SymbolId` sites for density
+   assumptions (`as usize` indexing beyond `SymbolTable`), prototype the
+   hash id, and measure the struct-sort and print-order fallout.
+5. **Expander mutation parity.** The region-native syntax migration is
+   whole (see *Region-native syntax*), and its bar is parity with the
+   Rust-heap tree it replaces. Benchmark expansion-heavy compiles on a
+   prototype before committing the full migration; the boundary-only split
+   exists only as a last resort behind a measured deal-breaker.
+6. **Fingerprint strength.** Size/align probes do not pin field offsets.
+   Record `offset_of!` for every field of every sealed variant, so the
+   two-stage embed build cannot pass the fingerprint with a shifted layout.
+
+## Landing order
+
+Foundations first — each lands green on the existing corpus with no image
+code, and each deletes image machinery:
+
+1. **symbol** — stable content-addressed symbol identity; deletes the
+   symbol remap pass, the sorted-container re-sort hazard, `symbol_names`
+   maps, and `send`'s re-interning.
+2. **struct** — region-native immutable struct payloads.
+3. **template** — the flattened, region-resident `ClosureTemplate`;
+   `MakeClosure` references instead of clones.
+4. **syntax** — the region-native syntax tree; deletes the syntax codec and
+   fixes `send`'s syntax defect at the root.
+
+Then the image milestones:
+
+5. **store** — the file-backed page flag in the pool, then dumper/hydrator
+   for data-only graphs (no closures), the object-index rebuild, and the
+   fingerprint fallback. Proves the format, mapping, relocation, and
+   teardown end to end. The mechanism here is independent of the
+   foundations — pairs, strings, and arrays are already sealed — so a
+   deliberately small spike of this milestone may run in parallel with them
+   to retire the mapping and pool-interplay risk early; it must not grow
+   compensating machinery (remap passes, codecs) that the foundations
+   delete.
+6. **boot** — cell snapping, dump-boot, warm cache, embedded blob,
+   per-worker hydration for `sys/spawn`, the encoded-LIR side-stream with
+   lazy decode, compiler-state persistence, and the parity gate (bytecode
+   *and* tier).
+7. **environment** — `image/save` and `image/load`, manifest deltas over
+   boot, mutable side-stream.
+
+## Test plan
+
+- Foundations: existing corpus plus targeted unit tests pinning the new
+  layouts, the no-clone `MakeClosure`, stable symbol ordering across two
+  tables, and syntax round-trips through `send`.
+- Round-trip: dump a data graph, hydrate in a fresh runtime, assert
+  structural equality — and a counter-factual load with a corrupted
+  fingerprint falls back cleanly.
+- Hygiene: hydrate, run, exit — the live region count returns to baseline
+  and the leak suite stays green with no image-specific carve-out. Free the
+  hydrated region explicitly under `--trace=guardfree` and assert the
+  cascade releases its cross-image edges exactly once.
+- Relocation: hydrate the same image twice in one process (two regions, two
+  address sets) and assert both hydrations are correct and independent.
+- Mapping: replace the image file by rename while a hydration is live, then
+  read the hydrated values — the old inode's mapping is intact. Release a
+  file-backed page and assert the pool unmapped it rather than caching it.
+  Run scrub and guardfree over a hydrated region.
+- Snapping: boot from image, run the full smoke corpus — behavior identical
+  to source boot. A stdlib top-level that is `assign`ed must fail the dump
+  with a named error.
+- Compile parity: compile the same user file under image boot and source
+  boot and assert byte-identical bytecode — the acceptance gate for the
+  persisted compiler state (inline templates, dispatch wrappers).
+- Tier parity: a hot stdlib function reaches the JIT under image boot
+  exactly as under source boot — the lazy LIR decode feeds `submit_jit_task`
+  and the compiled result executes.
+- Names: print an image keyword and an image symbol (the display registries
+  learned them) and raise an image-defined signal (the replayed bit matches
+  the baked profile).
+- Macros: a macro whose transformer cache was empty at dump expands
+  correctly after hydration (the lazy fill still works).
+- Parameters: after image boot, `println` writes to the process's real
+  stdout (the reconstructed default, not a stale dump-time resource), and
+  `parameterize` of `*stdout*` redirects it — the captured `Parameter`
+  identity and the fiber's frame lookup both survived hydration.
+- Determinism: dump the same graph twice and assert byte-identical files.
+- Resolution: a unit test pins that an image pointer resolves through the
+  interval table without touching the header ladder, and that `owns` on a
+  hydrated region is a range check.

--- a/docs/impl/image.md
+++ b/docs/impl/image.md
@@ -150,12 +150,30 @@ process-local, so a persisted sorted container is correct only where it was
 built.
 
 The fix is the identity model keywords already use: the id is a 64-bit
-FNV-1a hash of the name, stable across tables, processes, and builds, with a
-global hash→name registry for display and a collision panic. Then symbol
-values are as portable as keyword values; sort orders are stable by
+FNV-1a hash of the name, stable across tables, processes, and builds. Then
+symbol values are as portable as keyword values; sort orders are stable by
 construction; the image needs no symbol remap pass, no re-sort pass, no
 symbol watermark; templates lose their `symbol_names` maps; `send` stops
-re-interning; the `CompileCtx` ordering invariant dissolves.
+re-interning for identity; the `CompileCtx` ordering invariant dissolves.
+
+No global registry backs this. Minting an id consults nothing — the hash
+is the id — so the only remaining jobs are display (hash→name) and
+collision detection, and both stay per instance. `SymbolTable` survives as
+an instance-local hash→name **display memo** on the plumbing it rides
+today: no lock, because no structure is shared; teardown drops the memo
+with its instance, so the leak guarantee holds without a carve-out. The
+memo learns names at the boundaries where names already travel — the
+reader, `send`'s name field (now display-only data the receiver records),
+hydration's name-table replay, `ConstTemplate` decode — and every learning
+site doubles as the collision check: recording a hash the memo maps to a
+different name is the panic. That catches cross-thread, cross-image, and
+cross-build collisions at the moment they would first confuse a reader,
+which one process-wide table cannot. A CI test hashes every static name —
+the primitive tables and aliases, every symbol read from core, prelude,
+and stdlib — and asserts distinctness, so the built-in vocabulary is
+proven collision-free per build; the runtime panic covers dynamic names,
+where the 64-bit birthday bound is ~3×10⁻¹⁰ at 10⁵ symbols. The keyword
+registry takes the same demotion in this migration.
 
 Migration notes: `SymbolId(u32)` widens to `u64` (the `Value` payload
 already is one); the `SYNTHETIC` sentinel survives as a reserved hash;
@@ -320,7 +338,7 @@ One image is one file (or one embedded blob):
 | relocations | pointer stream: (slot offset, target segment, target offset); primitive stream: (slot offset); reconstruction stream: (slot offset, constructor tag). Offsets are region-relative bytes: the hydrated region is one contiguous interval (Hydration step 3), so `base + offset` names any slot or target in O(1) and the (page, offset) pair collapses |
 | object index | (offset, tag) per heap object, sorted — rebuilds `dtors`/`ref_objs` and drives the verifier |
 | primitive table | primitive names in dump-time `prim_id` order |
-| name table | symbol and keyword names in the body — hashes are stable, but the process-global hash→name display registries must learn them |
+| name table | symbol and keyword names in the body — hashes are stable, but the hydrating instance's display memos must learn them |
 | signal table | user-defined signal names in dump-time bit order |
 | watermarks | dump-time counters: parameter id, static-region mint, hygiene scope id, next signal bit |
 | manifest | bindings: name, kind (function / macro / core), value location, signal, arity, doc location; macro entries add parameter lists, template-syntax and transformer-cache locations; inline-fn syntax locations; plus root locations and dependency fingerprints |
@@ -374,7 +392,8 @@ migration.
 
 1. Validate the fingerprint; on failure, fall back (boot: compile sources;
    environment: report the mismatch).
-2. Register the name table in the symbol and keyword display registries.
+2. Register the name table in the hydrating instance's symbol and keyword
+   display memos.
    Replay the signal table so user signal bits land where the dump minted
    them. Check the primitive table against the live registry.
 3. Mint a region and map the page section: reserve an aligned `PROT_NONE`
@@ -774,9 +793,9 @@ Then the image milestones:
 - Tier parity: a hot stdlib function reaches the JIT under image boot
   exactly as under source boot — the lazy LIR decode feeds `submit_jit_task`
   and the compiled result executes.
-- Names: print an image keyword and an image symbol (the display registries
-  learned them) and raise an image-defined signal (the replayed bit matches
-  the baked profile).
+- Names: print an image keyword and an image symbol (the instance's display
+  memos learned them) and raise an image-defined signal (the replayed bit
+  matches the baked profile).
 - Macros: a macro whose transformer cache was empty at dump expands
   correctly after hydration (the lazy fill still works).
 - Parameters: after image boot, `println` writes to the process's real

--- a/docs/impl/image.md
+++ b/docs/impl/image.md
@@ -159,9 +159,11 @@ re-interning; the `CompileCtx` ordering invariant dissolves.
 
 Migration notes: `SymbolId(u32)` widens to `u64` (the `Value` payload
 already is one); the `SYNTHETIC` sentinel survives as a reserved hash;
-bytecode operand widths at symbol sites must be audited; struct and set
-iteration order changes from intern-order to hash-order — deterministic, but
-print-order test expectations churn once.
+struct and set iteration order changes from intern-order to hash-order —
+deterministic, and measured to churn nothing. Risk item 4 records the
+full site audit and the measured cost: no bytecode operand carries a
+symbol id, no live dense-index site exists, and the widening is ~75
+mechanical seam edits.
 
 ### Region-native immutable structs
 
@@ -600,9 +602,38 @@ wrong about. Run these before the foundations land, in this order:
    hydrated region, the `(fd, offset)` input form (memfd for byte
    sources), and the always-on verifier's pointer-bounds walk beyond the
    tag check.
-4. **Symbol-identity scout.** Audit the ~220 `SymbolId` sites for density
-   assumptions (`as usize` indexing beyond `SymbolTable`), prototype the
-   hash id, and measure the struct-sort and print-order fallout.
+4. **Symbol-identity scout — dispatched, migration confirmed cheap.** The
+   audit classified all 221 `SymbolId` sites, and a throwaway prototype —
+   `SymbolId(u64)` minted as the FNV-1a name hash, `SymbolTable` reduced
+   to a hash→name registry with the keyword collision panic — ran the full
+   suites. Site classes and the cost of each:
+
+   | Site class | Sites | Migration cost |
+   |------------|-------|----------------|
+   | Opaque keys and pass-throughs (`PrimitiveMeta`, classification maps, inline/dispatch registries, JIT `scc_peers`, binding arenas) | ~170 | none — already hash-keyed |
+   | Width seams: `SymbolId(u32)`; `Value::symbol(u32)`; the truncating `as_symbol() → u32`; `Bytecode::add_symbol(u32)`; `SendValue::Symbol.id` (dead on receive); `errors.rs` parses `SymbolId(N)` as `u32`; 66 `HashMap<u32, String>` name maps | ~75 | mechanical widening — the whole prototype is 39 files, ±110 lines, and compiles clean beyond these seams |
+   | Dense indexing beyond `SymbolTable` | 1 | `jit/group.rs` `globals[sym.0 as usize]` — dead code with test-only callers; there is no VM globals table (the letrec model has no `LoadGlobal`), so no live density assumption exists |
+   | Bytecode operands carrying a symbol id | 0 | none to audit: symbols reach bytecode only as constant-pool `Value`s (u16 pool index) and `ConstTemplate`s, which already encode symbols by name |
+   | Raw-id comparators (`Value::Ord` rank-3 arm, `TableKey::Ord` symbol arm) | 2 | sort order flips to hash order coherently; sorted structs, sets, and their binary searches stay correct because build and probe share the comparator |
+   | Sentinel `SYNTHETIC = u32::MAX` | 1 production read | becomes a reserved `u64::MAX`; the binding's existing `is_synthetic` flag could replace it outright |
+
+   Measured fallout: Rust suites green except two tests that pin the
+   property being removed (the sequential-mint assertion, and a
+   different-ids-across-two-tables setup assert). The full smoke corpus —
+   2,264 files, VM and JIT — passes with **zero expectation churn**: no
+   Elle test observes symbol sort or print order. `(environment)` is the
+   one producer of symbol-keyed structs, and nothing pins its key order.
+   Keyword-keyed containers sort by name string and are unaffected. Boot
+   is unharmed: quiet-machine stdlib-compile is not slower under hash
+   interning. Deleted by the migration: the five `symbol_names` maps and
+   their threading, `all_names()`, `send`'s by-name symbol re-intern,
+   `intern_primitive_names` and its five call sites, and the `CompileCtx`
+   registration-order invariant (including the docs/pipeline.md bullet).
+   The audit also found two live cross-table id holes that stable ids
+   close: `send` ships `LirConst::Symbol` inside the live `LirFunction`
+   verbatim, so worker-side JIT re-emission pools sender-space ids; and
+   `TableKey::Symbol` keys inside sent structs cross untranslated. The
+   symbol milestone must land regression tests for both.
 5. **Expander mutation parity.** The region-native syntax migration is
    whole (see *Region-native syntax*), and its bar is parity with the
    Rust-heap tree it replaces. Benchmark expansion-heavy compiles on a

--- a/docs/impl/image.md
+++ b/docs/impl/image.md
@@ -354,6 +354,14 @@ instruction-set high-water mark, `CURRENT_EPOCH`, the feature set, a hash of
 the primitive name list in registration order, and (for the boot
 configuration) the hashes of the three sources.
 
+Size and align alone do not pin field offsets. The fingerprint therefore
+also records the probed layout of every variant the dumper can emit: the
+discriminant byte and each leaf field's offset and length (risk item 6
+records the probe mechanism and the measured layout). A build whose layout
+reorders a field or moves the discriminant fails the fingerprint instead of
+hydrating garbage, so the two-stage embed build cannot pass with a shifted
+layout. The same extents drive slot canonicalization (§ Dumping).
+
 On mismatch the loader falls back — the `include_str!` sources never go away,
 so the image is an optimization, not a correctness dependency. Images are
 regenerated, not migrated; epochs stay a source-level concept. An environment
@@ -476,18 +484,17 @@ environment dump it is the session's delta.
 Dump determinism is engineered, not assumed: the walk visits roots and
 children in sorted order and never iterates a hash map, so the same graph
 always yields the same layout — offsets, page table, relocation table, and
-object index are byte-identical across dumps, and the dumper canonicalizes
-everything it can in the page bytes (headers, cursor gaps, alignment slack,
-and every relocation slot are written as zeros). The store spike measured
-the one residue: raw object-slot bytes are *not* byte-stable, because a
-`repr(Rust)` enum copy carries uninitialized padding from its construction
-temporary, and no Rust construct can zero it without per-variant field
-extents. Those extents are exactly what the `offset_of!` probes of risk
-item 6 record; once known, the dumper zeroes non-field slot bytes and the
-whole file becomes canonical. Until then nothing is lost: the warm cache
-keys on the fingerprint (not a content hash), and concurrent dumpers racing
-through the atomic rename need only produce valid images for the same
-fingerprint, which layout determinism already guarantees.
+object index are byte-identical across dumps. The page bytes are assembled
+canonically from a zeroed buffer: headers, cursor gaps, alignment slack,
+and relocation slots stay zero, and each object slot receives only its
+discriminant byte and the leaf-field extents the layout probes record
+(§ Fingerprint). A `repr(Rust)` enum copy carries uninitialized padding
+from its construction temporary — the store spike measured this residue —
+so the dumper never copies a slot wholesale; the extent copy leaves padding
+out, and two dumps of the same graph are byte-identical whole files. The
+warm cache still keys on the fingerprint, not a content hash; whole-file
+determinism buys reproducible embedded blobs, and concurrent dumpers racing
+through the atomic rename produce identical files.
 
 Mutable bindings are the dump-policy fork. The strict policy (boot) fails
 the dump, naming the binding. The environment policy defaults to the same
@@ -597,7 +604,8 @@ wrong about. Run these before the foundations land, in this order:
    flag the release path checks. Two findings: relocation slots and targets
    collapse to region-relative offsets (recorded in § File format), and
    raw object-slot bytes are not byte-deterministic under `repr(Rust)`
-   padding (recorded in § Dumping; resolution rides risk item 6). Still
+   padding (recorded in § Dumping; resolved by risk item 6's extent
+   copy). Still
    open for the full **store** milestone: scrub/guardfree exercised over a
    hydrated region, the `(fd, offset)` input form (memfd for byte
    sources), and the always-on verifier's pointer-bounds walk beyond the
@@ -681,9 +689,31 @@ wrong about. Run these before the foundations land, in this order:
    `#[cfg(test)]` bench under `src/syntax/expand/` building the prototype
    node from `read_syntax_all` output and running stamp/flip/add/build/
    teardown against `stamp_scope`/`flip_scope_recursive`.
-6. **Fingerprint strength.** Size/align probes do not pin field offsets.
-   Record `offset_of!` for every field of every sealed variant, so the
-   two-stage embed build cannot pass the fingerprint with a shifted layout.
+6. **Fingerprint strength — dispatched, probes landed.** Size/align probes
+   do not pin field offsets; the fingerprint now records, per dumpable
+   variant, the discriminant byte and every leaf field's offset and length
+   (`src/image/layout.rs`), so the two-stage embed build cannot pass the
+   fingerprint with a shifted layout. Mechanism finding: `offset_of!`
+   cannot name an enum variant's field on stable Rust (E0658,
+   rust-lang/rust#120141), so the probes construct one exemplar per variant
+   and measure each field's address against the object's base, with
+   `offset_of!` covering the nested structs (`Pair`, `Value`,
+   `RegionSlice`). Measured layout (rustc 1.95, x86-64): `HeapObject` is
+   288 bytes, align 8 — the by-value `ClosureTemplate` variant sets the
+   size, so a `Float` slot is ~95% padding until the template foundation
+   shrinks it. The discriminant is one byte at offset 0 (declaration index
+   plus 3) with bytes 1–7 zero; every probed variant places its payload
+   field at 8 and `traits` at 24 (`Pair` nests its whole struct at 8).
+   `RegionSlice`'s `u32` len leaves interior padding at bytes 12–16 of the
+   field, which is why extents are recorded per leaf field, never per
+   variant field. The probes verify themselves on first use — distinct
+   discriminant bytes, zero upper discriminant bytes, disjoint in-bounds
+   extents, and a canonicalize-then-read-back check per variant — and
+   panic on violation, so a rustc that moves the tag or reorders fields
+   fails loudly before any image is written or trusted. The unlock
+   (§ Dumping): the dumper assembles object slots from the extents, dumps
+   are byte-identical whole files, and the determinism pin asserts
+   whole-file equality with a poisoned-padding counter-factual.
 
 ## Landing order
 
@@ -753,10 +783,10 @@ Then the image milestones:
   stdout (the reconstructed default, not a stale dump-time resource), and
   `parameterize` of `*stdout*` redirects it — the captured `Parameter`
   identity and the fiber's frame lookup both survived hydration.
-- Determinism: dump the same graph twice and assert identical metadata
-  sections and layout, with any byte difference confined to object slots
-  (the `repr(Rust)` padding residue — § Dumping); byte-identical whole
-  files become the assertion once risk item 6's field extents land.
+- Determinism: dump the same graph twice and assert byte-identical whole
+  files. The counter-factual: scribble a pattern into a live object's
+  padding bytes before the dump and assert the file does not change — a
+  wholesale slot copy would carry the pattern into the artifact.
 - Resolution: a unit test pins that an image pointer resolves through the
   interval table without touching the header ladder, and that `owns` on a
   hydrated region is a range check.

--- a/docs/impl/image.md
+++ b/docs/impl/image.md
@@ -333,7 +333,7 @@ One image is one file (or one embedded blob):
 | Section | Content |
 |---------|---------|
 | header | magic, format version, fingerprint, section offsets, page count |
-| pages | the dumped region's pages, largest first: body bytes per page at 4 KiB-aligned file offsets, so the section is mappable. Descending size order makes the packed layout self-aligning: every earlier page's size is a multiple of every later page's, so each page's offset — in the file and in the mapped interval — is a multiple of its own size, satisfying the masked-header walk with no padding |
+| pages | the dumped region's pages, largest first: body bytes per page at base-page-aligned file offsets, so the section is mappable. Descending size order makes the packed layout self-aligning: every earlier page's size is a multiple of every later page's, so each page's offset — in the file and in the mapped interval — is a multiple of its own size, satisfying the masked-header walk with no padding |
 | page table | (size, object cursor, data cursor) per page, in placement order — rebuilds each page's cursors |
 | relocations | pointer stream: (slot offset, target segment, target offset); primitive stream: (slot offset); reconstruction stream: (slot offset, constructor tag). Offsets are region-relative bytes: the hydrated region is one contiguous interval (Hydration step 3), so `base + offset` names any slot or target in O(1) and the (page, offset) pair collapses |
 | object index | (offset, tag) per heap object, sorted — rebuilds `dtors`/`ref_objs` and drives the verifier |
@@ -343,6 +343,16 @@ One image is one file (or one embedded blob):
 | watermarks | dump-time counters: parameter id, static-region mint, hygiene scope id, next signal bit |
 | manifest | bindings: name, kind (function / macro / core), value location, signal, arity, doc location; macro entries add parameter lists, template-syntax and transformer-cache locations; inline-fn syntax locations; plus root locations and dependency fingerprints |
 | side-stream | typed streams, present in any image: encoded `LirFunction`s keyed by template location (the boot configuration requires this stream — see *JIT*); `SendValue`-encoded mutable bindings (present only where the dump policy permits mutables) |
+
+**The pages section starts at a base-page boundary.** `mmap` accepts only a
+file offset that is a multiple of the OS page size, and that size is a
+property of the running machine rather than of the format: Linux on x86-64
+reports 4 KiB, macOS on arm64 reports 16 KiB. The header block is therefore
+padded with zeros up to the first base-page boundary at or after it, and the
+pages section begins there. Pinning the section to a fixed 4 KiB start
+instead would map on a 4 KiB machine and fail every page with `EINVAL` on a
+16 KiB one — the header block is the only part of the file read with `read`
+rather than mapped, so it is the only part whose offset is free.
 
 **Relocation slots.** A pointer slot is any 8-byte field holding an absolute
 address: a heap-tagged `Value`'s payload, a `RegionSlice`'s ptr. A primitive
@@ -369,8 +379,16 @@ layout agrees with the dumper's. The fingerprint records: format version,
 rustc version and target triple, `size_of`/`align_of` for `Value`,
 `HeapObject`, `RegionSlice`, `Closure`, `ClosureTemplate`, and `TableKey`, the
 instruction-set high-water mark, `CURRENT_EPOCH`, the feature set, a hash of
-the primitive name list in registration order, and (for the boot
-configuration) the hashes of the three sources.
+the primitive name list in registration order, the OS base page size, and
+(for the boot configuration) the hashes of the three sources.
+
+The base page size earns its place because the file's geometry is built from
+it: the pages section starts at a base-page boundary (§ File format) and
+every page size in the page table is a multiple of it. Two machines can
+agree on the target triple and still disagree here — arm64 Linux ships both
+4 KiB and 64 KiB kernels. Recording the size turns that case into a
+fingerprint mismatch, which falls back to sources, instead of a page table
+the reader rejects as corrupt or an offset `mmap` refuses.
 
 Size and align alone do not pin field offsets. The fingerprint therefore
 also records the probed layout of every variant the dumper can emit: the

--- a/docs/impl/image.md
+++ b/docs/impl/image.md
@@ -313,9 +313,10 @@ One image is one file (or one embedded blob):
 | Section | Content |
 |---------|---------|
 | header | magic, format version, fingerprint, section offsets, page count |
-| pages | the dumped region's pages in order: size class + body bytes per page; each page's bytes start at a 4 KiB-aligned file offset (padding between pages), so the section is mappable |
-| relocations | pointer stream: (slot page, slot offset, target segment, target page, target offset); primitive stream: (slot page, slot offset); reconstruction stream: (slot page, slot offset, constructor tag) |
-| object index | (page, offset, tag) per heap object, sorted — rebuilds `dtors`/`ref_objs`/cursors and drives the verifier |
+| pages | the dumped region's pages, largest first: body bytes per page at 4 KiB-aligned file offsets, so the section is mappable. Descending size order makes the packed layout self-aligning: every earlier page's size is a multiple of every later page's, so each page's offset — in the file and in the mapped interval — is a multiple of its own size, satisfying the masked-header walk with no padding |
+| page table | (size, object cursor, data cursor) per page, in placement order — rebuilds each page's cursors |
+| relocations | pointer stream: (slot offset, target segment, target offset); primitive stream: (slot offset); reconstruction stream: (slot offset, constructor tag). Offsets are region-relative bytes: the hydrated region is one contiguous interval (Hydration step 3), so `base + offset` names any slot or target in O(1) and the (page, offset) pair collapses |
+| object index | (offset, tag) per heap object, sorted — rebuilds `dtors`/`ref_objs` and drives the verifier |
 | primitive table | primitive names in dump-time `prim_id` order |
 | name table | symbol and keyword names in the body — hashes are stable, but the process-global hash→name display registries must learn them |
 | signal table | user-defined signal names in dump-time bit order |
@@ -331,7 +332,7 @@ missing from the live registry is minted on the spot from its static def
 can hold ids the fresh process has not minted yet). Symbol and keyword
 payloads are stable hashes and need no relocation. The dumper emits each
 entry as it copies the object — it knows every variant's layout, so there is
-no post-hoc discovery, and targets are (page, offset) pairs so hydration
+no post-hoc discovery, and targets are region-relative offsets so hydration
 rewrites each slot in O(1) with no address search.
 
 **Static region slots** baked into bytecode operands are opaque per-function
@@ -472,9 +473,19 @@ environment dump it is the session's delta.
 
 Dump determinism is engineered, not assumed: the walk visits roots and
 children in sorted order and never iterates a hash map, so the same graph
-always yields byte-identical output. That is what lets the warm-cache path
-key the artifact content-addressably and lets concurrent dumpers race
-harmlessly through the atomic rename.
+always yields the same layout — offsets, page table, relocation table, and
+object index are byte-identical across dumps, and the dumper canonicalizes
+everything it can in the page bytes (headers, cursor gaps, alignment slack,
+and every relocation slot are written as zeros). The store spike measured
+the one residue: raw object-slot bytes are *not* byte-stable, because a
+`repr(Rust)` enum copy carries uninitialized padding from its construction
+temporary, and no Rust construct can zero it without per-variant field
+extents. Those extents are exactly what the `offset_of!` probes of risk
+item 6 record; once known, the dumper zeroes non-field slot bytes and the
+whole file becomes canonical. Until then nothing is lost: the warm cache
+keys on the fingerprint (not a content hash), and concurrent dumpers racing
+through the atomic rename need only produce valid images for the same
+fingerprint, which layout determinism already guarantees.
 
 Mutable bindings are the dump-policy fork. The strict policy (boot) fails
 the dump, naming the binding. The environment policy defaults to the same
@@ -572,8 +583,23 @@ wrong about. Run these before the foundations land, in this order:
    per KiB of payload. `shared-templates 0`: every boot closure already
    references a region-resident template object, so the template
    foundation rewrites representation, not sharing structure.
-3. **The store spike** (already in the landing order): mapping, the pool
-   flag, relocation, teardown, on data-only graphs.
+3. **The store spike — dispatched, mechanism proven.** `src/image` dumps
+   and hydrates data-only graphs (pairs, strings, bytes, arrays, floats,
+   portable immediates) end to end, pinned by `tests/integration/image.rs`
+   against the § Test plan: round-trip equality in a fresh heap, sharing
+   preservation, corrupted-fingerprint fallback with no leaked region or
+   mapping, double hydration with independent address sets, rename-over-a-
+   live-mapping, teardown to baseline, and file-backed release as `munmap`
+   (never cached — also pinned at the pool in `pagepool/tests.rs`). The
+   pool interplay reduced to one field: `MmapPage` carries a `file_backed`
+   flag the release path checks. Two findings: relocation slots and targets
+   collapse to region-relative offsets (recorded in § File format), and
+   raw object-slot bytes are not byte-deterministic under `repr(Rust)`
+   padding (recorded in § Dumping; resolution rides risk item 6). Still
+   open for the full **store** milestone: scrub/guardfree exercised over a
+   hydrated region, the `(fd, offset)` input form (memfd for byte
+   sources), and the always-on verifier's pointer-bounds walk beyond the
+   tag check.
 4. **Symbol-identity scout.** Audit the ~220 `SymbolId` sites for density
    assumptions (`as usize` indexing beyond `SymbolTable`), prototype the
    hash id, and measure the struct-sort and print-order fallout.
@@ -654,7 +680,10 @@ Then the image milestones:
   stdout (the reconstructed default, not a stale dump-time resource), and
   `parameterize` of `*stdout*` redirects it — the captured `Parameter`
   identity and the fiber's frame lookup both survived hydration.
-- Determinism: dump the same graph twice and assert byte-identical files.
+- Determinism: dump the same graph twice and assert identical metadata
+  sections and layout, with any byte difference confined to object slots
+  (the `repr(Rust)` padding residue — § Dumping); byte-identical whole
+  files become the assertion once risk item 6's field extents land.
 - Resolution: a unit test pins that an image pointer resolves through the
   interval table without touching the header ladder, and that `owns` on a
   hydrated region is a range check.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -33,6 +33,7 @@ Provide the complete Elle implementation:
 | `compiler` | Bytecode instruction definitions and debug formatting |
 | `vm` | Bytecode execution, builtin documentation storage |
 | `value` | Runtime value representation (16-byte tagged union) with types: LArray, LArrayMut, LStruct, LStructMut, LString, LStringMut, LBytes, LBytesMut, LSet, LSetMut |
+| `image` | Image persistence: dump a sealed value graph as page bytes + relocations, hydrate by private file mapping (docs/impl/image.md) |
 | `signals` | Signal type system (`Signal` struct with `bits` and `propagates`) |
 | `lint` | Diagnostic types and lint rules |
 | `symbols` | Symbol index types for IDE features |

--- a/src/config/keywords.rs
+++ b/src/config/keywords.rs
@@ -33,6 +33,8 @@ pub const TRACE_KEYWORDS: &[&str] = &[
     "gpu",
     // Boot-sequence phase timing (string-traced, no bit; src/trace.rs).
     "boot",
+    // Post-boot heap census (string-traced, no bit; value/fiberheap/census.rs).
+    "census",
     // Region/free diagnostics (see src/value/fiberheap/freelog.rs).
     "free",
     "guardfree",

--- a/src/config/keywords.rs
+++ b/src/config/keywords.rs
@@ -31,6 +31,8 @@ pub const TRACE_KEYWORDS: &[&str] = &[
     "spirv",
     "mlir",
     "gpu",
+    // Boot-sequence phase timing (string-traced, no bit; src/trace.rs).
+    "boot",
     // Region/free diagnostics (see src/value/fiberheap/freelog.rs).
     "free",
     "guardfree",

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -94,17 +94,19 @@ fn trace_all_covers_every_defined_bit() {
 fn trace_keywords_are_known() {
     // Future GPU backends — accepted without error, no bit yet.
     const FORWARD_COMPAT: &[&str] = &["spirv", "mlir", "gpu"];
-    // Region/free diagnostics, boot-phase timing, the park trace, and the
-    // syncjit compile mode: functional today but checked via the string
-    // `has_trace` (cold free paths in fiberheap/freelog.rs; the phase marks
-    // in trace.rs; the park/resume seam; the submit path in
-    // vm/jit_entry.rs), so they deliberately carry no `trace_bits` entry.
+    // Region/free diagnostics, boot-phase timing, the post-boot census, the
+    // park trace, and the syncjit compile mode: functional today but checked
+    // via the string `has_trace` (cold free paths in fiberheap/freelog.rs;
+    // the phase marks and census in trace.rs; the park/resume seam; the
+    // submit path in vm/jit_entry.rs), so they deliberately carry no
+    // `trace_bits` entry.
     const STRING_TRACED: &[&str] = &[
         "free",
         "guardfree",
         "freebt",
         "scrub",
         "boot",
+        "census",
         "park",
         "syncjit",
     ];

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -94,12 +94,20 @@ fn trace_all_covers_every_defined_bit() {
 fn trace_keywords_are_known() {
     // Future GPU backends — accepted without error, no bit yet.
     const FORWARD_COMPAT: &[&str] = &["spirv", "mlir", "gpu"];
-    // Region/free diagnostics, the park trace, and the syncjit compile
-    // mode: functional today but checked via the string `has_trace` (cold
-    // free paths in fiberheap/freelog.rs; the park/resume seam; the submit
-    // path in vm/jit_entry.rs), so they deliberately carry no `trace_bits`
-    // entry.
-    const STRING_TRACED: &[&str] = &["free", "guardfree", "freebt", "scrub", "park", "syncjit"];
+    // Region/free diagnostics, boot-phase timing, the park trace, and the
+    // syncjit compile mode: functional today but checked via the string
+    // `has_trace` (cold free paths in fiberheap/freelog.rs; the phase marks
+    // in trace.rs; the park/resume seam; the submit path in
+    // vm/jit_entry.rs), so they deliberately carry no `trace_bits` entry.
+    const STRING_TRACED: &[&str] = &[
+        "free",
+        "guardfree",
+        "freebt",
+        "scrub",
+        "boot",
+        "park",
+        "syncjit",
+    ];
     for kw in TRACE_KEYWORDS {
         let recognized = trace_bits::from_name(kw) != 0
             || FORWARD_COMPAT.contains(kw)

--- a/src/image/dump.rs
+++ b/src/image/dump.rs
@@ -8,12 +8,15 @@
 //!
 //! Determinism is engineered: the copy visits children in order, the visited
 //! map is only ever probed (never iterated), and the file's page bytes are
-//! assembled from a zeroed buffer — the page header, the cursor gap, and
-//! data-area alignment slack are never copied from the scratch pages, so
-//! recycled-page residue cannot leak into the artifact.
+//! assembled from a zeroed buffer. Object slots are never copied wholesale —
+//! each receives only its discriminant byte and probed leaf-field extents
+//! (`layout::write_canonical`), so neither recycled-page residue nor a
+//! construction temporary's uninitialized padding can reach the artifact,
+//! and two dumps of the same graph are byte-identical whole files.
 
 use std::collections::HashMap;
 use std::io::Write;
+use std::mem::size_of;
 use std::path::Path;
 
 use crate::hir::region::RuntimeRegion;
@@ -26,6 +29,7 @@ use crate::value::repr::{
 use crate::value::Value;
 
 use super::format::{self, Header, PageEntry, HEADER_BLOCK};
+use super::layout;
 use super::ImageError;
 
 /// Dump `root`'s value graph to `path`, atomically (temp file + rename).
@@ -73,8 +77,10 @@ fn dump_into(
         })
     };
 
-    // Walk the copied objects: index entries, relocation slots, and the
-    // meaningful data spans (slice backings) to copy into the file.
+    // Walk the copied objects: canonical slot bytes into the zeroed pages
+    // buffer, index entries, relocation slots, and the meaningful data
+    // spans (slice backings) to copy into the file.
+    let mut pages = vec![0u8; pages_len as usize];
     let mut relocs: Vec<(u64, u64)> = Vec::new();
     let mut index: Vec<(u64, u64)> = Vec::new();
     let mut data_spans: Vec<(u64, usize, usize)> = Vec::new(); // (rel, src, len)
@@ -83,6 +89,8 @@ fn dump_into(
             let addr = obj as *const HeapObject as usize;
             let obj_off = in_image(off_of(addr))?;
             index.push((obj_off, obj.tag() as u64));
+            let dst = obj_off as usize;
+            layout::write_canonical(obj, &mut pages[dst..dst + size_of::<HeapObject>()]);
             let mut slot = |slot_addr: usize, target: usize| -> Result<(), ImageError> {
                 let s = in_image(off_of(slot_addr))?;
                 let t = in_image(off_of(target))?;
@@ -122,31 +130,24 @@ fn dump_into(
     relocs.sort_unstable();
     index.sort_unstable();
 
-    // Assemble the pages section from a zeroed buffer: object spans verbatim,
-    // slice backings individually; headers, gaps, and alignment slack stay
-    // zero (see the module docs on determinism).
-    let mut pages = vec![0u8; pages_len as usize];
-    let mut entries: Vec<PageEntry> = Vec::new();
-    for (l, &(base, _, r)) in layouts.iter().zip(intervals.iter()) {
-        entries.push(PageEntry {
+    // Object slots are already canonical in `pages`; add the slice
+    // backings. Headers, gaps, alignment slack, and slot padding stay zero
+    // (see the module docs on determinism).
+    let entries: Vec<PageEntry> = layouts
+        .iter()
+        .map(|l| PageEntry {
             size: l.len as u64,
             obj_cursor: l.obj_cursor as u64,
             data_cursor: l.data_cursor as u64,
-        });
-        let dst = r as usize;
-        let span = unsafe {
-            std::slice::from_raw_parts((base + 16) as *const u8, l.obj_cursor.saturating_sub(16))
-        };
-        pages[dst + 16..dst + l.obj_cursor].copy_from_slice(span);
-    }
+        })
+        .collect();
     for &(rel, src, len) in &data_spans {
         let bytes = unsafe { std::slice::from_raw_parts(src as *const u8, len) };
         pages[rel as usize..rel as usize + len].copy_from_slice(bytes);
     }
     // Canonicalize every relocation slot to zero: its dump-time content is a
-    // scratch-region absolute address — meaningless to the file, rewritten
-    // wholesale by hydration's relocation pass, and the one thing that would
-    // make two dumps of the same graph differ.
+    // scratch-region absolute address — meaningless to the file and rewritten
+    // wholesale by hydration's relocation pass.
     for &(slot, _) in &relocs {
         pages[slot as usize..slot as usize + 8].fill(0);
     }

--- a/src/image/dump.rs
+++ b/src/image/dump.rs
@@ -1,0 +1,304 @@
+//! The dumper (docs/impl/image.md § Dumping): a compacting copy of a sealed
+//! data graph into a fresh scratch region, then the scratch pages written as
+//! an image file with relocations, page table, and object index. The spike
+//! scope is data-only: pairs, strings, bytes, arrays, floats, and the
+//! portable immediates (ints, inline floats, bools, nil, the empty list,
+//! keywords — keyword payloads are stable name hashes). Anything else fails
+//! the dump with an error naming the variant.
+//!
+//! Determinism is engineered: the copy visits children in order, the visited
+//! map is only ever probed (never iterated), and the file's page bytes are
+//! assembled from a zeroed buffer — the page header, the cursor gap, and
+//! data-area alignment slack are never copied from the scratch pages, so
+//! recycled-page residue cannot leak into the artifact.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+
+use crate::hir::region::RuntimeRegion;
+use crate::value::fiberheap::FiberHeap;
+use crate::value::heap::{deref, HeapObject, Pair};
+use crate::value::region_slice::RegionSlice;
+use crate::value::repr::{
+    TAG_EMPTY_LIST, TAG_FALSE, TAG_FLOAT, TAG_INT, TAG_KEYWORD, TAG_NIL, TAG_TRUE,
+};
+use crate::value::Value;
+
+use super::format::{self, Header, PageEntry, HEADER_BLOCK};
+use super::ImageError;
+
+/// Dump `root`'s value graph to `path`, atomically (temp file + rename).
+/// The graph must be sealed data; a refused value fails the dump before any
+/// byte is written, and the scratch region is dropped either way.
+pub fn dump(heap: &mut FiberHeap, root: Value, path: &Path) -> Result<(), ImageError> {
+    let scratch = heap.new_runtime_region();
+    let result = dump_into(heap, scratch, root, path);
+    heap.decref_region_if_present(scratch);
+    result
+}
+
+fn dump_into(
+    heap: &mut FiberHeap,
+    scratch: RuntimeRegion,
+    root: Value,
+    path: &Path,
+) -> Result<(), ImageError> {
+    let mut visited: HashMap<usize, Value> = HashMap::new();
+    let copied = copy_value(heap, scratch, root, &mut visited)?;
+
+    // Page layout, largest page first: packing in descending size order keeps
+    // every page's offset a multiple of its own size (§ File format).
+    let mut layouts = heap
+        .region_pool(scratch)
+        .map(|p| p.page_layouts())
+        .unwrap_or_default();
+    layouts.sort_by_key(|l| std::cmp::Reverse(l.len));
+    let mut intervals: Vec<(usize, usize, u64)> = Vec::new(); // (base, len, rel)
+    let mut rel = 0u64;
+    for l in &layouts {
+        intervals.push((l.base, l.len, rel));
+        rel += l.len as u64;
+    }
+    let pages_len = rel;
+    let off_of = |addr: usize| -> Option<u64> {
+        intervals
+            .iter()
+            .find(|&&(base, len, _)| addr >= base && addr < base + len)
+            .map(|&(base, _, r)| r + (addr - base) as u64)
+    };
+    let in_image = |off: Option<u64>| -> Result<u64, ImageError> {
+        off.ok_or_else(|| {
+            ImageError::Corrupt("dump: a copied value points outside the scratch region".into())
+        })
+    };
+
+    // Walk the copied objects: index entries, relocation slots, and the
+    // meaningful data spans (slice backings) to copy into the file.
+    let mut relocs: Vec<(u64, u64)> = Vec::new();
+    let mut index: Vec<(u64, u64)> = Vec::new();
+    let mut data_spans: Vec<(u64, usize, usize)> = Vec::new(); // (rel, src, len)
+    if let Some(pool) = heap.region_pool(scratch) {
+        for obj in pool.live_objects() {
+            let addr = obj as *const HeapObject as usize;
+            let obj_off = in_image(off_of(addr))?;
+            index.push((obj_off, obj.tag() as u64));
+            let mut slot = |slot_addr: usize, target: usize| -> Result<(), ImageError> {
+                let s = in_image(off_of(slot_addr))?;
+                let t = in_image(off_of(target))?;
+                relocs.push((s, t));
+                Ok(())
+            };
+            match obj {
+                HeapObject::Pair(pair) => {
+                    for v in [&pair.first, &pair.rest] {
+                        if let Some(p) = v.as_heap_ptr() {
+                            slot(&v.payload as *const u64 as usize, p as usize)?;
+                        }
+                    }
+                }
+                HeapObject::LString { s, .. } => {
+                    slice_slots(s, &mut slot, &mut data_spans, &off_of)?;
+                }
+                HeapObject::LBytes { data, .. } => {
+                    slice_slots(data, &mut slot, &mut data_spans, &off_of)?;
+                }
+                HeapObject::LArray { elements, .. } => {
+                    slice_slots(elements, &mut slot, &mut data_spans, &off_of)?;
+                    for v in elements.iter() {
+                        if let Some(p) = v.as_heap_ptr() {
+                            slot(&v.payload as *const u64 as usize, p as usize)?;
+                        }
+                    }
+                }
+                HeapObject::Float(_) => {}
+                other => {
+                    // copy_value only allocates the variants above.
+                    unreachable!("unexpected {:?} in dump scratch", other.tag());
+                }
+            }
+        }
+    }
+    relocs.sort_unstable();
+    index.sort_unstable();
+
+    // Assemble the pages section from a zeroed buffer: object spans verbatim,
+    // slice backings individually; headers, gaps, and alignment slack stay
+    // zero (see the module docs on determinism).
+    let mut pages = vec![0u8; pages_len as usize];
+    let mut entries: Vec<PageEntry> = Vec::new();
+    for (l, &(base, _, r)) in layouts.iter().zip(intervals.iter()) {
+        entries.push(PageEntry {
+            size: l.len as u64,
+            obj_cursor: l.obj_cursor as u64,
+            data_cursor: l.data_cursor as u64,
+        });
+        let dst = r as usize;
+        let span = unsafe {
+            std::slice::from_raw_parts((base + 16) as *const u8, l.obj_cursor.saturating_sub(16))
+        };
+        pages[dst + 16..dst + l.obj_cursor].copy_from_slice(span);
+    }
+    for &(rel, src, len) in &data_spans {
+        let bytes = unsafe { std::slice::from_raw_parts(src as *const u8, len) };
+        pages[rel as usize..rel as usize + len].copy_from_slice(bytes);
+    }
+    // Canonicalize every relocation slot to zero: its dump-time content is a
+    // scratch-region absolute address — meaningless to the file, rewritten
+    // wholesale by hydration's relocation pass, and the one thing that would
+    // make two dumps of the same graph differ.
+    for &(slot, _) in &relocs {
+        pages[slot as usize..slot as usize + 8].fill(0);
+    }
+
+    let (root_is_heap, root_payload) = match copied.as_heap_ptr() {
+        Some(p) => (true, in_image(off_of(p as usize))?),
+        None => (false, copied.payload),
+    };
+    let header = Header {
+        pages_len,
+        n_pages: entries.len() as u64,
+        n_relocs: relocs.len() as u64,
+        n_objects: index.len() as u64,
+        root_tag: copied.tag,
+        root_payload,
+        root_is_heap,
+        fingerprint: format::fingerprint(),
+    };
+
+    let mut file_bytes = header.to_block()?;
+    file_bytes.extend_from_slice(&pages);
+    for e in &entries {
+        format::write_page_entry(&mut file_bytes, *e);
+    }
+    for &(s, t) in &relocs {
+        format::write_u64_pair(&mut file_bytes, s, t);
+    }
+    for &(o, t) in &index {
+        format::write_u64_pair(&mut file_bytes, o, t);
+    }
+    debug_assert_eq!(file_bytes.len() % 8, 0);
+    debug_assert!(HEADER_BLOCK as u64 + pages_len <= file_bytes.len() as u64);
+
+    // Never rewrite an image file in place (§ Hydration): a mapped old inode
+    // must stay stable while a new image replaces the path.
+    let tmp = path.with_file_name(format!(
+        ".{}.tmp{}",
+        path.file_name().and_then(|n| n.to_str()).unwrap_or("image"),
+        std::process::id()
+    ));
+    let mut f = std::fs::File::create(&tmp)?;
+    f.write_all(&file_bytes)?;
+    f.sync_all()?;
+    drop(f);
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+/// Record a slice field's relocation slot (its `ptr`, at offset 0 of the
+/// `repr(C)` `RegionSlice`) and its backing bytes as a data span. An empty
+/// slice has a dangling constant pointer — no slot, no span.
+fn slice_slots<T: 'static>(
+    s: &RegionSlice<T>,
+    slot: &mut impl FnMut(usize, usize) -> Result<(), ImageError>,
+    data_spans: &mut Vec<(u64, usize, usize)>,
+    off_of: &impl Fn(usize) -> Option<u64>,
+) -> Result<(), ImageError> {
+    if s.is_empty() {
+        return Ok(());
+    }
+    let backing = s.as_ptr() as usize;
+    slot(s as *const RegionSlice<T> as usize, backing)?;
+    let len = s.len() * std::mem::size_of::<T>();
+    let rel = off_of(backing).ok_or_else(|| {
+        ImageError::Corrupt("dump: a slice backing lies outside the scratch region".into())
+    })?;
+    data_spans.push((rel, backing, len));
+    Ok(())
+}
+
+/// Deep-copy one sealed data value into the scratch region, preserving
+/// sharing through the visited map (keyed on source payload address). A
+/// value outside the spike's sealed set fails the copy, naming the variant.
+fn copy_value(
+    heap: &mut FiberHeap,
+    region: RuntimeRegion,
+    v: Value,
+    visited: &mut HashMap<usize, Value>,
+) -> Result<Value, ImageError> {
+    if !v.is_heap() {
+        return match v.tag {
+            TAG_INT | TAG_FLOAT | TAG_NIL | TAG_TRUE | TAG_FALSE | TAG_EMPTY_LIST | TAG_KEYWORD => {
+                Ok(v)
+            }
+            _ => Err(ImageError::Unsupported(format!(
+                "immediate {} is not portable data",
+                v.type_name()
+            ))),
+        };
+    }
+    let key = v.payload as usize;
+    if let Some(&copy) = visited.get(&key) {
+        return Ok(copy);
+    }
+    let obj = unsafe { deref(v) };
+    if obj.traits() != Value::NIL {
+        return Err(ImageError::Unsupported(format!(
+            "{:?} carries traits — instance state the image cannot own",
+            obj.tag()
+        )));
+    }
+    let copy = match obj {
+        HeapObject::Pair(pair) => {
+            let first = copy_value(heap, region, pair.first, visited)?;
+            let rest = copy_value(heap, region, pair.rest, visited)?;
+            heap.alloc_in_region(HeapObject::Pair(Pair::new(first, rest)), region)
+        }
+        HeapObject::LString { s, .. } => {
+            let slice = heap.alloc_region_slice_in_region(s.as_slice(), region);
+            heap.alloc_in_region(
+                HeapObject::LString {
+                    s: slice,
+                    traits: Value::NIL,
+                },
+                region,
+            )
+        }
+        HeapObject::LBytes { data, .. } => {
+            let slice = heap.alloc_region_slice_in_region(data.as_slice(), region);
+            heap.alloc_in_region(
+                HeapObject::LBytes {
+                    data: slice,
+                    traits: Value::NIL,
+                },
+                region,
+            )
+        }
+        HeapObject::LArray { elements, .. } => {
+            let mut copies = Vec::with_capacity(elements.len());
+            for &el in elements.iter() {
+                copies.push(copy_value(heap, region, el, visited)?);
+            }
+            let slice = heap.alloc_region_slice_in_region(&copies, region);
+            heap.alloc_in_region(
+                HeapObject::LArray {
+                    elements: slice,
+                    traits: Value::NIL,
+                },
+                region,
+            )
+        }
+        HeapObject::Float(f) => heap.alloc_in_region(HeapObject::Float(*f), region),
+        other => {
+            return Err(ImageError::Unsupported(format!(
+                "{:?} is not sealed data (docs/impl/image.md § Sealing)",
+                other.tag()
+            )))
+        }
+    };
+    visited.insert(key, copy);
+    Ok(copy)
+}

--- a/src/image/dump.rs
+++ b/src/image/dump.rs
@@ -28,7 +28,7 @@ use crate::value::repr::{
 };
 use crate::value::Value;
 
-use super::format::{self, Header, PageEntry, HEADER_BLOCK};
+use super::format::{self, Header, PageEntry};
 use super::layout;
 use super::ImageError;
 
@@ -179,7 +179,7 @@ fn dump_into(
         format::write_u64_pair(&mut file_bytes, o, t);
     }
     debug_assert_eq!(file_bytes.len() % 8, 0);
-    debug_assert!(HEADER_BLOCK as u64 + pages_len <= file_bytes.len() as u64);
+    debug_assert!(format::pages_offset() as u64 + pages_len <= file_bytes.len() as u64);
 
     // Never rewrite an image file in place (§ Hydration): a mapped old inode
     // must stay stable while a new image replaces the path.

--- a/src/image/format.rs
+++ b/src/image/format.rs
@@ -28,10 +28,13 @@ pub(crate) const HEADER_BLOCK: usize = 4096;
 const FINGERPRINT_AT: usize = 80;
 
 /// The live process's image fingerprint. An image whose stored fingerprint
-/// differs is rejected at hydration — images are regenerated, never migrated.
+/// differs is rejected at hydration — images are regenerated, never
+/// migrated. Beyond sizes and aligns, the fingerprint carries the probed
+/// per-variant layout (docs/impl/image.md § Fingerprint): size checks alone
+/// cannot see a reordered field or a moved discriminant.
 pub fn fingerprint() -> String {
     format!(
-        "elle-image v{} rustc={} target={}-{} value={}/{} heapobject={}/{} regionslice={}/{} epoch={}",
+        "elle-image v{} rustc={} target={}-{} value={}/{} heapobject={}/{} regionslice={}/{} epoch={} {}",
         VERSION,
         env!("ELLE_RUSTC"),
         std::env::consts::ARCH,
@@ -43,6 +46,7 @@ pub fn fingerprint() -> String {
         size_of::<RegionSlice<u8>>(),
         align_of::<RegionSlice<u8>>(),
         crate::epoch::rules::CURRENT_EPOCH,
+        super::layout::fingerprint_component(),
     )
 }
 

--- a/src/image/format.rs
+++ b/src/image/format.rs
@@ -1,0 +1,208 @@
+//! The image file's byte layout (docs/impl/image.md § "File format") and the
+//! fingerprint that gates hydration (§ "Fingerprint: regenerate, never
+//! migrate").
+//!
+//! One header block of `HEADER_BLOCK` bytes, then the pages section at that
+//! 4 KiB-aligned offset, then the metadata sections (page table, relocations,
+//! object index). Pages are stored largest first, so packing them
+//! contiguously keeps every page's offset a multiple of its own size — the
+//! self-alignment the masked-header walk requires — and every file offset
+//! 4 KiB-aligned for `mmap`. All integers are little-endian u64 unless noted.
+
+use std::mem::{align_of, size_of};
+
+use crate::value::heap::{HeapObject, HeapTag};
+use crate::value::region_slice::RegionSlice;
+use crate::value::Value;
+
+use super::ImageError;
+
+pub(crate) const MAGIC: [u8; 8] = *b"ELLEIMG\0";
+pub(crate) const VERSION: u32 = 0;
+
+/// Fixed size of the header block; the pages section starts here. Holds the
+/// magic, the section geometry, the root, and the fingerprint string.
+pub(crate) const HEADER_BLOCK: usize = 4096;
+
+/// Byte offset of the fingerprint length field; the string follows it.
+const FINGERPRINT_AT: usize = 80;
+
+/// The live process's image fingerprint. An image whose stored fingerprint
+/// differs is rejected at hydration — images are regenerated, never migrated.
+pub fn fingerprint() -> String {
+    format!(
+        "elle-image v{} rustc={} target={}-{} value={}/{} heapobject={}/{} regionslice={}/{} epoch={}",
+        VERSION,
+        env!("ELLE_RUSTC"),
+        std::env::consts::ARCH,
+        std::env::consts::OS,
+        size_of::<Value>(),
+        align_of::<Value>(),
+        size_of::<HeapObject>(),
+        align_of::<HeapObject>(),
+        size_of::<RegionSlice<u8>>(),
+        align_of::<RegionSlice<u8>>(),
+        crate::epoch::rules::CURRENT_EPOCH,
+    )
+}
+
+/// Everything the header block records besides the fingerprint.
+#[derive(Debug, Clone)]
+pub(crate) struct Header {
+    /// Total bytes of the pages section (sum of page sizes).
+    pub pages_len: u64,
+    pub n_pages: u64,
+    pub n_relocs: u64,
+    pub n_objects: u64,
+    /// The root value: its tag word, and — when `root_is_heap` — the
+    /// region-relative offset of its object; otherwise the raw payload.
+    pub root_tag: u64,
+    pub root_payload: u64,
+    pub root_is_heap: bool,
+    pub fingerprint: String,
+}
+
+/// One entry of the page table: a page's size and its two bump cursors.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PageEntry {
+    pub size: u64,
+    pub obj_cursor: u64,
+    pub data_cursor: u64,
+}
+
+pub(crate) const PAGE_ENTRY_BYTES: usize = 24;
+pub(crate) const RELOC_BYTES: usize = 16;
+pub(crate) const INDEX_BYTES: usize = 16;
+
+fn put(buf: &mut [u8], at: usize, v: u64) {
+    buf[at..at + 8].copy_from_slice(&v.to_le_bytes());
+}
+
+fn get(buf: &[u8], at: usize) -> u64 {
+    u64::from_le_bytes(buf[at..at + 8].try_into().expect("8-byte read"))
+}
+
+impl Header {
+    /// Serialize into a fresh `HEADER_BLOCK`-byte block.
+    pub fn to_block(&self) -> Result<Vec<u8>, ImageError> {
+        let fp = self.fingerprint.as_bytes();
+        if FINGERPRINT_AT + 8 + fp.len() > HEADER_BLOCK {
+            return Err(ImageError::Corrupt(
+                "fingerprint does not fit the header block".into(),
+            ));
+        }
+        let mut block = vec![0u8; HEADER_BLOCK];
+        block[0..8].copy_from_slice(&MAGIC);
+        block[8..12].copy_from_slice(&VERSION.to_le_bytes());
+        put(&mut block, 16, self.pages_len);
+        put(&mut block, 24, self.n_pages);
+        put(&mut block, 32, self.n_relocs);
+        put(&mut block, 40, self.n_objects);
+        put(&mut block, 48, self.root_tag);
+        put(&mut block, 56, self.root_payload);
+        put(&mut block, 64, self.root_is_heap as u64);
+        put(&mut block, FINGERPRINT_AT, fp.len() as u64);
+        block[FINGERPRINT_AT + 8..FINGERPRINT_AT + 8 + fp.len()].copy_from_slice(fp);
+        Ok(block)
+    }
+
+    /// Parse a header block. Rejects a wrong magic or version as corrupt;
+    /// the fingerprint is parsed here and compared by the caller.
+    pub fn parse(block: &[u8]) -> Result<Header, ImageError> {
+        if block.len() < HEADER_BLOCK {
+            return Err(ImageError::Corrupt("file shorter than the header".into()));
+        }
+        if block[0..8] != MAGIC {
+            return Err(ImageError::Corrupt("bad magic".into()));
+        }
+        let version = u32::from_le_bytes(block[8..12].try_into().expect("4-byte read"));
+        if version != VERSION {
+            return Err(ImageError::Corrupt(format!(
+                "format version {version}, this binary reads {VERSION}"
+            )));
+        }
+        let fp_len = get(block, FINGERPRINT_AT) as usize;
+        if FINGERPRINT_AT + 8 + fp_len > HEADER_BLOCK {
+            return Err(ImageError::Corrupt(
+                "fingerprint length out of range".into(),
+            ));
+        }
+        let fingerprint =
+            String::from_utf8(block[FINGERPRINT_AT + 8..FINGERPRINT_AT + 8 + fp_len].to_vec())
+                .map_err(|_| ImageError::Corrupt("fingerprint is not UTF-8".into()))?;
+        Ok(Header {
+            pages_len: get(block, 16),
+            n_pages: get(block, 24),
+            n_relocs: get(block, 32),
+            n_objects: get(block, 40),
+            root_tag: get(block, 48),
+            root_payload: get(block, 56),
+            root_is_heap: get(block, 64) != 0,
+            fingerprint,
+        })
+    }
+}
+
+pub(crate) fn write_page_entry(out: &mut Vec<u8>, e: PageEntry) {
+    out.extend_from_slice(&e.size.to_le_bytes());
+    out.extend_from_slice(&e.obj_cursor.to_le_bytes());
+    out.extend_from_slice(&e.data_cursor.to_le_bytes());
+}
+
+pub(crate) fn read_page_entry(buf: &[u8], i: usize) -> PageEntry {
+    let at = i * PAGE_ENTRY_BYTES;
+    PageEntry {
+        size: get(buf, at),
+        obj_cursor: get(buf, at + 8),
+        data_cursor: get(buf, at + 16),
+    }
+}
+
+pub(crate) fn write_u64_pair(out: &mut Vec<u8>, a: u64, b: u64) {
+    out.extend_from_slice(&a.to_le_bytes());
+    out.extend_from_slice(&b.to_le_bytes());
+}
+
+pub(crate) fn read_u64_pair(buf: &[u8], i: usize, stride: usize) -> (u64, u64) {
+    let at = i * stride;
+    (get(buf, at), get(buf, at + 8))
+}
+
+/// Decode a stored tag word. Exhaustive over `HeapTag`: an unknown value is
+/// image corruption, not a variant to guess at.
+pub(crate) fn tag_from_u64(raw: u64) -> Result<HeapTag, ImageError> {
+    use HeapTag::*;
+    let tag = match raw {
+        x if x == LString as u64 => LString,
+        x if x == Pair as u64 => Pair,
+        x if x == LArrayMut as u64 => LArrayMut,
+        x if x == LStructMut as u64 => LStructMut,
+        x if x == LStruct as u64 => LStruct,
+        x if x == Closure as u64 => Closure,
+        x if x == Syntax as u64 => Syntax,
+        x if x == LArray as u64 => LArray,
+        x if x == LBox as u64 => LBox,
+        x if x == Float as u64 => Float,
+        x if x == LibHandle as u64 => LibHandle,
+        x if x == ThreadHandle as u64 => ThreadHandle,
+        x if x == Fiber as u64 => Fiber,
+        x if x == FFISignature as u64 => FFISignature,
+        x if x == FFIType as u64 => FFIType,
+        x if x == ManagedPointer as u64 => ManagedPointer,
+        x if x == LStringMut as u64 => LStringMut,
+        x if x == LBytes as u64 => LBytes,
+        x if x == LBytesMut as u64 => LBytesMut,
+        x if x == External as u64 => External,
+        x if x == Parameter as u64 => Parameter,
+        x if x == LSet as u64 => LSet,
+        x if x == LSetMut as u64 => LSetMut,
+        x if x == CaptureCell as u64 => CaptureCell,
+        x if x == ClosureTemplate as u64 => ClosureTemplate,
+        _ => {
+            return Err(ImageError::Corrupt(format!(
+                "unknown heap tag {raw} in object index"
+            )))
+        }
+    };
+    Ok(tag)
+}

--- a/src/image/format.rs
+++ b/src/image/format.rs
@@ -2,12 +2,13 @@
 //! fingerprint that gates hydration (§ "Fingerprint: regenerate, never
 //! migrate").
 //!
-//! One header block of `HEADER_BLOCK` bytes, then the pages section at that
-//! 4 KiB-aligned offset, then the metadata sections (page table, relocations,
-//! object index). Pages are stored largest first, so packing them
-//! contiguously keeps every page's offset a multiple of its own size — the
-//! self-alignment the masked-header walk requires — and every file offset
-//! 4 KiB-aligned for `mmap`. All integers are little-endian u64 unless noted.
+//! One header block of `HEADER_BLOCK` bytes zero-padded to `pages_offset()`,
+//! then the pages section, then the metadata sections (page table,
+//! relocations, object index). Pages are stored largest first, so packing
+//! them contiguously keeps every page's offset a multiple of its own size —
+//! the self-alignment the masked-header walk requires — and, since the
+//! section starts on a base-page boundary, every file offset stays legal for
+//! `mmap`. All integers are little-endian u64 unless noted.
 
 use std::mem::{align_of, size_of};
 
@@ -20,9 +21,28 @@ use super::ImageError;
 pub(crate) const MAGIC: [u8; 8] = *b"ELLEIMG\0";
 pub(crate) const VERSION: u32 = 0;
 
-/// Fixed size of the header block; the pages section starts here. Holds the
-/// magic, the section geometry, the root, and the fingerprint string.
+/// Fixed size of the serialized header block: the magic, the section
+/// geometry, the root, and the fingerprint string. The pages section starts
+/// at [`pages_offset`], at or after this.
 pub(crate) const HEADER_BLOCK: usize = 4096;
+
+/// File offset where the pages section starts, for this machine's OS page
+/// size (docs/impl/image.md § "The pages section starts at a base-page
+/// boundary").
+pub(crate) fn pages_offset() -> usize {
+    pages_offset_for(crate::value::fiberheap::pagepool::base_page())
+}
+
+/// The pages-section start for an OS base page size, as a pure function of
+/// it: the first multiple of `base_page` at or after the header block.
+///
+/// Split out from [`pages_offset`] so the alignment rule can be checked at
+/// page sizes this machine does not have — the defect it replaces was a
+/// fixed 4 KiB start, which no test on a 4 KiB host could distinguish from a
+/// correct one.
+pub(crate) fn pages_offset_for(base_page: usize) -> usize {
+    HEADER_BLOCK.next_multiple_of(base_page)
+}
 
 /// Byte offset of the fingerprint length field; the string follows it.
 const FINGERPRINT_AT: usize = 80;
@@ -34,11 +54,12 @@ const FINGERPRINT_AT: usize = 80;
 /// cannot see a reordered field or a moved discriminant.
 pub fn fingerprint() -> String {
     format!(
-        "elle-image v{} rustc={} target={}-{} value={}/{} heapobject={}/{} regionslice={}/{} epoch={} {}",
+        "elle-image v{} rustc={} target={}-{} page={} value={}/{} heapobject={}/{} regionslice={}/{} epoch={} {}",
         VERSION,
         env!("ELLE_RUSTC"),
         std::env::consts::ARCH,
         std::env::consts::OS,
+        crate::value::fiberheap::pagepool::base_page(),
         size_of::<Value>(),
         align_of::<Value>(),
         size_of::<HeapObject>(),
@@ -87,7 +108,10 @@ fn get(buf: &[u8], at: usize) -> u64 {
 }
 
 impl Header {
-    /// Serialize into a fresh `HEADER_BLOCK`-byte block.
+    /// Serialize into the file's whole header prefix: the `HEADER_BLOCK`
+    /// bytes of fields, then zero padding out to [`pages_offset`]. Emitting
+    /// the padding here keeps the pages section's start in one place — the
+    /// dumper appends pages to whatever this returns.
     pub fn to_block(&self) -> Result<Vec<u8>, ImageError> {
         let fp = self.fingerprint.as_bytes();
         if FINGERPRINT_AT + 8 + fp.len() > HEADER_BLOCK {
@@ -95,7 +119,7 @@ impl Header {
                 "fingerprint does not fit the header block".into(),
             ));
         }
-        let mut block = vec![0u8; HEADER_BLOCK];
+        let mut block = vec![0u8; pages_offset()];
         block[0..8].copy_from_slice(&MAGIC);
         block[8..12].copy_from_slice(&VERSION.to_le_bytes());
         put(&mut block, 16, self.pages_len);
@@ -172,6 +196,12 @@ pub(crate) fn read_u64_pair(buf: &[u8], i: usize, stride: usize) -> (u64, u64) {
     (get(buf, at), get(buf, at + 8))
 }
 
+/// Page sizes a host may report. 4 KiB is Linux on x86-64, 16 KiB is macOS
+/// on arm64, 64 KiB is an arm64 Linux kernel build — the alignment rule has
+/// to hold at every one of them, not just this machine's.
+#[cfg(test)]
+const HOST_PAGE_SIZES: [usize; 3] = [4096, 16384, 65536];
+
 /// Decode a stored tag word. Exhaustive over `HeapTag`: an unknown value is
 /// image corruption, not a variant to guess at.
 pub(crate) fn tag_from_u64(raw: u64) -> Result<HeapTag, ImageError> {
@@ -209,4 +239,96 @@ pub(crate) fn tag_from_u64(raw: u64) -> Result<HeapTag, ImageError> {
         }
     };
     Ok(tag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::fiberheap::pagepool::base_page;
+
+    // The trap, discovered on macOS CI: `mmap` rejects a file offset that is
+    // not a multiple of the OS page size, and that size is a property of the
+    // host, not of the format — 4 KiB on Linux x86-64, 16 KiB on macOS
+    // arm64. The counter-factual: a fixed 4 KiB start passes every check a
+    // 4 KiB host can run, then fails all six hydration tests with EINVAL on
+    // a 16 KiB one. Asserting over HOST_PAGE_SIZES, not over base_page(),
+    // is what makes this test able to fail here.
+    #[test]
+    fn pages_section_starts_on_a_boundary_of_every_host_page_size() {
+        for p in HOST_PAGE_SIZES {
+            let off = pages_offset_for(p);
+            assert_eq!(
+                off % p,
+                0,
+                "pages start {off} is not a multiple of page {p}"
+            );
+        }
+    }
+
+    // The header block must still fit in front of the pages: aligning up may
+    // only ever push the section later, never overlap the block it follows.
+    #[test]
+    fn pages_section_starts_at_or_after_the_header_block() {
+        for p in HOST_PAGE_SIZES {
+            assert!(
+                pages_offset_for(p) >= HEADER_BLOCK,
+                "page {p} puts the pages section inside the header block"
+            );
+        }
+    }
+
+    // Aligning up must not waste a whole page when the block already sits on
+    // a boundary — the 4 KiB host keeps the layout it had.
+    #[test]
+    fn a_page_sized_header_block_needs_no_padding() {
+        assert_eq!(pages_offset_for(HEADER_BLOCK), HEADER_BLOCK);
+    }
+
+    // The live wiring, as opposed to the rule: whatever this host reports,
+    // the offset the dumper writes at and the hydrator maps from is legal
+    // for it.
+    #[test]
+    fn this_hosts_pages_offset_is_mmap_legal() {
+        assert_eq!(pages_offset() % base_page(), 0);
+        assert_eq!(pages_offset(), pages_offset_for(base_page()));
+    }
+
+    // The dumper appends pages directly to `to_block`'s output, and the
+    // hydrator maps them from `pages_offset` — so the block's length is the
+    // agreement between the two halves. The counter-factual: a block padded
+    // to HEADER_BLOCK while the hydrator maps from a 16 KiB boundary reads
+    // 12 KiB of header as page bytes, and every object decodes as garbage.
+    #[test]
+    fn the_header_block_runs_exactly_up_to_the_pages_section() {
+        let header = Header {
+            pages_len: 0,
+            n_pages: 0,
+            n_relocs: 0,
+            n_objects: 0,
+            root_tag: 0,
+            root_payload: 0,
+            root_is_heap: false,
+            fingerprint: fingerprint(),
+        };
+        let block = header.to_block().expect("fingerprint fits");
+        assert_eq!(block.len(), pages_offset());
+        assert!(
+            block[HEADER_BLOCK..].iter().all(|&b| b == 0),
+            "padding between the header fields and the pages section is not zero"
+        );
+    }
+
+    // The page size shapes the file geometry, so an image built under a
+    // different one cannot be mapped here. Recording it makes that a
+    // fingerprint mismatch — the documented fallback — instead of a page
+    // table the reader calls corrupt (§ "Fingerprint: regenerate, never
+    // migrate").
+    #[test]
+    fn the_fingerprint_records_the_host_page_size() {
+        assert!(
+            fingerprint().contains(&format!("page={}", base_page())),
+            "fingerprint omits the page size: {}",
+            fingerprint()
+        );
+    }
 }

--- a/src/image/hydrate.rs
+++ b/src/image/hydrate.rs
@@ -17,15 +17,6 @@ use crate::value::Value;
 use super::format::{self, Header, HEADER_BLOCK, INDEX_BYTES, PAGE_ENTRY_BYTES, RELOC_BYTES};
 use super::{Hydrated, ImageError};
 
-/// The variants a spike (data-only) image may contain. The verifier rejects
-/// anything else at load, before a torn read can happen later.
-fn spike_sealed(tag: HeapTag) -> bool {
-    matches!(
-        tag,
-        HeapTag::Pair | HeapTag::LString | HeapTag::LBytes | HeapTag::LArray | HeapTag::Float
-    )
-}
-
 /// An address reservation that unmaps itself unless disarmed — the cleanup
 /// for every fallible step between `mmap` and region installation.
 struct Reservation {
@@ -113,7 +104,8 @@ pub fn hydrate(heap: &mut FiberHeap, path: &Path) -> Result<Hydrated, ImageError
     for i in 0..header.n_objects as usize {
         let (off, raw_tag) = format::read_u64_pair(index_table, i, INDEX_BYTES);
         let tag = format::tag_from_u64(raw_tag)?;
-        if !spike_sealed(tag) {
+        // The accept set is the dumper's emit set, spelled once (layout.rs).
+        if !super::layout::dumpable(tag) {
             return Err(ImageError::Corrupt(format!(
                 "{tag:?} in a data-only image (docs/impl/image.md § Sealing)"
             )));

--- a/src/image/hydrate.rs
+++ b/src/image/hydrate.rs
@@ -14,7 +14,7 @@ use crate::value::heap::{HeapObject, HeapTag};
 use crate::value::repr::TAG_HEAP_START;
 use crate::value::Value;
 
-use super::format::{self, Header, HEADER_BLOCK, INDEX_BYTES, PAGE_ENTRY_BYTES, RELOC_BYTES};
+use super::format::{self, Header, INDEX_BYTES, PAGE_ENTRY_BYTES, RELOC_BYTES};
 use super::{Hydrated, ImageError};
 
 /// An address reservation that unmaps itself unless disarmed — the cleanup
@@ -39,8 +39,12 @@ pub fn hydrate(heap: &mut FiberHeap, path: &Path) -> Result<Hydrated, ImageError
     let file = std::fs::File::open(path)?;
     let file_len = file.metadata()?.len();
 
-    let mut block = vec![0u8; HEADER_BLOCK];
-    if file_len < HEADER_BLOCK as u64 {
+    // The header fields are read, not mapped, so only they need to be
+    // present before parsing; the padding out to `pages_offset` is checked
+    // with the rest of the geometry below.
+    let pages_at = format::pages_offset();
+    let mut block = vec![0u8; format::HEADER_BLOCK];
+    if file_len < format::HEADER_BLOCK as u64 {
         return Err(ImageError::Corrupt("file shorter than the header".into()));
     }
     file.read_exact_at(&mut block, 0)?;
@@ -63,7 +67,7 @@ pub fn hydrate(heap: &mut FiberHeap, path: &Path) -> Result<Hydrated, ImageError
     let meta_len = header.n_pages * PAGE_ENTRY_BYTES as u64
         + header.n_relocs * RELOC_BYTES as u64
         + header.n_objects * INDEX_BYTES as u64;
-    let meta_off = HEADER_BLOCK as u64 + pages_len;
+    let meta_off = pages_at as u64 + pages_len;
     if file_len < meta_off + meta_len {
         return Err(corrupt("file shorter than its sections claim"));
     }
@@ -177,8 +181,9 @@ pub fn hydrate(heap: &mut FiberHeap, path: &Path) -> Result<Hydrated, ImageError
     };
 
     // Map each page from the file into its slot (step 3). The pages section
-    // starts at the 4 KiB-aligned HEADER_BLOCK and offsets are multiples of
-    // each page's (≥ 4 KiB) size, so every file offset is mmap-legal.
+    // starts on a base-page boundary and each offset within it is a multiple
+    // of that page's own (≥ base-page) size, so every file offset here is a
+    // multiple of the OS page size — the only offsets `mmap` accepts.
     for &(off, e) in &entries {
         let want = (base + off as usize) as *mut libc::c_void;
         let got = unsafe {
@@ -188,7 +193,7 @@ pub fn hydrate(heap: &mut FiberHeap, path: &Path) -> Result<Hydrated, ImageError
                 libc::PROT_READ | libc::PROT_WRITE,
                 libc::MAP_PRIVATE | libc::MAP_FIXED,
                 file.as_raw_fd(),
-                (HEADER_BLOCK as u64 + off) as libc::off_t,
+                (pages_at as u64 + off) as libc::off_t,
             )
         };
         if got == libc::MAP_FAILED {

--- a/src/image/hydrate.rs
+++ b/src/image/hydrate.rs
@@ -1,0 +1,253 @@
+//! The hydrator (docs/impl/image.md § Hydration): validate the fingerprint,
+//! reserve one aligned contiguous interval, `MAP_FIXED` + `MAP_PRIVATE` each
+//! page from the file into its slot, run the relocation pass, and install
+//! the pages as a freshly minted `Counted` region. No value is deserialized;
+//! cost is O(relocations) + O(objects).
+
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::FileExt;
+use std::path::Path;
+
+use crate::value::fiberheap::pagepool::MmapPage;
+use crate::value::fiberheap::FiberHeap;
+use crate::value::heap::{HeapObject, HeapTag};
+use crate::value::repr::TAG_HEAP_START;
+use crate::value::Value;
+
+use super::format::{self, Header, HEADER_BLOCK, INDEX_BYTES, PAGE_ENTRY_BYTES, RELOC_BYTES};
+use super::{Hydrated, ImageError};
+
+/// The variants a spike (data-only) image may contain. The verifier rejects
+/// anything else at load, before a torn read can happen later.
+fn spike_sealed(tag: HeapTag) -> bool {
+    matches!(
+        tag,
+        HeapTag::Pair | HeapTag::LString | HeapTag::LBytes | HeapTag::LArray | HeapTag::Float
+    )
+}
+
+/// An address reservation that unmaps itself unless disarmed — the cleanup
+/// for every fallible step between `mmap` and region installation.
+struct Reservation {
+    base: usize,
+    len: usize,
+    armed: bool,
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        if self.armed && self.len > 0 {
+            unsafe { libc::munmap(self.base as *mut libc::c_void, self.len) };
+        }
+    }
+}
+
+/// Hydrate the image at `path` into `heap`. On any failure the heap is
+/// untouched: no region minted, no mapping left behind.
+pub fn hydrate(heap: &mut FiberHeap, path: &Path) -> Result<Hydrated, ImageError> {
+    let file = std::fs::File::open(path)?;
+    let file_len = file.metadata()?.len();
+
+    let mut block = vec![0u8; HEADER_BLOCK];
+    if file_len < HEADER_BLOCK as u64 {
+        return Err(ImageError::Corrupt("file shorter than the header".into()));
+    }
+    file.read_exact_at(&mut block, 0)?;
+    let header = Header::parse(&block)?;
+
+    let expected = format::fingerprint();
+    if header.fingerprint != expected {
+        return Err(ImageError::Fingerprint {
+            expected,
+            found: header.fingerprint,
+        });
+    }
+
+    // Section geometry, checked against the real file before any mapping.
+    let corrupt = |what: &str| ImageError::Corrupt(what.into());
+    let pages_len = header.pages_len;
+    if header.n_pages > 1 << 20 || header.n_relocs > 1 << 32 || header.n_objects > 1 << 32 {
+        return Err(corrupt("section counts out of range"));
+    }
+    let meta_len = header.n_pages * PAGE_ENTRY_BYTES as u64
+        + header.n_relocs * RELOC_BYTES as u64
+        + header.n_objects * INDEX_BYTES as u64;
+    let meta_off = HEADER_BLOCK as u64 + pages_len;
+    if file_len < meta_off + meta_len {
+        return Err(corrupt("file shorter than its sections claim"));
+    }
+    let mut meta = vec![0u8; meta_len as usize];
+    file.read_exact_at(&mut meta, meta_off)?;
+
+    let page_table_bytes = header.n_pages as usize * PAGE_ENTRY_BYTES;
+    let reloc_bytes = header.n_relocs as usize * RELOC_BYTES;
+    let (page_table, rest) = meta.split_at(page_table_bytes);
+    let (reloc_table, index_table) = rest.split_at(reloc_bytes);
+
+    // Page table: sizes are powers of two ≥ the base page, descending, with
+    // ordered cursors; the packed offsets must sum to the section length.
+    let mut entries = Vec::with_capacity(header.n_pages as usize);
+    let mut offset = 0u64;
+    let mut prev_size = u64::MAX;
+    for i in 0..header.n_pages as usize {
+        let e = format::read_page_entry(page_table, i);
+        let size_ok = e.size.is_power_of_two()
+            && e.size >= crate::value::fiberheap::pagepool::base_page() as u64
+            && e.size <= prev_size;
+        let cursors_ok =
+            16 <= e.obj_cursor && e.obj_cursor <= e.data_cursor && e.data_cursor <= e.size;
+        if !size_ok || !cursors_ok {
+            return Err(corrupt("bad page table entry"));
+        }
+        prev_size = e.size;
+        entries.push((offset, e));
+        offset += e.size;
+    }
+    if offset != pages_len {
+        return Err(corrupt("page sizes do not sum to the pages section"));
+    }
+
+    // Object index, decoded and bounds-checked before mapping.
+    let obj_size = std::mem::size_of::<HeapObject>() as u64;
+    let mut objects: Vec<(usize, HeapTag)> = Vec::with_capacity(header.n_objects as usize);
+    for i in 0..header.n_objects as usize {
+        let (off, raw_tag) = format::read_u64_pair(index_table, i, INDEX_BYTES);
+        let tag = format::tag_from_u64(raw_tag)?;
+        if !spike_sealed(tag) {
+            return Err(ImageError::Corrupt(format!(
+                "{tag:?} in a data-only image (docs/impl/image.md § Sealing)"
+            )));
+        }
+        if off + obj_size > pages_len {
+            return Err(corrupt("object offset out of range"));
+        }
+        objects.push((off as usize, tag));
+    }
+
+    // Root, checked before mapping.
+    if header.root_is_heap {
+        if header.root_tag < TAG_HEAP_START || header.root_payload + obj_size > pages_len {
+            return Err(corrupt("bad heap root"));
+        }
+        if header.n_pages == 0 {
+            return Err(corrupt("heap root with no pages"));
+        }
+    } else if header.root_tag >= TAG_HEAP_START {
+        return Err(corrupt("immediate root with a heap tag"));
+    }
+
+    // An immediate-rooted image maps nothing; the region is empty.
+    if header.n_pages == 0 {
+        let region = heap.install_hydrated_region(Vec::new(), &[], 0);
+        return Ok(Hydrated {
+            root: Value {
+                tag: header.root_tag,
+                payload: header.root_payload,
+            },
+            region,
+        });
+    }
+
+    // Reserve one contiguous interval aligned to the largest page (step 3):
+    // with pages placed largest-first, base alignment makes every page
+    // self-aligned for the masked-header walk.
+    let max_align = entries[0].1.size as usize;
+    let total = pages_len as usize;
+    let reserve_len = total + max_align;
+    let raw = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            reserve_len,
+            libc::PROT_NONE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_NORESERVE,
+            -1,
+            0,
+        )
+    };
+    if raw == libc::MAP_FAILED {
+        return Err(ImageError::Io(std::io::Error::last_os_error()));
+    }
+    let base = (raw as usize + max_align - 1) & !(max_align - 1);
+    let prefix = base - raw as usize;
+    let suffix = reserve_len - prefix - total;
+    unsafe {
+        if prefix > 0 {
+            libc::munmap(raw, prefix);
+        }
+        if suffix > 0 {
+            libc::munmap((base + total) as *mut libc::c_void, suffix);
+        }
+    }
+    let mut guard = Reservation {
+        base,
+        len: total,
+        armed: true,
+    };
+
+    // Map each page from the file into its slot (step 3). The pages section
+    // starts at the 4 KiB-aligned HEADER_BLOCK and offsets are multiples of
+    // each page's (≥ 4 KiB) size, so every file offset is mmap-legal.
+    for &(off, e) in &entries {
+        let want = (base + off as usize) as *mut libc::c_void;
+        let got = unsafe {
+            libc::mmap(
+                want,
+                e.size as usize,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_FIXED,
+                file.as_raw_fd(),
+                (HEADER_BLOCK as u64 + off) as libc::off_t,
+            )
+        };
+        if got == libc::MAP_FAILED {
+            return Err(ImageError::Io(std::io::Error::last_os_error()));
+        }
+        debug_assert_eq!(got, want, "MAP_FIXED returned a different address");
+    }
+
+    // The relocation pass (step 4): one linear sweep, each write faulting
+    // its 4 KiB frame copy-on-write private.
+    for i in 0..header.n_relocs as usize {
+        let (slot, target) = format::read_u64_pair(reloc_table, i, RELOC_BYTES);
+        if slot + 8 > pages_len || target >= pages_len {
+            return Err(corrupt("relocation out of range"));
+        }
+        unsafe {
+            ((base + slot as usize) as *mut u64).write_unaligned((base + target as usize) as u64);
+        }
+    }
+
+    // The verifier (§ Verifier): every indexed object's bytes must carry the
+    // tag the index claims — format drift fails loudly at load, not as a
+    // torn read later.
+    for &(off, tag) in &objects {
+        let found = unsafe { (*((base + off) as *const HeapObject)).tag() };
+        if found != tag {
+            return Err(ImageError::Corrupt(format!(
+                "object at offset {off} decodes as {found:?}, index says {tag:?}"
+            )));
+        }
+    }
+
+    // Install (steps 5–6): the mapped pages become a freshly minted Counted
+    // region; the header stamps and cursor rebuild happen inside.
+    let pages: Vec<(MmapPage, usize, usize)> = entries
+        .iter()
+        .map(|&(off, e)| {
+            let page = unsafe {
+                MmapPage::from_fixed_mapping((base + off as usize) as *mut u8, e.size as usize)
+            };
+            (page, e.obj_cursor as usize, e.data_cursor as usize)
+        })
+        .collect();
+    guard.armed = false; // ownership of every byte moved into the MmapPages
+    let region = heap.install_hydrated_region(pages, &objects, base);
+
+    Ok(Hydrated {
+        root: Value::from_heap_ptr(
+            (base + header.root_payload as usize) as *const (),
+            header.root_tag,
+        ),
+        region,
+    })
+}

--- a/src/image/layout.rs
+++ b/src/image/layout.rs
@@ -1,0 +1,426 @@
+//! Layout probes for the variants the dumper emits (docs/impl/image.md
+//! § Fingerprint, risk item 6): each variant's discriminant byte and the
+//! byte extents of its leaf fields.
+//!
+//! `offset_of!` cannot name an enum variant's field on stable Rust
+//! (E0658), so each variant is probed through a constructed exemplar:
+//! field addresses measured against the object's base address, with
+//! `offset_of!` covering the nested structs (`Pair`, `Value`,
+//! `RegionSlice`). The probe verifies its own assumptions on first use and
+//! panics on violation, so a compiler that moves the discriminant or
+//! reorders fields fails loudly before any image is written or trusted.
+//!
+//! Two callers consume the extents. The fingerprint records them, so a
+//! binary whose layout shifted rejects foreign images. The dumper copies
+//! only the discriminant byte and these extents into zeroed slots, so a
+//! construction temporary's uninitialized padding never reaches the file
+//! and dumps are byte-identical whole files.
+
+use std::mem::{offset_of, size_of};
+use std::sync::OnceLock;
+
+use crate::value::heap::{HeapObject, HeapTag, Pair};
+use crate::value::region_slice::RegionSlice;
+use crate::value::Value;
+
+/// One leaf field of a variant: `len` meaningful bytes at `offset` from the
+/// object's base. Leaf means padding-free — a field with interior padding
+/// (a `RegionSlice`) contributes one extent per inner field instead.
+pub(crate) struct FieldExtent {
+    pub name: &'static str,
+    pub offset: usize,
+    pub len: usize,
+}
+
+impl FieldExtent {
+    fn new(name: &'static str, offset: usize, len: usize) -> Self {
+        FieldExtent { name, offset, len }
+    }
+}
+
+/// The probed layout of one dumpable variant.
+pub(crate) struct VariantLayout {
+    pub tag: HeapTag,
+    /// Byte 0 of a constructed exemplar. The probe asserts bytes 1..8 are
+    /// zero on a pattern-painted stack, so this one byte plus zeros
+    /// reproduces the discriminant's whole representation.
+    pub disc: u8,
+    /// Leaf extents, sorted by offset, pairwise disjoint, all ≥ `DISC_BYTES`.
+    pub fields: Vec<FieldExtent>,
+}
+
+/// Bytes at the slot's base reserved for the discriminant representation.
+pub(crate) const DISC_BYTES: usize = 8;
+
+/// The probed layouts, one per variant the dumper can emit. First use runs
+/// the probe and its self-checks.
+pub(crate) fn sealed_layouts() -> &'static [VariantLayout] {
+    static LAYOUTS: OnceLock<Vec<VariantLayout>> = OnceLock::new();
+    LAYOUTS.get_or_init(probe)
+}
+
+/// The layout for `tag`, or `None` when the dumper cannot emit `tag`.
+pub(crate) fn variant_layout(tag: HeapTag) -> Option<&'static VariantLayout> {
+    sealed_layouts().iter().find(|l| l.tag == tag)
+}
+
+/// True exactly for the probed variants: what the dumper may emit and the
+/// hydration verifier may accept.
+pub(crate) fn dumpable(tag: HeapTag) -> bool {
+    variant_layout(tag).is_some()
+}
+
+/// Copy `obj`'s canonical bytes into the zeroed slot `dst`: the
+/// discriminant byte plus every leaf-field extent. Padding stays zero, so
+/// the result is independent of the construction that produced `obj`.
+/// Panics when `obj`'s variant has no probe — extend this module before
+/// teaching the dumper a new variant.
+pub(crate) fn write_canonical(obj: &HeapObject, dst: &mut [u8]) {
+    debug_assert_eq!(dst.len(), size_of::<HeapObject>());
+    let layout = variant_layout(obj.tag())
+        .unwrap_or_else(|| panic!("no layout probe for {:?} (src/image/layout.rs)", obj.tag()));
+    let src = obj as *const HeapObject as *const u8;
+    // Read only probed-initialized bytes: byte 0 and the leaf fields.
+    unsafe {
+        dst[0] = *src;
+        debug_assert_eq!(dst[0], layout.disc, "discriminant drifted from probe");
+        for f in &layout.fields {
+            std::ptr::copy_nonoverlapping(src.add(f.offset), dst[f.offset..].as_mut_ptr(), f.len);
+        }
+    }
+}
+
+/// The fingerprint's layout section: nested-struct offsets plus every
+/// probed variant's discriminant and extents, in probe order.
+pub(crate) fn fingerprint_component() -> String {
+    let (sp, sl, sn) = RegionSlice::<u8>::header_layout();
+    let mut out = format!(
+        "layout=value:tag@{},payload@{};slice:ptr@{},len@{}+{};pair:first@{},rest@{},traits@{}",
+        offset_of!(Value, tag),
+        offset_of!(Value, payload),
+        sp,
+        sl,
+        sn,
+        offset_of!(Pair, first),
+        offset_of!(Pair, rest),
+        offset_of!(Pair, traits),
+    );
+    for l in sealed_layouts() {
+        out.push_str(&format!(";{:?}#{}", l.tag, l.disc));
+        for (i, f) in l.fields.iter().enumerate() {
+            out.push(if i == 0 { '{' } else { ',' });
+            out.push_str(&format!("{}@{}+{}", f.name, f.offset, f.len));
+        }
+        out.push('}');
+    }
+    out
+}
+
+/// Fill `depth + 1` stack frames with `pattern` so a construction
+/// temporary materialized by the next call inherits pattern bytes in any
+/// padding. The probe paints before constructing each exemplar: if the
+/// discriminant's upper bytes were padding rather than written zeros, the
+/// zero-assert below would fail here, loudly, instead of dump determinism
+/// failing silently later.
+#[inline(never)]
+fn paint_stack(pattern: u8, depth: usize) -> u64 {
+    let buf = [pattern; 4096];
+    let sum: u64 = buf.iter().map(|&b| b as u64).sum();
+    if depth == 0 {
+        sum
+    } else {
+        sum ^ paint_stack(pattern, depth - 1)
+    }
+}
+
+fn field_offset(obj: &HeapObject, field: *const u8) -> usize {
+    field as usize - obj as *const HeapObject as usize
+}
+
+/// Leaf extents of one exemplar, measured through its live references.
+fn extents_for(obj: &HeapObject) -> Vec<FieldExtent> {
+    let (slice_ptr, slice_len, slice_len_size) = RegionSlice::<u8>::header_layout();
+    let value = size_of::<Value>();
+    let slice_extents = |name2: [&'static str; 2], base: usize| {
+        vec![
+            FieldExtent::new(name2[0], base + slice_ptr, size_of::<*const u8>()),
+            FieldExtent::new(name2[1], base + slice_len, slice_len_size),
+        ]
+    };
+    match obj {
+        HeapObject::LString { s, traits } => {
+            let mut v = slice_extents(["s.ptr", "s.len"], field_offset(obj, s as *const _ as _));
+            v.push(FieldExtent::new(
+                "traits",
+                field_offset(obj, traits as *const _ as _),
+                value,
+            ));
+            v
+        }
+        HeapObject::LBytes { data, traits } => {
+            let mut v = slice_extents(
+                ["data.ptr", "data.len"],
+                field_offset(obj, data as *const _ as _),
+            );
+            v.push(FieldExtent::new(
+                "traits",
+                field_offset(obj, traits as *const _ as _),
+                value,
+            ));
+            v
+        }
+        HeapObject::LArray { elements, traits } => {
+            let mut v = slice_extents(
+                ["elements.ptr", "elements.len"],
+                field_offset(obj, elements as *const _ as _),
+            );
+            v.push(FieldExtent::new(
+                "traits",
+                field_offset(obj, traits as *const _ as _),
+                value,
+            ));
+            v
+        }
+        HeapObject::Pair(p) => {
+            let base = field_offset(obj, p as *const _ as _);
+            vec![
+                FieldExtent::new("first", base + offset_of!(Pair, first), value),
+                FieldExtent::new("rest", base + offset_of!(Pair, rest), value),
+                FieldExtent::new("traits", base + offset_of!(Pair, traits), value),
+            ]
+        }
+        HeapObject::Float(f) => vec![FieldExtent::new(
+            "0",
+            field_offset(obj, f as *const _ as _),
+            size_of::<f64>(),
+        )],
+        other => panic!("no exemplar for {:?} (src/image/layout.rs)", other.tag()),
+    }
+}
+
+#[inline(never)]
+fn exemplar(tag: HeapTag) -> HeapObject {
+    match tag {
+        HeapTag::LString => HeapObject::LString {
+            s: RegionSlice::empty(),
+            traits: Value::NIL,
+        },
+        HeapTag::LBytes => HeapObject::LBytes {
+            data: RegionSlice::empty(),
+            traits: Value::NIL,
+        },
+        HeapTag::LArray => HeapObject::LArray {
+            elements: RegionSlice::empty(),
+            traits: Value::NIL,
+        },
+        HeapTag::Pair => HeapObject::Pair(Pair::new(Value::int(1), Value::int(2))),
+        HeapTag::Float => HeapObject::Float(1.5),
+        other => panic!("no exemplar for {other:?} (src/image/layout.rs)"),
+    }
+}
+
+const PROBED: [HeapTag; 5] = [
+    HeapTag::LString,
+    HeapTag::Pair,
+    HeapTag::LArray,
+    HeapTag::LBytes,
+    HeapTag::Float,
+];
+
+fn probe() -> Vec<VariantLayout> {
+    // The nested structs must be padding-free where an extent spans them
+    // whole: a `Value` extent is meaningful for all 16 bytes, and `Pair`'s
+    // extents tile its three `Value`s.
+    assert_eq!(offset_of!(Value, tag), 0, "image layout probe: Value.tag");
+    assert_eq!(
+        offset_of!(Value, payload) + 8,
+        size_of::<Value>(),
+        "image layout probe: Value has padding"
+    );
+    assert_eq!(
+        size_of::<Pair>(),
+        3 * size_of::<Value>() + offset_of!(Pair, first),
+        "image layout probe: Pair has padding"
+    );
+    let (u8_layout, value_layout) = (
+        RegionSlice::<u8>::header_layout(),
+        RegionSlice::<Value>::header_layout(),
+    );
+    assert_eq!(
+        u8_layout, value_layout,
+        "image layout probe: RegionSlice layout depends on T"
+    );
+
+    let size = size_of::<HeapObject>();
+    let mut out: Vec<VariantLayout> = Vec::new();
+    for (i, &tag) in PROBED.iter().enumerate() {
+        // Alternate paint patterns so padding cannot hide as stable bytes.
+        paint_stack(if i % 2 == 0 { 0xAA } else { 0x55 }, 16);
+        let ex = exemplar(tag);
+        let disc = unsafe { *(&ex as *const HeapObject as *const u8) };
+        for b in 1..DISC_BYTES {
+            let byte = unsafe { *(&ex as *const HeapObject as *const u8).add(b) };
+            assert_eq!(
+                byte, 0,
+                "image layout probe: {tag:?} discriminant byte {b} is nonzero"
+            );
+        }
+        assert!(
+            !out.iter().any(|l| l.disc == disc),
+            "image layout probe: duplicate discriminant byte {disc}"
+        );
+
+        let mut fields = extents_for(&ex);
+        fields.sort_by_key(|f| f.offset);
+        let mut prev_end = DISC_BYTES;
+        for f in &fields {
+            assert!(
+                f.offset >= prev_end && f.offset + f.len <= size,
+                "image layout probe: {tag:?}.{} extent out of place",
+                f.name
+            );
+            prev_end = f.offset + f.len;
+        }
+
+        let layout = VariantLayout { tag, disc, fields };
+        verify_canonical(&ex, &layout);
+        out.push(layout);
+    }
+    out
+}
+
+/// Read-back check: an exemplar rebuilt from only its canonical bytes must
+/// still decode as the same variant with the same field values. This is
+/// what makes zeroing the unprobed bytes safe rather than assumed safe.
+fn verify_canonical(ex: &HeapObject, layout: &VariantLayout) {
+    let mut slot = std::mem::MaybeUninit::<HeapObject>::zeroed();
+    let dst = unsafe {
+        std::slice::from_raw_parts_mut(slot.as_mut_ptr() as *mut u8, size_of::<HeapObject>())
+    };
+    let src = ex as *const HeapObject as *const u8;
+    unsafe {
+        dst[0] = *src;
+        for f in &layout.fields {
+            std::ptr::copy_nonoverlapping(src.add(f.offset), dst[f.offset..].as_mut_ptr(), f.len);
+        }
+    }
+    // Every probed variant tolerates arbitrary bit patterns in its fields
+    // (raw pointers, integers, floats, `Value` words), so reading the
+    // rebuilt slot is defined even if the probe were wrong — and the tag
+    // comparison below then fails loudly.
+    let rebuilt = unsafe { &*slot.as_ptr() };
+    assert_eq!(
+        rebuilt.tag(),
+        layout.tag,
+        "image layout probe: canonical bytes decode as the wrong variant"
+    );
+    let intact = match (ex, rebuilt) {
+        (HeapObject::LString { s: a, .. }, HeapObject::LString { s: b, .. }) => {
+            a.as_ptr() == b.as_ptr() && a.len() == b.len()
+        }
+        (HeapObject::LBytes { data: a, .. }, HeapObject::LBytes { data: b, .. }) => {
+            a.as_ptr() == b.as_ptr() && a.len() == b.len()
+        }
+        (HeapObject::LArray { elements: a, .. }, HeapObject::LArray { elements: b, .. }) => {
+            a.as_ptr() == b.as_ptr() && a.len() == b.len()
+        }
+        (HeapObject::Pair(a), HeapObject::Pair(b)) => {
+            a.first == b.first && a.rest == b.rest && a.traits == b.traits
+        }
+        (HeapObject::Float(a), HeapObject::Float(b)) => a.to_bits() == b.to_bits(),
+        _ => false,
+    };
+    assert!(
+        intact,
+        "image layout probe: canonical bytes lost a field of {:?}",
+        layout.tag
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The probed set and the dumper's sealed set are the same set, spelled
+    // once (`dumpable`). The counter-factual: a variant added to the
+    // dumper without a probe panics in `write_canonical`, and a probe for
+    // a variant the dumper cannot emit would widen the verifier's accept
+    // set — this pin catches both drifts.
+    #[test]
+    fn probes_cover_exactly_the_dumpable_set() {
+        for tag in PROBED {
+            assert!(dumpable(tag), "{tag:?} probed but not dumpable");
+        }
+        assert_eq!(sealed_layouts().len(), PROBED.len());
+        assert!(!dumpable(HeapTag::LArrayMut));
+        assert!(!dumpable(HeapTag::Closure));
+    }
+
+    // Canonicalization masks construction residue: an object whose padding
+    // bytes are deliberately poisoned canonicalizes to the same bytes as a
+    // clean twin. The trap this guards: `repr(Rust)` enum copies carry
+    // uninitialized padding from their construction temporaries, so any
+    // slot byte outside the probed extents can differ between two
+    // identical constructions.
+    #[test]
+    fn canonical_bytes_are_construction_independent() {
+        for &tag in &PROBED {
+            let clean = exemplar(tag);
+            let layout = variant_layout(tag).expect("probed");
+
+            // A poisoned twin: same bytes, then 0xBD over everything the
+            // canonical mask excludes (padding only — byte 0 and the
+            // fields stay, so the value remains valid to read).
+            let mut twin = std::mem::MaybeUninit::<HeapObject>::zeroed();
+            let bytes = unsafe {
+                std::ptr::copy_nonoverlapping(&clean as *const HeapObject, twin.as_mut_ptr(), 1);
+                std::slice::from_raw_parts_mut(
+                    twin.as_mut_ptr() as *mut u8,
+                    size_of::<HeapObject>(),
+                )
+            };
+            for (i, byte) in bytes.iter_mut().enumerate().skip(1) {
+                let in_field = (i < DISC_BYTES)
+                    || layout
+                        .fields
+                        .iter()
+                        .any(|f| i >= f.offset && i < f.offset + f.len);
+                if !in_field {
+                    *byte = 0xBD;
+                }
+            }
+            let poisoned = unsafe { &*twin.as_ptr() };
+
+            let mut a = vec![0u8; size_of::<HeapObject>()];
+            let mut b = vec![0u8; size_of::<HeapObject>()];
+            write_canonical(&clean, &mut a);
+            write_canonical(poisoned, &mut b);
+            assert_eq!(
+                a, b,
+                "{tag:?}: poisoned padding leaked into canonical bytes"
+            );
+        }
+    }
+
+    // Non-empty field values survive canonicalization byte-exactly — the
+    // extents cover every meaningful byte, not just the exemplars' zeros.
+    #[test]
+    fn canonical_bytes_preserve_field_values() {
+        static BACKING: [u8; 11] = *b"hello image";
+        let obj = HeapObject::LString {
+            s: unsafe { RegionSlice::from_raw(BACKING.as_ptr(), BACKING.len() as u32) },
+            traits: Value::NIL,
+        };
+        let mut slot = std::mem::MaybeUninit::<HeapObject>::zeroed();
+        let dst = unsafe {
+            std::slice::from_raw_parts_mut(slot.as_mut_ptr() as *mut u8, size_of::<HeapObject>())
+        };
+        write_canonical(&obj, dst);
+        let rebuilt = unsafe { &*slot.as_ptr() };
+        let HeapObject::LString { s, traits } = rebuilt else {
+            panic!("canonical bytes decode as {:?}", rebuilt.tag());
+        };
+        assert_eq!(s.as_slice(), BACKING);
+        assert_eq!(*traits, Value::NIL);
+    }
+}

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,0 +1,70 @@
+//! Image persistence, store milestone (docs/impl/image.md — the design
+//! home). An image is the page bytes of one compacted region plus a
+//! relocation table; hydration maps the pages privately, rewrites the
+//! pointer slots, and installs the result as an ordinary counted region.
+//!
+//! Current scope is the data-only spike (§ "Landing order" item 5): sealed
+//! data graphs — pairs, strings, bytes, arrays, floats, portable immediates
+//! — dumped and hydrated end to end. Closures, structs, sets, symbols, and
+//! the boot/environment configurations arrive with the foundations and the
+//! later milestones.
+
+mod dump;
+mod format;
+mod hydrate;
+
+pub use dump::dump;
+pub use format::fingerprint;
+pub use hydrate::hydrate;
+
+use crate::hir::region::RuntimeRegion;
+use crate::value::Value;
+
+/// A successful hydration: the image's root value and the counted region
+/// holding the mapped pages (rc 1 — the caller's reference; release it with
+/// the ordinary region RC, or register it as a process root).
+#[derive(Debug, Clone, Copy)]
+pub struct Hydrated {
+    pub root: Value,
+    pub region: RuntimeRegion,
+}
+
+/// Why a dump or hydration refused.
+#[derive(Debug)]
+pub enum ImageError {
+    Io(std::io::Error),
+    /// The image was built by a binary whose layout disagrees with this one.
+    /// Fall back to sources — images are regenerated, never migrated.
+    Fingerprint {
+        expected: String,
+        found: String,
+    },
+    /// The graph holds a value the dump policy refuses, named.
+    Unsupported(String),
+    /// The file is not a well-formed image for this format version.
+    Corrupt(String),
+}
+
+impl std::fmt::Display for ImageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ImageError::Io(e) => write!(f, "image io: {e}"),
+            ImageError::Fingerprint { expected, found } => {
+                write!(
+                    f,
+                    "image fingerprint mismatch: built for {found:?}, this binary is {expected:?}"
+                )
+            }
+            ImageError::Unsupported(what) => write!(f, "image refuses: {what}"),
+            ImageError::Corrupt(what) => write!(f, "corrupt image: {what}"),
+        }
+    }
+}
+
+impl std::error::Error for ImageError {}
+
+impl From<std::io::Error> for ImageError {
+    fn from(e: std::io::Error) -> Self {
+        ImageError::Io(e)
+    }
+}

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -12,6 +12,7 @@
 mod dump;
 mod format;
 mod hydrate;
+mod layout;
 
 pub use dump::dump;
 pub use format::fingerprint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub mod error;
 pub mod ffi;
 pub mod formatter;
 pub mod hir;
+pub mod image;
 pub mod io;
 #[cfg(feature = "jit")]
 pub mod jit;

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -104,17 +104,24 @@ impl CompileCtx {
     /// Shared compile-context construction over an already-built macro VM
     /// (standalone or instance-heap-sharing).
     fn on_vm(mut vm: VM) -> Self {
+        let boot = crate::trace::boot();
         let mut init_symbols = SymbolTable::new();
+        let t = std::time::Instant::now();
         let mut meta = register_primitives(&mut vm, &mut init_symbols);
         let mut expander = Expander::new();
         // Macro-transformer bodies compile against primitives (+ stdlib once
         // `init_stdlib` runs); seed it before `load_prelude`, whose macro
         // expansions evaluate transformer bodies via `eval_syntax`.
         expander.set_eval_meta(build_primitive_meta(&mut init_symbols));
+        crate::trace::phase(boot, "boot", "primitives-macrovm", t);
+        let t = std::time::Instant::now();
         compile_core(&mut vm, &mut init_symbols, &mut meta, &mut expander);
+        crate::trace::phase(boot, "boot", "core", t);
+        let t = std::time::Instant::now();
         expander
             .load_prelude(&mut init_symbols, &mut vm)
             .expect("prelude loading must succeed");
+        crate::trace::phase(boot, "boot", "prelude", t);
         // `init_symbols` is a throwaway used only for this setup; `expand` pointed
         // the macro VM at it. Reset to null so the dropped table is never reached
         // — the next `expand` (a real compile) re-points the VM at the instance's

--- a/src/pipeline/compile.rs
+++ b/src/pipeline/compile.rs
@@ -300,13 +300,16 @@ fn compile_file_inner(
     cctx: &mut CompileCtx,
     source_name: &str,
 ) -> Result<(CompileResult, crate::syntax::Expander), String> {
+    let ct = crate::trace::compile();
     let (hir, arena, expander, prim_values, signal_projection) =
         compile_file_frontend(source, symbols, cctx, source_name)?;
 
     // Lower to LIR
+    let t = std::time::Instant::now();
     let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols, cctx.primitive_meta());
     let region_info =
         crate::hir::analyze_regions_with(&hir, &arena, pc.call_classification.clone());
+    crate::trace::phase(ct, "compile", &format!("{} regions", source_name), t);
     if crate::config::get().trace_bits() & crate::config::trace_bits::REGIONS != 0 {
         let names = symbols.all_names();
         eprintln!(
@@ -314,6 +317,7 @@ fn compile_file_inner(
             crate::hir::format_regions(&region_info, &arena, &names)
         );
     }
+    let t = std::time::Instant::now();
     let symbol_names = symbols.all_names();
     let mut lowerer = Lowerer::new(&arena)
         .with_primitive_classification(pc)
@@ -322,11 +326,14 @@ fn compile_file_inner(
         .with_region_info(region_info);
 
     let lir_module = lowerer.lower(&hir)?;
+    crate::trace::phase(ct, "compile", &format!("{} lower", source_name), t);
 
     // Emit bytecode
+    let t = std::time::Instant::now();
     let signal = lir_module.entry.signal;
     let mut emitter = Emitter::new_with_symbols(symbol_names);
     let (mut bytecode, _, _) = emitter.emit_module(&lir_module);
+    crate::trace::phase(ct, "compile", &format!("{} emit", source_name), t);
     bytecode.signal = signal;
     bytecode.signal_projection = signal_projection;
 

--- a/src/pipeline/compile/frontend.rs
+++ b/src/pipeline/compile/frontend.rs
@@ -50,7 +50,14 @@ pub(super) fn compile_file_frontend_xform(
     xform: impl FnOnce(Vec<Syntax>, crate::syntax::ScopeId) -> Vec<Syntax>,
 ) -> FrontendResult {
     with_transient(cctx.heap_ptr(), || {
+        let t = std::time::Instant::now();
         let syntaxes = read_syntax_all_for(source, source_name)?;
+        crate::trace::phase(
+            crate::trace::compile(),
+            "compile",
+            &format!("{} read", source_name),
+            t,
+        );
         compile_syntaxes_frontend_xform_inner(syntaxes, symbols, cctx, source_name, xform)
     })
 }
@@ -86,6 +93,8 @@ fn compile_syntaxes_frontend_xform_inner(
     xform: impl FnOnce(Vec<Syntax>, crate::syntax::ScopeId) -> Vec<Syntax>,
 ) -> FrontendResult {
     intern_primitive_names(symbols);
+    let ct = crate::trace::compile();
+    let t = std::time::Instant::now();
 
     let source_epoch = crate::epoch::extract_epoch(&mut syntaxes)?;
     if let Some(epoch) = source_epoch {
@@ -113,6 +122,8 @@ fn compile_syntaxes_frontend_xform_inner(
             }
             Ok::<_, String>((expanded_forms, expander, meta))
         })?;
+    crate::trace::phase(ct, "compile", &format!("{} expand", source_name), t);
+    let t = std::time::Instant::now();
 
     // A fresh scope for any accumulator/temporaries `xform` injects, minted after
     // expansion so it cannot collide with a scope the expander already assigned.
@@ -168,6 +179,7 @@ fn compile_syntaxes_frontend_xform_inner(
 
     let (dispatch_wrappers, fn_inline) = cctx.compile_registries_mut();
     crate::hir::regularize(&mut hir, &mut arena, symbols, dispatch_wrappers, fn_inline)?;
+    crate::trace::phase(ct, "compile", &format!("{} analyze", source_name), t);
 
     Ok((hir, arena, expander, prim_values, signal_projection))
 }

--- a/src/primitives/module_init.rs
+++ b/src/primitives/module_init.rs
@@ -18,10 +18,14 @@ const STDLIB: &str = include_str!("../stdlib.lisp");
 /// export into the compilation cache's PrimitiveMeta so that
 /// `bind_primitives` pre-binds them for all subsequent compilations.
 pub fn init_stdlib(vm: &mut VM, symbols: &mut SymbolTable, cctx: &mut CompileCtx) {
+    let boot = crate::trace::boot();
+    let t = std::time::Instant::now();
     let result = match compile_file(STDLIB, symbols, cctx, "<stdlib>") {
         Ok(r) => r,
         Err(e) => panic!("stdlib compilation failed: {}", e),
     };
+    crate::trace::phase(boot, "boot", "stdlib-compile", t);
+    let t = std::time::Instant::now();
     // Execute stdlib — returns the last expression (a closure).
     let closure_val = match vm.execute(&result.bytecode) {
         Ok(v) => v,
@@ -29,6 +33,8 @@ pub fn init_stdlib(vm: &mut VM, symbols: &mut SymbolTable, cctx: &mut CompileCtx
     };
     // Call the returned closure to get the exports struct.
     let exports_val = call_closure(vm, closure_val);
+    crate::trace::phase(boot, "boot", "stdlib-execute", t);
+    let t = std::time::Instant::now();
     // Root the stdlib export aggregate (the struct + its module closure), not
     // each export. `exports_val` references every stdlib export, and the `Value`s
     // registered into the compilation caches below are aliases into those
@@ -44,6 +50,7 @@ pub fn init_stdlib(vm: &mut VM, symbols: &mut SymbolTable, cctx: &mut CompileCtx
     // Extract exports from the struct and register them.
     let exports = extract_exports(exports_val, symbols);
     register_stdlib_exports(cctx, symbols, &exports);
+    crate::trace::phase(boot, "boot", "stdlib-exports", t);
     // Arm guardfree page-protection (no-op unless --trace=guardfree): from
     // here on, freed pages are mprotected so the first user-program
     // use-after-free faults at the exact dereference. Stdlib init has its

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -210,6 +210,15 @@ impl Runtime {
             core.load_stdlib();
         }
 
+        // The post-boot heap census (docs/impl/image.md § "Open risks and
+        // dispatch experiments", item 2): at this point every live object is
+        // boot state, the graph a boot image must dump.
+        if crate::trace::census() {
+            for line in core.heap().census().lines() {
+                eprintln!("[trace:census] {}", line);
+            }
+        }
+
         Runtime {
             core,
             torn_down: false,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -95,7 +95,9 @@ impl RuntimeCore {
         let mut vm = Box::new(VM::new_with_heap(heap_ptr));
         vm.set_unicode_generation(gen);
         let mut symbols = Box::new(SymbolTable::new());
+        let t = std::time::Instant::now();
         let meta = register_primitives(&mut vm, &mut symbols);
+        crate::trace::phase(crate::trace::boot(), "boot", "primitives", t);
         // Point the VM at this instance's symbol table (stable boxed address),
         // so the runtime `eval` instruction, the meta/read/debug primitives, and
         // value name-resolution resolve in THIS instance's own table. Mirrors

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -29,6 +29,12 @@ pub(crate) fn boot() -> bool {
     crate::config::get().has_trace("boot")
 }
 
+/// True when `--trace=census` is active. Read once, after boot completes —
+/// same static-CLI gating as `boot` (no VM trace cell exists yet).
+pub(crate) fn census() -> bool {
+    crate::config::get().has_trace("census")
+}
+
 /// True when `--trace=compile` is active. Compile phases run on the
 /// compiler's own thread against the static CLI config — the same
 /// gating the `[trace:regions]` dump in `compile_file_inner` uses.

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -21,3 +21,29 @@ macro_rules! etrace {
         }
     };
 }
+
+/// True when `--trace=boot` is active. Boot marks fire before any VM
+/// trace cell exists, so they gate on the static CLI config, like the
+/// other string-traced keywords (`free`, `guardfree`).
+pub(crate) fn boot() -> bool {
+    crate::config::get().has_trace("boot")
+}
+
+/// True when `--trace=compile` is active. Compile phases run on the
+/// compiler's own thread against the static CLI config — the same
+/// gating the `[trace:regions]` dump in `compile_file_inner` uses.
+pub(crate) fn compile() -> bool {
+    crate::config::get().trace_bits() & crate::config::trace_bits::COMPILE != 0
+}
+
+/// Print one phase-timing mark: `[trace:SUBSYSTEM] LABEL 12.3ms`.
+pub(crate) fn phase(enabled: bool, subsystem: &str, label: &str, start: std::time::Instant) {
+    if enabled {
+        eprintln!(
+            "[trace:{}] {} {:.1}ms",
+            subsystem,
+            label,
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+    }
+}

--- a/src/value/fiberheap/AGENTS.md
+++ b/src/value/fiberheap/AGENTS.md
@@ -29,7 +29,8 @@ heap and region explicitly through `arena`.
 | `regionstore/mintscope.rs` | closed allocation-scope mint log (macro expansion): `begin_mint_log` / `reclaim_mint_scope` RC-balance the scratch DAG by `rc − in_degree` (an `Owned` survivor is left to its owner's drop) |
 | `regionpool.rs` | `RegionPool`: dual-ended pages, page-header stamp, `header_of_page_ptr` |
 | `regionpool/introspect.rs` | `find_object_cross_refs` content scan (cascade + diagnostics) |
-| `pagepool.rs` | `PagePool`: per-thread mmap page cache by size class; the `PageDirty` release-time body reset; live traffic counters (`arena/page-claims`); guardfree leak hook |
+| `pagepool.rs` | `PagePool`: per-thread mmap page cache by size class; the `PageDirty` release-time body reset; live traffic counters (`arena/page-claims`); guardfree leak hook; file-backed (hydrated image) pages bypass the cache — their release is `munmap` |
+| `regionstore/hydrate.rs` | Install a hydrated image region: adopt mapped pages, rebuild object bookkeeping from the image's index (docs/impl/image.md § Hydration) |
 | `freelog.rs` | `--trace=free`/`freebt` free-log; guardfree arming |
 | `census.rs` | `--trace=census` post-boot heap census: per-tag histogram, sealing classification, relocation-slot counts (docs/impl/image.md § Sealing) |
 | `tests.rs` | `FiberHeap` unit tests |

--- a/src/value/fiberheap/AGENTS.md
+++ b/src/value/fiberheap/AGENTS.md
@@ -31,6 +31,7 @@ heap and region explicitly through `arena`.
 | `regionpool/introspect.rs` | `find_object_cross_refs` content scan (cascade + diagnostics) |
 | `pagepool.rs` | `PagePool`: per-thread mmap page cache by size class; the `PageDirty` release-time body reset; live traffic counters (`arena/page-claims`); guardfree leak hook |
 | `freelog.rs` | `--trace=free`/`freebt` free-log; guardfree arming |
+| `census.rs` | `--trace=census` post-boot heap census: per-tag histogram, sealing classification, relocation-slot counts (docs/impl/image.md § Sealing) |
 | `tests.rs` | `FiberHeap` unit tests |
 
 ## Page layout

--- a/src/value/fiberheap/census.rs
+++ b/src/value/fiberheap/census.rs
@@ -1,0 +1,425 @@
+//! The post-boot heap census (docs/impl/image.md § "Open risks and dispatch
+//! experiments", item 2): enumerate every live object in this instance's
+//! region store and report the graph a boot image must dump. Reached from
+//! `Runtime::build_with` under `--trace=census` and from the sealing
+//! regression net in `tests/integration/census.rs`.
+//!
+//! Byte accounting is a dump-size estimate, not an allocator audit. Each
+//! object contributes its `HeapObject` shell plus its payload wherever the
+//! payload lives today — region pages (`RegionSlice` backings) or the Rust
+//! heap (struct `Vec`s, template bytecode, syntax trees), since the
+//! foundations move the latter into the body. Payloads shared through `Rc`
+//! or an aliased `RegionSlice` are counted once (first holder). Not counted:
+//! per-container `Rc`/`RefCell` bookkeeping, template location maps and
+//! masks, and fiber-internal state (fibers are refused from the body).
+//!
+//! Pointer-slot counting follows the image format's relocation definition
+//! (docs/impl/image.md § "Relocation slots"): a heap-tagged `Value` slot or
+//! a non-empty `RegionSlice`'s `ptr`; native-fn slots (the primitive
+//! stream, remapped by name) are counted separately. `Rc` pointers are not
+//! counted — the foundations delete them from persistable objects.
+
+use std::mem::size_of;
+use std::rc::Rc;
+
+use rustc_hash::FxHashSet;
+
+use crate::syntax::{Syntax, SyntaxKind};
+use crate::value::heap::{HeapObject, HeapTag};
+use crate::value::region_slice::RegionSlice;
+use crate::value::types::TableKey;
+use crate::value::Value;
+
+use super::regionstore::RegionStore;
+use super::FiberHeap;
+
+/// How the image dumper treats a `HeapTag` (docs/impl/image.md § Sealing).
+/// The design doc owns the argument; this is its executable form, pinned by
+/// `tests/integration/census.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Sealing {
+    /// Body data: byte-self-contained after the foundations.
+    Sealed,
+    /// `CaptureCell`: rewritten to its final value by the dumper, never
+    /// persisted as an object.
+    Snapped,
+    /// Refused from the body: mutable stores, process and foreign handles.
+    Unsealed,
+}
+
+/// Classify a tag against the sealed set. Exhaustive on purpose: a new
+/// `HeapTag` variant must choose its dump treatment here to compile.
+pub fn sealing(tag: HeapTag) -> Sealing {
+    use HeapTag::*;
+    match tag {
+        LString | Pair | LStruct | Closure | LArray | LBytes | LSet | Syntax | Float
+        | Parameter | ClosureTemplate => Sealing::Sealed,
+        CaptureCell => Sealing::Snapped,
+        LArrayMut | LStructMut | LStringMut | LBytesMut | LSetMut | LBox | LibHandle
+        | ThreadHandle | Fiber | FFISignature | FFIType | ManagedPointer | External => {
+            Sealing::Unsealed
+        }
+    }
+}
+
+/// Per-tag census row.
+#[derive(Debug, Clone)]
+pub struct TagCensus {
+    pub tag: HeapTag,
+    pub count: usize,
+    /// Shell + payload bytes (module docs describe the estimate).
+    pub bytes: usize,
+    /// Heap-tagged `Value` slots (relocation candidates).
+    pub ptr_slots: usize,
+    /// Non-empty `RegionSlice` fields (each `ptr` is a relocation slot).
+    pub region_slices: usize,
+}
+
+/// One kind of dump-refused object found live, aggregated.
+#[derive(Debug, Clone)]
+pub struct UnsealedLeaf {
+    pub tag: HeapTag,
+    /// The `External` type name; empty for other tags.
+    pub detail: String,
+    pub count: usize,
+}
+
+/// The whole-store census.
+#[derive(Debug, Clone)]
+pub struct HeapCensus {
+    /// Active regions in the store.
+    pub regions: usize,
+    /// Live objects across all regions.
+    pub objects: usize,
+    /// Committed region-page bytes.
+    pub region_bytes: usize,
+    /// Shell + payload bytes summed over all rows.
+    pub payload_bytes: usize,
+    /// Rows for every tag present, largest `bytes` first.
+    pub tags: Vec<TagCensus>,
+    /// Snapping candidates (`CaptureCell` count).
+    pub capture_cells: usize,
+    /// Total heap-tagged `Value` slots.
+    pub ptr_slots: usize,
+    /// Total native-fn `Value` slots (primitive-stream relocations).
+    pub prim_slots: usize,
+    /// Total non-empty `RegionSlice` fields.
+    pub region_slices: usize,
+    /// Closures whose template is an `Rc` blueprint rather than a region
+    /// object — work for the template foundation, visible here.
+    pub shared_templates: usize,
+    /// Dump-refused objects, aggregated by (tag, detail).
+    pub unsealed: Vec<UnsealedLeaf>,
+}
+
+impl FiberHeap {
+    /// Census every live object in this instance's region store.
+    pub fn census(&self) -> HeapCensus {
+        HeapCensus::of_store(&self.region_store)
+    }
+}
+
+#[derive(Default)]
+struct ObjStat {
+    bytes: usize,
+    ptr_slots: usize,
+    prim_slots: usize,
+    region_slices: usize,
+    shared_template: bool,
+}
+
+impl HeapCensus {
+    pub(crate) fn of_store(store: &RegionStore) -> HeapCensus {
+        let mut rows: Vec<Option<TagCensus>> = Vec::new();
+        let mut unsealed: Vec<UnsealedLeaf> = Vec::new();
+        let mut seen: FxHashSet<usize> = FxHashSet::default();
+        let mut objects = 0usize;
+        let mut payload_bytes = 0usize;
+        let mut ptr_slots = 0usize;
+        let mut prim_slots = 0usize;
+        let mut region_slices = 0usize;
+        let mut shared_templates = 0usize;
+
+        for obj in store.live_objects() {
+            let tag = obj.tag();
+            let stat = measure(obj, &mut seen);
+            objects += 1;
+            payload_bytes += stat.bytes;
+            ptr_slots += stat.ptr_slots;
+            prim_slots += stat.prim_slots;
+            region_slices += stat.region_slices;
+            shared_templates += stat.shared_template as usize;
+
+            let idx = tag as usize;
+            if rows.len() <= idx {
+                rows.resize_with(idx + 1, || None);
+            }
+            let row = rows[idx].get_or_insert(TagCensus {
+                tag,
+                count: 0,
+                bytes: 0,
+                ptr_slots: 0,
+                region_slices: 0,
+            });
+            row.count += 1;
+            row.bytes += stat.bytes;
+            row.ptr_slots += stat.ptr_slots;
+            row.region_slices += stat.region_slices;
+
+            if sealing(tag) == Sealing::Unsealed {
+                let detail = match obj {
+                    HeapObject::External { obj, .. } => obj.type_name.to_string(),
+                    _ => String::new(),
+                };
+                match unsealed
+                    .iter_mut()
+                    .find(|l| l.tag == tag && l.detail == detail)
+                {
+                    Some(l) => l.count += 1,
+                    None => unsealed.push(UnsealedLeaf {
+                        tag,
+                        detail,
+                        count: 1,
+                    }),
+                }
+            }
+        }
+
+        let capture_cells = rows
+            .get(HeapTag::CaptureCell as usize)
+            .and_then(|r| r.as_ref())
+            .map_or(0, |r| r.count);
+        let mut tags: Vec<TagCensus> = rows.into_iter().flatten().collect();
+        tags.sort_by_key(|row| std::cmp::Reverse(row.bytes));
+
+        HeapCensus {
+            regions: store.active_region_count(),
+            objects,
+            region_bytes: store.region_bytes(),
+            payload_bytes,
+            tags,
+            capture_cells,
+            ptr_slots,
+            prim_slots,
+            region_slices,
+            shared_templates,
+            unsealed,
+        }
+    }
+
+    /// The census as report lines (no prefix; the caller adds `[trace:census]`).
+    pub fn lines(&self) -> Vec<String> {
+        let mut out = Vec::new();
+        out.push(format!("regions {}", self.regions));
+        out.push(format!(
+            "objects {} region-bytes {} payload-bytes {}",
+            self.objects, self.region_bytes, self.payload_bytes
+        ));
+        for row in &self.tags {
+            out.push(format!(
+                "tag {:?} count {} bytes {} ptr-slots {} slices {}",
+                row.tag, row.count, row.bytes, row.ptr_slots, row.region_slices
+            ));
+        }
+        out.push(format!("capture-cells {}", self.capture_cells));
+        out.push(format!("shared-templates {}", self.shared_templates));
+        let kib = (self.region_bytes as f64 / 1024.0).max(1.0);
+        out.push(format!(
+            "ptr-slots {} prim-slots {} region-slices {} per-kib {:.2} {:.2} {:.2}",
+            self.ptr_slots,
+            self.prim_slots,
+            self.region_slices,
+            self.ptr_slots as f64 / kib,
+            self.prim_slots as f64 / kib,
+            self.region_slices as f64 / kib
+        ));
+        for leaf in &self.unsealed {
+            out.push(format!(
+                "unsealed {:?}({}) {}",
+                leaf.tag, leaf.detail, leaf.count
+            ));
+        }
+        out.push(format!(
+            "unsealed-total {}",
+            self.unsealed.iter().map(|l| l.count).sum::<usize>()
+        ));
+        out
+    }
+}
+
+fn heap_slot(v: &Value, stat: &mut ObjStat) {
+    if v.is_heap() {
+        stat.ptr_slots += 1;
+    } else if v.is_native_fn() {
+        stat.prim_slots += 1;
+    }
+}
+
+fn slice_stat<T: 'static>(sl: &RegionSlice<T>, seen: &mut FxHashSet<usize>, stat: &mut ObjStat) {
+    if sl.is_empty() {
+        return;
+    }
+    stat.region_slices += 1;
+    if seen.insert(sl.as_ptr() as usize) {
+        stat.bytes += sl.len() * size_of::<T>();
+    }
+}
+
+fn key_bytes(k: &TableKey) -> usize {
+    match k {
+        TableKey::String(s) | TableKey::Keyword(s) => s.len(),
+        TableKey::Array(ks) => ks.iter().map(key_bytes).sum(),
+        _ => 0,
+    }
+}
+
+fn syntax_bytes(s: &Syntax, seen: &mut FxHashSet<usize>) -> usize {
+    let mut b = size_of::<Syntax>() + std::mem::size_of_val(s.scopes.as_slice());
+    match &s.kind {
+        SyntaxKind::Symbol(x)
+        | SyntaxKind::Keyword(x)
+        | SyntaxKind::String(x)
+        | SyntaxKind::StringMut(x) => b += x.len(),
+        SyntaxKind::List(v)
+        | SyntaxKind::Array(v)
+        | SyntaxKind::ArrayMut(v)
+        | SyntaxKind::Struct(v)
+        | SyntaxKind::StructMut(v)
+        | SyntaxKind::Set(v)
+        | SyntaxKind::SetMut(v)
+        | SyntaxKind::Bytes(v)
+        | SyntaxKind::BytesMut(v) => b += v.iter().map(|c| syntax_bytes(c, seen)).sum::<usize>(),
+        SyntaxKind::Quote(c)
+        | SyntaxKind::Quasiquote(c)
+        | SyntaxKind::Unquote(c)
+        | SyntaxKind::UnquoteSplicing(c)
+        | SyntaxKind::Splice(c) => b += syntax_bytes(c, seen),
+        SyntaxKind::SyntaxLiteral(rc) => {
+            if seen.insert(Rc::as_ptr(rc) as usize) {
+                b += syntax_bytes(rc, seen);
+            }
+        }
+        SyntaxKind::Nil | SyntaxKind::Bool(_) | SyntaxKind::Int(_) | SyntaxKind::Float(_) => {}
+    }
+    b
+}
+
+/// Payload bytes and relocation slots of one object (module docs describe
+/// what is and is not counted).
+fn measure(obj: &HeapObject, seen: &mut FxHashSet<usize>) -> ObjStat {
+    let mut stat = ObjStat {
+        bytes: size_of::<HeapObject>(),
+        ..ObjStat::default()
+    };
+    heap_slot(&obj.traits(), &mut stat);
+
+    match obj {
+        HeapObject::LString { s, .. } => slice_stat(s, seen, &mut stat),
+        HeapObject::LBytes { data, .. } => slice_stat(data, seen, &mut stat),
+        HeapObject::Pair(pair) => {
+            heap_slot(&pair.first, &mut stat);
+            heap_slot(&pair.rest, &mut stat);
+        }
+        HeapObject::LArray { elements, .. } => {
+            slice_stat(elements, seen, &mut stat);
+            for v in elements.iter() {
+                heap_slot(v, &mut stat);
+            }
+        }
+        HeapObject::LSet { data, .. } => {
+            slice_stat(data, seen, &mut stat);
+            for v in data.iter() {
+                heap_slot(v, &mut stat);
+            }
+        }
+        HeapObject::LStruct { data, .. } => {
+            stat.bytes += data.len() * size_of::<(TableKey, Value)>();
+            for (k, v) in data.iter() {
+                stat.bytes += key_bytes(k);
+                k.for_each_heap_value(&mut |kv| heap_slot(kv, &mut stat));
+                heap_slot(v, &mut stat);
+            }
+        }
+        HeapObject::Closure { closure, .. } => {
+            slice_stat(&closure.env, seen, &mut stat);
+            for v in closure.env.iter() {
+                heap_slot(v, &mut stat);
+            }
+            match &closure.template {
+                crate::value::closure::TemplateRef::Region(tv) => heap_slot(tv, &mut stat),
+                _ => stat.shared_template = true,
+            }
+        }
+        HeapObject::ClosureTemplate(t) => {
+            if seen.insert(Rc::as_ptr(&t.bytecode) as usize) {
+                stat.bytes += t.bytecode.len();
+            }
+            if seen.insert(Rc::as_ptr(&t.constants) as usize) {
+                stat.bytes += t.constants.len() * size_of::<Value>();
+            }
+            for v in t.constants.iter() {
+                heap_slot(v, &mut stat);
+            }
+            if let Some(name) = &t.name {
+                if seen.insert(Rc::as_ptr(name) as *const u8 as usize) {
+                    stat.bytes += name.len();
+                }
+            }
+            if let Some(doc) = &t.doc {
+                if seen.insert(Rc::as_ptr(doc) as *const u8 as usize) {
+                    stat.bytes += doc.len();
+                }
+            }
+        }
+        HeapObject::Syntax { syntax, .. } => stat.bytes += syntax_bytes(syntax, seen),
+        HeapObject::Parameter { default, .. } => heap_slot(default, &mut stat),
+        HeapObject::LBox { cell, .. } | HeapObject::CaptureCell { cell, .. } => {
+            stat.bytes += size_of::<Value>();
+            if let Ok(v) = cell.try_borrow() {
+                heap_slot(&v, &mut stat);
+            }
+        }
+        HeapObject::LArrayMut { data, .. } => {
+            if let Ok(vs) = data.try_borrow() {
+                stat.bytes += vs.len() * size_of::<Value>();
+                for v in vs.iter() {
+                    heap_slot(v, &mut stat);
+                }
+            }
+        }
+        HeapObject::LSetMut { data, .. } => {
+            if let Ok(vs) = data.try_borrow() {
+                stat.bytes += vs.len() * size_of::<Value>();
+                for v in vs.iter() {
+                    heap_slot(v, &mut stat);
+                }
+            }
+        }
+        HeapObject::LStructMut { data, .. } => {
+            if let Ok(m) = data.try_borrow() {
+                stat.bytes += m.len() * size_of::<(TableKey, Value)>();
+                for (k, v) in m.iter() {
+                    stat.bytes += key_bytes(k);
+                    k.for_each_heap_value(&mut |kv| heap_slot(kv, &mut stat));
+                    heap_slot(v, &mut stat);
+                }
+            }
+        }
+        HeapObject::LStringMut { data, .. } | HeapObject::LBytesMut { data, .. } => {
+            if let Ok(bs) = data.try_borrow() {
+                stat.bytes += bs.len();
+            }
+        }
+        // Shell-only: refused from the body (fiber internals are process
+        // state the dump never carries) or payload-free.
+        HeapObject::Float(_)
+        | HeapObject::LibHandle(_)
+        | HeapObject::ThreadHandle { .. }
+        | HeapObject::Fiber { .. }
+        | HeapObject::FFISignature(_, _)
+        | HeapObject::FFIType(_)
+        | HeapObject::ManagedPointer { .. }
+        | HeapObject::External { .. } => {}
+    }
+    stat
+}

--- a/src/value/fiberheap/mod.rs
+++ b/src/value/fiberheap/mod.rs
@@ -16,6 +16,8 @@ pub(crate) mod pagepool;
 pub(crate) mod regionpool;
 pub(crate) mod regionstore;
 
+pub mod census;
+
 // The `FiberHeap` surface is split by concern across sibling submodules; each
 // is an inherent `impl` block or `pub(crate)` free fn, so callers reach them by
 // method-call or path resolution unchanged. See each module's own docs.

--- a/src/value/fiberheap/pagepool.rs
+++ b/src/value/fiberheap/pagepool.rs
@@ -146,6 +146,12 @@ unsafe fn unmap(addr: usize, len: usize) {
 pub(crate) struct MmapPage {
     ptr: *mut u8,
     len: usize,
+    /// A hydrated image page: a `MAP_PRIVATE` view of an image file
+    /// (docs/impl/image.md § Hydration step 3). The pool neither caches nor
+    /// recycles such a page — its body is image bytes, not the blank slate
+    /// the claim contract hands out — so its release is this page's `Drop`:
+    /// `munmap`. Anonymous pages (every other constructor) are `false`.
+    file_backed: bool,
 }
 
 impl MmapPage {
@@ -187,6 +193,7 @@ impl MmapPage {
         Some(MmapPage {
             ptr: trim.base as *mut u8,
             len,
+            file_backed: false,
         })
     }
 
@@ -209,7 +216,30 @@ impl MmapPage {
             Some(MmapPage {
                 ptr: ptr as *mut u8,
                 len,
+                file_backed: false,
             })
+        }
+    }
+
+    /// Wrap an already-established fixed mapping (a hydrated image page) as a
+    /// file-backed page the region system owns. See [`MmapPage::file_backed`].
+    ///
+    /// # Safety
+    /// `ptr` must be the base of a live `len`-byte private mapping, `len`-aligned
+    /// (the masked-header walk requires self-alignment), owned by no other
+    /// `MmapPage` — this takes over its `munmap`.
+    pub(crate) unsafe fn from_fixed_mapping(ptr: *mut u8, len: usize) -> Self {
+        debug_assert!(len >= base_page() && len.is_power_of_two());
+        debug_assert_eq!(
+            ptr as usize & (len - 1),
+            0,
+            "hydrated page not self-aligned"
+        );
+        MAPPED_BYTES.fetch_add(len as u64, Ordering::Relaxed);
+        MmapPage {
+            ptr,
+            len,
+            file_backed: true,
         }
     }
 
@@ -477,6 +507,11 @@ impl PagePool {
     pub fn release(&mut self, mut page: MmapPage, dirty: PageDirty) {
         if crate::value::fiberheap::freelog::guard_armed() {
             page.guard_and_leak();
+            return;
+        }
+        if page.file_backed {
+            // A hydrated image page: never cached, never recycled — drop
+            // unmaps it (see `MmapPage::file_backed`).
             return;
         }
         let size = page.len();

--- a/src/value/fiberheap/pagepool/tests.rs
+++ b/src/value/fiberheap/pagepool/tests.rs
@@ -339,3 +339,33 @@ fn large_pages_are_self_aligned() {
         );
     }
 }
+
+// A file-backed (hydrated image) page is never cached: its release is
+// `munmap`, even when the cache has room (docs/impl/image.md § Hydration
+// step 3). The anonymous release above (`release_and_reclaim`) is the
+// counter-factual: same pool, same room, an anonymous page IS cached.
+#[test]
+fn file_backed_release_is_munmap_not_cache() {
+    let mut pool = PagePool::default();
+    // A self-aligned anonymous mapping standing in for a hydrated image
+    // page (a private file view behaves identically at release).
+    let raw = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            base_page(),
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        )
+    };
+    assert_ne!(raw, libc::MAP_FAILED);
+    let page = unsafe { MmapPage::from_fixed_mapping(raw as *mut u8, base_page()) };
+    let dirty = all_of(&page);
+    pool.release(page, dirty);
+    assert_eq!(
+        pool.cached_bytes(),
+        0,
+        "file-backed page entered the cache instead of being unmapped"
+    );
+}

--- a/src/value/fiberheap/region.rs
+++ b/src/value/fiberheap/region.rs
@@ -191,6 +191,34 @@ impl FiberHeap {
         self.alloc_count -= freed;
     }
 
+    /// Install a hydrated image region (docs/impl/image.md § Hydration):
+    /// adopt the mapped pages, rebuild the object bookkeeping from the index
+    /// (`base`-relative offsets), and account the objects like any other
+    /// allocation. Returns the minted `Counted` region — rc 1, the caller's
+    /// reference.
+    pub(crate) fn install_hydrated_region(
+        &mut self,
+        pages: Vec<(super::pagepool::MmapPage, usize, usize)>,
+        objects: &[(usize, crate::value::heap::HeapTag)],
+        base: usize,
+    ) -> RuntimeRegion {
+        let id = self
+            .region_store
+            .install_hydrated_region(pages, objects, base);
+        self.alloc_count += objects.len();
+        if self.alloc_count > self.peak_alloc_count {
+            self.peak_alloc_count = self.alloc_count;
+        }
+        self.total_alloc_count += objects.len() as u64;
+        id
+    }
+
+    /// The page layouts and live objects of one region, for the image dumper
+    /// (docs/impl/image.md § Dumping). `None` for an absent region.
+    pub(crate) fn region_pool(&self, id: RuntimeRegion) -> Option<&super::regionpool::RegionPool> {
+        self.region_store.region_pool(id)
+    }
+
     /// Page size used by the region store's page pool.
     pub fn region_page_size(&self) -> usize {
         self.region_store.page_size()

--- a/src/value/fiberheap/regionpool.rs
+++ b/src/value/fiberheap/regionpool.rs
@@ -186,6 +186,15 @@ impl RegionPage {
     }
 }
 
+/// One page's byte layout, as [`RegionPool::page_layouts`] reports it.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PageLayout {
+    pub base: usize,
+    pub len: usize,
+    pub obj_cursor: usize,
+    pub data_cursor: usize,
+}
+
 /// Per-region storage: owns pages, tracks objects needing Drop.
 pub(crate) struct RegionPool {
     pages: Vec<RegionPage>,
@@ -343,6 +352,59 @@ impl RegionPool {
         let freed = self.obj_count;
         self.obj_count = 0;
         freed
+    }
+
+    /// Byte layout of every page this region owns, in claim order. The image
+    /// dumper reads these to copy page bytes and bound the meaningful spans
+    /// (docs/impl/image.md § Dumping).
+    pub(crate) fn page_layouts(&self) -> Vec<PageLayout> {
+        self.pages
+            .iter()
+            .map(|p| PageLayout {
+                base: p.page.as_ptr() as usize,
+                len: p.page.len(),
+                obj_cursor: p.obj_cursor,
+                data_cursor: p.data_cursor,
+            })
+            .collect()
+    }
+
+    /// Adopt a hydrated image page (docs/impl/image.md § Hydration steps 3–5):
+    /// stamp its header with this region's identity and install the cursors
+    /// the image's page table recorded, so later allocation into this region
+    /// and the release spans both see the true layout.
+    pub(crate) fn adopt_hydrated_page(
+        &mut self,
+        page: MmapPage,
+        obj_cursor: usize,
+        data_cursor: usize,
+    ) {
+        debug_assert!(
+            HEADER_SIZE <= obj_cursor && obj_cursor <= data_cursor && data_cursor <= page.len(),
+            "hydrated page cursors out of order: {obj_cursor}..{data_cursor} in {}",
+            page.len(),
+        );
+        let mut rp = RegionPage::new(page, self.region_id, self.stamp);
+        rp.obj_cursor = obj_cursor;
+        rp.data_cursor = data_cursor;
+        self.pages.push(rp);
+    }
+
+    /// Rebuild the object bookkeeping from an image's object index
+    /// (docs/impl/image.md § Hydration step 5): route each object to `dtors`
+    /// or `ref_objs` by the same predicates the alloc path uses, and count it.
+    pub(crate) fn install_object_index(
+        &mut self,
+        objects: &[(*mut HeapObject, crate::value::heap::HeapTag)],
+    ) {
+        for &(ptr, tag) in objects {
+            if needs_drop(tag) {
+                self.dtors.push(ptr);
+            } else if holds_value_refs(tag) {
+                self.ref_objs.push(ptr);
+            }
+        }
+        self.obj_count += objects.len();
     }
 
     /// Add a new page from the pool.

--- a/src/value/fiberheap/regionstore.rs
+++ b/src/value/fiberheap/regionstore.rs
@@ -174,6 +174,7 @@ pub(crate) struct RegionStore {
 
 mod alloc;
 mod free;
+mod hydrate;
 mod introspect;
 mod mintscope;
 mod ownership;

--- a/src/value/fiberheap/regionstore/hydrate.rs
+++ b/src/value/fiberheap/regionstore/hydrate.rs
@@ -1,0 +1,47 @@
+//! Installing a hydrated image region (docs/impl/image.md § Hydration
+//! steps 3–6): the mapped, relocated pages become the pages of a freshly
+//! minted `Counted` region, indistinguishable from any other region to RC,
+//! teardown, and the diagnostics. The mapping and relocation themselves
+//! happen in `crate::image::hydrate`; this is the region-store seam.
+
+use super::super::pagepool::MmapPage;
+use super::*;
+use crate::value::heap::HeapTag;
+
+impl RegionStore {
+    /// Mint a region and adopt `pages` (each with the cursors the image's
+    /// page table recorded) plus the object index (`base`-relative offsets).
+    /// The region is `Counted(1)` — the caller holds the one reference.
+    pub(crate) fn install_hydrated_region(
+        &mut self,
+        pages: Vec<(MmapPage, usize, usize)>,
+        objects: &[(usize, HeapTag)],
+        base: usize,
+    ) -> RuntimeRegion {
+        let id = self.new_runtime_region();
+        self.ensure(id);
+        let entry = self.regions[id.get() as usize]
+            .as_mut()
+            .expect("ensure created the entry");
+        for (page, obj_cursor, data_cursor) in pages {
+            entry
+                .pool
+                .adopt_hydrated_page(page, obj_cursor, data_cursor);
+        }
+        let ptrs: Vec<(*mut crate::value::heap::HeapObject, HeapTag)> = objects
+            .iter()
+            .map(|&(off, tag)| ((base + off) as *mut crate::value::heap::HeapObject, tag))
+            .collect();
+        entry.pool.install_object_index(&ptrs);
+        id
+    }
+
+    /// The pool of one live region (read-only), for the image dumper's page
+    /// and object walks. `None` for an absent region.
+    pub(crate) fn region_pool(&self, id: RuntimeRegion) -> Option<&RegionPool> {
+        self.regions
+            .get(id.get() as usize)
+            .and_then(|s| s.as_ref())
+            .map(|e| &e.pool)
+    }
+}

--- a/src/value/fiberheap/regionstore/introspect.rs
+++ b/src/value/fiberheap/regionstore/introspect.rs
@@ -131,6 +131,25 @@ impl RegionStore {
         self.regions.len()
     }
 
+    /// Every live object across every active region, in region-id order.
+    /// Drives the post-boot heap census (value/fiberheap/census.rs).
+    pub(crate) fn live_objects(&self) -> impl Iterator<Item = &HeapObject> {
+        self.regions
+            .iter()
+            .filter_map(|r| r.as_ref())
+            .flat_map(|e| e.pool.live_objects())
+    }
+
+    /// Committed region-page bytes, excluding the pool's cached (unowned)
+    /// pages that `allocated_bytes` includes.
+    pub(crate) fn region_bytes(&self) -> usize {
+        self.regions
+            .iter()
+            .filter_map(|r| r.as_ref())
+            .map(|e| e.pool.allocated_bytes())
+            .sum()
+    }
+
     /// Object tags currently live in a region (the `arena/dump` diagnostic).
     pub fn region_tags(&self, id: u32) -> Vec<crate::value::heap::HeapTag> {
         self.regions

--- a/src/value/region_slice.rs
+++ b/src/value/region_slice.rs
@@ -101,6 +101,18 @@ impl<T: 'static> RegionSlice<T> {
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.as_slice().iter()
     }
+
+    /// Byte layout of the slice header itself, for the image layout probes
+    /// (docs/impl/image.md § Fingerprint): the `ptr` and `len` field offsets
+    /// and the `len` field's size. Lives here because the fields are private.
+    pub(crate) fn header_layout() -> (usize, usize, usize) {
+        let probe = Self::empty();
+        (
+            std::mem::offset_of!(Self, ptr),
+            std::mem::offset_of!(Self, len),
+            std::mem::size_of_val(&probe.len),
+        )
+    }
 }
 
 // Manual Clone/Copy: just copies the pointer and length.

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -112,6 +112,8 @@ Tests are organized by feature area in separate files:
 | `environment.rs` | Environment variables |
 | `escape.rs` | Escape analysis |
 | `arena.rs` | Arena allocation |
+| `trace_boot.rs` | `--trace=boot`/`--trace=compile` phase-timing marks |
+| `census.rs` | Post-boot heap census: the sealing regression net and the `--trace=census` report (docs/impl/image.md) |
 | `allocator.rs` | Memory allocation |
 | ~~`parameters.rs`~~ | Migrated to `tests/elle/parameters.lisp` |
 | `ports.rs` | I/O ports |

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -114,6 +114,7 @@ Tests are organized by feature area in separate files:
 | `arena.rs` | Arena allocation |
 | `trace_boot.rs` | `--trace=boot`/`--trace=compile` phase-timing marks |
 | `census.rs` | Post-boot heap census: the sealing regression net and the `--trace=census` report (docs/impl/image.md) |
+| `image.rs` | Image store spike: dump/hydrate round-trip, fingerprint fallback, relocation independence, mapping and pool-interplay pins (docs/impl/image.md § Test plan) |
 | `allocator.rs` | Memory allocation |
 | ~~`parameters.rs`~~ | Migrated to `tests/elle/parameters.lisp` |
 | `ports.rs` | I/O ports |

--- a/tests/integration/census.rs
+++ b/tests/integration/census.rs
@@ -1,0 +1,178 @@
+// The post-boot heap census (docs/impl/image.md § "Open risks and dispatch
+// experiments", item 2): after `Runtime::new()` completes, every live object
+// in the instance's region store is boot state, and the census enumerates the
+// graph a boot image must dump. These tests are the permanent regression net
+// for the sealing claims: they fail the moment an unsealed variant enters the
+// boot graph, which is exactly the condition that would make the boot image
+// undumpable.
+
+use elle::runtime::Runtime;
+use elle::value::fiberheap::census::Sealing;
+use elle::value::HeapTag;
+use std::process::Command;
+
+// ── The sealing net ─────────────────────────────────────────────────
+
+// docs/impl/image.md § Sealing names the boot graph's only unsealed leaves,
+// both handled by the reconstruction stream: the three `External` stdio
+// ports (the *stdin*/*stdout*/*stderr* `Parameter` defaults) and the
+// instance's two default traitsets (`@struct`s built by `init_default_traits`
+// at VM init). Anything else unsealed is a new dump obstacle and must be
+// recorded in the design before this expectation moves. The counter-factual
+// this guards: a stdlib change that defines a mutable top-level (an @struct
+// cache, a box) would boot fine and pass every behavioral test, yet silently
+// make the future boot image undumpable — this assertion is what fails
+// instead.
+#[test]
+fn boot_heap_unsealed_leaves_are_exactly_the_reconstructible_set() {
+    let mut rt = Runtime::new();
+    let census = rt.heap().census();
+
+    let mut unsealed: Vec<String> = census
+        .unsealed
+        .iter()
+        .map(|leaf| format!("{:?}({}) x{}", leaf.tag, leaf.detail, leaf.count))
+        .collect();
+    unsealed.sort();
+    assert_eq!(
+        unsealed,
+        vec![
+            "External(port) x3".to_string(),
+            "LStructMut() x2".to_string()
+        ],
+        "boot graph's unsealed leaves changed; census:\n{}",
+        census.lines().join("\n")
+    );
+}
+
+// § Sealing: "The stdlib file-letrec allocates one `CaptureCell` per captured
+// top-level binding" — the cells snapping must rewrite. Zero cells would mean
+// the letrec lowering changed shape and the snapping design step is stale.
+#[test]
+fn boot_heap_holds_capture_cells_for_snapping() {
+    let mut rt = Runtime::new();
+    let census = rt.heap().census();
+    assert!(
+        census.capture_cells > 0,
+        "expected stdlib letrec capture cells in the boot graph; census:\n{}",
+        census.lines().join("\n")
+    );
+}
+
+// Shape of the census itself: the boot graph must show closures, region
+// templates, pointer slots, and region slices, and the store must hold the
+// many per-cell letrec regions the design's compaction argument rests on.
+#[test]
+fn boot_census_reports_the_expected_shape() {
+    let mut rt = Runtime::new();
+    let census = rt.heap().census();
+
+    assert!(census.objects > 0, "empty boot census");
+    assert!(
+        census.regions > 1,
+        "boot produced {} region(s); the compaction argument expects many",
+        census.regions
+    );
+    // The trap this loop already caught once: the boot residue is function
+    // definitions, not data — no `Pair` (or string, or array) survives to
+    // the post-boot heap, so only the code-object tags may be asserted here.
+    for tag in [
+        HeapTag::Closure,
+        HeapTag::ClosureTemplate,
+        HeapTag::CaptureCell,
+    ] {
+        assert!(
+            census.tags.iter().any(|t| t.tag == tag && t.count > 0),
+            "boot census lacks {:?} objects:\n{}",
+            tag,
+            census.lines().join("\n")
+        );
+    }
+    assert!(census.ptr_slots > 0, "no pointer slots counted");
+    assert!(census.region_slices > 0, "no region slices counted");
+    // The per-tag rows must add up to the totals the density math uses.
+    let count_sum: usize = census.tags.iter().map(|t| t.count).sum();
+    assert_eq!(count_sum, census.objects, "per-tag counts drift from total");
+}
+
+// The sealing classification is the image design's sealed set (§ Sealing),
+// not an implementation echo: every mutable variant and every process/foreign
+// handle is refused, CaptureCell is snapped, everything else is body data.
+#[test]
+fn sealing_classification_matches_the_design() {
+    use elle::value::fiberheap::census::sealing;
+    for tag in [
+        HeapTag::LString,
+        HeapTag::Pair,
+        HeapTag::LStruct,
+        HeapTag::Closure,
+        HeapTag::LArray,
+        HeapTag::LBytes,
+        HeapTag::LSet,
+        HeapTag::Syntax,
+        HeapTag::Float,
+        HeapTag::Parameter,
+        HeapTag::ClosureTemplate,
+    ] {
+        assert_eq!(sealing(tag), Sealing::Sealed, "{:?} should be sealed", tag);
+    }
+    assert_eq!(sealing(HeapTag::CaptureCell), Sealing::Snapped);
+    for tag in [
+        HeapTag::LArrayMut,
+        HeapTag::LStructMut,
+        HeapTag::LStringMut,
+        HeapTag::LBytesMut,
+        HeapTag::LSetMut,
+        HeapTag::LBox,
+        HeapTag::LibHandle,
+        HeapTag::ThreadHandle,
+        HeapTag::Fiber,
+        HeapTag::FFISignature,
+        HeapTag::FFIType,
+        HeapTag::ManagedPointer,
+        HeapTag::External,
+    ] {
+        assert_eq!(
+            sealing(tag),
+            Sealing::Unsealed,
+            "{:?} should be unsealed",
+            tag
+        );
+    }
+}
+
+// ── The CLI diagnostic ──────────────────────────────────────────────
+
+// `--trace=` rejects unknown keywords, so a binary without the `census`
+// keyword fails this run outright rather than running silently without the
+// report (the same trap trace_boot.rs pins for `boot`).
+#[test]
+fn census_trace_reports_the_boot_heap() {
+    let dir = crate::common::ScratchDir::new("trace-census");
+    let script = dir.join("script.lisp");
+    std::fs::write(&script, "(+ 1 2)\n").expect("write script");
+    let out = Command::new(env!("CARGO_BIN_EXE_elle"))
+        .arg("--trace=census")
+        .arg(&script)
+        .output()
+        .expect("run elle");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "elle --trace=census failed; stderr:\n{}",
+        stderr
+    );
+    for needle in [
+        "[trace:census] regions ",
+        "[trace:census] tag ",
+        "[trace:census] capture-cells ",
+        "[trace:census] unsealed",
+    ] {
+        assert!(
+            stderr.lines().any(|l| l.starts_with(needle)),
+            "missing '{}' line; stderr:\n{}",
+            needle,
+            stderr
+        );
+    }
+}

--- a/tests/integration/image.rs
+++ b/tests/integration/image.rs
@@ -211,17 +211,30 @@ fn double_hydration_is_correct_and_independent() {
 
 // ── Determinism ─────────────────────────────────────────────────────
 
-// § Test plan, "Determinism" / § Dumping: the ordered walk makes the dump's
-// LAYOUT deterministic — identical lengths, identical header and metadata
-// sections — and any byte difference between two dumps of the same graph is
-// confined to object slots. The trap the spike measured: a `repr(Rust)`
-// enum copy carries uninitialized padding from its construction temporary,
-// so raw object-slot bytes cannot be canonicalized until the field-extent
-// probes (risk item 6) land — but headers, gaps, alignment slack, and
-// relocation slots ARE canonicalized (zeroed), and this test fails if any
-// of those, or any metadata byte, ever differs.
+/// Fill `depth + 1` stack frames with `pattern` so that any construction
+/// temporary a later call materializes inherits pattern bytes in its
+/// padding. The xor keeps the recursion and the buffer observable.
+#[inline(never)]
+fn paint_stack(pattern: u8, depth: usize) -> u64 {
+    let buf = [pattern; 4096];
+    let sum: u64 = buf.iter().map(|&b| b as u64).sum();
+    if depth == 0 {
+        sum
+    } else {
+        sum ^ paint_stack(pattern, depth - 1)
+    }
+}
+
+// § Test plan, "Determinism" / § Dumping: two dumps of the same graph are
+// byte-identical whole files. The counter-factual is the stack painting:
+// the dumper's scratch objects are `repr(Rust)` enum copies whose padding
+// comes from their construction temporaries, so a dumper that copies slot
+// bytes wholesale writes whatever the stack held into the file — painting
+// the stack differently before each dump forced ~700 differing bytes.
+// Only a dumper that assembles slots from the probed field extents
+// (docs/impl/image.md risk item 6) keeps the files identical.
 #[test]
-fn dump_layout_is_deterministic_and_diffs_confine_to_object_slots() {
+fn dump_is_byte_deterministic_whole_file() {
     let dir = crate::common::ScratchDir::new("image-determinism");
     let a = dir.join("a.image");
     let b = dir.join("b.image");
@@ -229,42 +242,35 @@ fn dump_layout_is_deterministic_and_diffs_confine_to_object_slots() {
     let mut src = FiberHeap::new();
     let region = src.new_runtime_region();
     let root = build_graph(&mut src, region);
+    paint_stack(0xAA, 16);
     image::dump(&mut src, root, &a).expect("dump a");
+    paint_stack(0x55, 16);
     image::dump(&mut src, root, &b).expect("dump b");
 
     let ba = std::fs::read(&a).expect("read a");
     let bb = std::fs::read(&b).expect("read b");
-    assert_eq!(ba.len(), bb.len(), "dump lengths differ");
-
-    // Header geometry (fixed little-endian offsets; see image/format.rs).
-    let u64_at = |buf: &[u8], at: usize| u64::from_le_bytes(buf[at..at + 8].try_into().unwrap());
-    const HEADER_BLOCK: usize = 4096;
-    let pages_len = u64_at(&ba, 16) as usize;
-    let n_pages = u64_at(&ba, 24) as usize;
-
-    assert_eq!(ba[..HEADER_BLOCK], bb[..HEADER_BLOCK], "headers differ");
-    let meta_at = HEADER_BLOCK + pages_len;
-    assert_eq!(ba[meta_at..], bb[meta_at..], "metadata sections differ");
-
-    // Object spans per page, from the page table: [16, obj_cursor) at each
-    // page's placement offset. Every remaining diff must fall inside one.
-    let mut spans: Vec<std::ops::Range<usize>> = Vec::new();
-    let mut page_off = HEADER_BLOCK;
-    for i in 0..n_pages {
-        let entry = meta_at + i * 24;
-        let size = u64_at(&ba, entry) as usize;
-        let obj_cursor = u64_at(&ba, entry + 8) as usize;
-        spans.push(page_off + 16..page_off + obj_cursor);
-        page_off += size;
-    }
-    let stray: Vec<usize> = (HEADER_BLOCK..meta_at)
-        .filter(|&i| ba[i] != bb[i] && !spans.iter().any(|s| s.contains(&i)))
+    let diff: Vec<usize> = (0..ba.len().min(bb.len()))
+        .filter(|&i| ba[i] != bb[i])
         .collect();
+    assert_eq!(ba.len(), bb.len(), "dump lengths differ");
     assert!(
-        stray.is_empty(),
-        "dumps differ outside object slots at offsets {:?}",
-        &stray[..stray.len().min(16)]
+        diff.is_empty(),
+        "dumps differ at {} offsets, first: {:?}",
+        diff.len(),
+        &diff[..diff.len().min(16)]
     );
+}
+
+// § Fingerprint: the layout probes participate in the fingerprint, so a
+// binary whose `HeapObject` layout shifted rejects the image instead of
+// hydrating garbage. Pin that every dumpable variant appears with extents.
+#[test]
+fn fingerprint_records_variant_layouts() {
+    let fp = image::fingerprint();
+    assert!(fp.contains("layout="), "no layout section: {fp}");
+    for variant in ["LString", "Pair", "LArray", "LBytes", "Float"] {
+        assert!(fp.contains(variant), "layout section lacks {variant}: {fp}");
+    }
 }
 
 // ── Pool interplay ──────────────────────────────────────────────────

--- a/tests/integration/image.rs
+++ b/tests/integration/image.rs
@@ -1,0 +1,428 @@
+// The store spike (docs/impl/image.md § "Landing order" item 5, dispatched as
+// risk-item 3): dump a data-only value graph as page bytes plus relocations,
+// hydrate it by private file mapping into an ordinary counted region, and
+// prove the format, the mapping, the relocation pass, and teardown end to
+// end. These are the § "Test plan" pins the store milestone must keep.
+
+use std::rc::Rc;
+
+use elle::image::{self, ImageError};
+use elle::value::fiberheap::FiberHeap;
+use elle::value::heap::deref;
+use elle::value::{HeapObject, Pair, Value};
+
+// ── Graph builders (trait-less data values, one region) ─────────────
+
+fn alloc_str(heap: &mut FiberHeap, region: elle::hir::region::RuntimeRegion, s: &str) -> Value {
+    let slice = heap.alloc_region_slice_in_region(s.as_bytes(), region);
+    heap.alloc_in_region(
+        HeapObject::LString {
+            s: slice,
+            traits: Value::NIL,
+        },
+        region,
+    )
+}
+
+fn alloc_bytes(heap: &mut FiberHeap, region: elle::hir::region::RuntimeRegion, b: &[u8]) -> Value {
+    let slice = heap.alloc_region_slice_in_region(b, region);
+    heap.alloc_in_region(
+        HeapObject::LBytes {
+            data: slice,
+            traits: Value::NIL,
+        },
+        region,
+    )
+}
+
+fn alloc_pair(
+    heap: &mut FiberHeap,
+    region: elle::hir::region::RuntimeRegion,
+    first: Value,
+    rest: Value,
+) -> Value {
+    heap.alloc_in_region(HeapObject::Pair(Pair::new(first, rest)), region)
+}
+
+fn alloc_array(
+    heap: &mut FiberHeap,
+    region: elle::hir::region::RuntimeRegion,
+    items: &[Value],
+) -> Value {
+    let slice = heap.alloc_region_slice_in_region(items, region);
+    heap.alloc_in_region(
+        HeapObject::LArray {
+            elements: slice,
+            traits: Value::NIL,
+        },
+        region,
+    )
+}
+
+/// A representative data graph: nesting, every supported heap variant, and
+/// supported immediates (ints, inline floats, bools, nil, keywords).
+fn build_graph(heap: &mut FiberHeap, region: elle::hir::region::RuntimeRegion) -> Value {
+    let s = alloc_str(heap, region, "hello image");
+    let b = alloc_bytes(heap, region, &[0xE1, 0x1E, 0x5C]);
+    let inner = alloc_array(
+        heap,
+        region,
+        &[Value::int(7), s, Value::keyword("spike"), Value::float(2.5)],
+    );
+    let tail = alloc_pair(heap, region, Value::bool(true), Value::EMPTY_LIST);
+    let mid = alloc_pair(heap, region, inner, tail);
+    let mid2 = alloc_pair(heap, region, b, mid);
+    alloc_pair(heap, region, Value::int(1), mid2)
+}
+
+// ── Round-trip ──────────────────────────────────────────────────────
+
+// § Test plan, "Round-trip": dump a data graph, hydrate in a fresh heap,
+// assert structural equality. The fresh heap is what a fresh process would
+// hold: nothing in it predates the hydration, so equality can only come from
+// the mapped pages and the relocation pass.
+#[test]
+fn data_graph_round_trips_through_dump_and_hydrate() {
+    let dir = crate::common::ScratchDir::new("image-roundtrip");
+    let path = dir.join("graph.image");
+
+    let mut src = FiberHeap::new();
+    let region = src.new_runtime_region();
+    let root = build_graph(&mut src, region);
+    image::dump(&mut src, root, &path).expect("dump");
+
+    let mut dst = FiberHeap::new();
+    let hydrated = image::hydrate(&mut dst, &path).expect("hydrate");
+    assert_eq!(root, hydrated.root, "hydrated graph differs from source");
+}
+
+// Sharing is preserved (§ Dumping: the visited map keys on payload address,
+// "cycles and sharing preserved — unlike `send`"). The counter-factual: a
+// per-edge copier would round-trip to a structurally equal graph and pass
+// the test above while silently doubling every shared subgraph.
+#[test]
+fn hydration_preserves_sharing() {
+    let dir = crate::common::ScratchDir::new("image-sharing");
+    let path = dir.join("shared.image");
+
+    let mut src = FiberHeap::new();
+    let region = src.new_runtime_region();
+    let shared = alloc_str(&mut src, region, "shared once");
+    let root = alloc_array(&mut src, region, &[shared, shared]);
+    image::dump(&mut src, root, &path).expect("dump");
+
+    let mut dst = FiberHeap::new();
+    let hydrated = image::hydrate(&mut dst, &path).expect("hydrate");
+    let obj = unsafe { deref(hydrated.root) };
+    let HeapObject::LArray { elements, .. } = obj else {
+        panic!("hydrated root is not an array");
+    };
+    let elems = elements.as_slice();
+    assert_eq!(elems.len(), 2);
+    assert_eq!(
+        elems[0].as_heap_ptr(),
+        elems[1].as_heap_ptr(),
+        "shared child was duplicated by the dump"
+    );
+}
+
+// ── Fingerprint fallback ────────────────────────────────────────────
+
+// § Test plan, "Round-trip": a load with a corrupted fingerprint falls back
+// cleanly — a typed error, no region minted, no mapping left behind.
+#[test]
+fn corrupted_fingerprint_falls_back_cleanly() {
+    let dir = crate::common::ScratchDir::new("image-fingerprint");
+    let path = dir.join("graph.image");
+
+    let mut src = FiberHeap::new();
+    let region = src.new_runtime_region();
+    let root = build_graph(&mut src, region);
+    image::dump(&mut src, root, &path).expect("dump");
+
+    // Corrupt one byte inside the stored fingerprint string.
+    let mut bytes = std::fs::read(&path).expect("read image");
+    let fp = image::fingerprint();
+    let pos = bytes
+        .windows(fp.len())
+        .position(|w| w == fp.as_bytes())
+        .expect("fingerprint not found in image header");
+    bytes[pos] ^= 0x20;
+    std::fs::write(&path, &bytes).expect("rewrite image");
+
+    let mut dst = FiberHeap::new();
+    let before = dst.active_region_count();
+    match image::hydrate(&mut dst, &path) {
+        Err(ImageError::Fingerprint { .. }) => {}
+        other => panic!("expected fingerprint mismatch, got {other:?}"),
+    }
+    assert_eq!(
+        dst.active_region_count(),
+        before,
+        "failed hydration leaked a region"
+    );
+}
+
+// A file that is not an image at all is rejected as corrupt, not mapped.
+#[test]
+fn garbage_file_is_rejected() {
+    let dir = crate::common::ScratchDir::new("image-garbage");
+    let path = dir.join("garbage.image");
+    std::fs::write(&path, b"not an image at all").expect("write");
+    let mut dst = FiberHeap::new();
+    match image::hydrate(&mut dst, &path) {
+        Err(ImageError::Corrupt(_)) => {}
+        other => panic!("expected corrupt-image error, got {other:?}"),
+    }
+}
+
+// ── Relocation independence ─────────────────────────────────────────
+
+// § Test plan, "Relocation": hydrate the same image twice in one process —
+// two regions, two address sets — and assert both hydrations are correct
+// and independent (freeing the first leaves the second intact).
+#[test]
+fn double_hydration_is_correct_and_independent() {
+    let dir = crate::common::ScratchDir::new("image-double");
+    let path = dir.join("graph.image");
+
+    let mut src = FiberHeap::new();
+    let region = src.new_runtime_region();
+    let root = build_graph(&mut src, region);
+    image::dump(&mut src, root, &path).expect("dump");
+
+    let mut dst = FiberHeap::new();
+    let first = image::hydrate(&mut dst, &path).expect("first hydrate");
+    let second = image::hydrate(&mut dst, &path).expect("second hydrate");
+    assert_ne!(
+        first.root.as_heap_ptr(),
+        second.root.as_heap_ptr(),
+        "two hydrations share an address set"
+    );
+    assert_eq!(root, first.root);
+    assert_eq!(root, second.root);
+
+    dst.decref_region_if_present(first.region);
+    assert_eq!(
+        root, second.root,
+        "freeing the first hydration corrupted the second"
+    );
+}
+
+// ── Determinism ─────────────────────────────────────────────────────
+
+// § Test plan, "Determinism" / § Dumping: the ordered walk makes the dump's
+// LAYOUT deterministic — identical lengths, identical header and metadata
+// sections — and any byte difference between two dumps of the same graph is
+// confined to object slots. The trap the spike measured: a `repr(Rust)`
+// enum copy carries uninitialized padding from its construction temporary,
+// so raw object-slot bytes cannot be canonicalized until the field-extent
+// probes (risk item 6) land — but headers, gaps, alignment slack, and
+// relocation slots ARE canonicalized (zeroed), and this test fails if any
+// of those, or any metadata byte, ever differs.
+#[test]
+fn dump_layout_is_deterministic_and_diffs_confine_to_object_slots() {
+    let dir = crate::common::ScratchDir::new("image-determinism");
+    let a = dir.join("a.image");
+    let b = dir.join("b.image");
+
+    let mut src = FiberHeap::new();
+    let region = src.new_runtime_region();
+    let root = build_graph(&mut src, region);
+    image::dump(&mut src, root, &a).expect("dump a");
+    image::dump(&mut src, root, &b).expect("dump b");
+
+    let ba = std::fs::read(&a).expect("read a");
+    let bb = std::fs::read(&b).expect("read b");
+    assert_eq!(ba.len(), bb.len(), "dump lengths differ");
+
+    // Header geometry (fixed little-endian offsets; see image/format.rs).
+    let u64_at = |buf: &[u8], at: usize| u64::from_le_bytes(buf[at..at + 8].try_into().unwrap());
+    const HEADER_BLOCK: usize = 4096;
+    let pages_len = u64_at(&ba, 16) as usize;
+    let n_pages = u64_at(&ba, 24) as usize;
+
+    assert_eq!(ba[..HEADER_BLOCK], bb[..HEADER_BLOCK], "headers differ");
+    let meta_at = HEADER_BLOCK + pages_len;
+    assert_eq!(ba[meta_at..], bb[meta_at..], "metadata sections differ");
+
+    // Object spans per page, from the page table: [16, obj_cursor) at each
+    // page's placement offset. Every remaining diff must fall inside one.
+    let mut spans: Vec<std::ops::Range<usize>> = Vec::new();
+    let mut page_off = HEADER_BLOCK;
+    for i in 0..n_pages {
+        let entry = meta_at + i * 24;
+        let size = u64_at(&ba, entry) as usize;
+        let obj_cursor = u64_at(&ba, entry + 8) as usize;
+        spans.push(page_off + 16..page_off + obj_cursor);
+        page_off += size;
+    }
+    let stray: Vec<usize> = (HEADER_BLOCK..meta_at)
+        .filter(|&i| ba[i] != bb[i] && !spans.iter().any(|s| s.contains(&i)))
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "dumps differ outside object slots at offsets {:?}",
+        &stray[..stray.len().min(16)]
+    );
+}
+
+// ── Pool interplay ──────────────────────────────────────────────────
+
+// § Test plan, "Mapping": release a file-backed page and assert the pool
+// unmapped it rather than caching it. Per-heap byte accounting is the
+// race-free observable: `allocated_bytes` counts region pages AND cached
+// pages, so if the freed hydrated pages were cached the count would not
+// return to its pre-hydration value.
+#[test]
+fn hydrated_pages_release_by_munmap_not_cache() {
+    let dir = crate::common::ScratchDir::new("image-munmap");
+    let path = dir.join("graph.image");
+
+    let mut src = FiberHeap::new();
+    let region = src.new_runtime_region();
+    let root = build_graph(&mut src, region);
+    image::dump(&mut src, root, &path).expect("dump");
+
+    let mut dst = FiberHeap::new();
+    let before = dst.allocated_bytes();
+    let hydrated = image::hydrate(&mut dst, &path).expect("hydrate");
+    assert!(
+        dst.allocated_bytes() > before,
+        "hydration added no page bytes"
+    );
+    dst.decref_region_if_present(hydrated.region);
+    assert_eq!(
+        dst.allocated_bytes(),
+        before,
+        "freed hydrated pages were cached instead of unmapped"
+    );
+}
+
+// § Test plan, "Hygiene": hydrate, free, and the heap returns to its
+// baseline — no image-specific carve-out in the region accounting.
+#[test]
+fn hydration_teardown_returns_to_baseline() {
+    let dir = crate::common::ScratchDir::new("image-baseline");
+    let path = dir.join("graph.image");
+
+    let mut src = FiberHeap::new();
+    let region = src.new_runtime_region();
+    let root = build_graph(&mut src, region);
+    image::dump(&mut src, root, &path).expect("dump");
+    // The dump's scratch region was dropped: the source heap is back to its
+    // own baseline (the graph's one region).
+    assert_eq!(src.active_region_count(), 1, "dump leaked its scratch");
+
+    let mut dst = FiberHeap::new();
+    let regions_before = dst.region_info_vec();
+    let objs_before = dst.visible_len();
+    let hydrated = image::hydrate(&mut dst, &path).expect("hydrate");
+    assert!(dst.visible_len() > objs_before);
+    dst.decref_region_if_present(hydrated.region);
+    assert_eq!(dst.region_info_vec(), regions_before);
+    assert_eq!(dst.visible_len(), objs_before);
+}
+
+// ── Mapping stability ───────────────────────────────────────────────
+
+// § Hydration: "Never rewrite an image file in place" — the atomic
+// temp-and-rename discipline keeps a mapped old inode stable while a new
+// file replaces the path. Pin the read side: replace the file by rename
+// while a hydration is live, then read the hydrated values.
+#[test]
+fn replaced_file_keeps_live_mapping_intact() {
+    let dir = crate::common::ScratchDir::new("image-rename");
+    let path = dir.join("graph.image");
+
+    let mut src = FiberHeap::new();
+    let region = src.new_runtime_region();
+    let root = build_graph(&mut src, region);
+    image::dump(&mut src, root, &path).expect("dump");
+
+    let mut dst = FiberHeap::new();
+    let hydrated = image::hydrate(&mut dst, &path).expect("hydrate");
+
+    // Replace the path with a different (garbage) file via rename.
+    let replacement = dir.join("replacement");
+    std::fs::write(&replacement, vec![0xAA; 1 << 16]).expect("write replacement");
+    std::fs::rename(&replacement, &path).expect("rename over image");
+
+    assert_eq!(
+        root, hydrated.root,
+        "live mapping read through the replaced path's old inode failed"
+    );
+}
+
+// ── Dump policy ─────────────────────────────────────────────────────
+
+// § Dumping: "Unsupported values fail the dump with an error naming the
+// binding" — for the spike, naming the refused variant. A mutable store
+// must never be silently dropped or frozen into the body.
+#[test]
+fn mutable_value_refuses_dump() {
+    let dir = crate::common::ScratchDir::new("image-mutable");
+    let path = dir.join("mutable.image");
+
+    let mut src = FiberHeap::new();
+    let region = src.new_runtime_region();
+    let arr = src.alloc_in_region(
+        HeapObject::LArrayMut {
+            data: Rc::new(std::cell::RefCell::new(vec![Value::int(1)])),
+            traits: Value::NIL,
+        },
+        region,
+    );
+    let root = alloc_pair(&mut src, region, Value::int(1), arr);
+    match image::dump(&mut src, root, &path) {
+        Err(ImageError::Unsupported(what)) => {
+            assert!(
+                what.contains("LArrayMut"),
+                "refusal does not name the variant: {what}"
+            );
+        }
+        other => panic!("expected unsupported-value refusal, got {other:?}"),
+    }
+    assert!(!path.exists(), "refused dump left a partial file");
+}
+
+// A carried traitset is a reference out of the data graph (the default
+// traitsets are instance infrastructure — § "Process-owned resources
+// reconstruct in place"); the spike's dumper refuses it rather than
+// persisting a dangling instance pointer.
+#[test]
+fn traited_value_refuses_dump() {
+    let dir = crate::common::ScratchDir::new("image-traits");
+    let path = dir.join("traits.image");
+
+    let mut src = FiberHeap::new();
+    let region = src.new_runtime_region();
+    let table = alloc_str(&mut src, region, "pretend traitset");
+    let slice = src.alloc_region_slice_in_region("x".as_bytes(), region);
+    let traited = src.alloc_in_region(
+        HeapObject::LString {
+            s: slice,
+            traits: table,
+        },
+        region,
+    );
+    match image::dump(&mut src, traited, &path) {
+        Err(ImageError::Unsupported(what)) => {
+            assert!(what.contains("traits"), "refusal does not say traits: {what}");
+        }
+        other => panic!("expected traits refusal, got {other:?}"),
+    }
+}
+
+// An immediate root needs no pages at all; the round trip is the header.
+#[test]
+fn immediate_root_round_trips() {
+    let dir = crate::common::ScratchDir::new("image-immediate");
+    let path = dir.join("imm.image");
+
+    let mut src = FiberHeap::new();
+    image::dump(&mut src, Value::keyword("just-me"), &path).expect("dump");
+    let mut dst = FiberHeap::new();
+    let hydrated = image::hydrate(&mut dst, &path).expect("hydrate");
+    assert_eq!(hydrated.root, Value::keyword("just-me"));
+}

--- a/tests/integration/image.rs
+++ b/tests/integration/image.rs
@@ -420,6 +420,58 @@ fn traited_value_refuses_dump() {
     }
 }
 
+// ── The platform rule the file geometry is built on ─────────────────
+
+// The trap, and the reason the pages section is aligned at all: `mmap`
+// refuses a file offset that is not a multiple of the OS page size. This
+// cost six hydration failures on macOS arm64, where the page is 16 KiB and
+// the pages section started at a hardcoded 4 KiB — legal on the 4 KiB hosts
+// every other CI job runs, EINVAL there.
+//
+// The counter-factual this pins: the round-trip tests above cannot catch
+// that class of bug, because the dumper and the hydrator agreed on the wrong
+// offset and agreement is all a round trip checks. This test asserts against
+// the kernel instead of against the other half of our own code.
+#[test]
+fn mmap_refuses_a_file_offset_off_the_page_boundary() {
+    let dir = crate::common::ScratchDir::new("image-mmap-offset");
+    let path = dir.join("offsets.bin");
+
+    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
+    std::fs::write(&path, vec![0u8; page * 4]).expect("write");
+    let file = std::fs::File::open(&path).expect("open");
+    let fd = std::os::fd::AsRawFd::as_raw_fd(&file);
+
+    let map_at = |offset: usize| unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            page,
+            libc::PROT_READ,
+            libc::MAP_PRIVATE,
+            fd,
+            offset as libc::off_t,
+        )
+    };
+
+    // A page-aligned offset maps; half a page in does not.
+    let good = map_at(page);
+    assert_ne!(good, libc::MAP_FAILED, "page-aligned offset must map");
+    unsafe { libc::munmap(good, page) };
+
+    let bad = map_at(page / 2);
+    assert_eq!(
+        bad,
+        libc::MAP_FAILED,
+        "a half-page offset mapped; this platform's rule is not what the \
+         image format assumes"
+    );
+    assert_eq!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::EINVAL),
+        "expected EINVAL for a misaligned file offset"
+    );
+}
+
 // An immediate root needs no pages at all; the round trip is the header.
 #[test]
 fn immediate_root_round_trips() {

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -143,6 +143,9 @@ mod truncation {
 mod timeout_capture {
     include!("timeout_capture.rs");
 }
+mod trace_boot {
+    include!("trace_boot.rs");
+}
 mod trace_isolation {
     include!("trace_isolation.rs");
 }

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -143,6 +143,9 @@ mod truncation {
 mod census {
     include!("census.rs");
 }
+mod image {
+    include!("image.rs");
+}
 mod timeout_capture {
     include!("timeout_capture.rs");
 }

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -140,6 +140,9 @@ mod scratch {
 mod truncation {
     include!("truncation.rs");
 }
+mod census {
+    include!("census.rs");
+}
 mod timeout_capture {
     include!("timeout_capture.rs");
 }

--- a/tests/integration/trace_boot.rs
+++ b/tests/integration/trace_boot.rs
@@ -1,0 +1,79 @@
+// Boot attribution rides the trace system: `--trace=boot` marks each boot
+// phase (primitive registration, core, prelude, stdlib) and `--trace=compile`
+// marks each pipeline phase, both as `[trace:...] <label> <N>ms` on stderr.
+// The trap this pins: `--trace=` rejects unknown keywords, so a binary
+// without the `boot` keyword fails these runs outright rather than running
+// silently without marks.
+
+use std::process::Command;
+
+fn elle_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_elle")
+}
+
+fn run_traced(trace: &str, source: &str, tag: &str) -> (bool, String) {
+    let dir = crate::common::ScratchDir::new(tag);
+    let script = dir.join("script.lisp");
+    std::fs::write(&script, source).expect("write script");
+    let out = Command::new(elle_binary())
+        .arg(format!("--trace={}", trace))
+        .arg(&script)
+        .output()
+        .expect("run elle");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn boot_trace_marks_attribute_startup_phases() {
+    let (ok, stderr) = run_traced("boot", "(+ 1 2)\n", "trace-boot");
+    assert!(ok, "elle --trace=boot failed; stderr:\n{}", stderr);
+    for label in [
+        "primitives",
+        "core",
+        "prelude",
+        "stdlib-compile",
+        "stdlib-execute",
+    ] {
+        let line = stderr
+            .lines()
+            .find(|l| l.starts_with("[trace:boot]") && l.contains(label));
+        let line = line.unwrap_or_else(|| {
+            panic!(
+                "missing [trace:boot] mark for phase '{}'; stderr:\n{}",
+                label, stderr
+            )
+        });
+        assert!(
+            line.trim_end().ends_with("ms"),
+            "boot mark for '{}' lacks a duration: {}",
+            label,
+            line
+        );
+    }
+}
+
+#[test]
+fn compile_trace_times_pipeline_phases() {
+    let (ok, stderr) = run_traced("compile", "(+ 1 2)\n", "trace-compile");
+    assert!(ok, "elle --trace=compile failed; stderr:\n{}", stderr);
+    for label in ["read", "expand", "analyze", "regions", "lower", "emit"] {
+        let line = stderr
+            .lines()
+            .find(|l| l.starts_with("[trace:compile]") && l.contains(label));
+        let line = line.unwrap_or_else(|| {
+            panic!(
+                "missing [trace:compile] mark for phase '{}'; stderr:\n{}",
+                label, stderr
+            )
+        });
+        assert!(
+            line.trim_end().ends_with("ms"),
+            "compile mark for '{}' lacks a duration: {}",
+            label,
+            line
+        );
+    }
+}


### PR DESCRIPTION
The image-persistence design (docs/impl/image.md) plus the six experiments its risk list dispatched — all now complete. The doc owns the design argument: an image is the page bytes of one compacted region plus a relocation table; hydration maps the pages privately, rewrites pointer slots in one linear pass, and installs the result as an ordinary counted region — page speed, not serde speed, with no second memory class and no carve-outs in the leak suite. One mechanism serves two shipped configurations (the boot image and user environment images), and four representation foundations (symbol, struct, template, syntax) land first because each is independently valuable and deletes image machinery.

The experiments, in dispatch order:

1. **Boot attribution** (`--trace=boot,compile`, pinned by `tests/integration/trace_boot.rs`). A warm release boot of a trivial script spends ~494 ms of ~545 ms in the stdlib frontend compile; stdlib *execution* is 1.4 ms. The image removes everything but a ~38 ms floor — roughly a 10× boot.
2. **Post-boot census** (`--trace=census`, pinned by `tests/integration/census.rs`). 405 regions, 630 objects, ~455 KiB body payload; the residue is code, not data. All 210 capture cells snap (zero top-level `assign`s in stdlib), and the only unsealed leaves are the three stdio externals and the two default traitsets — exactly the reconstruction stream's classes. The sealing net fails the moment stdlib grows an undumpable binding.
3. **Store spike** (`src/image`, pinned by `tests/integration/image.rs`). Dumps and hydrates data-only graphs end to end: format, MAP_FIXED mapping, region-relative relocation, fingerprint fallback, pool interplay (file-backed pages release by `munmap`, never the cache), and teardown to baseline.
4. **Symbol-identity scout** (findings in risk item 4). All 221 `SymbolId` sites classified; the hash-identity migration is ~75 mechanical seam edits across 39 files with zero corpus expectation churn, no live density assumption, no symbol bytecode operands, and boot at parity. Two live cross-table id holes in `send` recorded for regression tests.
5. **Expander-parity scout** (findings in risk item 5). A region-native syntax node beats the Rust-heap tree 2–5× on every expansion-hot operation; the expand phase is clone-dominated (464k deep-cloned nodes per stdlib expand), so the migration projects expansion-heavy compiles roughly a third faster. The boundary-only split is retired.
6. **Layout probes** (`src/image/layout.rs`). `offset_of!` cannot name an enum variant's field on stable Rust (E0658), so exemplar probes record each dumpable variant's discriminant byte and leaf-field extents, self-verified on first use. The fingerprint records them — a shifted layout is rejected instead of hydrated — and the dumper assembles object slots from them, so construction-temporary padding never reaches the file. Dumps are byte-identical whole files, pinned by a painted-stack counter-factual (~1200 differing bytes under the old wholesale copy, zero now).

The risk list is fully dispatched; the next work is the foundations in the doc's landing order, starting with stable symbol identity. Full `make test` is green locally with the release corpus.