### PR TITLE
wasm: the tiered path reads the signal channel, not the status word

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,12 @@ ELLE_SKIP_FFI := -e ffi.lisp -e prim-ffi.lisp -e region-ffi-callback-arg-uaf.lis
 # Skip list for the whole-file --wasm=full pass only (eval = dynamic
 # compilation, not in the WASM backend). The runner needs no list: a form a
 # tier cannot host is recorded :ineligible→skip per form.
-WASM_SKIP := -e eval.lisp -e eval-env.lisp
+#
+# wasm-tier-error-signal drives the TIERED backend through `compile/run-on
+# :wasm`, which a whole-file `--wasm=full` compile cannot host — the forced tier
+# needs the bytecode VM underneath it. Same shape as eval: the runner records it
+# :ineligible per form, so the corpus pass still covers the file.
+WASM_SKIP := -e eval.lisp -e eval-env.lisp -e wasm-tier-error-signal.lisp
 
 # One corpus pass through the agent-first runner. Shared by smoke-elle and the
 # featured-build targets: the runner probes the tiers the binary carries, so

--- a/src/wasm/emit.rs
+++ b/src/wasm/emit.rs
@@ -204,6 +204,15 @@ pub(super) const FN_ENTRY: u32 = 11;
 // Linear memory layout
 pub(super) const ARGS_BASE: i32 = 256;
 
+/// Reserved 8-byte slot at the base of linear memory holding the `SignalBits` a
+/// compiled function raised.
+///
+/// A compiled function answers on two channels, and both must be read. The
+/// `status` word it returns says whether it suspended; the signal it raised
+/// goes here. Reading only `status` reports a failed primitive as a successful
+/// return of the error value — see `store::take_raised_signal`.
+pub(in crate::wasm) const SIGNAL_SLOT: i32 = 0;
+
 /// Reserved 16-byte slot in linear memory holding the **executing closure**
 /// (tag at `SELF_SLOT`, payload at `SELF_SLOT + 8`) — the WASM analogue of the
 /// interpreter's `Fiber::current_closure` and the JIT's `self_tag_payload`. A

--- a/src/wasm/lazy.rs
+++ b/src/wasm/lazy.rs
@@ -227,8 +227,20 @@ impl WasmTier {
             .call(&mut store, (env_base as i32, 0, 0, 0))
             .map_err(|e| e.to_string())?;
 
+        // A standalone module has no suspension machinery: no frame deque, no
+        // env snapshots, no resume chain. `standalone_emittable` refuses every
+        // shape that could park here, so a non-zero status means the emission
+        // gate and this caller have drifted apart. Report that rather than
+        // inventing a resume nobody can drive.
+        if status != 0 {
+            return Err(format!(
+                "wasm tier: standalone closure suspended at resume state {status}, \
+                 which the tiered path cannot drive"
+            ));
+        }
+
         let value = store.data().inner.wasm_to_value(tag, payload);
-        let signal = SignalBits::new(status as u64);
+        let signal = super::store::take_raised_signal(&mut store, &memory);
         Ok((value, signal))
     }
 }

--- a/src/wasm/store.rs
+++ b/src/wasm/store.rs
@@ -27,6 +27,29 @@ pub(in crate::wasm) fn write_self_slot<T: 'static>(
     data[base + 8..base + 16].copy_from_slice(&payload.to_le_bytes());
 }
 
+/// Take the signal a compiled function raised, clearing the channel behind it.
+///
+/// A compiled WASM function answers on two channels: the `status` word it
+/// returns (0 = ran to completion, >0 = the resume state it suspended at), and
+/// the `SignalBits` it raised, written to `SIGNAL_SLOT`. A caller that reads
+/// only `status` reports a failed primitive as a successful return of the error
+/// value — pinned by `tests/elle/wasm-tier-error-signal.lisp`.
+///
+/// Generic over the host type so the full-module (`ElleHost`) and tiered
+/// (`TieredHost`) paths, and both `Caller` and `Store` contexts, share it.
+pub(in crate::wasm) fn take_raised_signal<T: 'static>(
+    mut ctx: impl wasmtime::AsContextMut<Data = T>,
+    memory: &wasmtime::Memory,
+) -> crate::value::fiber::SignalBits {
+    let base = super::emit::SIGNAL_SLOT as usize;
+    let data = memory.data_mut(ctx.as_context_mut());
+    let raw = i64::from_le_bytes(data[base..base + 8].try_into().unwrap());
+    if raw != 0 {
+        data[base..base + 8].copy_from_slice(&0i64.to_le_bytes());
+    }
+    crate::value::fiber::SignalBits::new(raw as u64)
+}
+
 /// Read the executing closure `(tag, payload)` out of the reserved `SELF_SLOT`.
 /// The mirror of [`write_self_slot`] — used to save/restore the slot around a
 /// nested call and to snapshot it into a suspension frame at yield.

--- a/src/wasm/store/call.rs
+++ b/src/wasm/store/call.rs
@@ -56,11 +56,7 @@ pub(in crate::wasm) fn handle_wasm_result(
             } else {
                 caller.data_mut().env_stack_ptr = env_base;
 
-                let mut signal =
-                    i64::from_le_bytes(memory.data(&*caller)[0..8].try_into().unwrap());
-                if signal != 0 {
-                    memory.data_mut(&mut *caller)[0..8].copy_from_slice(&0i64.to_le_bytes());
-                }
+                let mut signal = super::take_raised_signal(&mut *caller, &memory).raw() as i64;
                 // A NativeFn tail call that yielded SIG_IO (written to
                 // memory[0..8] by rt_prepare_tail_call — the tail-position path a
                 // stdlib wrapper like `tcp/connect`'s `(apply tcp/connect-ip …)`
@@ -576,11 +572,35 @@ pub(in crate::wasm) fn call_precached_closure(
 
     match func.call(&mut store, (env_base as i32, 0, 0, 0)) {
         Ok((tag, payload, status)) => {
+            // The third slot of this function's result is the host's SIGNAL, not
+            // the wasm `status` word. They are different channels: `status` says
+            // whether the closure suspended, and the signal it raised lives in
+            // this store's SIGNAL_SLOT. Returning `status` here reported a failed
+            // primitive as a successful return of the error value.
+            //
+            // A precached closure cannot suspend — precaching only engages when
+            // no closure in the module may suspend, and `standalone_emittable`
+            // refuses every parking shape besides — so a non-zero status means
+            // the emission gate and this caller have drifted apart.
+            if status != 0 {
+                let heap = unsafe { &mut *caller.data().heap_ptr() };
+                let ctx = crate::primitives::ctx::Alloc::new(heap);
+                let err = ctx.error(
+                    "internal-error",
+                    format!(
+                        "precached closure suspended at resume state {status}, \
+                         which a standalone store cannot drive"
+                    ),
+                );
+                let (tag, payload) = caller.data_mut().value_to_wasm(err);
+                return (tag, payload, crate::value::fiber::SIG_ERROR.raw() as i64);
+            }
+            let signal = super::take_raised_signal(&mut store, &memory);
             // Convert result from standalone store's handle space
             // back to the caller's handle space.
             let value = store.data().wasm_to_value(tag, payload);
             let (caller_tag, caller_payload) = caller.data_mut().value_to_wasm(value);
-            (caller_tag, caller_payload, status)
+            (caller_tag, caller_payload, signal.raw() as i64)
         }
         Err(e) => {
             let heap = unsafe { &mut *caller.data().heap_ptr() };

--- a/tests/elle/wasm-tier-error-signal.lisp
+++ b/tests/elle/wasm-tier-error-signal.lisp
@@ -1,0 +1,50 @@
+(elle/epoch 12)
+## wasm/tier-error-signal — an error raised inside a closure on the forced WASM
+## tier reaches the caller as an error, not as a value.
+##
+## THE TRAP: a compiled WASM closure answers on two channels. The `status` word
+## it returns says whether it suspended (0 = ran to completion, >0 = the resume
+## state it parked at). The signal it raised is written to linear memory[0..8).
+## `WasmTier::call` read only `status` and built the caller's SignalBits from it
+## (`SignalBits::new(status as u64)`), so a primitive that failed inside the
+## closure wrote SIG_ERROR to memory, returned status 0, and reached the caller
+## as SIG_OK carrying the error struct as an ordinary return value.
+##
+## COUNTER-FACTUAL: the *value* is the same either way — the error struct comes
+## back whichever channel is read — so comparing return values across tiers
+## passes. The divergence is in pass/fail: `protect` reported ok?=true on :wasm
+## and ok?=false on :bytecode and :jit. Assert on ok?, not on the value.
+
+# Gate: a build without the wasm feature answers every `compile/run-on :wasm`
+# with :tier-rejected. `(fn [] 0)` is trivially standalone-emittable, so a
+# rejection of it means the tier is absent, not that a closure was ineligible.
+(def _wasm-available
+  (let [[ok? v] (protect (compile/run-on :wasm (fn [] 0)))]
+    (if (and (not ok?) (= (get v :error) :tier-rejected))
+      (error (struct :error :gated :reason "WASM tier not compiled in"))
+      true)))
+
+# The failing call must NOT be in tail position. `standalone_emittable`
+# (src/wasm/emit.rs) refuses a TailCall, so a tail-position `(length 5)` is
+# rejected before it runs and never reaches the signal channel at all.
+(defn failing-body []
+  (let [x (length 5)]
+    x))
+
+(let [[ok? v] (protect (compile/run-on :wasm failing-body))]
+  (assert (not ok?)
+          "a primitive error inside a WASM-tier closure propagates as an error")
+  (assert (= (get v :error) :type-error)
+          "the propagated error keeps its own payload, not a wasm-error wrapper"))
+
+# Every tier that can host this closure must agree it fails. A tier the build
+# lacks answers :tier-rejected; that is absence, not disagreement, so skip it.
+(each tier in [:bytecode :jit :wasm]
+  (let [[ok? v] (protect (compile/run-on tier failing-body))]
+    (unless (and (not ok?) (= (get v :error) :tier-rejected))
+      (assert (not ok?)
+              (string "tier " tier " must report the error as a failure"))
+      (assert (= (get v :error) :type-error)
+              (string "tier " tier " must report the type-error payload")))))
+
+(println "wasm-tier-error-signal: ok")


### PR DESCRIPTION
First of four, stacked. Base: `main`.

A compiled WASM function answers on **two channels**. The `status` word it returns says whether it suspended; the `SignalBits` it raised are written to `SIGNAL_SLOT`, the 8 bytes at the base of linear memory.

`WasmTier::call` built the caller's signal from `status` alone and never read the channel. A primitive that failed inside a forced-tier closure therefore came back as a **successful return of the error struct**:

```
wasm  ok?:true   v:{:error :type-error :message "length: no trait table on integer value"}
bytec ok?:false  v:{:error :type-error ...}
jit   ok?:false  v:{:error :type-error ...}
```

The corpus never caught it because the *value* is identical on both paths — only pass/fail diverges, and a value-comparing cross-tier check sees agreement. `tests/elle/wasm-tier-error-signal.lisp` asserts on `ok?` and records that as the counter-factual. It was RED for exactly that reason.

`call_precached_closure` had the same confusion in the same slot. That path is unreachable today — precaching engages only when no closure in the module may suspend, which the stdlib never satisfies — so it carries no test of its own and is not claimed as a live bug.

The fix gives the two channels one reader, `store::take_raised_signal`, used at all three sites that had hand-rolled it, and names the slot the emitters have been writing as a bare `0`. A non-zero `status` on a standalone store now raises a loud error instead of misreporting: `standalone_emittable` refuses every parking shape, so it cannot happen.

The new test drives the tiered backend through `compile/run-on :wasm`, which a whole-file `--wasm=full` compile cannot host, so it joins `WASM_SKIP` for that pass only. The runner still covers it per form.

**Verification:** full corpus 0 fail / 0 diverge / 0 timeout; WASM suite green; `cargo fmt`, `clippy`, rustdoc clean.