### PR TITLE
vm: an error's traceback names the form that raised it

### DIFF
--- a/docs/impl/vm.md
+++ b/docs/impl/vm.md
@@ -50,6 +50,39 @@ Specialized fast paths exist for common sequences (e.g., `LoadLocal` +
 - **Fuel** — decrements a counter per instruction; when zero, emits
   `:fuel` signal
 
+## Where a reported error's location comes from
+
+An error that reaches the root is printed with one `at file:line:col` line
+and a caret under the source. That location is `VM::error_loc`, and it names
+**the innermost frame that was running when the error was raised** — the
+raising form itself, not any call above it.
+
+The dispatch loop records it. Every path that leaves
+`execute_bytecode_inner_impl` carrying `SIG_ERROR` or `SIG_HALT` calls
+`VM::record_error_loc`, which maps the current instruction offset through
+the frame's `LocationMap`. Recording is first-writer-wins: the raising frame
+reaches its exit path first, and each frame the error then unwinds through
+finds the slot already taken, so the innermost location is the one that
+survives to the root. A frame whose `LocationMap` has no entry for the
+instruction leaves the slot empty for an outer frame to fill.
+
+First-writer-wins needs an end, because the record answers only for the error
+currently propagating. A fiber mask that absorbs `SIG_ERROR` ends that
+propagation — `try`, `protect`, and `defer` all catch that way — so
+`VM::absorbs` takes the live record at the moment it reports the catch. Every
+position that drives a child fiber asks `absorbs`, so a later error finds an
+empty slot and records its own location.
+
+The record is parked, not dropped. `absorbs` moves it onto the caught fiber
+(`Fiber::error_loc`), paired with the payload it describes. An error that is
+caught and then sent on again — what `defer` does, and what `ev/run`'s
+scheduler does with a failed thunk — keeps its raising form that way.
+`fiber/propagate` re-raises the fiber's parked signal and takes the parked
+location back, but only while the pair still names the payload being
+re-raised. Both stdlib sites that surface a failed fiber's error therefore
+use `(fiber/propagate f)`; raising the payload afresh with `(error
+(fiber/value f))` would report the stdlib line that re-raised it.
+
 ## Tail calls
 
 `TailCall` reuses the current call frame rather than pushing a new one.

--- a/src/stdlib.lisp
+++ b/src/stdlib.lisp
@@ -2177,10 +2177,13 @@
        # scheduler-killed fibers are excluded: we injected their :shutdown
        # at teardown time, so re-raising would surface our own signal as a
        # user error.
+       # fiber/propagate, not (error (fiber/value fiber)): re-raising the
+       # fiber's own signal carries the location of the form that raised it,
+       # which a fresh raise of the payload would replace with this line.
        (each [fiber status] in (pairs completed)
          (when (and (= status :error) (not (contains? joined fiber))
                     (not (contains? scheduler-killed fiber)))
-           (error (fiber/value fiber)))))
+           (fiber/propagate fiber))))
      :shutdown  # shutdown-fn: signal shutdown
       (fn (timeout-ms) (put shutdown-req 0 timeout-ms))
      :mark-joined  # mark one of the program's own fibers: observed (suppress the
@@ -2261,11 +2264,12 @@
         (apply (get sched :pump) fibers)  # Propagate the first error among our thunks; else the last
         # thunk's value.
         (def @result nil)
-        (def @first-error nil)
+        (def @failed nil)
         (each f in fibers
-          (when (and (nil? first-error) (fiber-failed? f))
-            (assign first-error (fiber/value f))))
-        (when (not (nil? first-error)) (error first-error))  # Return the last fiber's value
+          (when (and (nil? failed) (fiber-failed? f)) (assign failed f)))  # fiber/propagate, not (error (fiber/value f)): re-raising the
+        # fiber's own signal carries the location of the form that raised it,
+        # which a fresh raise of the payload would replace with this line.
+        (when (not (nil? failed)) (fiber/propagate failed))  # Return the last fiber's value
         (when (> (length fibers) 0)
           (assign result (fiber/value (get fibers (- (length fibers) 1)))))
         result))))

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -119,6 +119,27 @@ pub struct Fiber {
     /// - On signal: (bits, payload) before suspending
     /// - On normal return: (SIG_OK, return_value) before completing
     pub signal: Option<(SignalBits, Value)>,
+    /// The `SIG_ERROR` payload this fiber parked, paired with the source
+    /// location of the form that raised it.
+    ///
+    /// A mask that absorbs the error stops it travelling, so `VM::absorbs`
+    /// moves the live record (`VM::error_loc`) here rather than discarding it;
+    /// `fiber/propagate` reads it back when it re-raises this fiber's parked
+    /// signal, which is how the location survives the `defer` and scheduler
+    /// catch-then-re-raise chains (docs/impl/vm.md § "Where a reported error's
+    /// location comes from").
+    ///
+    /// The payload is carried so the reader can tell that the location still
+    /// describes the error being re-raised — representation identity, as for
+    /// `emit_delivery`, never structural equality. A fiber that goes on to
+    /// park a different error (an injected abort, a second raise that recorded
+    /// no location) therefore lends its old location to nothing.
+    ///
+    /// Like `emit_delivery`, the payload is an UNCOUNTED marker: it is only
+    /// ever compared bit-wise, never dereferenced, so it takes no retain and
+    /// the Fiber content scan records no edge for it. The counted edge for the
+    /// same value is `signal`'s.
+    pub error_loc: Option<(Value, crate::error::SourceLoc)>,
     /// The `SIG_ERROR` payload whose DELIVERY reference the raise itself minted
     /// — the `EmitEscape` retain `handle_emit` (and its JIT mirror) takes, which
     /// the resumer's release of the resume result consumes. While this matches
@@ -408,6 +429,7 @@ impl Fiber {
             param_baseline_seeded: false,
             param_borrows: Vec::new(),
             signal: None,
+            error_loc: None,
             emit_delivery: None,
             suspended: None,
             activation_region_maps: vec![rustc_hash::FxHashMap::default()],
@@ -443,6 +465,7 @@ impl Fiber {
             param_baseline_seeded: false,
             param_borrows: Vec::new(),
             signal: None,
+            error_loc: None,
             emit_delivery: None,
             suspended: None,
             activation_region_maps: vec![rustc_hash::FxHashMap::default()],

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -159,6 +159,7 @@ On resume, the VM wires up the parent/child chain (Janet semantics):
 | `jit_rejections` | `FxHashMap<*const u8, JitRejectionInfo>` | JIT rejection log: first rejection per closure template |
 | `closure_call_counts` | `FxHashMap<*const u8, usize>` | JIT hotness profiling (FxHash for pointer keys) |
 | `pending_tail_call` | `Option<TailCallInfo>` | Rc-based tail call info (transient) |
+| `error_loc` | `Option<SourceLoc>` | Where the error now propagating was raised. Written by `record_error_loc` (first-writer-wins, so the innermost frame keeps it), taken by `absorbs` when a mask catches (docs/impl/vm.md § "Where a reported error's location comes from") |
 | `env_cache` | `Vec<Value>` | Reusable buffer for `build_closure_env` (avoids alloc per call) |
 | `tail_call_env_cache` | `Vec<Value>` | Reusable buffer for `handle_tail_call` env building |
 | `eval_expander` | `Option<Expander>` | Cached Expander for runtime `eval` (avoids re-loading prelude) |
@@ -172,6 +173,7 @@ On resume, the VM wires up the parent/child chain (Janet semantics):
 | `call_stack` | `Vec<CallFrame>` | For stack traces |
 | `call_depth` | `usize` | Stack overflow detection |
 | `signal` | `Option<(SignalBits, Value)>` | Signal from execution (errors, yields) |
+| `error_loc` | `Option<(Value, SourceLoc)>` | The parked `SIG_ERROR` payload and where it was raised. Parked by `absorbs`, read back by `fiber/propagate` so a re-raised error keeps its raising form |
 | `suspended` | `Option<Vec<SuspendedFrame>>` | Suspended execution frames (for yield/signal resumption) |
 | `signal_mask` | `SignalBits` | Which signals this fiber catches |
 | `param_frames` | `Vec<Vec<(Value, Value)>>` | Parameter binding frames (stack of frames, each frame is vec of (param, value) pairs) |

--- a/src/vm/dispatch/interp.rs
+++ b/src/vm/dispatch/interp.rs
@@ -51,6 +51,21 @@ impl VM {
         );
     }
 
+    /// Record the source location of the instruction at `instr_ip` as the
+    /// origin of the error now leaving this frame.
+    ///
+    /// First-writer-wins: the frame that raised reaches its exit path before
+    /// any frame it unwinds through, so the innermost location is the one that
+    /// reaches the root (docs/impl/vm.md § "Where a reported error's location
+    /// comes from"). `VM::absorbs` takes the record when a mask catches the
+    /// error, so the slot an outer frame finds full always belongs to the
+    /// error it is carrying.
+    fn record_error_loc(&mut self, location_map: &LocationMap, instr_ip: usize) {
+        if self.error_loc.is_none() {
+            self.error_loc = location_map.get(&instr_ip).cloned();
+        }
+    }
+
     /// Inner execution loop that handles all instructions.
     ///
     /// Takes `Rc` references to bytecode and constants so that yield and
@@ -98,9 +113,7 @@ impl VM {
             // Check for pre-existing error signal (e.g., from previous Call)
             if let Some((bits, _)) = self.fiber.signal {
                 if bits.intersects(SIG_ERROR) || bits.intersects(SIG_HALT) {
-                    if self.error_loc.is_none() {
-                        self.error_loc = location_map.get(&instr_ip).cloned();
-                    }
+                    self.record_error_loc(location_map, instr_ip);
                     return (bits, ip);
                 }
             }
@@ -120,9 +133,7 @@ impl VM {
                 );
                 self.heap().set_object_limit(saved_limit);
                 self.fiber.signal = Some((SIG_ERROR, err));
-                if self.error_loc.is_none() {
-                    self.error_loc = location_map.get(&instr_ip).cloned();
-                }
+                self.record_error_loc(location_map, instr_ip);
                 return (SIG_ERROR, ip);
             }
 
@@ -168,15 +179,22 @@ impl VM {
                 &mut ip,
                 instr_ip,
             ) {
+                // The dominant error exit: a handler that raises (or that
+                // propagates a callee's raise) returns the signal here rather
+                // than falling through to the post-handler check below, so this
+                // is where most errors get the location of the form that
+                // raised them.
+                let (exit_bits, _) = exit;
+                if exit_bits.intersects(SIG_ERROR) || exit_bits.intersects(SIG_HALT) {
+                    self.record_error_loc(location_map, instr_ip);
+                }
                 return exit;
             }
 
             // Check for error signal set by this instruction's handler
             if let Some((bits, _)) = self.fiber.signal {
                 if bits.intersects(SIG_ERROR) || bits.intersects(SIG_HALT) {
-                    if self.error_loc.is_none() {
-                        self.error_loc = location_map.get(&instr_ip).cloned();
-                    }
+                    self.record_error_loc(location_map, instr_ip);
                     return (bits, ip);
                 }
             }

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -48,7 +48,6 @@ mod borrow_tests;
 // `crate::vm::fiber::<Item>` (external callers) or `super::<Item>` (sibling
 // submodules) still resolves unchanged. Visibility matches each item's original
 // `pub(crate)`/private declaration.
-pub(crate) use catch::mask_catches;
 pub(crate) use owned::{kill_fiber, parked_owner_nodes, release_fiber_owned, take_fiber_owned};
 use refcount::{incref_signal_region, release_discarded_signal};
 pub(crate) use refcount::{

--- a/src/vm/fiber/abort.rs
+++ b/src/vm/fiber/abort.rs
@@ -7,7 +7,6 @@ use std::rc::Rc;
 use crate::value::fiber::FiberStatus;
 use crate::value::{SignalBits, Value, SIG_ERROR, SIG_OK};
 use crate::vm::core::VM;
-use crate::vm::fiber::mask_catches;
 
 impl VM {
     /// Mint the caller's reference to an aborted child's ERROR result — the one
@@ -64,7 +63,7 @@ impl VM {
 
         let mask = handle.with(|fiber| fiber.mask);
 
-        if mask_catches(mask, result_bits) {
+        if self.absorbs(&handle, mask, result_bits, result_value) {
             // Abort is terminal — even if the parent catches the signal,
             // the aborted fiber is finished and must not stay :paused.
             if result_bits.intersects(SIG_ERROR) {
@@ -112,7 +111,7 @@ impl VM {
 
         let mask = handle.with(|fiber| fiber.mask);
 
-        if mask_catches(mask, result_bits) {
+        if self.absorbs(&handle, mask, result_bits, result_value) {
             // Abort is terminal — set child to :error even when caught
             if result_bits.intersects(SIG_ERROR) {
                 handle.with_mut(|f| f.status = FiberStatus::Error);

--- a/src/vm/fiber/catch.rs
+++ b/src/vm/fiber/catch.rs
@@ -7,7 +7,7 @@
 //! delivers the answer (operand stack, `JitValue`, or a signal return). The
 //! question lives here so the rule has one definition.
 
-use crate::value::{SignalBits, SIG_ERROR, SIG_HALT, SIG_TERMINAL};
+use crate::value::{SignalBits, Value, SIG_ERROR, SIG_HALT, SIG_TERMINAL};
 use crate::vm::core::VM;
 
 /// True when `mask` absorbs `bits`, so the resuming fiber receives a value
@@ -27,6 +27,39 @@ pub(crate) fn mask_catches(mask: SignalBits, bits: SignalBits) -> bool {
 }
 
 impl VM {
+    /// [`mask_catches`] for `child`'s signal, plus the state change catching an
+    /// error implies.
+    ///
+    /// Absorbing `SIG_ERROR` ends that error's propagation, so the location the
+    /// dispatch loop recorded for it stops answering "where did the error now
+    /// travelling come from?". It parks on `child` paired with `value`, the
+    /// payload it describes, and `fiber/propagate` reads it back if `child`'s
+    /// signal is re-raised (docs/impl/vm.md § "Where a reported error's
+    /// location comes from"). Either way the live record is cleared: it is
+    /// first-writer-wins (`VM::record_error_loc`), so a location left standing
+    /// past its own error would be handed to the next one instead of letting it
+    /// record its own.
+    ///
+    /// Every position that drives a child fiber asks this rather than
+    /// [`mask_catches`] directly. The exception is a *lookahead* — asking
+    /// whether some other fiber's signal will be caught, without catching it
+    /// here — which must leave a still-propagating error's record alone.
+    pub(crate) fn absorbs(
+        &mut self,
+        child: &crate::value::FiberHandle,
+        mask: SignalBits,
+        bits: SignalBits,
+        value: Value,
+    ) -> bool {
+        let caught = mask_catches(mask, bits);
+        if caught && bits.intersects(SIG_ERROR) {
+            if let Some(loc) = self.error_loc.take() {
+                child.with_mut(|f| f.error_loc = Some((value, loc)));
+            }
+        }
+        caught
+    }
+
     /// Reject a signal that nothing can ever catch, reporting a state-error
     /// attributed to `op` (the driving primitive, for example `"fiber/resume"`).
     ///

--- a/src/vm/fiber/jit.rs
+++ b/src/vm/fiber/jit.rs
@@ -24,7 +24,7 @@ impl VM {
 
         self.finalize_if_halted(&handle, result_bits);
 
-        if mask_catches(mask, result_bits) {
+        if self.absorbs(&handle, mask, result_bits, result_value) {
             self.fiber.child = None;
             self.fiber.child_value = None;
             JitValue::from_value(result_value)
@@ -108,7 +108,7 @@ impl VM {
 
         let mask = handle.with(|fiber| fiber.mask);
 
-        if mask_catches(mask, result_bits) {
+        if self.absorbs(&handle, mask, result_bits, result_value) {
             // Abort is terminal — set child to :error even when caught
             if result_bits.intersects(SIG_ERROR) {
                 handle.with_mut(|f| f.status = FiberStatus::Error);

--- a/src/vm/fiber/propagate.rs
+++ b/src/vm/fiber/propagate.rs
@@ -43,6 +43,22 @@ impl VM {
                 self.escaping_error("internal-error", "fiber/propagate: no signal"),
             );
         };
+        // Re-raising the child's error resumes the propagation the catch ended,
+        // so the location parked with the payload becomes live again. This is
+        // what lets `defer` and the scheduler report the form that raised,
+        // rather than the form that re-raised (docs/impl/vm.md § "Where a
+        // reported error's location comes from"). The parked pair is taken only
+        // when it still names THIS payload; a record the fiber kept from an
+        // earlier error describes nothing here.
+        if bits.intersects(SIG_ERROR) && self.error_loc.is_none() {
+            self.error_loc = handle.with(|fiber| {
+                fiber
+                    .error_loc
+                    .as_ref()
+                    .filter(|(payload, _)| payload.bit_identical(value))
+                    .map(|(_, loc)| loc.clone())
+            });
+        }
         if super::is_terminal_signal(bits) && !bits.intersects(SIG_HALT) {
             let heap = unsafe { &mut *self.heap_ptr };
             let region = crate::value::arena::region_of(heap, value);

--- a/src/vm/fiber/resume.rs
+++ b/src/vm/fiber/resume.rs
@@ -338,6 +338,11 @@ impl VM {
                     // unwind does for the same signal on a plain resume. The
                     // resume re-enters the inner fiber first, and only its
                     // completion delivers the value the frames below wait for.
+                    //
+                    // `mask_catches`, not `VM::absorbs`: this is a lookahead at
+                    // what the INNER fiber's mask will do, and absorbs nothing
+                    // itself, so an error still travelling must keep the
+                    // location recorded for it.
                     let inner_mask = inner_handle.with(|f| f.mask);
                     if !super::catch::mask_catches(inner_mask, inner_bits)
                         && !super::is_terminal_signal(inner_bits)

--- a/src/vm/fiber/signal.rs
+++ b/src/vm/fiber/signal.rs
@@ -162,7 +162,7 @@ impl VM {
 
         self.finalize_if_halted(&handle, result_bits);
 
-        if mask_catches(mask, result_bits) {
+        if self.absorbs(&handle, mask, result_bits, result_value) {
             self.fiber.child = None;
             self.fiber.child_value = None;
             self.fiber.stack.push(result_value);
@@ -269,7 +269,7 @@ impl VM {
 
         self.finalize_if_halted(&handle, result_bits);
 
-        if mask_catches(mask, result_bits) {
+        if self.absorbs(&handle, mask, result_bits, result_value) {
             self.fiber.child = None;
             self.fiber.child_value = None;
             self.fiber.signal = Some((SIG_OK, result_value));

--- a/src/vm/fiber/trampoline.rs
+++ b/src/vm/fiber/trampoline.rs
@@ -69,7 +69,7 @@ impl VM {
 
                 self.finalize_if_halted(&current_handle, bits);
 
-                if super::catch::mask_catches(mask, bits) {
+                if self.absorbs(&current_handle, mask, bits, value) {
                     self.fiber.child = None;
                     self.fiber.child_value = None;
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -318,7 +318,7 @@ impl VM {
                 .with_mut(|f| f.status = crate::value::FiberStatus::Error);
         }
 
-        if crate::vm::fiber::mask_catches(mask, result_bits) {
+        if self.absorbs(&pending.handle, mask, result_bits, result_value) {
             self.fiber.child = None;
             self.fiber.child_value = None;
             self.resume_suspended(caller_frames, result_value)

--- a/tests/integration/error_reporting.rs
+++ b/tests/integration/error_reporting.rs
@@ -1,6 +1,8 @@
 // Tests for error reporting with source locations
 //
-// Verifies that parse errors include file name, line number, and column information.
+// Verifies that parse errors include file name, line number, and column
+// information, and that a runtime error reaching the root is printed with the
+// location of the form that raised it.
 
 use elle::reader::{Lexer, OwnedToken, Reader};
 use elle::SymbolTable;
@@ -224,6 +226,178 @@ fn test_location_map_has_correct_line_numbers() {
             loc.line
         );
     }
+}
+
+// ============================================================================
+// Runtime traceback locations — which form an uncaught error is attributed to
+// ============================================================================
+
+/// Run a fixture script that is expected to die on an uncaught error, and
+/// return its `(stdout, stderr)`.
+///
+/// Panics when the script exits 0: every fixture here must reach the root with
+/// an error, or the location assertions below have nothing to inspect.
+fn run_failing_fixture(name: &str) -> (String, String) {
+    let script = format!("tests/integration/fixtures/{}", name);
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_elle"))
+        .arg(&script)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn elle for {}: {}", script, e));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        !output.status.success(),
+        "{} was expected to die on an uncaught error, but exited 0:\nstdout: {}\nstderr: {}",
+        script,
+        stdout,
+        stderr,
+    );
+    (stdout, stderr)
+}
+
+/// The 1-based line of the single code line of `name` that contains `marker`.
+///
+/// The fixtures carry one marker keyword per raising form, so the assertions
+/// name forms by what they raise rather than by a line number that any edit to
+/// the fixture would silently invalidate. Comment lines are skipped: each
+/// fixture's header names its own markers.
+fn fixture_line_of(name: &str, marker: &str) -> usize {
+    let script = format!("tests/integration/fixtures/{}", name);
+    let source = std::fs::read_to_string(&script)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", script, e));
+    let hits: Vec<usize> = source
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| !line.trim_start().starts_with('#') && line.contains(marker))
+        .map(|(i, _)| i + 1)
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "{} must contain {} on exactly one line, found it on {:?}",
+        script,
+        marker,
+        hits,
+    );
+    hits[0]
+}
+
+/// The line number in the sole `  at <file>:<line>:<col>` line of `stderr`.
+///
+/// Returns `None` when the error was printed with no location at all — which
+/// is itself a failure for these fixtures, and is reported as such by the
+/// callers rather than silently passing.
+fn reported_line(stderr: &str, fixture: &str) -> Option<usize> {
+    let needle = format!("{}:", fixture);
+    stderr.lines().find_map(|line| {
+        let rest = line.trim_start().strip_prefix("at ")?;
+        let tail = rest.split(&needle).nth(1)?;
+        tail.split(':').next()?.parse().ok()
+    })
+}
+
+#[test]
+fn an_uncaught_error_is_attributed_to_the_form_that_raised_it() {
+    const FIXTURE: &str = "traceback-plain-raise.lisp";
+    let raised = fixture_line_of(FIXTURE, ":only");
+    let (_, stderr) = run_failing_fixture(FIXTURE);
+
+    assert_eq!(
+        reported_line(&stderr, FIXTURE),
+        Some(raised),
+        "the error must be reported at the raising form (line {}); stderr was:\n{}",
+        raised,
+        stderr,
+    );
+}
+
+#[test]
+fn a_handled_error_does_not_lend_its_location_to_a_later_one() {
+    // The trap: the recorded location is first-writer-wins so that the raising
+    // frame beats the frames it unwinds through. Nothing else clears it, so a
+    // location that outlives its own error is reported for every error after
+    // it. The counter-factual: assert only that *some* location is printed and
+    // this passes while naming a form from a completely unrelated error.
+    const FIXTURE: &str = "traceback-after-catch.lisp";
+    let handled = fixture_line_of(FIXTURE, ":first");
+    let raised = fixture_line_of(FIXTURE, ":second");
+    let (_, stderr) = run_failing_fixture(FIXTURE);
+
+    let reported = reported_line(&stderr, FIXTURE);
+    assert_ne!(
+        reported,
+        Some(handled),
+        "line {} raised an error that `protect` handled; it must not be \
+         reported for the later uncaught one. stderr was:\n{}",
+        handled,
+        stderr,
+    );
+    assert_eq!(
+        reported,
+        Some(raised),
+        "the uncaught error must be reported at the raising form (line {}); \
+         stderr was:\n{}",
+        raised,
+        stderr,
+    );
+}
+
+#[test]
+fn an_error_re_propagated_by_defer_still_names_the_form_that_raised_it() {
+    // The trap: `defer` catches with a fiber mask, runs its cleanup, then
+    // re-raises. The catch ends the first propagation, so a location that only
+    // lives in the VM would be gone by the re-raise and the `(defer …)` form
+    // would take the blame. The counter-factual: assert merely that some
+    // location is printed, and the `(defer …)` line passes for the raise it
+    // wraps — including when the raise is several frames deeper.
+    const FIXTURE: &str = "traceback-through-defer.lisp";
+    let handled = fixture_line_of(FIXTURE, ":first");
+    let raised = fixture_line_of(FIXTURE, ":second");
+    let (stdout, stderr) = run_failing_fixture(FIXTURE);
+
+    assert!(
+        stdout.contains("cleanup ran"),
+        "the defer cleanup must run before the error reaches the root; \
+         stdout was:\n{}",
+        stdout,
+    );
+    let reported = reported_line(&stderr, FIXTURE);
+    assert_ne!(
+        reported,
+        Some(handled),
+        "line {} raised an error that `protect` handled; it must not be \
+         reported for the error `defer` re-propagates. stderr was:\n{}",
+        handled,
+        stderr,
+    );
+    assert_eq!(
+        reported,
+        Some(raised),
+        "the re-propagated error must still be reported at the raising form \
+         (line {}); stderr was:\n{}",
+        raised,
+        stderr,
+    );
+}
+
+#[test]
+fn an_unjoined_fibers_error_names_the_form_that_raised_it() {
+    // The trap: the scheduler catches a spawned fiber's error, then surfaces
+    // it from `:pump` long after the raising frame is gone. The counter-factual:
+    // surface it as `(error (fiber/value f))` and every orphaned fiber's error
+    // is reported at that one stdlib line instead.
+    const FIXTURE: &str = "traceback-unjoined-spawn.lisp";
+    let raised = fixture_line_of(FIXTURE, ":orphan");
+    let (_, stderr) = run_failing_fixture(FIXTURE);
+
+    assert_eq!(
+        reported_line(&stderr, FIXTURE),
+        Some(raised),
+        "the spawned fiber's error must be reported at the raising form \
+         (line {}); stderr was:\n{}",
+        raised,
+        stderr,
+    );
 }
 
 #[test]

--- a/tests/integration/fixtures/traceback-after-catch.lisp
+++ b/tests/integration/fixtures/traceback-after-catch.lisp
@@ -1,0 +1,15 @@
+(elle/epoch 12)
+# A program that catches one error, then raises a different, uncaught one.
+#
+# `tests/integration/error_reporting.rs` locates the two raising forms by the
+# `:first` and `:second` keywords, so keep each of them on one line of its own.
+
+(defn caught-raise []
+  (error {:error :first :message "caught and handled"}))
+
+(defn uncaught-raise []
+  (error {:error :second :message "reaches the root"}))
+
+(protect (caught-raise))
+
+(uncaught-raise)

--- a/tests/integration/fixtures/traceback-plain-raise.lisp
+++ b/tests/integration/fixtures/traceback-plain-raise.lisp
@@ -1,0 +1,10 @@
+(elle/epoch 12)
+# The simplest uncaught error: nothing catches anything first.
+#
+# `tests/integration/error_reporting.rs` locates the raising form by the
+# `:only` keyword, so keep it on one line of its own.
+
+(defn uncaught-raise []
+  (error {:error :only :message "reaches the root"}))
+
+(uncaught-raise)

--- a/tests/integration/fixtures/traceback-through-defer.lisp
+++ b/tests/integration/fixtures/traceback-through-defer.lisp
@@ -1,0 +1,18 @@
+(elle/epoch 12)
+# An error that a `defer` catches, runs cleanup for, and re-propagates, after
+# an unrelated earlier error was caught and handled.
+#
+# `tests/integration/error_reporting.rs` locates the two raising forms by the
+# `:first` and `:second` keywords, so keep each of them on one line of its own.
+
+(defn caught-raise []
+  (error {:error :first :message "caught and handled"}))
+
+(defn uncaught-raise []
+  (error {:error :second :message "reaches the root through defer"}))
+
+(protect (caught-raise))
+
+(defer
+  (println "cleanup ran")
+  (uncaught-raise))

--- a/tests/integration/fixtures/traceback-unjoined-spawn.lisp
+++ b/tests/integration/fixtures/traceback-unjoined-spawn.lisp
@@ -1,0 +1,13 @@
+(elle/epoch 12)
+# An error raised in a spawned fiber that nothing joins. The scheduler catches
+# it, and surfaces it when the program's own work finishes.
+#
+# `tests/integration/error_reporting.rs` locates the raising form by the
+# `:orphan` keyword, so keep it on one line of its own.
+
+(defn uncaught-raise []
+  (error {:error :orphan :message "raised in an unjoined fiber"}))
+
+(ev/spawn (fn [] (uncaught-raise)))
+
+(ev/sleep 0.05)


### PR DESCRIPTION
Fixes #901.

## The defect

The `at file:line:col` a runtime error prints is `VM::error_loc`. It is written
first-writer-wins, so the raising frame beats the frames the error unwinds
through. Two gaps made it name an unrelated form:

- Only two rare dispatch-loop exits wrote it. The dominant path —
  `dispatch_instruction` returning an error signal — wrote nothing.
- Nothing ended the record when a mask caught the error.

So an uncaught error usually printed no location at all, and when it printed
one it was the location of the first error the program ever *caught*. That is
the `docs/io.md:201:47` in the issue: a closure 200 lines above the failure,
which sent #885 chasing a TCP read that never failed.

## The fix

- **Record on the dominant exit too.** A new `record_error_loc` helper replaces
  the three copies of the guard and is now called on every path that leaves
  `execute_bytecode_inner_impl` carrying `SIG_ERROR` or `SIG_HALT`.
- **End the record where the propagation ends.** `VM::absorbs` is
  `mask_catches` plus the state change catching implies. Every position that
  drives a child fiber asks it; the one lookahead in `do_fiber_abort` keeps
  `mask_catches`, because it absorbs nothing.
- **Keep the raising form across a catch-then-re-raise.** `absorbs` parks the
  record on the caught fiber (`Fiber::error_loc`), paired with the payload it
  describes, and `fiber/propagate` takes it back while the pair still names
  that payload. This is what `defer` and the `ev/run` scheduler need. Both
  stdlib sites that surface a failed fiber's error now use
  `(fiber/propagate f)`; raising the payload afresh with
  `(error (fiber/value f))` reported the stdlib line that re-raised it.

Design written up in `docs/impl/vm.md` § "Where a reported error's location
comes from".

## Result on the issue's repro

Running `docs/io.md` with a binary that cannot resolve `std/process`:

```
  at docs/io.md:201:47                     # before — an unrelated closure
  at /Fast/work/ec/docs/io.md:422:15       # after  — the failing import
   (def process ((import "std/process")))
                 ^
```

## Tests

Four fixtures under `tests/integration/fixtures/`, asserted in
`tests/integration/error_reporting.rs`. They locate raising forms by marker
keyword rather than by line number, so editing a fixture cannot silently
invalidate an assertion.

| Test | Covers |
|------|--------|
| `an_uncaught_error_is_attributed_to_the_form_that_raised_it` | plain raise |
| `a_handled_error_does_not_lend_its_location_to_a_later_one` | the #901 shape |
| `an_error_re_propagated_by_defer_still_names_the_form_that_raised_it` | catch, clean up, re-raise |
| `an_unjoined_fibers_error_names_the_form_that_raised_it` | the scheduler's re-raise |

Each was written before the code and fails without it. The counter-factuals:
the first two printed no location at all; the second then reproduced #901
exactly, reporting the handled error's line; the last two reported
`<stdlib>:2186` and the `(defer …)` form instead of the raising form.

## Verification

`make test` green — smoke, fmt, clippy, macOS crosscheck, rustdoc, unit, and
integration.
