### PR TITLE
wasm: emitted code parks on a word the host sets, not on a signal bit

### DIFF
--- a/docs/impl/wasm.md
+++ b/docs/impl/wasm.md
@@ -129,9 +129,43 @@ Closure WASM type: `(env_ptr: i32, args_ptr: i32, nargs: i32, ctx: i32) -> (tag:
 - `ctx`: resume state (0 = initial call, >0 = resuming after yield).
 - `status`: 0 = normal return, >0 = suspended (resume state ID).
 
+A compiled function reports on **two channels, and both must be read**.
+`status` says whether the function suspended. The `SignalBits` it raised
+go to `SIGNAL_SLOT`, the 8 bytes at the base of linear memory. Neither
+word implies the other: a function can raise `:error` and return
+(`status = 0`, signal set), suspend carrying `:io` (`status > 0`, signal
+on the frame), or return a value (both clear).
+
 Tail calls use `return_call_indirect` (WASM tail-call proposal) via
 `rt_prepare_tail_call`, which resolves the target and builds the
 callee's env at the caller's env position.
+
+### `rt_call` and the suspended flag
+
+`rt_call` returns four words: `(tag: i64, payload: i64, signal: i64,
+suspended: i64)`. `suspended` is the host's answer to "must my caller
+park?", and the emitted code branches on it alone.
+
+Emitted code must not derive that answer from the signal word. The
+callee's signal is its own vocabulary — `:io`, `:wait`, a user bit — and
+which of those suspend is the interpreter's rule, not the emitter's.
+`signals::dispatch::classify` owns it, and `rt_call` applies it once so
+the tiers cannot disagree.
+
+Testing a bit instead costs correctness twice over. A suspending signal
+need not carry any particular bit — `fiber/emit` of a bare `|:io|` does
+not — so a bit test misses the park, captures no continuation frame, and
+drops the code after the suspend; the fiber then returns its resume value.
+And a host that answers "suspended" by OR-ing a bit back onto the signal
+puts that bit where programs can see it: `fiber/bits` reports
+`|:io :yield|` where the VM reports `|:io|`. Pinned by
+`tests/elle/wasm-suspend-not-by-bit.lisp`.
+
+A non-zero `status` likewise does not mean "parked". `(yield v)` and
+`(error …)` both compile to an `Emit` terminator and both route through
+`rt_yield`, so an error also returns `status > 0`. `handle_wasm_result`
+reads the signal off the frame `rt_yield` pushed and classifies it, which
+is what makes an uncaught error unwind rather than park.
 
 ### Callee dispatch spectrum
 

--- a/src/signals/dispatch.rs
+++ b/src/signals/dispatch.rs
@@ -65,5 +65,30 @@ pub fn classify(bits: SignalBits, value: &Value) -> SignalAction {
     SignalAction::Suspend
 }
 
+/// True when `bits` parks its caller rather than returning, unwinding, or
+/// asking the VM to do something.
+///
+/// The question every tier asks after a call, and it must have one answer. The
+/// interpreter asks it in `VM::call_inner`; the WASM tier asks it in `rt_call`,
+/// where the result becomes the `suspended` word emitted code branches on.
+///
+/// Deliberately not a test for any particular bit. `:yield`, `:io`, `:wait`,
+/// `:fuel`, and every user-defined signal all park, and a compound signal parks
+/// on the strength of any of them — so the rule is stated by exclusion.
+///
+/// The VM-internal dispatch signals are excluded because they are requests to
+/// the VM, not suspensions: `SIG_QUERY` asks it to read fiber state, `SIG_RESUME`
+/// and `SIG_PROPAGATE` to drive a child fiber. Treating one as a park makes a
+/// caller wait for a resume nobody will deliver. `SIG_ABORT` needs no case of
+/// its own — it is `SIG_ERROR | SIG_TERMINAL`, so the error test already covers
+/// it. `dispatch/tests.rs` pins that this agrees with [`classify`] bit for bit.
+#[inline]
+pub fn is_suspending(bits: SignalBits) -> bool {
+    if bits.is_empty() || bits == SIG_RESUME || bits == SIG_PROPAGATE || bits == SIG_QUERY {
+        return false;
+    }
+    !bits.intersects(SIG_ERROR) && !bits.intersects(SIG_HALT)
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/signals/dispatch/tests.rs
+++ b/src/signals/dispatch/tests.rs
@@ -64,3 +64,43 @@ fn abort_without_fiber_falls_through() {
     // SIG_ABORT = SIG_ERROR | SIG_TERMINAL).
     assert_eq!(classify(SIG_ABORT, &Value::NIL), SignalAction::Error);
 }
+
+#[test]
+fn is_suspending_agrees_with_classify_on_every_shape() {
+    // The WASM tier branches on `is_suspending` while the interpreter branches
+    // on `classify`. They are separate functions, so nothing but this test stops
+    // them drifting — and a drift is silent: the tier parks a caller the
+    // interpreter would have let return, or vice versa.
+    //
+    // COUNTER-FACTUAL: `is_suspending` first read "not empty, not error, not
+    // halt", which sends SIG_QUERY to Suspend where classify sends it to Query.
+    // Under --wasm=full that parked the caller of `vm/config` and
+    // `list-primitives` forever instead of reporting them unsupported
+    // (tests/elle/{trace,unicode,vm}.lisp).
+    let user_bit = SignalBits::from_bit(32);
+    let shapes = [
+        SIG_OK,
+        SIG_ERROR,
+        SIG_HALT,
+        SIG_YIELD,
+        SIG_IO,
+        SIG_DEBUG,
+        SIG_RESUME,
+        SIG_PROPAGATE,
+        SIG_QUERY,
+        SIG_ABORT,
+        user_bit,
+        SIG_YIELD | SIG_IO,
+        SIG_ERROR | SIG_IO,
+        SIG_IO | user_bit,
+        SIG_HALT | SIG_IO,
+    ];
+    for bits in shapes {
+        let by_classify = classify(bits, &Value::NIL) == SignalAction::Suspend;
+        assert_eq!(
+            is_suspending(bits),
+            by_classify,
+            "is_suspending and classify disagree on {bits}"
+        );
+    }
+}

--- a/src/wasm/emit.rs
+++ b/src/wasm/emit.rs
@@ -409,7 +409,7 @@ impl WasmEmitter {
     /// Type indices:
     ///   0: entry `(ctx: i32) -> (tag, payload, status)`
     ///   1: call_primitive `(prim_id, args_ptr, nargs, ctx) -> (tag, payload, signal)`
-    ///   2: rt_call `(func_tag, func_payload, args_ptr, nargs, ctx) -> (tag, payload, signal)`
+    ///   2: rt_call `(func_tag, func_payload, args_ptr, nargs, ctx) -> (tag, payload, signal, suspended)`
     ///   3: rt_load_const `(index) -> (tag, payload)`
     ///   4: rt_data_op `(op, args_ptr, nargs) -> (tag, payload, signal)`
     ///   5: closure `(env_ptr, args_ptr, nargs, ctx) -> (tag, payload, status)`
@@ -431,7 +431,10 @@ impl WasmEmitter {
             [ValType::I32, ValType::I32, ValType::I32, ValType::I32],
             [ValType::I64, ValType::I64, ValType::I64],
         );
-        // 2: rt_call
+        // 2: rt_call. The fourth result is `suspended`: whether the caller must
+        // park. It is a separate word from `signal` because which signals park
+        // is the interpreter's rule (`signals::dispatch::is_suspending`), not a
+        // bit the emitter can test — see docs/impl/wasm.md § rt_call.
         types.ty().function(
             [
                 ValType::I64,
@@ -440,7 +443,7 @@ impl WasmEmitter {
                 ValType::I32,
                 ValType::I32,
             ],
-            [ValType::I64, ValType::I64, ValType::I64],
+            [ValType::I64, ValType::I64, ValType::I64, ValType::I64],
         );
         // 3: rt_load_const
         types
@@ -527,6 +530,15 @@ impl WasmEmitter {
         } else {
             0
         }
+    }
+
+    /// The local holding `rt_call`'s fourth result: whether the callee parked.
+    ///
+    /// Declared immediately after `signal_local` in every function variant
+    /// (`emit_function` / `emit_closure_function`), so the two words that
+    /// describe one call sit together. The tail-call scratch follows it.
+    pub(in crate::wasm) fn suspended_local(&self) -> u32 {
+        self.signal_local + 1
     }
 
     pub(super) fn tag_local(&self, reg: Reg) -> u32 {

--- a/src/wasm/emit/functions.rs
+++ b/src/wasm/emit/functions.rs
@@ -215,11 +215,13 @@ impl WasmEmitter {
         self.yield_state_map.clear();
         self.call_state_map.clear();
 
+        // The trailing I64 pair is `signal_local` then `suspended_local`
+        // (`WasmEmitter::suspended_local`); they must stay adjacent and last.
         let mut f = Function::new([
             (n, ValType::I64),
             (n, ValType::I64),
             (1, ValType::I32),
-            (1, ValType::I64),
+            (2, ValType::I64),
         ]);
 
         self.emit_cfg(&mut f, func);
@@ -306,8 +308,10 @@ impl WasmEmitter {
         self.signal_local = 4 + 2 * n + 2 * m;
 
         if self.may_suspend {
-            self.resume_tag_local = 4 + 2 * n + 2 * m + 4;
-            self.resume_pay_local = 4 + 2 * n + 2 * m + 5;
+            // Past signal_local, suspended_local, and the three I32 tail-call
+            // scratch locals (see `emit_tail_call_dispatch`).
+            self.resume_tag_local = 4 + 2 * n + 2 * m + 5;
+            self.resume_pay_local = 4 + 2 * n + 2 * m + 6;
 
             self.pre_scan_resume_states(func);
             self.next_resume_state = 1;
@@ -344,7 +348,7 @@ impl WasmEmitter {
                 (n, ValType::I64),
                 (m, ValType::I64),
                 (m, ValType::I64),
-                (1, ValType::I64),
+                (2, ValType::I64),
                 (3, ValType::I32),
                 (2, ValType::I64),
             ]);
@@ -357,7 +361,7 @@ impl WasmEmitter {
                 (n, ValType::I64),
                 (m, ValType::I64),
                 (m, ValType::I64),
-                (1, ValType::I64),
+                (2, ValType::I64),
                 (3, ValType::I32),
             ]);
             self.emit_cfg(&mut f, func);

--- a/src/wasm/host.rs
+++ b/src/wasm/host.rs
@@ -227,6 +227,22 @@ impl ElleHost {
         self.suspension_frames.get_mut(&id)?.front_mut()
     }
 
+    /// The signal on the most recently pushed frame for the current fiber.
+    ///
+    /// `handle_wasm_result` classifies an `Emit` with this. An `Emit` terminator
+    /// carries whatever the emission raised — `(yield v)` and `(error …)` alike
+    /// route through `rt_yield` — so "the function returned a non-zero status"
+    /// does not by itself mean it parked. This is the back frame rather than the
+    /// front because the front may still be a stale outer frame from a previous
+    /// suspension until `drive_resume_chain` rotates.
+    pub fn back_suspension_frame_signal(&self) -> Option<crate::value::fiber::SignalBits> {
+        let id = self.current_fiber_id();
+        self.suspension_frames
+            .get(&id)?
+            .back()
+            .map(|f| crate::value::fiber::SignalBits::new(f.signal_bits))
+    }
+
     /// Get the back suspension frame for the current fiber (most recently pushed).
     /// Used by handle_wasm_result to update the frame that rt_yield just pushed.
     pub fn back_suspension_frame_mut(&mut self) -> Option<&mut WasmSuspensionFrame> {

--- a/src/wasm/instruction/calls.rs
+++ b/src/wasm/instruction/calls.rs
@@ -2,7 +2,9 @@
 //!
 //! These emitters marshal register values into linear memory at `ARGS_BASE`,
 //! invoke the runtime dispatch functions (`rt_call`, `rt_make_closure`), and
-//! unpack the `(tag, payload, signal)` triple they return.
+//! unpack the words they return. `rt_call` returns four —
+//! `(tag, payload, signal, suspended)` — while `rt_data_op` and `call_primitive`
+//! return three; the two shapes have separate store helpers below.
 
 use super::*;
 
@@ -107,7 +109,7 @@ impl WasmEmitter {
         f.instruction(&Instruction::I32Const(args.len() as i32));
         f.instruction(&Instruction::I32Const(0));
         f.instruction(&Instruction::Call(FN_RT_CALL));
-        self.store_result_with_signal(f, dst);
+        self.store_call_result(f, dst);
     }
 
     /// Emit CallArrayMut via rt_call with nargs=-1 protocol.
@@ -126,15 +128,32 @@ impl WasmEmitter {
         f.instruction(&Instruction::I32Const(-1));
         f.instruction(&Instruction::I32Const(0));
         f.instruction(&Instruction::Call(FN_RT_CALL));
+        self.store_call_result(f, dst);
+    }
+
+    /// Store `rt_call`'s FOUR-word result in a NON-suspending function.
+    ///
+    /// This function has no continuation frame to capture, so a callee that
+    /// parked is handled the same way as one that raised: the signal goes to
+    /// `SIGNAL_SLOT` and the function returns with `status = 0`. The caller's
+    /// `handle_wasm_result` reads the slot and classifies it there — that is the
+    /// yield-through path, and it is why `suspended` is popped and dropped here
+    /// rather than branched on.
+    ///
+    /// Only `rt_call` returns four words. `rt_data_op` and `call_primitive`
+    /// return three and use [`store_result_with_signal`] directly.
+    pub(in crate::wasm) fn store_call_result(&self, f: &mut Function, dst: Reg) {
+        f.instruction(&Instruction::LocalSet(self.suspended_local()));
         self.store_result_with_signal(f, dst);
     }
 
-    /// Store result from (tag, payload, signal) triple, early-return on error.
+    /// Store a THREE-word `(tag, payload, signal)` result, early-returning on
+    /// any signal. Shared by `rt_data_op` and `call_primitive`.
     pub(in crate::wasm) fn store_result_with_signal(&self, f: &mut Function, dst: Reg) {
         f.instruction(&Instruction::LocalSet(self.signal_local));
         f.instruction(&Instruction::LocalSet(self.pay_local(dst)));
         f.instruction(&Instruction::LocalSet(self.tag_local(dst)));
-        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::I32Const(SIGNAL_SLOT));
         f.instruction(&Instruction::LocalGet(self.signal_local));
         f.instruction(&Instruction::I64Store(MemArg {
             offset: 0,
@@ -157,9 +176,10 @@ impl WasmEmitter {
         let tc_signal = self.signal_local;
         let tc_payload = self.pay_local(Reg(0));
         let tc_tag = self.tag_local(Reg(0));
-        let tc_is_wasm = self.signal_local + 1;
-        let tc_table_idx = self.signal_local + 2;
-        let tc_env_ptr = self.signal_local + 3;
+        // The I32 scratch trio sits after signal_local and suspended_local.
+        let tc_is_wasm = self.signal_local + 2;
+        let tc_table_idx = self.signal_local + 3;
+        let tc_env_ptr = self.signal_local + 4;
 
         f.instruction(&Instruction::LocalSet(tc_signal));
         f.instruction(&Instruction::LocalSet(tc_payload));

--- a/src/wasm/lazy/env.rs
+++ b/src/wasm/lazy/env.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::wasm::outcome::CallOutcome;
 
 /// Build closure environment in WASM linear memory.
 ///
@@ -132,7 +133,7 @@ pub(super) fn create_tiered_linker(engine: &Engine) -> Result<Linker<TieredHost>
          args_ptr: i32,
          nargs: i32,
          _ctx: i32|
-         -> (i64, i64, i64) {
+         -> (i64, i64, i64, i64) {
             let func_val = caller.data().inner.wasm_to_value(func_tag, func_payload);
             let args = read_args(&mut caller, args_ptr, nargs);
 
@@ -145,7 +146,7 @@ pub(super) fn create_tiered_linker(engine: &Engine) -> Result<Linker<TieredHost>
                 let (bits, result) = native_fn(&mut ctx, &args);
                 let (bits, result) = caller.data_mut().inner.maybe_execute_io(bits, result);
                 let (tag, payload) = caller.data_mut().inner.value_to_wasm(result);
-                return (tag, payload, bits.raw() as i64);
+                return CallOutcome::signalled(tag, payload, bits).to_wasm();
             }
 
             if let Some((id, default)) = func_val.as_parameter() {
@@ -157,11 +158,11 @@ pub(super) fn create_tiered_linker(engine: &Engine) -> Result<Linker<TieredHost>
                         format!("parameter call: expected 0 arguments, got {}", args.len()),
                     );
                     let (tag, payload) = caller.data_mut().inner.value_to_wasm(err);
-                    return (tag, payload, 1);
+                    return CallOutcome::error(tag, payload).to_wasm();
                 }
                 let value = caller.data().inner.resolve_parameter(id, default);
                 let (tag, payload) = caller.data_mut().inner.value_to_wasm(value);
-                return (tag, payload, 0);
+                return CallOutcome::value(tag, payload).to_wasm();
             }
 
             if let Some(closure) = func_val.as_closure() {
@@ -225,14 +226,31 @@ pub(super) fn create_tiered_linker(engine: &Engine) -> Result<Linker<TieredHost>
                             let status = results[2].unwrap_i64();
                             // Restore env_stack_ptr after the call
                             caller.data_mut().inner.env_stack_ptr = env_base;
-                            return (tag, payload, status);
+                            // `status` is not a signal. A tiered closure cannot
+                            // park — `standalone_emittable` refuses every parking
+                            // shape — so a non-zero one means the emission gate
+                            // and this caller have drifted apart. The signal it
+                            // raised is in SIGNAL_SLOT.
+                            if status != 0 {
+                                let heap = unsafe { &mut *(*caller.data().vm).heap_ptr };
+                                let ctx = crate::primitives::ctx::Alloc::new(heap);
+                                let err = ctx.error(
+                                    "internal-error",
+                                    format!("wasm self-call suspended at resume state {status}"),
+                                );
+                                let (tag, payload) = caller.data_mut().inner.value_to_wasm(err);
+                                return CallOutcome::error(tag, payload).to_wasm();
+                            }
+                            let signal =
+                                super::super::store::take_raised_signal(&mut caller, &self_memory);
+                            return CallOutcome::signalled(tag, payload, signal).to_wasm();
                         }
                         Err(e) => {
                             let heap = unsafe { &mut *(*caller.data().vm).heap_ptr };
                             let ctx = crate::primitives::ctx::Alloc::new(heap);
                             let err = ctx.error("internal-error", format!("wasm self-call: {}", e));
                             let (tag, payload) = caller.data_mut().inner.value_to_wasm(err);
-                            return (tag, payload, 1);
+                            return CallOutcome::error(tag, payload).to_wasm();
                         }
                     }
                 }
@@ -253,28 +271,23 @@ pub(super) fn create_tiered_linker(engine: &Engine) -> Result<Linker<TieredHost>
                     let wasm_tier = vm_ref.wasm_tier.as_ref().unwrap();
                     match wasm_tier.call(vm, bytecode_ptr, &closure_rc, &args, func_val) {
                         Ok((value, signal)) => {
-                            if signal.is_empty() {
-                                let (tag, payload) = caller.data_mut().inner.value_to_wasm(value);
-                                return (tag, payload, 0);
-                            } else if signal == crate::value::SIG_HALT {
-                                if value == Value::NIL {
-                                    let (tag, payload) =
-                                        caller.data_mut().inner.value_to_wasm(value);
-                                    return (tag, payload, 0);
-                                }
-                                // Non-NIL halt: propagate as error
-                                let (tag, payload) = caller.data_mut().inner.value_to_wasm(value);
-                                return (tag, payload, signal.raw() as i64);
-                            }
+                            // A NIL `(halt)` is a normal return; every other
+                            // signal rides back out for the caller to classify.
+                            let signal = if signal == crate::value::SIG_HALT && value == Value::NIL
+                            {
+                                crate::value::SIG_OK
+                            } else {
+                                signal
+                            };
                             let (tag, payload) = caller.data_mut().inner.value_to_wasm(value);
-                            return (tag, payload, signal.raw() as i64);
+                            return CallOutcome::signalled(tag, payload, signal).to_wasm();
                         }
                         Err(e) => {
                             let heap = unsafe { &mut *(*caller.data().vm).heap_ptr };
                             let ctx = crate::primitives::ctx::Alloc::new(heap);
                             let err = ctx.error("internal-error", format!("wasm: {}", e));
                             let (tag, payload) = caller.data_mut().inner.value_to_wasm(err);
-                            return (tag, payload, 1);
+                            return CallOutcome::error(tag, payload).to_wasm();
                         }
                     }
                 }
@@ -292,22 +305,7 @@ pub(super) fn create_tiered_linker(engine: &Engine) -> Result<Linker<TieredHost>
                         if bits.is_empty() {
                             let (_, val) = vm_ref.fiber.signal.take().unwrap();
                             let (tag, payload) = caller.data_mut().inner.value_to_wasm(val);
-                            (tag, payload, 0)
-                        } else if bits == crate::value::SIG_HALT {
-                            let val = vm_ref
-                                .fiber
-                                .signal
-                                .as_ref()
-                                .map(|(_, v)| *v)
-                                .unwrap_or(Value::NIL);
-                            if val == Value::NIL {
-                                vm_ref.fiber.signal.take();
-                                let (tag, payload) = caller.data_mut().inner.value_to_wasm(val);
-                                (tag, payload, 0)
-                            } else {
-                                let (tag, payload) = caller.data_mut().inner.value_to_wasm(val);
-                                (tag, payload, bits.raw() as i64)
-                            }
+                            CallOutcome::value(tag, payload).to_wasm()
                         } else {
                             let val = vm_ref
                                 .fiber
@@ -315,8 +313,16 @@ pub(super) fn create_tiered_linker(engine: &Engine) -> Result<Linker<TieredHost>
                                 .as_ref()
                                 .map(|(_, v)| *v)
                                 .unwrap_or(Value::NIL);
+                            // A NIL `(halt)` is a normal return; every other
+                            // signal rides back out on the signal word.
+                            let bits = if bits == crate::value::SIG_HALT && val == Value::NIL {
+                                vm_ref.fiber.signal.take();
+                                crate::value::SIG_OK
+                            } else {
+                                bits
+                            };
                             let (tag, payload) = caller.data_mut().inner.value_to_wasm(val);
-                            (tag, payload, bits.raw() as i64)
+                            CallOutcome::signalled(tag, payload, bits).to_wasm()
                         }
                     }
                     None => {
@@ -333,7 +339,7 @@ pub(super) fn create_tiered_linker(engine: &Engine) -> Result<Linker<TieredHost>
                             .map(|(b, _)| *b)
                             .unwrap_or(crate::value::SIG_ERROR);
                         let (tag, payload) = caller.data_mut().inner.value_to_wasm(val);
-                        (tag, payload, bits.raw() as i64)
+                        CallOutcome::signalled(tag, payload, bits).to_wasm()
                     }
                 }
             } else {
@@ -344,7 +350,7 @@ pub(super) fn create_tiered_linker(engine: &Engine) -> Result<Linker<TieredHost>
                     format!("rt_call: cannot call {}", func_val.type_name()),
                 );
                 let (tag, payload) = caller.data_mut().inner.value_to_wasm(err);
-                (tag, payload, 1)
+                CallOutcome::error(tag, payload).to_wasm()
             }
         },
     )?;

--- a/src/wasm/linker.rs
+++ b/src/wasm/linker.rs
@@ -5,6 +5,7 @@ use wasmtime::*;
 use super::host::ElleHost;
 use crate::value::repr::TAG_HEAP_START;
 use crate::value::Value;
+use crate::wasm::outcome::CallOutcome;
 
 mod dataop;
 pub use dataop::*;
@@ -25,12 +26,12 @@ pub use create::*;
 /// here via the VM makes the call transparent; without this the caller aborts
 /// with "bytecode closure in WASM backend". Pinned by
 /// `tests/elle/wasm-bytecode-closure-call.lisp`.
-pub(crate) fn run_bytecode_closure(
+pub(in crate::wasm) fn run_bytecode_closure(
     caller: &mut Caller<'_, ElleHost>,
     closure: &crate::value::Closure,
     func_val: Value,
     args: &[Value],
-) -> (i64, i64, i64) {
+) -> CallOutcome {
     let vm = caller.data().vm;
     // Raw-pointer deref: the VM outlives the call, and it is a distinct object
     // from the `ElleHost` reached via `caller.data_mut()` below (the value/handle
@@ -44,7 +45,7 @@ pub(crate) fn run_bytecode_closure(
             .signal
             .unwrap_or((crate::value::SIG_ERROR, Value::NIL));
         let (tag, payload) = caller.data_mut().value_to_wasm(val);
-        return (tag, payload, bits.raw() as i64);
+        return CallOutcome::signalled(tag, payload, bits);
     };
     // Hand the callee its executing-closure register via the one-shot (the
     // WASM→interp entry boundary), so a self-reference in the body resolves to
@@ -71,12 +72,12 @@ pub(crate) fn run_bytecode_closure(
         vm_ref.fiber.signal.take();
     }
     let (tag, payload) = caller.data_mut().value_to_wasm(val);
-    (tag, payload, signal.raw() as i64)
+    CallOutcome::signalled(tag, payload, signal)
 }
 
 /// Apply a **callable collection** — a struct/array/set/string/bytes indexed by
 /// a key (`(request :op)`, `(arr i)`, `(set x)`) — via the interpreter's shared
-/// `call_collection`, returning `(tag, payload, signal)` for the wasm caller.
+/// `call_collection`, returning a [`CallOutcome`] for the wasm caller.
 /// When `func_val` is not a collection either, produces the `cannot call …` type
 /// error so both dispatch sites (`rt_call`, `rt_prepare_tail_call`) share one
 /// tail. Mirrors the collection arm of the interpreter's `call_inner`.
@@ -92,12 +93,12 @@ pub(crate) fn run_bytecode_closure(
 /// The full-module tier makes region instructions structural no-ops, so — like
 /// the native-fn arm of `rt_call` — this skips the interpreter's Rule-5 escape
 /// retain and mints a fresh `Alloc` only for the element/error it may build.
-pub(crate) fn run_collection_call(
+pub(in crate::wasm) fn run_collection_call(
     caller: &mut Caller<'_, ElleHost>,
     func_val: Value,
     args: &[Value],
     what: &str,
-) -> (i64, i64, i64) {
+) -> CallOutcome {
     let call_result = {
         let gen = unsafe { &*caller.data().vm }.unicode_generation();
         let heap = unsafe { &mut *caller.data().heap_ptr() };
@@ -105,11 +106,11 @@ pub(crate) fn run_collection_call(
         crate::vm::call::call_collection(&func_val, args, gen, &mut ctx)
     };
     let (value, signal) = match call_result {
-        Some(Ok(value)) => (value, crate::value::SIG_OK.raw() as i64),
+        Some(Ok(value)) => (value, crate::value::SIG_OK),
         Some(Err((kind, msg))) => {
             let heap = unsafe { &mut *caller.data().heap_ptr() };
             let ctx = crate::primitives::ctx::Alloc::new(heap);
-            (ctx.error(kind, msg), crate::value::SIG_ERROR.raw() as i64)
+            (ctx.error(kind, msg), crate::value::SIG_ERROR)
         }
         None => {
             let heap = unsafe { &mut *caller.data().heap_ptr() };
@@ -118,9 +119,9 @@ pub(crate) fn run_collection_call(
                 "type-error",
                 format!("{}: cannot call {}", what, func_val.type_name()),
             );
-            (err, crate::value::SIG_ERROR.raw() as i64)
+            (err, crate::value::SIG_ERROR)
         }
     };
     let (tag, payload) = caller.data_mut().value_to_wasm(value);
-    (tag, payload, signal)
+    CallOutcome::signalled(tag, payload, signal)
 }

--- a/src/wasm/linker/create/call.rs
+++ b/src/wasm/linker/create/call.rs
@@ -7,6 +7,7 @@ use wasmtime::*;
 
 use crate::wasm::host::ElleHost;
 use crate::wasm::linker::read_args_from_memory;
+use crate::wasm::outcome::CallOutcome;
 
 pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
     // call_primitive(prim_id: i32, args_ptr: i32, nargs: i32, ctx: i32) -> (tag: i64, payload: i64, signal: i64)
@@ -27,7 +28,12 @@ pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
         },
     )?;
 
-    // rt_call(func_tag: i64, func_payload: i64, args_ptr: i32, nargs: i32, ctx: i32) -> (tag: i64, payload: i64, signal: i64)
+    // rt_call(func_tag: i64, func_payload: i64, args_ptr: i32, nargs: i32, ctx: i32)
+    //   -> (tag: i64, payload: i64, signal: i64, suspended: i64)
+    //
+    // `suspended` is the word emitted code branches on. It is computed here, once,
+    // by `signals::dispatch::is_suspending` — never inferred from a bit of
+    // `signal`. See docs/impl/wasm.md § rt_call.
     linker.func_wrap(
         "elle",
         "rt_call",
@@ -37,7 +43,7 @@ pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
          args_ptr: i32,
          nargs: i32,
          _ctx: i32|
-         -> (i64, i64, i64) {
+         -> (i64, i64, i64, i64) {
             // Resolve the function value
             let func_val = caller.data().wasm_to_value(func_tag, func_payload);
 
@@ -88,7 +94,8 @@ pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
                 // signal. Convert it to the child's (bits, value) so the body
                 // unwinds with the real error (defer/with's tail unwind branch).
                 if bits.raw() & crate::value::fiber::SIG_PROPAGATE.raw() != 0 {
-                    return crate::wasm::resume::handle_fiber_propagate(&mut caller, result);
+                    return crate::wasm::resume::handle_fiber_propagate(&mut caller, result)
+                        .to_wasm();
                 }
 
                 // Handle SIG_RESUME: fiber/resume returns this signal.
@@ -98,15 +105,15 @@ pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
                     let r = crate::wasm::resume::handle_fiber_resume(&mut caller, result);
                     if caller.data().debug {
                         eprintln!(
-                            "[rt_call] handle_fiber_resume returned: tag={} payload={} signal={}",
-                            r.0, r.1, r.2
+                            "[rt_call] handle_fiber_resume returned: tag={} payload={} signal={} suspended={}",
+                            r.tag, r.payload, r.signal, r.suspended
                         );
                     }
-                    return r;
+                    return r.to_wasm();
                 }
 
                 let (tag, payload) = caller.data_mut().value_to_wasm(result);
-                (tag, payload, bits.raw() as i64)
+                CallOutcome::signalled(tag, payload, bits)
             } else if let Some((id, default)) = func_val.as_parameter() {
                 if caller.data().debug {
                     eprintln!("[rt_call] parameter id={} default={:?}", id, default);
@@ -119,11 +126,11 @@ pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
                         format!("parameter call: expected 0 arguments, got {}", args.len()),
                     );
                     let (tag, payload) = caller.data_mut().value_to_wasm(err);
-                    (tag, payload, 1)
+                    CallOutcome::error(tag, payload)
                 } else {
                     let value = caller.data().resolve_parameter(id, default);
                     let (tag, payload) = caller.data_mut().value_to_wasm(value);
-                    (tag, payload, 0)
+                    CallOutcome::value(tag, payload)
                 }
             } else if let Some(closure) = func_val.as_closure() {
                 if let Some(wasm_idx) = closure.template.wasm_func_idx {
@@ -167,6 +174,7 @@ pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
                 // `cannot call` type error. See `run_collection_call`.
                 crate::wasm::linker::run_collection_call(&mut caller, func_val, &args, "rt_call")
             }
+            .to_wasm()
         },
     )?;
 

--- a/src/wasm/linker/create/tailcall.rs
+++ b/src/wasm/linker/create/tailcall.rs
@@ -7,6 +7,34 @@ use wasmtime::*;
 
 use crate::wasm::host::ElleHost;
 use crate::wasm::linker::read_args_from_memory;
+use crate::wasm::outcome::CallOutcome;
+
+/// Hand a tail callee's outcome back through `SIGNAL_SLOT`, returning the
+/// `(env_ptr, table_idx, is_wasm, tag, payload, signal)` tuple that tells the
+/// caller to `return` rather than `return_call_indirect`.
+///
+/// A tail call replaces the frame, so there is no continuation here to capture
+/// and no status word to set — the dispatch returns `(tag, payload, 0)` right
+/// after this. The signal therefore travels in the slot, and the caller's
+/// `handle_wasm_result` classifies it there. That is why `suspended` is dropped:
+/// re-deriving it from the signal is exactly what `is_suspending` is for, and
+/// doing it in one place keeps the tail and non-tail paths agreeing.
+fn return_via_slot(
+    caller: &mut Caller<'_, ElleHost>,
+    out: CallOutcome,
+) -> (i32, i32, i32, i64, i64, i64) {
+    let signal = out.signal.raw() as i64;
+    if signal != 0 {
+        if let Some(memory) = caller
+            .get_export("__elle_memory")
+            .and_then(|e| e.into_memory())
+        {
+            let base = crate::wasm::emit::SIGNAL_SLOT as usize;
+            memory.data_mut(&mut *caller)[base..base + 8].copy_from_slice(&signal.to_le_bytes());
+        }
+    }
+    (0, 0, 0, out.tag, out.payload, signal)
+}
 
 pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
     // rt_prepare_tail_call(func_tag, func_payload, args_ptr, nargs, caller_env_ptr)
@@ -105,21 +133,13 @@ pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
                 // and hand the caller the result to `return` (is_wasm = 0),
                 // routing any non-zero signal through memory[0..8] exactly as the
                 // native-tail path below does.
-                let (tag, payload, signal) = crate::wasm::linker::run_bytecode_closure(
+                let out = crate::wasm::linker::run_bytecode_closure(
                     &mut caller,
                     closure,
                     func_val,
                     &args,
                 );
-                if signal != 0 {
-                    if let Some(memory) = caller
-                        .get_export("__elle_memory")
-                        .and_then(|e| e.into_memory())
-                    {
-                        memory.data_mut(&mut caller)[0..8].copy_from_slice(&signal.to_le_bytes());
-                    }
-                }
-                return (0, 0, 0, tag, payload, signal);
+                return return_via_slot(&mut caller, out);
             }
 
             if func_val.is_native_fn() {
@@ -140,36 +160,16 @@ pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
                 // memory[0..8] like the native-error path below so the caller's
                 // epilogue observes it (tail dispatch returns tag/payload/0).
                 if bits.raw() & crate::value::fiber::SIG_RESUME.raw() != 0 {
-                    let (tag, payload, signal) =
-                        crate::wasm::resume::handle_fiber_resume(&mut caller, result);
-                    if signal != 0 {
-                        if let Some(memory) = caller
-                            .get_export("__elle_memory")
-                            .and_then(|e| e.into_memory())
-                        {
-                            memory.data_mut(&mut caller)[0..8]
-                                .copy_from_slice(&signal.to_le_bytes());
-                        }
-                    }
-                    return (0, 0, 0, tag, payload, signal);
+                    let out = crate::wasm::resume::handle_fiber_resume(&mut caller, result);
+                    return return_via_slot(&mut caller, out);
                 }
                 // A tail-position `(fiber/propagate …)` re-raises the child's
                 // caught signal (defer/with unwind branch). Convert it to the
                 // child's (bits, value) and route through memory[0..8] like the
                 // resume path, so the caller's epilogue observes the real error.
                 if bits.raw() & crate::value::fiber::SIG_PROPAGATE.raw() != 0 {
-                    let (tag, payload, signal) =
-                        crate::wasm::resume::handle_fiber_propagate(&mut caller, result);
-                    if signal != 0 {
-                        if let Some(memory) = caller
-                            .get_export("__elle_memory")
-                            .and_then(|e| e.into_memory())
-                        {
-                            memory.data_mut(&mut caller)[0..8]
-                                .copy_from_slice(&signal.to_le_bytes());
-                        }
-                    }
-                    return (0, 0, 0, tag, payload, signal);
+                    let out = crate::wasm::resume::handle_fiber_propagate(&mut caller, result);
+                    return return_via_slot(&mut caller, out);
                 }
                 // Write non-zero signal to memory[0..8] so handle_wasm_result
                 // picks it up. The WASM tail call dispatch returns immediately
@@ -210,21 +210,13 @@ pub(super) fn register(linker: &mut Linker<ElleHost>) -> Result<()> {
             // to `return` (is_wasm = 0), routing any non-zero signal through
             // memory[0..8] exactly as the native-tail path above does. A value
             // that is not a collection either yields the `cannot call` error.
-            let (tag, payload, signal) = crate::wasm::linker::run_collection_call(
+            let out = crate::wasm::linker::run_collection_call(
                 &mut caller,
                 func_val,
                 &args,
                 "rt_prepare_tail_call",
             );
-            if signal != 0 {
-                if let Some(memory) = caller
-                    .get_export("__elle_memory")
-                    .and_then(|e| e.into_memory())
-                {
-                    memory.data_mut(&mut caller)[0..8].copy_from_slice(&signal.to_le_bytes());
-                }
-            }
-            (0, 0, 0, tag, payload, signal)
+            return_via_slot(&mut caller, out)
         },
     )?;
 

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -32,6 +32,7 @@ mod instruction;
 pub mod lazy;
 pub mod linker;
 mod liveness;
+mod outcome;
 pub mod regalloc;
 pub mod resume;
 pub mod store;

--- a/src/wasm/outcome.rs
+++ b/src/wasm/outcome.rs
@@ -1,0 +1,80 @@
+//! What a call reports back to emitted WASM code.
+
+use crate::value::fiber::SignalBits;
+
+/// The four words `rt_call` returns: a value, the signal it raised, and whether
+/// the caller must park.
+///
+/// `signal` and `suspended` answer different questions and neither implies the
+/// other. A callee can raise `:error` and return (`suspended` false), park
+/// carrying `:io` (`suspended` true), or return a plain value (both clear).
+///
+/// This exists as a struct rather than a tuple because the two words are both
+/// `i64` on the wire and mean opposite things: returning one where the other
+/// belongs type-checks, compiles, and produces a silent wrong answer — the
+/// defect `tests/elle/wasm-tier-error-signal.lisp` pins. Build one through a
+/// constructor and the pair cannot be crossed.
+#[derive(Clone, Copy, Debug)]
+pub(in crate::wasm) struct CallOutcome {
+    pub tag: i64,
+    pub payload: i64,
+    pub signal: SignalBits,
+    pub suspended: bool,
+}
+
+impl CallOutcome {
+    /// A normal return: a value, no signal, no suspension.
+    pub(in crate::wasm) fn value(tag: i64, payload: i64) -> Self {
+        CallOutcome {
+            tag,
+            payload,
+            signal: SignalBits::EMPTY,
+            suspended: false,
+        }
+    }
+
+    /// A callee that raised `signal`, classified by the shared rule.
+    ///
+    /// The only constructor that decides whether to park, and it defers to
+    /// `signals::dispatch::is_suspending` so the WASM tier and the interpreter
+    /// cannot disagree about which signals park.
+    pub(in crate::wasm) fn signalled(tag: i64, payload: i64, signal: SignalBits) -> Self {
+        CallOutcome {
+            tag,
+            payload,
+            signal,
+            suspended: crate::signals::dispatch::is_suspending(signal),
+        }
+    }
+
+    /// A callee that parked carrying `signal`, where the caller already knows it
+    /// parked and holds the signal itself.
+    pub(in crate::wasm) fn parked(tag: i64, payload: i64, signal: SignalBits) -> Self {
+        CallOutcome {
+            tag,
+            payload,
+            signal,
+            suspended: true,
+        }
+    }
+
+    /// An error carrying `payload` as its value.
+    pub(in crate::wasm) fn error(tag: i64, payload: i64) -> Self {
+        CallOutcome {
+            tag,
+            payload,
+            signal: crate::value::fiber::SIG_ERROR,
+            suspended: false,
+        }
+    }
+
+    /// The tuple the wasm import returns: `(tag, payload, signal, suspended)`.
+    pub(in crate::wasm) fn to_wasm(self) -> (i64, i64, i64, i64) {
+        (
+            self.tag,
+            self.payload,
+            self.signal.raw() as i64,
+            self.suspended as i64,
+        )
+    }
+}

--- a/src/wasm/resume.rs
+++ b/src/wasm/resume.rs
@@ -20,41 +20,7 @@ use wasmtime::*;
 use super::host::ElleHost;
 use super::store::{call_wasm_closure, resume_wasm_closure};
 use crate::value::Value;
-
-/// Read signal_bits from the front (innermost) suspension frame for a fiber.
-/// The innermost frame carries the original signal (e.g. SIG_IO); outer frames
-/// only have SIG_YIELD.
-fn front_frame_signal(caller: &Caller<'_, ElleHost>) -> u64 {
-    caller
-        .data()
-        .first_suspension_frame()
-        .map(|f| f.signal_bits)
-        .unwrap_or(crate::value::fiber::SIG_YIELD.raw())
-}
-
-/// The real signal bits a fiber's SUSPEND carries, given the `signal` word a
-/// closure call/resume returned. A closure signals a suspend by setting the
-/// SIG_YIELD bit; two shapes reach here:
-///
-/// - **Pure `SIG_YIELD`** (the `rt_yield` suspension path) — a call in the body
-///   suspended and pushed a frame; the frame carries the original signal
-///   (SIG_IO / SIG_WAIT), so read it from the front frame.
-/// - **`SIG_YIELD` set alongside another bit** — a tail-position io returned
-///   through the function epilogue (`handle_wasm_result` OR-ed SIG_YIELD onto the
-///   native's SIG_IO). No frame was pushed, so `front_frame_signal` would
-///   mis-default to SIG_YIELD; the real signal IS `signal` itself.
-///
-/// Keeping SIG_IO visible here is what lets the scheduler submit the io: a fiber
-/// whose final action is a tail `println`/`port/write` (the whole-program thunk
-/// under `ev/run` ends this way) would otherwise be mis-routed. Pinned by
-/// tests/elle/wasm-tail-io-in-fiber.lisp.
-fn yield_sig_bits(caller: &Caller<'_, ElleHost>, signal: i64) -> u64 {
-    if signal as u64 == crate::value::fiber::SIG_YIELD.raw() {
-        front_frame_signal(caller)
-    } else {
-        signal as u64
-    }
-}
+use crate::wasm::outcome::CallOutcome;
 
 /// Resume outcome from drive_resume_chain.
 enum ResumeOutcome {
@@ -93,16 +59,15 @@ fn redrive_child(
         handle.with_mut(|f| f.signal = Some((crate::value::fiber::SIG_OK, resume_value)));
     }
     let current = caller.data().current_fiber_id();
-    let (t, p, s) = handle_fiber_resume(caller, child_value);
+    let out = handle_fiber_resume(caller, child_value);
     caller.data_mut().pending_redrive.remove(&current);
 
-    let raw = s as u64;
-    if raw == 0 {
-        RedriveOutcome::Completed(caller.data().wasm_to_value(t, p))
-    } else if raw & crate::value::fiber::SIG_YIELD.raw() != 0 {
-        RedriveOutcome::Suspended(t, p, raw)
+    if out.suspended {
+        RedriveOutcome::Suspended(out.tag, out.payload, out.signal.raw())
+    } else if !out.signal.is_empty() {
+        RedriveOutcome::Errored(out.tag, out.payload, out.signal.raw())
     } else {
-        RedriveOutcome::Errored(t, p, raw)
+        RedriveOutcome::Completed(caller.data().wasm_to_value(out.tag, out.payload))
     }
 }
 
@@ -119,7 +84,6 @@ fn redrive_child(
 /// the new yield point. We evict the stale frames so the next
 /// resume starts from the new innermost frame.
 fn drive_resume_chain(caller: &mut Caller<'_, ElleHost>, initial_value: Value) -> ResumeOutcome {
-    let yield_signal = crate::value::fiber::SIG_YIELD.raw() as i64;
     let mut result_val = initial_value;
 
     loop {
@@ -150,31 +114,28 @@ fn drive_resume_chain(caller: &mut Caller<'_, ElleHost>, initial_value: Value) -
         // new inner chain is consumed first on the next resume.
         let frames_before = caller.data().suspension_frame_count();
         match resume_wasm_closure(caller, result_val) {
-            Some((t, p, s)) => {
-                if s & yield_signal != 0 {
-                    if s == yield_signal {
-                        // Re-yield via `rt_yield`: a call in the resumed body
-                        // suspended again and pushed new frames to the back. After
-                        // pop in resume_wasm_closure, old outer frames are at
-                        // positions 0..remaining, new frames after — rotate the old
-                        // ones behind so the new inner chain resumes first.
-                        let remaining_old = frames_before.saturating_sub(1);
+            Some(out) => {
+                if out.suspended {
+                    // Did `rt_yield` push new frames, or did a tail-position io
+                    // ride out through the epilogue with no frame at all? Ask the
+                    // deque, not the signal word: `resume_wasm_closure` popped one
+                    // frame, so any count above `frames_before - 1` is new.
+                    let remaining_old = frames_before.saturating_sub(1);
+                    if caller.data().suspension_frame_count() > remaining_old {
+                        // Re-yield: after the pop, old outer frames sit at
+                        // 0..remaining_old and the new ones after them. Rotate the
+                        // old ones behind so the new inner chain resumes first.
                         for _ in 0..remaining_old {
                             if let Some(frame) = caller.data_mut().pop_suspension_frame() {
                                 caller.data_mut().push_suspension_frame(frame);
                             }
                         }
                     }
-                    // Otherwise SIG_YIELD rode out alongside SIG_IO on a
-                    // tail-position io returned through the epilogue: no new frame,
-                    // so no rotation, and `yield_sig_bits` reads the signal from `s`
-                    // rather than the (absent) front frame.
-                    let sig_bits = yield_sig_bits(caller, s);
-                    return ResumeOutcome::Yielded(t, p, sig_bits);
-                } else if s != 0 {
-                    return ResumeOutcome::Error(t, p, s as u64);
+                    return ResumeOutcome::Yielded(out.tag, out.payload, out.signal.raw());
+                } else if !out.signal.is_empty() {
+                    return ResumeOutcome::Error(out.tag, out.payload, out.signal.raw());
                 }
-                result_val = caller.data().wasm_to_value(t, p);
+                result_val = caller.data().wasm_to_value(out.tag, out.payload);
             }
             None => {
                 return ResumeOutcome::Dead(result_val);
@@ -216,8 +177,9 @@ fn install_signal(
 ///   WASM tier's nested-`handle_fiber_resume` recursion otherwise skipped, which
 ///   left an uncaught `(emit :error …)` wrongly `:paused`.
 /// - A `SIG_WAIT`/`SIG_IO` suspension the fiber's mask does NOT cover → PROPAGATE
-///   it to the resumer (as `SIG_YIELD | bits`, so the resumer's `fiber/resume`
-///   SuspendingCall captures a continuation and the wait reaches the scheduler)
+///   it to the resumer, parked (so the resumer's `fiber/resume` SuspendingCall
+///   captures a continuation and the wait reaches the scheduler) and carrying the
+///   fiber's real bits, not a transport bit OR-ed on top —
 ///   and register a re-drive of this fiber against the parent, so the parent's
 ///   next resume feeds the scheduler's value back into this fiber rather than
 ///   into the parent's continuation. This is the WASM analogue of the VM
@@ -241,7 +203,7 @@ fn route_emit(
     payload: i64,
     bits: crate::value::SignalBits,
     value: Value,
-) -> (i64, i64, i64) {
+) -> CallOutcome {
     let mask = fiber_handle.with(|f| f.mask);
 
     if bits.intersects(crate::value::SIG_ERROR) && !mask.covers(bits) {
@@ -253,24 +215,18 @@ fn route_emit(
             bits,
             value,
         );
-        return (tag, payload, bits.raw() as i64);
+        return CallOutcome::signalled(tag, payload, bits);
     }
 
     // An uncaught scheduler suspension (wait/io the mask does not cover) must
     // propagate to the resumer so the scheduler drives it — the resumer's mask,
-    // one level up, decides where it is finally caught. `bits` may carry the
-    // SIG_YIELD transport bit alongside the real signal (a tail-io rides out as
-    // SIG_IO|SIG_YIELD); strip it before the mask test, which speaks the emit
-    // signals the VM checks (SIG_IO / SIG_WAIT), not the tier's transport.
-    let yield_bit = crate::value::fiber::SIG_YIELD.raw();
-    let emit_raw = bits.raw() & !yield_bit;
+    // one level up, decides where it is finally caught. `bits` is the fiber's
+    // own signal, in the vocabulary the VM checks; the tier no longer mixes a
+    // transport bit into it.
     let is_scheduler_suspend =
-        emit_raw & (crate::signals::SIG_IO.raw() | crate::signals::SIG_WAIT.raw()) != 0;
+        bits.intersects(crate::signals::SIG_IO.union(crate::signals::SIG_WAIT));
     let stack_len = caller.data().fiber_id_stack.len();
-    if is_scheduler_suspend
-        && !mask.covers(crate::value::SignalBits::new(emit_raw))
-        && stack_len >= 2
-    {
+    if is_scheduler_suspend && !mask.covers(bits) && stack_len >= 2 {
         // Park this fiber holding its wait so it stays resumable with its frames;
         // the parent re-drives it (overwriting this signal) on resume.
         install_signal(
@@ -288,9 +244,11 @@ fn route_emit(
             .data_mut()
             .pending_redrive
             .insert(parent_id, fiber_value);
-        // Set SIG_YIELD so the parent's `fiber/resume` SuspendingCall fires;
-        // carry the real emit bits so the parent's park records the wait/io.
-        return (tag, payload, (emit_raw | yield_bit) as i64);
+        // Park the parent — its `fiber/resume` SuspendingCall must capture a
+        // continuation — and carry the fiber's real bits so the parent's own
+        // park records the wait/io. `suspended` says park; the bits stay clean,
+        // which is what keeps `fiber/bits` reporting |:io| and not |:io :yield|.
+        return CallOutcome::parked(tag, payload, bits);
     }
 
     install_signal(
@@ -301,7 +259,7 @@ fn route_emit(
         bits,
         value,
     );
-    (tag, payload, 0)
+    CallOutcome::value(tag, payload)
 }
 
 /// Route an ERROR that propagated up into this fiber's body from a resumed child
@@ -319,7 +277,7 @@ fn route_error(
     payload: i64,
     bits: crate::value::SignalBits,
     value: Value,
-) -> (i64, i64, i64) {
+) -> CallOutcome {
     let caught =
         bits.intersects(crate::value::SIG_ERROR) && fiber_handle.with(|f| f.mask).covers(bits);
     if caught {
@@ -331,7 +289,7 @@ fn route_error(
             bits,
             value,
         );
-        (tag, payload, 0)
+        CallOutcome::value(tag, payload)
     } else {
         install_signal(
             caller,
@@ -341,9 +299,8 @@ fn route_error(
             bits,
             value,
         );
-        // The unwind signal re-returned to the caller IS this fiber's bits (the
-        // callers pass `SignalBits::new(signal)` and `signal` in lockstep).
-        (tag, payload, bits.raw() as i64)
+        // The unwind signal re-returned to the caller IS this fiber's bits.
+        CallOutcome::signalled(tag, payload, bits)
     }
 }
 
@@ -356,7 +313,7 @@ fn route_error(
 pub(super) fn handle_fiber_propagate(
     caller: &mut Caller<'_, ElleHost>,
     fiber_value: Value,
-) -> (i64, i64, i64) {
+) -> CallOutcome {
     use crate::value::fiber::SIG_ERROR;
 
     let (child_bits, child_value) = match fiber_value.as_fiber() {
@@ -373,12 +330,12 @@ pub(super) fn handle_fiber_propagate(
             let ctx = crate::primitives::ctx::Alloc::new(heap);
             let err = ctx.error("internal-error", "fiber/propagate: not a fiber");
             let (tag, payload) = caller.data_mut().value_to_wasm(err);
-            return (tag, payload, SIG_ERROR.raw() as i64);
+            return CallOutcome::error(tag, payload);
         }
     };
 
     let (tag, payload) = caller.data_mut().value_to_wasm(child_value);
-    (tag, payload, child_bits.raw() as i64)
+    CallOutcome::signalled(tag, payload, child_bits)
 }
 
 /// When `fiber/resume` returns SIG_RESUME, the fiber value contains the
@@ -386,8 +343,8 @@ pub(super) fn handle_fiber_propagate(
 pub(super) fn handle_fiber_resume(
     caller: &mut Caller<'_, ElleHost>,
     fiber_value: Value,
-) -> (i64, i64, i64) {
-    use crate::value::fiber::{FiberStatus, SignalBits, SIG_ERROR, SIG_OK, SIG_YIELD};
+) -> CallOutcome {
+    use crate::value::fiber::{FiberStatus, SignalBits, SIG_OK};
 
     let fiber_handle = match fiber_value.as_fiber() {
         Some(f) => f.clone(),
@@ -396,7 +353,7 @@ pub(super) fn handle_fiber_resume(
             let ctx = crate::primitives::ctx::Alloc::new(heap);
             let err = ctx.error("type-error", "fiber/resume: not a fiber");
             let (tag, payload) = caller.data_mut().value_to_wasm(err);
-            return (tag, payload, SIG_ERROR.raw() as i64);
+            return CallOutcome::error(tag, payload);
         }
     };
 
@@ -419,7 +376,7 @@ pub(super) fn handle_fiber_resume(
             let ctx = crate::primitives::ctx::Alloc::new(heap);
             let err = ctx.error("internal-error", "fiber/resume: bytecode closure in WASM");
             let (tag, payload) = caller.data_mut().value_to_wasm(err);
-            return (tag, payload, SIG_ERROR.raw() as i64);
+            return CallOutcome::error(tag, payload);
         }
     };
 
@@ -440,7 +397,6 @@ pub(super) fn handle_fiber_resume(
         );
     }
 
-    let yield_signal = SIG_YIELD.raw() as i64;
     let fiber_id = fiber_handle.id();
 
     match status {
@@ -461,17 +417,16 @@ pub(super) fn handle_fiber_resume(
                 crate::primitives::ctx::Alloc::new(heap).closure((*closure).clone())
             };
             let (self_tag, self_payload) = caller.data_mut().value_to_wasm(self_val);
-            let (tag, payload, signal) =
-                call_wasm_closure(caller, &closure, wasm_idx, &args, self_tag, self_payload);
+            let out = call_wasm_closure(caller, &closure, wasm_idx, &args, self_tag, self_payload);
+            let (tag, payload) = (out.tag, out.payload);
 
-            if signal & yield_signal != 0 {
+            if out.suspended {
                 let yielded = caller.data().wasm_to_value(tag, payload);
-                let sig_bits = yield_sig_bits(caller, signal);
                 if caller.data().debug {
                     eprintln!(
-                        "[handle_fiber_resume] New yield: sig_bits={} (SIG_IO={})",
-                        sig_bits,
-                        sig_bits & 512
+                        "[handle_fiber_resume] New yield: signal={} (SIG_IO={})",
+                        out.signal,
+                        out.signal.intersects(crate::signals::SIG_IO)
                     );
                 }
                 let ret = route_emit(
@@ -480,12 +435,12 @@ pub(super) fn handle_fiber_resume(
                     fiber_value,
                     tag,
                     payload,
-                    SignalBits::new(sig_bits),
+                    out.signal,
                     yielded,
                 );
                 caller.data_mut().fiber_id_stack.pop();
                 ret
-            } else if signal != 0 {
+            } else if !out.signal.is_empty() {
                 let err_val = caller.data().wasm_to_value(tag, payload);
                 let ret = route_error(
                     caller,
@@ -493,7 +448,7 @@ pub(super) fn handle_fiber_resume(
                     fiber_value,
                     tag,
                     payload,
-                    SignalBits::new(signal as u64),
+                    out.signal,
                     err_val,
                 );
                 caller.data_mut().fiber_id_stack.pop();
@@ -509,7 +464,7 @@ pub(super) fn handle_fiber_resume(
                     ret_val,
                 );
                 caller.data_mut().fiber_id_stack.pop();
-                (tag, payload, 0)
+                CallOutcome::value(tag, payload)
             }
         }
         // An `:error` fiber is resumable via the restarts system (only `:dead` is
@@ -555,7 +510,7 @@ pub(super) fn handle_fiber_resume(
                         result_val,
                     );
                     let (t, p) = caller.data_mut().value_to_wasm(result_val);
-                    (t, p, 0)
+                    CallOutcome::value(t, p)
                 }
             };
 
@@ -567,7 +522,7 @@ pub(super) fn handle_fiber_resume(
             let ctx = crate::primitives::ctx::Alloc::new(heap);
             let err = ctx.error("fiber-error", "fiber/resume: fiber not resumable");
             let (tag, payload) = caller.data_mut().value_to_wasm(err);
-            (tag, payload, SIG_ERROR.raw() as i64)
+            CallOutcome::error(tag, payload)
         }
     }
 }

--- a/src/wasm/store.rs
+++ b/src/wasm/store.rs
@@ -7,8 +7,8 @@ use crate::value::repr::TAG_HEAP_START;
 use crate::value::Value;
 
 mod call;
-pub(in crate::wasm) use call::{call_precached_closure, call_wasm_closure};
-pub use call::{compile_module, resume_wasm_closure, run_module};
+pub(in crate::wasm) use call::{call_precached_closure, call_wasm_closure, resume_wasm_closure};
+pub use call::{compile_module, run_module};
 
 /// Write the executing closure `(tag, payload)` into the reserved `SELF_SLOT`
 /// (src/wasm/emit.rs) of `memory`. The host installs it at every closure entry so

--- a/src/wasm/store/call.rs
+++ b/src/wasm/store/call.rs
@@ -1,18 +1,26 @@
 use super::*;
+use crate::wasm::outcome::CallOutcome;
 
-/// Handle the result of a WASM closure call (shared by call and resume paths).
+/// Turn a compiled function's two channels into one [`CallOutcome`] (shared by
+/// the call and resume paths).
 ///
-/// If the function suspended (status > 0): snapshot env to the front frame,
-/// clear memory[0..8], restore env_stack_ptr, return SIG_YIELD.
-/// If normal return: read signal from memory[0..8], clear if non-zero, return.
-/// If error: restore env_stack_ptr, return error.
+/// The function answered on two channels and this is the only place that reads
+/// both. `status > 0` means it parked; the `SignalBits` it raised are in
+/// `SIGNAL_SLOT`, or — when it parked — on the suspension frame `rt_yield`
+/// pushed, because the signal that matters then is the innermost one.
+///
+/// It used to answer on one word, manufacturing `SIG_YIELD` to mean "parked" and
+/// OR-ing it onto a tail-position `SIG_IO`. Three sites downstream then guessed
+/// which had happened by testing whether the word equalled `SIG_YIELD` exactly.
+/// Reporting `suspended` separately removes the guess, and stops the transport
+/// bit reaching `fiber/bits` — see `tests/elle/wasm-suspend-not-by-bit.lisp`.
 pub(in crate::wasm) fn handle_wasm_result(
     caller: &mut Caller<'_, ElleHost>,
     call_result: std::result::Result<(), wasmtime::Error>,
     results: &[Val; 3],
     env_base: usize,
     label: &str,
-) -> (i64, i64, i64) {
+) -> CallOutcome {
     let memory = caller
         .get_export("__elle_memory")
         .and_then(|e| e.into_memory())
@@ -38,11 +46,13 @@ pub(in crate::wasm) fn handle_wasm_result(
                     frame.env_snapshot = env_snapshot;
                 }
 
-                if caller.data().debug {
-                    let old = i64::from_le_bytes(memory.data(&*caller)[0..8].try_into().unwrap());
-                    eprintln!("[{}] clearing memory[0..8] from {} to 0", label, old);
+                // Discard whatever is in SIGNAL_SLOT. Every emitted write of a
+                // non-zero signal returns immediately, so a park cannot carry
+                // one — the real signal is on the frame `rt_yield` just pushed.
+                let stale = super::take_raised_signal(&mut *caller, &memory);
+                if caller.data().debug && !stale.is_empty() {
+                    eprintln!("[{}] clearing SIGNAL_SLOT from {} to 0", label, stale);
                 }
-                memory.data_mut(&mut *caller)[0..8].copy_from_slice(&0i64.to_le_bytes());
                 caller.data_mut().env_stack_ptr = env_base;
 
                 if caller.data().debug {
@@ -52,25 +62,38 @@ pub(in crate::wasm) fn handle_wasm_result(
                     );
                 }
 
-                (tag, payload, crate::value::fiber::SIG_YIELD.raw() as i64)
+                // `status > 0` says the function ran an `Emit`, NOT that it
+                // parked: `(yield v)` and `(error …)` both route through
+                // `rt_yield`. The frame `rt_yield` just pushed carries which, so
+                // read it and let `is_suspending` classify.
+                //
+                // The BACK frame, not the front: during a resume the front may
+                // still be a stale outer frame from the previous suspension,
+                // until `drive_resume_chain` rotates. The back is always the one
+                // this call just pushed. Every frame in a yield-through chain
+                // records the same real signal, because the caller's `rt_yield`
+                // records the signal word this function returns.
+                //
+                // Classifying here is what makes an uncaught `(error …)` unwind.
+                // Reporting it as a park returned `status > 0` with an empty
+                // SIGNAL_SLOT, and `run_module`'s uncaught-error check then read
+                // zero and exited 0 silently (tests/elle/upvalue-u16.lisp).
+                let emitted = caller
+                    .data()
+                    .back_suspension_frame_signal()
+                    .unwrap_or(crate::value::fiber::SIG_YIELD);
+                CallOutcome::signalled(tag, payload, emitted)
             } else {
                 caller.data_mut().env_stack_ptr = env_base;
 
-                let mut signal = super::take_raised_signal(&mut *caller, &memory).raw() as i64;
-                // A NativeFn tail call that yielded SIG_IO (written to
-                // memory[0..8] by rt_prepare_tail_call — the tail-position path a
-                // stdlib wrapper like `tcp/connect`'s `(apply tcp/connect-ip …)`
-                // takes) must ADD SIG_YIELD, not REPLACE with it: the WASM caller
-                // keys yield-through off SIG_YIELD (bit 1), but the scheduler
-                // keys IO submission off SIG_IO (bit 9) via fiber/bits. Dropping
-                // SIG_IO here left the yielded io-request tagged as a plain yield,
-                // so the scheduler re-queued the fiber and resumed it with nil
-                // instead of submitting the IO — every tail-position IO
-                // (`tcp/connect`, and the framing built on it) then read nil for
-                // its port. Pinned by tests/elle/wasm-tail-io-in-fiber.lisp.
-                if signal as u64 & crate::signals::SIG_IO.raw() != 0 {
-                    signal |= crate::value::fiber::SIG_YIELD.raw() as i64;
-                }
+                // Whatever the function raised, classified by the shared rule.
+                // A tail-position native that yielded `SIG_IO` — the path
+                // `tcp/connect`'s `(apply tcp/connect-ip …)` takes, via
+                // `rt_prepare_tail_call` — lands here with no frame pushed, and
+                // `is_suspending` parks the caller on it without the signal
+                // having to carry `SIG_YIELD`. Pinned by
+                // tests/elle/wasm-tail-io-in-fiber.lisp.
+                let signal = super::take_raised_signal(&mut *caller, &memory);
 
                 if caller.data().debug {
                     let v = caller.data().wasm_to_value(tag, payload);
@@ -79,7 +102,7 @@ pub(in crate::wasm) fn handle_wasm_result(
                         label, tag, payload, signal, v
                     );
                 }
-                (tag, payload, signal)
+                CallOutcome::signalled(tag, payload, signal)
             }
         }
         Err(e) => {
@@ -88,7 +111,7 @@ pub(in crate::wasm) fn handle_wasm_result(
             let ctx = crate::primitives::ctx::Alloc::new(heap);
             let err = ctx.error("exec-error", e.to_string());
             let (tag, payload) = caller.data_mut().value_to_wasm(err);
-            (tag, payload, 1)
+            CallOutcome::error(tag, payload)
         }
     }
 }
@@ -105,7 +128,7 @@ pub(in crate::wasm) fn call_wasm_closure(
     args: &[Value],
     self_tag: i64,
     self_payload: i64,
-) -> (i64, i64, i64) {
+) -> CallOutcome {
     let env_base = caller.data().env_stack_ptr;
     prepare_wasm_env(caller, closure, args, env_base);
 
@@ -163,10 +186,10 @@ pub(in crate::wasm) fn call_wasm_closure(
 /// For multi-frame suspension chains (yield-through-call), the caller
 /// must call this repeatedly: first resume the innermost callee, then
 /// use its result to resume the next frame.
-pub fn resume_wasm_closure(
+pub(in crate::wasm) fn resume_wasm_closure(
     caller: &mut Caller<'_, ElleHost>,
     resume_val: Value,
-) -> Option<(i64, i64, i64)> {
+) -> Option<CallOutcome> {
     // Peek the front frame (innermost). During the WASM call, rt_load_saved_reg
     // reads from it. New frames pushed by rt_yield go to the back, so they
     // don't interfere. We pop_front AFTER the call completes.
@@ -277,14 +300,13 @@ pub fn resume_wasm_closure(
     caller.data_mut().pop_suspension_frame();
     caller.data_mut().resume_value = None;
 
-    let (t, p, s) = handle_wasm_result(
+    Some(handle_wasm_result(
         caller,
         call_result,
         &results,
         env_base,
         "resume_wasm_closure",
-    );
-    Some((t, p, s))
+    ))
 }
 
 /// Compile WASM bytes into a Module.
@@ -491,7 +513,7 @@ pub(in crate::wasm) fn call_precached_closure(
     pc: &super::super::host::PrecachedClosure,
     args: &[crate::value::Value],
     self_val: crate::value::Value,
-) -> (i64, i64, i64) {
+) -> CallOutcome {
     use crate::value::repr::TAG_HEAP_START;
 
     let engine = caller.engine().clone();
@@ -524,7 +546,7 @@ pub(in crate::wasm) fn call_precached_closure(
             let ctx = crate::primitives::ctx::Alloc::new(heap);
             let err = ctx.error("internal-error", e.to_string());
             let (tag, payload) = caller.data_mut().value_to_wasm(err);
-            return (tag, payload, 1);
+            return CallOutcome::error(tag, payload);
         }
     };
     let instance = match linker.instantiate(&mut store, &pc.module) {
@@ -534,7 +556,7 @@ pub(in crate::wasm) fn call_precached_closure(
             let ctx = crate::primitives::ctx::Alloc::new(heap);
             let err = ctx.error("internal-error", e.to_string());
             let (tag, payload) = caller.data_mut().value_to_wasm(err);
-            return (tag, payload, 1);
+            return CallOutcome::error(tag, payload);
         }
     };
 
@@ -566,18 +588,12 @@ pub(in crate::wasm) fn call_precached_closure(
             let ctx = crate::primitives::ctx::Alloc::new(heap);
             let err = ctx.error("internal-error", e.to_string());
             let (tag, payload) = caller.data_mut().value_to_wasm(err);
-            return (tag, payload, 1);
+            return CallOutcome::error(tag, payload);
         }
     };
 
     match func.call(&mut store, (env_base as i32, 0, 0, 0)) {
         Ok((tag, payload, status)) => {
-            // The third slot of this function's result is the host's SIGNAL, not
-            // the wasm `status` word. They are different channels: `status` says
-            // whether the closure suspended, and the signal it raised lives in
-            // this store's SIGNAL_SLOT. Returning `status` here reported a failed
-            // primitive as a successful return of the error value.
-            //
             // A precached closure cannot suspend — precaching only engages when
             // no closure in the module may suspend, and `standalone_emittable`
             // refuses every parking shape besides — so a non-zero status means
@@ -593,21 +609,21 @@ pub(in crate::wasm) fn call_precached_closure(
                     ),
                 );
                 let (tag, payload) = caller.data_mut().value_to_wasm(err);
-                return (tag, payload, crate::value::fiber::SIG_ERROR.raw() as i64);
+                return CallOutcome::error(tag, payload);
             }
             let signal = super::take_raised_signal(&mut store, &memory);
             // Convert result from standalone store's handle space
             // back to the caller's handle space.
             let value = store.data().wasm_to_value(tag, payload);
             let (caller_tag, caller_payload) = caller.data_mut().value_to_wasm(value);
-            (caller_tag, caller_payload, signal.raw() as i64)
+            CallOutcome::signalled(caller_tag, caller_payload, signal)
         }
         Err(e) => {
             let heap = unsafe { &mut *caller.data().heap_ptr() };
             let ctx = crate::primitives::ctx::Alloc::new(heap);
             let err = ctx.error("internal-error", e.to_string());
             let (tag, payload) = caller.data_mut().value_to_wasm(err);
-            (tag, payload, 1)
+            CallOutcome::error(tag, payload)
         }
     }
 }

--- a/src/wasm/suspend.rs
+++ b/src/wasm/suspend.rs
@@ -33,14 +33,15 @@ impl WasmEmitter {
         f.instruction(&Instruction::I32Const(0));
         f.instruction(&Instruction::Call(FN_RT_CALL));
 
+        f.instruction(&Instruction::LocalSet(self.suspended_local()));
         f.instruction(&Instruction::LocalSet(self.signal_local));
         f.instruction(&Instruction::LocalSet(self.pay_local(dst)));
         f.instruction(&Instruction::LocalSet(self.tag_local(dst)));
 
-        // Check SIG_YIELD (bit 1 = value 2)
-        f.instruction(&Instruction::LocalGet(self.signal_local));
-        f.instruction(&Instruction::I64Const(2));
-        f.instruction(&Instruction::I64And);
+        // Did the callee park? Ask the word the host set, never the signal: which
+        // signals park is `signals::dispatch::is_suspending`'s rule, and a
+        // suspension need not carry any particular bit.
+        f.instruction(&Instruction::LocalGet(self.suspended_local()));
         f.instruction(&Instruction::I64Const(0));
         f.instruction(&Instruction::I64Ne);
         f.instruction(&Instruction::If(BlockType::Empty));
@@ -62,12 +63,13 @@ impl WasmEmitter {
         }
         f.instruction(&Instruction::End);
 
-        // Check other signals (error etc.)
+        // Not a park, but still a signal: an error or a halt. Hand it to the
+        // caller through SIGNAL_SLOT with `status = 0`.
         f.instruction(&Instruction::LocalGet(self.signal_local));
         f.instruction(&Instruction::I64Const(0));
         f.instruction(&Instruction::I64Ne);
         f.instruction(&Instruction::If(BlockType::Empty));
-        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::I32Const(SIGNAL_SLOT));
         f.instruction(&Instruction::LocalGet(self.signal_local));
         f.instruction(&Instruction::I64Store(MemArg {
             offset: 0,
@@ -100,13 +102,14 @@ impl WasmEmitter {
         f.instruction(&Instruction::I32Const(0));
         f.instruction(&Instruction::Call(FN_RT_CALL));
 
+        f.instruction(&Instruction::LocalSet(self.suspended_local()));
         f.instruction(&Instruction::LocalSet(self.signal_local));
         f.instruction(&Instruction::LocalSet(self.pay_local(dst)));
         f.instruction(&Instruction::LocalSet(self.tag_local(dst)));
 
-        f.instruction(&Instruction::LocalGet(self.signal_local));
-        f.instruction(&Instruction::I64Const(2));
-        f.instruction(&Instruction::I64And);
+        // Park on the host's answer, not on a bit of the signal — see
+        // `emit_call_suspending`.
+        f.instruction(&Instruction::LocalGet(self.suspended_local()));
         f.instruction(&Instruction::I64Const(0));
         f.instruction(&Instruction::I64Ne);
         f.instruction(&Instruction::If(BlockType::Empty));
@@ -132,7 +135,7 @@ impl WasmEmitter {
         f.instruction(&Instruction::I64Const(0));
         f.instruction(&Instruction::I64Ne);
         f.instruction(&Instruction::If(BlockType::Empty));
-        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::I32Const(SIGNAL_SLOT));
         f.instruction(&Instruction::LocalGet(self.signal_local));
         f.instruction(&Instruction::I64Store(MemArg {
             offset: 0,

--- a/tests/elle/wasm-suspend-not-by-bit.lisp
+++ b/tests/elle/wasm-suspend-not-by-bit.lisp
@@ -1,0 +1,39 @@
+(elle/epoch 12)
+## wasm/suspend-not-by-bit — a suspending signal that does not carry `:yield`
+## still captures a continuation, and does not pick up a transport bit.
+##
+## THE TRAP: emitted WASM decided "did my callee suspend?" by testing bit 1 of
+## the callee's signal word (`signal & 2`, for SIG_YIELD). A suspending signal
+## without that bit fell through to the error path: no spill, no `rt_yield`, no
+## continuation frame. The host then OR-ed SIG_YIELD back on to mean "suspended",
+## so the fiber parked — with the code after the suspend already discarded, and
+## with the transport bit visible in `fiber/bits`.
+##
+## COUNTER-FACTUAL, and why `fiber/bits` is asserted as well as the value: on the
+## VM this reports 512 and `(resumed 99)`; the WASM tier reported 514 and plain
+## `99`. Asserting only the bits would miss the dropped continuation, and
+## asserting only the value would miss the leaked bit. Both, or neither is caught.
+##
+## `emit` needs a NON-LITERAL signal argument. A literal `(emit |:io| …)` is
+## recognized at compile time and lowers to an `Emit` terminator, which reports
+## suspension through the `status` word and was never affected. Only a native
+## call through `rt_call` reaches the bit test.
+
+(def sig |:io|)
+
+(defn suspend-then-continue []
+  (let [r (emit sig :req)]
+    (list :resumed r)))
+
+(let [f (fiber/new suspend-then-continue |:io|)]
+  (fiber/resume f)
+  (assert (= (fiber/bits f) 512)
+          (string "a bare |:io| suspension reports |:io|, with no transport bit "
+                  "riding along — got " (fiber/bits f)))
+  (assert (= (fiber/status f) :paused) "the fiber parks on the suspension")
+  (let [final (fiber/resume f 99)]
+    (assert (= final (list :resumed 99))
+            (string "the continuation after the suspending call runs on resume "
+                    "— got " final))))
+
+(println "wasm-suspend-not-by-bit: ok")


### PR DESCRIPTION
Second of four, stacked. Base: `wasm-signal-confusion` (#926).

Emitted WASM decided *"did my callee suspend?"* by testing bit 1 of the callee's signal — `I64Const(2); I64And`, for `SIG_YIELD` — and the host made that work by manufacturing `SIG_YIELD` to mean "suspended" and OR-ing it back onto a tail-position `SIG_IO`.

That costs correctness twice:

```
VM:   bits:512  second resume → (resumed 99)   ← continuation ran
WASM: bits:514  second resume → 99             ← continuation LOST
```

A suspending signal need not carry any particular bit, so the test missed the park, captured no continuation frame, and dropped the code after the suspend — the fiber returned its resume value instead. And the manufactured bit was visible to programs: `fiber/bits` reported `|:io :yield|` where the VM reported `|:io|`. Pinned by `tests/elle/wasm-suspend-not-by-bit.lisp`.

`rt_call` now returns four words, `(tag, payload, signal, suspended)`, and the emitters branch on `suspended` alone. Which signals park is `signals::dispatch::is_suspending`, applied once in the host so the tier and the interpreter cannot disagree; `dispatch/tests.rs` pins that it agrees with `classify` across every signal shape rather than claiming so in a comment.

`CallOutcome` carries the pair. Both words are `i64` on the wire and mean opposite things, so returning one where the other belongs type-checks and produces a silent wrong answer — exactly the defect #926 fixes at runtime. A constructor cannot cross them.

Three sites that re-derived by inference what the funnel discarded are gone, along with `front_frame_signal`:
- `yield_sig_bits`' `signal == 2`
- the frame-rotation guard's `s == yield_signal`
- `route_emit`'s strip-then-re-OR

A non-zero `status` does not mean "parked" either: `(yield v)` and `(error …)` both compile to an `Emit` terminator and both route through `rt_yield`. `handle_wasm_result` reads the signal off the frame `rt_yield` pushed and classifies it there, which keeps an uncaught error unwinding instead of parking. Reporting it as a park returned `status > 0` with an empty `SIGNAL_SLOT`, and `run_module`'s uncaught-error check then read zero and exited 0 with no output — a silent false pass.

The rotation guard now asks the frame deque whether new frames appeared, which is the question it was using a signal-word equality to approximate.

**Verification:** full corpus 0 fail / 0 diverge / 0 timeout; WASM suite green including `wasm-tail-io-in-fiber`, `wasm-wait-call-resumes`, `wasm-protect-suspend`, `wasm-multi-yield`; `wasm::` unit tests 36/36 including `wasm_full_uncaught_error_fails`.