### PR TITLE
jit: the JIT and the WASM tier share one Cranelift 0.133

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,29 +319,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8628cc4ba7f88a9205a7ee42327697abc61195a1e3d92cfae172d6a946e722e"
-dependencies = [
- "cranelift-assembler-x64-meta 0.131.1",
-]
-
-[[package]]
-name = "cranelift-assembler-x64"
 version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aadfd45214f09461ba0406f7dacecce5cac39bf0bdb4890eeb468f4ef090e07"
 dependencies = [
- "cranelift-assembler-x64-meta 0.133.3",
-]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d582754487e6c9a065a91c42ccf1bdd8d5977af33468dac5ae9bec0ce88acb3e"
-dependencies = [
- "cranelift-srcgen 0.131.1",
+ "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
@@ -350,17 +332,7 @@ version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57069faede9bd1f926364b4cf69ccc9bebc6f4af5ab897083581b7bc991bf20a"
 dependencies = [
- "cranelift-srcgen 0.133.3",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb59c81ace12ee7c33074db7903d4d75d1f40b28cd3e8e6f491de57b29129eb9"
-dependencies = [
- "cranelift-entity 0.131.1",
- "wasmtime-internal-core 44.0.1",
+ "cranelift-srcgen",
 ]
 
 [[package]]
@@ -369,17 +341,8 @@ version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1221450f2f9efaa996d916bf53a0a4d13346a4a75468afb828390209a4fdd4"
 dependencies = [
- "cranelift-entity 0.133.3",
- "wasmtime-internal-core 46.0.3",
-]
-
-[[package]]
-name = "cranelift-bitset"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25c06993a681be9cf3140798a3d4ac5bec955e7444416a2fdc87fda8567285d"
-dependencies = [
- "wasmtime-internal-core 44.0.1",
+ "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -390,34 +353,7 @@ checksum = "97706f2b466d67bdf0f69d1cf5c5c4a5cd31087cf1fa2e8e5fe0450dddc8661d"
 dependencies = [
  "serde",
  "serde_derive",
- "wasmtime-internal-core 46.0.3",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b61f95c5a211918f5d336254a61a488b36a5818de47a868e8c4658dce9cccc"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64 0.131.1",
- "cranelift-bforest 0.131.1",
- "cranelift-bitset 0.131.1",
- "cranelift-codegen-meta 0.131.1",
- "cranelift-codegen-shared 0.131.1",
- "cranelift-control 0.131.1",
- "cranelift-entity 0.131.1",
- "cranelift-isle 0.131.1",
- "gimli",
- "hashbrown 0.16.1",
- "libm",
- "log",
- "regalloc2",
- "rustc-hash",
- "serde",
- "smallvec",
- "target-lexicon",
- "wasmtime-internal-core 44.0.1",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -427,14 +363,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "432246ee44b2fc0140b412dca55801d200d6fb25d2d7d18c44bb29e8cd71268b"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.133.3",
- "cranelift-bforest 0.133.3",
- "cranelift-bitset 0.133.3",
- "cranelift-codegen-meta 0.133.3",
- "cranelift-codegen-shared 0.133.3",
- "cranelift-control 0.133.3",
- "cranelift-entity 0.133.3",
- "cranelift-isle 0.133.3",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
  "gimli",
  "hashbrown 0.17.0",
  "libm",
@@ -448,19 +384,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-core 46.0.3",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b85aa822fce72080d041d7c2cf7c3f5c6ecdea7afae68379ba4ef85269c4fa5"
-dependencies = [
- "cranelift-assembler-x64-meta 0.131.1",
- "cranelift-codegen-shared 0.131.1",
- "cranelift-srcgen 0.131.1",
- "heck",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -469,33 +393,18 @@ version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aa51eff0949f06a5c8f3d5adefef94a12ea99f71cd8985047b91d45f367150"
 dependencies = [
- "cranelift-assembler-x64-meta 0.133.3",
- "cranelift-codegen-shared 0.133.3",
- "cranelift-srcgen 0.133.3",
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
  "heck",
  "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9fc89326cd072cc19e96892f09b5692c0dfe17cd4da2858ba30c2cd85c0"
-
-[[package]]
-name = "cranelift-codegen-shared"
 version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6095e7095930b6169490138b4262fe7ec24290d3f604d7fe62e1e3138e740daa"
-
-[[package]]
-name = "cranelift-control"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d005320f487e6e8a3edcc7f2fd4f43fcc9946d1013bf206ea649789ac1617fc"
-dependencies = [
- "arbitrary",
-]
 
 [[package]]
 name = "cranelift-control"
@@ -508,36 +417,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e62ef34c6e720f347a79ece043e8584e242d168911da640bac654a33a6aaaf5"
-dependencies = [
- "cranelift-bitset 0.131.1",
- "wasmtime-internal-core 44.0.1",
-]
-
-[[package]]
-name = "cranelift-entity"
 version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e93867a79a06dd5d9ffeb96f7563dc7b6b142b5d89e42ab77e458a408a8aa9d5"
 dependencies = [
- "cranelift-bitset 0.133.3",
+ "cranelift-bitset",
  "serde",
  "serde_derive",
- "wasmtime-internal-core 46.0.3",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa2ad00399dd47e7e7e33cb1dc23b0e39ed9dcd01e8f026fc37af91655031b8"
-dependencies = [
- "cranelift-codegen 0.131.1",
- "log",
- "smallvec",
- "target-lexicon",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -546,18 +433,12 @@ version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1991dc32fefa54f14d2a63570d1e963826257605e478558733f83450b7e7661"
 dependencies = [
- "cranelift-codegen 0.133.3",
+ "cranelift-codegen",
  "hashbrown 0.17.0",
  "log",
  "smallvec",
  "target-lexicon",
 ]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c51975ed217b4e8e5a7fd11e9ec83a96104bdff311dddcb505d1d8a9fd7fc6"
 
 [[package]]
 name = "cranelift-isle"
@@ -567,44 +448,34 @@ checksum = "784546de9988ff6e1df0fd4d2450760469a7607344156c661e69ec28082c5da4"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.131.1"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4070d2acc5c976887c10c273d38dd2bebebb472fd1ba65fa17b548adf5f56350"
+checksum = "94a5a0f87a3dbfb2bfec13f903f80141fb51c061f2c1b9b13b2874da7477d75a"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.131.1",
- "cranelift-control 0.131.1",
- "cranelift-entity 0.131.1",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
  "cranelift-module",
- "cranelift-native 0.131.1",
+ "cranelift-native",
  "libc",
  "log",
+ "memmap2",
  "region",
  "target-lexicon",
- "wasmtime-internal-jit-icache-coherence 44.0.1",
+ "wasmtime-internal-jit-icache-coherence",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.131.1"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052a396328dbc7dadc29d1bd27d4aa57d9e9e493ead8ef6e2ab3b75c1bf9644c"
+checksum = "0d169439e152238c300df1704bff6bdcef51e02ea756369688f3adec1097de97"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.131.1",
- "cranelift-control 0.131.1",
-]
-
-[[package]]
-name = "cranelift-native"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b1889e00da9729d8f8525f3c12998ded86ea709058ff844ebe00b97548de0e"
-dependencies = [
- "cranelift-codegen 0.131.1",
- "libc",
- "target-lexicon",
+ "cranelift-codegen",
+ "cranelift-control",
 ]
 
 [[package]]
@@ -613,16 +484,10 @@ version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7107a4ae4a2ba48b5df8648365e638b08322fa1da11e86206bf5eddb862b21dd"
 dependencies = [
- "cranelift-codegen 0.133.3",
+ "cranelift-codegen",
  "libc",
  "target-lexicon",
 ]
-
-[[package]]
-name = "cranelift-srcgen"
-version = "0.131.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a8f82fd5124f009f72167e60139245cd3b56cfd4b53050f22110c48c5f4da1"
 
 [[package]]
 name = "cranelift-srcgen"
@@ -777,11 +642,11 @@ version = "2.0.0"
 dependencies = [
  "bumpalo",
  "camino",
- "cranelift-codegen 0.131.1",
- "cranelift-frontend 0.131.1",
+ "cranelift-codegen",
+ "cranelift-frontend",
  "cranelift-jit",
  "cranelift-module",
- "cranelift-native 0.131.1",
+ "cranelift-native",
  "criterion",
  "crossbeam-channel",
  "io-uring",
@@ -861,7 +726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1090,9 +955,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1163,7 +1025,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1367,6 +1229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
  "rustix",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1623,10 +1494,10 @@ version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f647f8aefd39efd5e38b484a8b7a926dd035ae366127df75c1d94d196f0a4ba"
 dependencies = [
- "cranelift-bitset 0.133.3",
+ "cranelift-bitset",
  "log",
  "pulley-macros",
- "wasmtime-internal-core 46.0.3",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1824,7 +1695,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2027,7 +1898,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2484,11 +2355,11 @@ dependencies = [
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
- "wasmtime-internal-core 46.0.3",
+ "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
  "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence 46.0.3",
+ "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
  "wat",
@@ -2504,9 +2375,9 @@ checksum = "2595a168541e8a7faeacf21e3d59da93628ee71468cd69fee9fc2a92c9b1c7d8"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-bforest 0.133.3",
- "cranelift-bitset 0.133.3",
- "cranelift-entity 0.133.3",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
  "gimli",
  "hashbrown 0.17.0",
  "indexmap",
@@ -2524,7 +2395,7 @@ dependencies = [
  "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
- "wasmtime-internal-core 46.0.3",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -2570,16 +2441,6 @@ checksum = "0e50df18c9a8e0deec353ad1e6364ef50538231719a12d80fa5dcb300be8d36b"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2c7fa6523647262bfb4095dbdf4087accefe525813e783f81a0c682f418ce4"
-dependencies = [
- "hashbrown 0.16.1",
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-core"
 version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93b097389e5fad89c8ff8ee0aeafd16447b5a288d52aa1131f17ab4c19fd5be3"
@@ -2597,11 +2458,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08b3e909115836655b83c8bdef7c2e20a34293e785218d9f71a4e5382a09c6b0"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.133.3",
- "cranelift-control 0.133.3",
- "cranelift-entity 0.133.3",
- "cranelift-frontend 0.133.3",
- "cranelift-native 0.133.3",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
  "gimli",
  "itertools 0.14.0",
  "log",
@@ -2612,7 +2473,7 @@ dependencies = [
  "thiserror 2.0.18",
  "wasmparser 0.251.0",
  "wasmtime-environ",
- "wasmtime-internal-core 46.0.3",
+ "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
 ]
@@ -2646,25 +2507,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1859e920871515d324fb9757c3e448d6ed1512ca6ccdff14b6e016505d6ada"
-dependencies = [
- "cfg-if",
- "libc",
- "wasmtime-internal-core 44.0.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-icache-coherence"
 version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3a381a9dd1ffe3893507733300b420605f465655d78c7a75a965a09d7b43d5"
 dependencies = [
  "cfg-if",
  "libc",
- "wasmtime-internal-core 46.0.3",
+ "wasmtime-internal-core",
  "windows-sys 0.61.2",
 ]
 
@@ -2675,7 +2524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f951f78a1a09001547838fa557522d56655385db97e47307d0f582ca866974"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.133.3",
+ "cranelift-codegen",
  "log",
  "object",
  "wasmtime-environ",
@@ -2759,7 +2608,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ path-clean = "1.0"
 pathdiff = { version = "0.2", features = ["camino"] }
 
 # JIT compilation (optional, enable with --features jit; on by default)
-cranelift-codegen = { version = "0.131", optional = true }
-cranelift-frontend = { version = "0.131", optional = true }
-cranelift-module = { version = "0.131", optional = true }
-cranelift-jit = { version = "0.131", optional = true }
-cranelift-native = { version = "0.131", optional = true }
+cranelift-codegen = { version = "0.133", optional = true }
+cranelift-frontend = { version = "0.133", optional = true }
+cranelift-module = { version = "0.133", optional = true }
+cranelift-jit = { version = "0.133", optional = true }
+cranelift-native = { version = "0.133", optional = true }
 target-lexicon = { version = "0.13", optional = true }
 
 # WASM backend (optional, enable with --features wasm)

--- a/docs/impl/jit.md
+++ b/docs/impl/jit.md
@@ -19,6 +19,26 @@ LIR → FunctionTranslator → Cranelift IR → Native code → JitCode
 - **`RuntimeHelpers`** — extern symbols the JIT calls back into the
   VM (allocation, GC barriers, signal checks)
 
+## Memory flags on emitted loads
+
+Every load the translator emits reads memory the runtime owns and has already
+validated: an argument array, a closure environment, a spill slot. Such an
+access is aligned and cannot trap, which Cranelift spells
+`MemFlagsData::trusted()`.
+
+Cranelift keeps the flag data in a table on the function
+(`func.dfg.mem_flags`) and puts a `MemFlags` handle — an index into that table
+— on the instruction. `InstBuilder::load` interns for its caller, so the
+translator passes `MemFlagsData` by value and holds no handle of its own. That
+is worth keeping: a handle means "trusted" only inside the function whose
+table minted it, so a handle cached across functions would index a table where
+the same slot holds different flags, or nothing at all.
+
+`load_value_slot` (`src/jit/translate.rs`) is where the JIT names those flags.
+It emits both halves of a `Value` — tag at `+0`, payload at `+8` — so the
+16-byte stride is written once, from `size_of`/`offset_of` rather than as a
+literal.
+
 ## Function selection
 
 Functions become JIT candidates based on a hotness threshold

--- a/docs/impl/wasm.md
+++ b/docs/impl/wasm.md
@@ -291,6 +291,26 @@ mishandles the boundary: a fuel-suspended callee's frame survives the JIT tier
 is retained as it escapes into `fiber.signal`, where the resumer reads it
 (`tests/elle/region-jit-emit-escape-uaf.lisp`).
 
+### One Cranelift in the dependency graph
+
+That sharing holds only while `wasmtime` and the JIT's `cranelift-*` crates
+resolve to the same `cranelift-codegen`. Cargo picks one version per
+semver-incompatible requirement, so a JIT held a minor line behind the
+Cranelift `wasmtime` carries puts two complete copies of the code generator
+into a `--features wasm` build. The copies do not stay independent either:
+they share the one `regalloc2` the union of their requirements allows, so the
+JIT every default build runs gets its register allocator chosen by the WASM
+tier's pin.
+
+The two pins therefore move together. `wasmtime 46` carries Cranelift 0.133,
+and `Cargo.toml` pins `cranelift-codegen`, `-frontend`, `-module`, `-jit`, and
+`-native` at 0.133 to match. Raising `wasmtime` means raising the JIT's
+Cranelift in the same change, which is a code change and not only a manifest
+one — 0.133 interns memory-operation flags per function (see
+[impl/jit.md](jit.md) § "Memory flags on emitted loads").
+`integration::deps` (`tests/integration/deps.rs`) reads `Cargo.lock` and fails
+if the graph ever holds two versions of `cranelift-codegen` or `regalloc2`.
+
 ## Full-module coverage and its two teardown/lowering invariants
 
 The full-module tier runs the whole corpus under `make smoke-wasm` except

--- a/src/jit/compiler.rs
+++ b/src/jit/compiler.rs
@@ -8,9 +8,7 @@ use std::sync::Arc;
 
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::types::{I32, I64};
-use cranelift_codegen::ir::{
-    AbiParam, BlockArg, Function, InstBuilder, MemFlags, Signature, UserFuncName,
-};
+use cranelift_codegen::ir::{AbiParam, BlockArg, Function, InstBuilder, Signature, UserFuncName};
 use cranelift_codegen::isa::CallConv;
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
@@ -21,7 +19,7 @@ use crate::lir::{Label, LirFunction};
 use crate::value::{Arity, SymbolId};
 
 use super::code::JitCode;
-use super::translate::FunctionTranslator;
+use super::translate::{load_value_slot, FunctionTranslator};
 use super::vtable::{self, RuntimeHelpers};
 use super::JitError;
 

--- a/src/jit/compiler/tests.rs
+++ b/src/jit/compiler/tests.rs
@@ -551,3 +551,78 @@ fn compile_batch_records_each_member_in_code_address_registry() {
         .map(|(_, name)| name);
     assert_eq!(name.as_deref(), Some("registry-probe-batch"));
 }
+
+/// fn() -> capture 0. With `num_captures = 1`, `LoadCapture` index 0 reads
+/// through the closure environment pointer rather than an argument variable.
+fn make_capture_read_lir() -> LirFunction {
+    LirFixture::new(Arity::Exact(0))
+        .signal(Signal::silent())
+        .num_captures(1)
+        .block(
+            0,
+            vec![LirInstr::LoadCapture {
+                dst: Reg(0),
+                index: 0,
+            }],
+            Terminator::Return(Reg(0)),
+        )
+        .build()
+}
+
+/// The `load` lines of a rendered Cranelift function, in emission order.
+fn load_lines(clif: &[String]) -> Vec<&str> {
+    clif.iter()
+        .map(|line| line.trim())
+        .filter(|line| line.contains("= load."))
+        .collect()
+}
+
+#[test]
+fn an_argument_load_carries_trusted_flags() {
+    // Trap: memory flags change the access the backend emits, never the value
+    // it computes, so nothing but the rendered CLIF shows which flags a load
+    // actually got.
+    //
+    // Counter-factual: passing `MemFlagsData::new()` instead of `::trusted()`
+    // compiles, and the compiled code returns the right answers, because the
+    // argument array really is aligned and mapped. It costs a trapping,
+    // unaligned-tolerant access on every parameter of every hot function.
+    let compiler = JitCompiler::new().expect("Failed to create compiler");
+    let clif = compiler
+        .clif_text(&make_simple_lir(), None)
+        .expect("Failed to translate");
+    let loads = load_lines(&clif);
+    assert!(
+        !loads.is_empty(),
+        "a one-parameter function loads its argument; got:\n{}",
+        clif.join("\n")
+    );
+    for load in &loads {
+        assert!(
+            load.contains("notrap aligned"),
+            "argument load without trusted flags: {load}"
+        );
+    }
+}
+
+#[test]
+fn a_capture_load_carries_trusted_flags() {
+    // The environment pointer is a second base pointer, reached from a
+    // different translator path than the argument array.
+    let compiler = JitCompiler::new().expect("Failed to create compiler");
+    let clif = compiler
+        .clif_text(&make_capture_read_lir(), None)
+        .expect("Failed to translate");
+    let loads = load_lines(&clif);
+    assert!(
+        !loads.is_empty(),
+        "reading capture 0 loads from the env pointer; got:\n{}",
+        clif.join("\n")
+    );
+    for load in &loads {
+        assert!(
+            load.contains("notrap aligned"),
+            "capture load without trusted flags: {load}"
+        );
+    }
+}

--- a/src/jit/compiler/translate.rs
+++ b/src/jit/compiler/translate.rs
@@ -123,15 +123,7 @@ impl JitCompiler {
 
             // Load required params unconditionally
             for i in 0..required as u32 {
-                let tag_offset = (i as i32) * 16;
-                let payload_offset = (i as i32) * 16 + 8;
-                let arg_tag = builder
-                    .ins()
-                    .load(I64, MemFlags::trusted(), args_ptr, tag_offset);
-                let arg_payload =
-                    builder
-                        .ins()
-                        .load(I64, MemFlags::trusted(), args_ptr, payload_offset);
+                let (arg_tag, arg_payload) = load_value_slot(&mut builder, args_ptr, i);
                 let base = arg_var_base + i;
                 if (i as u64) < 64 && (lir.capture_params_mask & (1 << i)) != 0 {
                     let (cell_t, cell_p) = translator.call_helper_value_vm(
@@ -168,16 +160,7 @@ impl JitCompiler {
 
                     builder.switch_to_block(then_block);
                     builder.seal_block(then_block);
-                    let tag_offset = (i as i32) * 16;
-                    let payload_offset = (i as i32) * 16 + 8;
-                    let arg_tag =
-                        builder
-                            .ins()
-                            .load(I64, MemFlags::trusted(), args_ptr, tag_offset);
-                    let arg_payload =
-                        builder
-                            .ins()
-                            .load(I64, MemFlags::trusted(), args_ptr, payload_offset);
+                    let (arg_tag, arg_payload) = load_value_slot(&mut builder, args_ptr, i);
                     builder.ins().jump(
                         merge_block,
                         &[BlockArg::Value(arg_tag), BlockArg::Value(arg_payload)],
@@ -275,16 +258,7 @@ impl JitCompiler {
                     // then: load from args
                     builder.switch_to_block(then_block);
                     builder.seal_block(then_block);
-                    let tag_offset = (i as i32) * 16;
-                    let payload_offset = (i as i32) * 16 + 8;
-                    let arg_tag =
-                        builder
-                            .ins()
-                            .load(I64, MemFlags::trusted(), args_ptr, tag_offset);
-                    let arg_payload =
-                        builder
-                            .ins()
-                            .load(I64, MemFlags::trusted(), args_ptr, payload_offset);
+                    let (arg_tag, arg_payload) = load_value_slot(&mut builder, args_ptr, i);
                     builder.ins().jump(
                         merge_block,
                         &[BlockArg::Value(arg_tag), BlockArg::Value(arg_payload)],
@@ -322,16 +296,7 @@ impl JitCompiler {
                     }
                 } else {
                     // Required param: load unconditionally
-                    let tag_offset = (i as i32) * 16;
-                    let payload_offset = (i as i32) * 16 + 8;
-                    let arg_tag =
-                        builder
-                            .ins()
-                            .load(I64, MemFlags::trusted(), args_ptr, tag_offset);
-                    let arg_payload =
-                        builder
-                            .ins()
-                            .load(I64, MemFlags::trusted(), args_ptr, payload_offset);
+                    let (arg_tag, arg_payload) = load_value_slot(&mut builder, args_ptr, i);
                     if (i as u64) < 64 && (lir.capture_params_mask & (1 << i)) != 0 {
                         let (cell_t, cell_p) = translator.call_helper_value_vm(
                             &mut builder,

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::types::{I32, I64};
-use cranelift_codegen::ir::{InstBuilder, MemFlags};
+use cranelift_codegen::ir::{InstBuilder, MemFlagsData};
 use cranelift_frontend::{FunctionBuilder, Variable};
 use cranelift_jit::JITModule;
 use cranelift_module::{FuncId, Module};
@@ -97,6 +97,27 @@ pub(crate) struct FunctionTranslator<'a> {
     /// (`elle_jit_release_activation_owner_node`) only for a function that can
     /// have minted a node; the common path pays no extra helper call.
     pub(crate) uses_activation_owner_node: bool,
+}
+
+/// Load the `index`-th `Value` of a runtime-owned array of `Value`s — an
+/// argument array, or a closure environment — as its (tag, payload) halves.
+///
+/// This is the JIT's only site for memory flags; see docs/impl/jit.md
+/// § "Memory flags on emitted loads".
+pub(crate) fn load_value_slot(
+    builder: &mut FunctionBuilder,
+    base: cranelift_codegen::ir::Value,
+    index: u32,
+) -> (cranelift_codegen::ir::Value, cranelift_codegen::ir::Value) {
+    const STRIDE: i32 = std::mem::size_of::<crate::value::Value>() as i32;
+    const TAG: i32 = std::mem::offset_of!(crate::value::Value, tag) as i32;
+    const PAYLOAD: i32 = std::mem::offset_of!(crate::value::Value, payload) as i32;
+
+    let flags = MemFlagsData::trusted();
+    let slot = index as i32 * STRIDE;
+    let tag = builder.ins().load(I64, flags, base, slot + TAG);
+    let payload = builder.ins().load(I64, flags, base, slot + PAYLOAD);
+    (tag, payload)
 }
 
 impl<'a> FunctionTranslator<'a> {

--- a/src/jit/translate/instr.rs
+++ b/src/jit/translate/instr.rs
@@ -85,19 +85,10 @@ impl<'a> FunctionTranslator<'a> {
                 let arity = self.lir.num_params as u16;
                 if *index < num_captures {
                     // Load from closure environment (captures)
-                    // Each Value is 16 bytes: tag at offset i*16, payload at i*16+8
                     let env_ptr = self.env_ptr.ok_or_else(|| {
                         JitError::InvalidLir("LoadCapture without env pointer".to_string())
                     })?;
-                    let tag_offset = (*index as i32) * 16;
-                    let payload_offset = (*index as i32) * 16 + 8;
-                    let raw_tag = builder
-                        .ins()
-                        .load(I64, MemFlags::trusted(), env_ptr, tag_offset);
-                    let raw_payload =
-                        builder
-                            .ins()
-                            .load(I64, MemFlags::trusted(), env_ptr, payload_offset);
+                    let (raw_tag, raw_payload) = load_value_slot(builder, env_ptr, *index as u32);
                     // Auto-unwrap LocalCell if present
                     let (val_tag, val_payload) = self.call_helper_value_unary(
                         builder,
@@ -149,15 +140,7 @@ impl<'a> FunctionTranslator<'a> {
                     let env_ptr = self.env_ptr.ok_or_else(|| {
                         JitError::InvalidLir("LoadCaptureRaw without env pointer".to_string())
                     })?;
-                    let tag_offset = (*index as i32) * 16;
-                    let payload_offset = (*index as i32) * 16 + 8;
-                    let raw_tag = builder
-                        .ins()
-                        .load(I64, MemFlags::trusted(), env_ptr, tag_offset);
-                    let raw_payload =
-                        builder
-                            .ins()
-                            .load(I64, MemFlags::trusted(), env_ptr, payload_offset);
+                    let (raw_tag, raw_payload) = load_value_slot(builder, env_ptr, *index as u32);
                     self.def_var_pair(builder, dst.0, raw_tag, raw_payload);
                 } else if *index < num_captures + arity {
                     let param_index = *index - num_captures;

--- a/tests/integration/deps.rs
+++ b/tests/integration/deps.rs
@@ -1,0 +1,69 @@
+// Dependency-graph shape tests.
+//
+// These read `Cargo.lock` directly. A duplicated crate is invisible to every
+// other test in the suite — both copies compile, both work — so nothing else
+// in the tree can catch the split.
+
+use std::collections::BTreeMap;
+
+/// Every `[[package]]` in `Cargo.lock`, as name -> the versions resolved for
+/// it. A name with more than one entry is in the graph twice.
+fn locked_versions() -> BTreeMap<String, Vec<String>> {
+    let lock = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.lock"))
+        .expect("Cargo.lock is checked in at the workspace root");
+    let mut versions: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut name: Option<String> = None;
+    for line in lock.lines() {
+        // Cargo.lock writes `name` then `version` inside each `[[package]]`,
+        // and quotes both. Nothing else in the file is at column 0 with these
+        // keys, so a scan needs no TOML parser.
+        if let Some(value) = line.strip_prefix("name = ") {
+            name = Some(value.trim_matches('"').to_string());
+        } else if let Some(value) = line.strip_prefix("version = ") {
+            if let Some(name) = name.take() {
+                versions
+                    .entry(name)
+                    .or_default()
+                    .push(value.trim_matches('"').to_string());
+            }
+        }
+    }
+    versions
+}
+
+fn assert_single_version(versions: &BTreeMap<String, Vec<String>>, crate_name: &str, why: &str) {
+    let found = versions
+        .get(crate_name)
+        .unwrap_or_else(|| panic!("{crate_name} is not in Cargo.lock"));
+    assert_eq!(
+        found.len(),
+        1,
+        "{crate_name} resolves to {found:?}; expected exactly one version. {why}"
+    );
+}
+
+#[test]
+fn the_graph_holds_one_cranelift_codegen() {
+    // The JIT (`cranelift-jit`) and the WASM tier (`wasmtime`) both pull the
+    // code generator. Two versions compile it twice and, because Cargo picks
+    // one `regalloc2` for the whole graph, hand the default-build JIT a
+    // register allocator chosen by an opt-in tier.
+    // See docs/impl/wasm.md § "One Cranelift in the dependency graph".
+    assert_single_version(
+        &locked_versions(),
+        "cranelift-codegen",
+        "Raise the `cranelift-*` pins in Cargo.toml to match wasmtime's Cranelift.",
+    );
+}
+
+#[test]
+fn the_graph_holds_one_regalloc2() {
+    // The allocator that assigns registers in JIT-compiled native code. Two
+    // copies mean the tier a given build runs is decided by dependency
+    // resolution rather than by the pin.
+    assert_single_version(
+        &locked_versions(),
+        "regalloc2",
+        "It follows cranelift-codegen; a split here means the Cranelift pins diverged.",
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -47,6 +47,9 @@ mod time_elapsed {
 // primitives tests migrated to tests/elle/primitives.lisp
 // ffi tests migrated to tests/elle/ffi.lisp
 // bracket_errors tests migrated to tests/elle/brackets.lisp
+mod deps {
+    include!("deps.rs");
+}
 mod dispatch {
     include!("dispatch.rs");
 }


### PR DESCRIPTION
Takes the "keep 46" branch of #886, and removes what it was going to cost.

## What #886 asked

RUSTSEC-2026-0222 moved wasmtime from 44 to 46. wasmtime 46 carries
Cranelift 0.133; the JIT pinned 0.131. The two choices on offer were to
keep 46 and accept the split, or to hold 44 and accept a standing
`cargo audit` exception. Keeping 46 cost two copies of
`cranelift-codegen` in a `--features wasm` build, and a `regalloc2`
chosen for the default-build JIT by the union of the two requirements.

This moves the JIT to 0.133, so the graph holds one Cranelift and the
advisory stays closed. Neither cost survives.

## The API break

0.133 interns memory-operation flags. `MemFlags` is a handle into a
per-function table and `MemFlagsData` holds the flags themselves, so
`MemFlags::trusted()` is gone. #886 read this as threading a flag set to
every load and store the JIT emits. It is less than that:
`InstBuilder::load` takes `impl Into<MemFlagsData>` and interns into the
function it is building, so a call site passes the data by value and
never holds a handle.

All twelve sites do the same thing — read the tag and payload halves of
a `Value` out of a runtime-owned array — so they collapse into one
`load_value_slot` in `src/jit/translate.rs`. It takes the stride and the
payload offset from `size_of`/`offset_of` rather than the literal 16 and
8 the sites each carried.

## Tests

- `integration::deps` reads `Cargo.lock` and fails when
  `cranelift-codegen` or `regalloc2` resolves to more than one version.
  This is the pin for the issue itself; it fails on the parent commit
  (`cranelift-codegen` resolves to 0.131.1 and 0.133.3) and passes here.
- `an_argument_load_carries_trusted_flags` and
  `a_capture_load_carries_trusted_flags` render the CLIF for a function
  that loads a parameter and one that reads a capture, and assert every
  emitted load carries `notrap aligned`. Memory flags change the access
  the backend emits and never the value it computes, so nothing else in
  the suite can see them. Both fail with `MemFlagsData::new()` in place
  of `::trusted()`.

Green: `make smoke` (release), `make crosscheck`, `cargo fmt --check`,
clippy over `--workspace --all-targets --all-features`, rustdoc,
`cargo test --workspace --lib --all-features`, `cargo test --test '*'`.

## One failure, outside this change

`make smoke-wasm`'s whole-file `--wasm=full` pass wedges on
`tests/elle/h2-rfc9113.lisp`: killed at the 300s budget having burned
1.9s of user CPU, so it is blocked, not computing. The same file passes
in 2.2s under `--jit=eager`, and passes in the `elle test` corpus on
both tiers. wasmtime is unchanged at 46.0.3 and its Cranelift was
already 0.133.3 before this commit, so the whole-module WASM tier
compiles exactly what it compiled before. `make check-wasm`, the gate
that runs in CI, passes.

## Docs

- `docs/impl/jit.md` § "Memory flags on emitted loads" — what the flags
  claim, and why the translator holds no `MemFlags` handle of its own.
- `docs/impl/wasm.md` § "One Cranelift in the dependency graph" — the
  two pins move together, and raising `wasmtime` is a code change.
