### PR TITLE
signals: an I/O request raises |:io|, and :yield means one thing again

### DIFF
--- a/docs/cookbook/plugins.md
+++ b/docs/cookbook/plugins.md
@@ -128,7 +128,7 @@ a.get_external::<T>(v, "name")   // Option<&T>
 // Results
 a.ok(value)             // ElleResult with SIG_OK
 a.err("kind", "msg")    // ElleResult with SIG_ERROR
-a.yield_io(request)     // ElleResult with SIG_YIELD | SIG_IO
+a.yield_io(request)     // ElleResult with SIG_IO
 
 // Async
 a.poll_fd(fd, events)   // Create poll-fd I/O request

--- a/docs/impl/gpu.md
+++ b/docs/impl/gpu.md
@@ -92,9 +92,9 @@ a `VkComputePipeline` with one storage buffer per binding.
 2. Builds a Send closure that allocates GPU buffers, uploads input
    data, records the dispatch, submits to the queue, waits on a
    fence FD.
-3. Returns `(SIG_YIELD | SIG_IO, IoRequest::task(closure))` — the
-   fiber suspends, the thread pool runs the closure, the fiber
-   resumes with the result bytes.
+3. Returns `(SIG_IO, IoRequest::task(closure))` — the fiber suspends,
+   the thread pool runs the closure, the fiber resumes with the result
+   bytes.
 
 Numeric data is extracted from Elle arrays into `Vec<f32>` (or
 `Vec<i64>`, etc., per `dtype`) **before** the closure is built — the

--- a/docs/io-completion-heap.md
+++ b/docs/io-completion-heap.md
@@ -56,7 +56,7 @@ fn prim_stream_read(ctx: &mut NativeCtx, args: &[Value]) -> (SignalBits, Value) 
     let timeout = extract_keyword_timeout(args, 2, "port/read", ctx)?;
     let buffer = ctx.bytes(vec![0u8; count]);  // ← in the caller's region, via NativeCtx
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(IoOp::Read { count, buffer }, port, timeout),
     )
 }

--- a/docs/signals/protocol.md
+++ b/docs/signals/protocol.md
@@ -78,8 +78,7 @@ infrastructure bit on both sides; see its doc comment.
 Examples of valid composed signals:
 
 - `|:yield|` — suspend, return a value to the caller
-- `|:yield :io|` — suspend AND request I/O; the scheduler sees both bits and
-  handles accordingly
+- `|:io|` — request I/O; the scheduler catches the bit and services the request
 - `|:io :error|` — I/O error; a scheduler might log it and halt
 - `|:io :error :halt|` — I/O error, halt the VM; the scheduler interprets all
   three bits
@@ -124,6 +123,26 @@ This is O(1) dispatch — a single AND operation. No handler chain traversal.
 When a handler catches a signal, it can walk the fiber chain to inspect the
 propagation path. Every fiber in the chain is suspended and can be resumed
 independently for non-unwinding recovery.
+
+### Reaching the root
+
+The root of the program is where propagation stops. `:error` and `:halt`
+have answers there: the error prints with the location of the form that
+raised it, and the halt ends the program with its value. Every other
+signal reaches the root with no handler left to run, so the program stops
+and reports which signal went unhandled:
+
+```text
+Unhandled signal {:io} outside fiber context
+```
+
+The report names the emitted bits through the signal registry. A raw mask
+names no signal: the reader would have to know which bit position each
+primitive raises. `:io` at the root means the program ran no scheduler. A
+user-defined keyword at the root means no fiber masked it.
+
+One message answers for every bit. Nothing caught the signal, and that is
+the whole condition, so `:yield` gets no report of its own.
 
 ### The Fiber Structure
 
@@ -335,29 +354,37 @@ Stream primitives (`port/read-line`, `port/read`, `port/read-all`,
 perform I/O themselves. Instead, they:
 
 1. Build an `IoRequest` (typed descriptor of the I/O operation)
-2. Return `(|:yield :io|, request)` to suspend the fiber and signal I/O
-3. Let the scheduler catch the fiber (because `:yield` is in its mask), see
-   the `:io` bit, and dispatch the `IoRequest` payload to a backend
+2. Return `(|:io|, request)` to raise the request
+3. Let the scheduler catch the fiber on the `:io` bit and dispatch the
+   `IoRequest` payload to a backend
 
 The backend (`AsyncBackend`) performs the actual I/O and returns
 `(|:ok|, result)` or `(|:error|, error)`. The scheduler resumes the fiber
 with the result.
 
-### Signal Composition in I/O
+### `:io` does not imply `:yield`
 
-The `:io` bit is just a bit — it has no special relationship with `:yield`.
-A fiber can signal:
+An I/O request raises `|:io|` and nothing else. It does suspend the calling
+fiber — but so does every signal. Suspension follows from raising a signal at
+all, not from any particular bit: `signals::dispatch::is_suspending` parks on
+anything that is neither empty, nor an error, nor a halt, and the VM and the
+WASM tier both ask it.
 
-- `|:yield|` — suspend without I/O
-- `|:yield :io|` — suspend and request I/O (the common case)
-- `|:io :error|` — I/O error; a scheduler might log it and halt
-- `|:yield :io :audit|` — suspend, request I/O, and emit an audit signal
+So `:yield` means one thing, the cooperative suspension `(yield v)` raises and
+a `|:yield|` mask catches. Bundling it onto I/O requests made it mean two, and
+a mask naming it could no longer say which one it wanted:
 
-The scheduler's job is to check the bits it cares about. A scheduler that
-catches `:yield` will see fibers signaling `|:yield :io|` and can inspect the
-`:io` bit to decide how to handle the I/O request. A different scheduler might
-catch `|:yield :io|` directly. The semantics of combinations are defined by
-the scheduler, not by the language.
+- `|:io|` — an I/O request
+- `|:yield|` — a generator yielding a value
+- `|:io :error|` — an I/O error; a scheduler might log it and halt
+- `|:io :audit|` — an I/O request that also emits an audit signal
+
+This is what lets a generator masked `|:yield|` do I/O in its body:
+`port/lines` (`src/stdlib.lisp`), `tls/lines` (`lib/tls.lisp`), and the SSE
+streams in `lib/http.lisp` all have that shape. Their `(yield line)` is caught
+by the consumer; their `port/read-line` raises `|:io|`, which the mask does not
+name, so it travels out to the scheduler. Pinned by
+`tests/elle/io-request-carries-no-yield.lisp`.
 
 
 ## Signal Registry

--- a/elle-plugin/src/lib.rs
+++ b/elle-plugin/src/lib.rs
@@ -319,9 +319,15 @@ impl Api {
         }
     }
 
+    /// Raise an I/O request for the scheduler to service.
+    ///
+    /// `SIG_IO` alone. The request does suspend the calling fiber, but that
+    /// follows from raising a signal at all, not from `SIG_YIELD` — and
+    /// `SIG_YIELD` is the keyword a generator's fiber mask names, so a request
+    /// carrying it would be swallowed by every such mask on its way out.
     pub fn yield_io(&self, request: ElleValue) -> ElleResult {
         ElleResult {
-            signal: SIG_YIELD | SIG_IO,
+            signal: SIG_IO,
             value: request,
         }
     }

--- a/src/hir/analyze/call.rs
+++ b/src/hir/analyze/call.rs
@@ -59,11 +59,18 @@ impl<'a> Analyzer<'a> {
                     HirKind::Keyword(kw) => {
                         let reg = crate::signals::registry::global_registry().lock().unwrap();
                         if let Some(bit_pos) = reg.lookup(kw) {
-                            // User signals are emitted via the yield mechanism.
-                            // Include SIG_YIELD so may_suspend() returns true,
-                            // enabling correct signal inference for the enclosing lambda.
-                            // Also include the specific user signal bit for accurate
-                            // squelch checking at the static type level.
+                            // The user bit alone carries the squelch analysis.
+                            // SIG_YIELD is added for the LIR lowering: a call
+                            // gets a resumable continuation only when its signal
+                            // meets `SIG_YIELD | SIG_DEBUG | SIG_IO | SIG_WAIT`
+                            // (src/lir/lower/control/call.rs), and a user bit is
+                            // in none of them — so without this, the code after
+                            // `(emit :my-signal v)` would be lost on resume.
+                            //
+                            // Compile-time only: the runtime bits come from
+                            // `prim_emit` resolving the keyword set the program
+                            // actually passed, so this never reaches `fiber/bits`
+                            // and never widens what a mask catches.
                             Signal {
                                 bits: crate::value::fiber::SignalBits::from_bit(bit_pos)
                                     .union(crate::signals::SIG_YIELD),

--- a/src/hir/analyze/lambda.rs
+++ b/src/hir/analyze/lambda.rs
@@ -261,11 +261,10 @@ impl<'a> Analyzer<'a> {
 
         // Check silent! assertion (before ceiling/muffle adjustments)
         if self.current_silence_assert && (inferred_signals != Signal::silent()) {
-            let reg = registry::global_registry().lock().unwrap();
             return Err(format!(
                 "{}: silent! assertion failed: function may emit {}",
                 span,
-                reg.format_signal_bits(inferred_signals.bits),
+                registry::format_bits(inferred_signals.bits),
             ));
         }
 
@@ -315,12 +314,11 @@ impl<'a> Analyzer<'a> {
             let effective_ceiling = ceiling.bits | muffle_bits;
             let excess = inferred_signals.bits.subtract(effective_ceiling);
             if !excess.is_empty() {
-                let reg = registry::global_registry().lock().unwrap();
                 return Err(format!(
                     "{}: function restricted to {} but body may emit {}",
                     span,
-                    reg.format_signal_bits(ceiling.bits),
-                    reg.format_signal_bits(excess),
+                    registry::format_bits(ceiling.bits),
+                    registry::format_bits(excess),
                 ));
             }
             if ceiling.propagates == 0 && inferred_signals.propagates != 0 {

--- a/src/jit/dispatch.rs
+++ b/src/jit/dispatch.rs
@@ -188,10 +188,8 @@ pub extern "C" fn elle_jit_check_signal_bound(
         let excess = signal_bits.subtract(allowed);
         if !excess.is_empty() {
             let vm_ref = unsafe { &mut *(vm as *mut crate::vm::VM) };
-            let registry = crate::signals::registry::global_registry().lock().unwrap();
-            let excess_str = registry.format_signal_bits(excess);
-            let allowed_str = registry.format_signal_bits(allowed);
-            drop(registry);
+            let excess_str = crate::signals::registry::format_bits(excess);
+            let allowed_str = crate::signals::registry::format_bits(allowed);
             vm_ref.set_error(
                 "signal-violation",
                 format!(

--- a/src/primitives/chan.rs
+++ b/src/primitives/chan.rs
@@ -27,7 +27,7 @@ use crossbeam_channel::{self, TryRecvError, TrySendError};
 
 use crate::io::request::{IoOp, IoRequest};
 use crate::signals::Signal;
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::Value;
 

--- a/src/primitives/chan/prims.rs
+++ b/src/primitives/chan/prims.rs
@@ -538,7 +538,7 @@ pub(super) fn prim_chan_wait_ready(
         };
         let cell = ChanSelectGuardCell::new(guard);
         let req = IoRequest::with_timeout(ctx, IoOp::ChanSelectPark(cell), Value::NIL, timeout);
-        (SIG_YIELD | SIG_IO, req)
+        (SIG_IO, req)
     }) {
         Ok(v) => v,
         Err(e) => e,

--- a/src/primitives/io.rs
+++ b/src/primitives/io.rs
@@ -7,7 +7,7 @@ use crate::io::AnyBackend;
 use crate::io::SubmissionId;
 use crate::primitives::def::{RegionEffect, RetType};
 use crate::signals::Signal;
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::Value;
 
@@ -242,10 +242,7 @@ fn prim_ev_sleep(
         );
     };
 
-    (
-        SIG_YIELD | SIG_IO,
-        IoRequest::portless(ctx, IoOp::Sleep { duration }),
-    )
+    (SIG_IO, IoRequest::portless(ctx, IoOp::Sleep { duration }))
 }
 
 /// Poll a raw fd for readiness — yields to the scheduler.
@@ -326,11 +323,8 @@ fn prim_ev_poll_fd(
     };
 
     match timeout {
-        Some(t) => (
-            SIG_YIELD | SIG_IO,
-            IoRequest::poll_fd_with_timeout(ctx, fd, events, t),
-        ),
-        None => (SIG_YIELD | SIG_IO, IoRequest::poll_fd(ctx, fd, events)),
+        Some(t) => (SIG_IO, IoRequest::poll_fd_with_timeout(ctx, fd, events, t)),
+        None => (SIG_IO, IoRequest::poll_fd(ctx, fd, events)),
     }
 }
 

--- a/src/primitives/net.rs
+++ b/src/primitives/net.rs
@@ -12,7 +12,7 @@ use crate::primitives::ctx::NativeCtx;
 use crate::primitives::def::RegionEffect;
 use crate::primitives::kwarg::{extract_connect_kwargs, extract_keyword_timeout};
 use crate::signals::Signal;
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::Value;
 

--- a/src/primitives/net/tcp.rs
+++ b/src/primitives/net/tcp.rs
@@ -58,7 +58,7 @@ pub(super) fn prim_tcp_accept(
         ),
     );
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(
             ctx,
             PortOp::Accept {
@@ -125,7 +125,7 @@ pub(super) fn prim_tcp_connect_ip(
         Port::new_unopened(PortKind::TcpStream, Direction::ReadWrite, encoding, peer),
     );
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(
             ctx,
             IoOp::Connect {
@@ -173,7 +173,7 @@ pub(super) fn prim_tcp_shutdown(
         Err(e) => return e,
     };
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::new(ctx, PortOp::Shutdown { how }.into(), port_val),
     )
 }

--- a/src/primitives/net/udp.rs
+++ b/src/primitives/net/udp.rs
@@ -50,7 +50,7 @@ pub(super) fn prim_udp_send_to(
         Err(e) => return e,
     };
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(
             ctx,
             PortOp::SendTo {
@@ -113,7 +113,7 @@ pub(super) fn prim_udp_recv_from(
         ctx.struct_from(fields)
     };
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(
             ctx,
             PortOp::RecvFrom { count, result }.into(),
@@ -131,8 +131,5 @@ pub(super) fn prim_sys_resolve(
         Ok(s) => s,
         Err(e) => return e,
     };
-    (
-        SIG_YIELD | SIG_IO,
-        IoRequest::portless(ctx, IoOp::Resolve { hostname }),
-    )
+    (SIG_IO, IoRequest::portless(ctx, IoOp::Resolve { hostname }))
 }

--- a/src/primitives/ports.rs
+++ b/src/primitives/ports.rs
@@ -6,7 +6,7 @@ use crate::primitives::ctx::NativeCtx;
 use crate::primitives::def::RegionEffect;
 use crate::primitives::kwarg::extract_keyword_timeout;
 use crate::signals::Signal;
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::Value;
 

--- a/src/primitives/ports/lifecycle.rs
+++ b/src/primitives/ports/lifecycle.rs
@@ -26,7 +26,7 @@ fn mode_to_flags(mode: &str) -> Option<(i32, Direction)> {
 /// Helper: open a file with the given encoding.
 ///
 /// Shared implementation for `port/open` and `port/open-bytes`.
-/// Yields `SIG_YIELD | SIG_IO` with an `IoRequest` containing `IoOp::Open`.
+/// Yields `SIG_IO` with an `IoRequest` containing `IoOp::Open`.
 /// Argument validation (path type, mode keyword, timeout) happens here before yielding.
 fn open_file(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
@@ -94,7 +94,7 @@ fn open_file(
         Port::new_unopened(PortKind::File, direction, encoding, path.clone()),
     );
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(
             ctx,
             IoOp::Open {
@@ -166,10 +166,7 @@ pub(super) fn prim_port_close(
     // it can cancel pending operations / shut down the stdin worker
     // before the fd is dropped (or, for stdin, the port is marked
     // closed and any in-flight read is woken).
-    (
-        SIG_YIELD | SIG_IO,
-        IoRequest::new(ctx, IoOp::Close, args[0]),
-    )
+    (SIG_IO, IoRequest::new(ctx, IoOp::Close, args[0]))
 }
 
 /// (port/stdin) → port

--- a/src/primitives/ports/query.rs
+++ b/src/primitives/ports/query.rs
@@ -215,7 +215,7 @@ pub(super) fn prim_port_seek(
     };
 
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::new(ctx, IoOp::Seek { offset, whence }, args[0]),
     )
 }
@@ -244,5 +244,5 @@ pub(super) fn prim_port_tell(
         );
     }
 
-    (SIG_YIELD | SIG_IO, IoRequest::new(ctx, IoOp::Tell, args[0]))
+    (SIG_IO, IoRequest::new(ctx, IoOp::Tell, args[0]))
 }

--- a/src/primitives/posix.rs
+++ b/src/primitives/posix.rs
@@ -10,7 +10,7 @@ use crate::io::sigmap;
 use crate::primitives::ctx::NativeCtx;
 use crate::primitives::def::RegionEffect;
 use crate::signals::{Signal, SIG_OS_SIGNAL};
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::Value;
 use std::collections::BTreeSet;
@@ -303,10 +303,7 @@ fn prim_sig_next(
             ),
         );
     }
-    (
-        SIG_YIELD | SIG_IO,
-        IoRequest::new(ctx, IoOp::SigNext, args[0]),
-    )
+    (SIG_IO, IoRequest::new(ctx, IoOp::SigNext, args[0]))
 }
 
 // ── os/sig-close ───────────────────────────────────────────────────────

--- a/src/primitives/stream.rs
+++ b/src/primitives/stream.rs
@@ -1,7 +1,7 @@
-//! Stream primitives — yield SIG_YIELD | SIG_IO with IoRequest descriptors.
+//! Stream primitives — yield SIG_IO with IoRequest descriptors.
 //!
 //! These primitives do not perform I/O themselves. They build an
-//! IoRequest and return (SIG_YIELD | SIG_IO, request), which suspends
+//! IoRequest and return (SIG_IO, request), which suspends
 //! the fiber. The scheduler catches SIG_IO and dispatches to a backend.
 
 use crate::io::request::{IoRequest, PortOp};
@@ -10,7 +10,7 @@ use crate::primitives::ctx::NativeCtx;
 use crate::primitives::def::RegionEffect;
 use crate::primitives::kwarg::extract_keyword_timeout;
 use crate::signals::Signal;
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::Value;
 
@@ -47,7 +47,7 @@ fn prim_stream_read_line(
     };
     let buffer = ctx.bytes(vec![0u8; READ_LINE_BUF_SIZE]);
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(ctx, PortOp::ReadLine { buffer }.into(), port, timeout),
     )
 }
@@ -87,7 +87,7 @@ fn prim_stream_read(
     };
     let buffer = ctx.bytes(vec![0u8; count]);
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(ctx, PortOp::Read { count, buffer }.into(), port, timeout),
     )
 }
@@ -140,7 +140,7 @@ fn prim_stream_read_exact(
     };
     let buffer = ctx.bytes(vec![0u8; buf_len]);
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(
             ctx,
             PortOp::ReadExact { count, buffer }.into(),
@@ -164,7 +164,7 @@ fn prim_stream_read_all(
         Err(e) => return e,
     };
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(ctx, PortOp::ReadAll.into(), port, timeout),
     )
 }
@@ -192,7 +192,7 @@ fn prim_stream_write(
         Err(e) => return e,
     };
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(ctx, PortOp::Write { data }.into(), port, timeout),
     )
 }
@@ -211,7 +211,7 @@ fn prim_stream_flush(
         Err(e) => return e,
     };
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(ctx, PortOp::Flush.into(), port, timeout),
     )
 }

--- a/src/primitives/subprocess.rs
+++ b/src/primitives/subprocess.rs
@@ -2,7 +2,7 @@
 use crate::io::request::{IoOp, IoRequest, ProcessHandle, SpawnRequest, StdioDisposition};
 use crate::primitives::def::RegionEffect;
 use crate::signals::{Signal, SIG_EXEC};
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_HALT, SIG_IO, SIG_OK, SIG_YIELD};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_HALT, SIG_IO, SIG_OK};
 use crate::value::heap::TableKey;
 use crate::value::types::Arity;
 use crate::value::{sorted_struct_get, Value};

--- a/src/primitives/subprocess/exec.rs
+++ b/src/primitives/subprocess/exec.rs
@@ -336,7 +336,7 @@ pub(super) fn prim_subprocess_exec(
             stderr: stderr_disp,
         }),
     );
-    (SIG_YIELD | SIG_IO | SIG_EXEC, request)
+    (SIG_IO | SIG_EXEC, request)
 }
 
 /// Wait for a subprocess to exit, returning an IoRequest that the scheduler executes.
@@ -360,7 +360,7 @@ pub(super) fn prim_subprocess_wait(
         );
     }
     let request = IoRequest::new(ctx, IoOp::ProcessWait, handle_val);
-    (SIG_YIELD | SIG_IO | SIG_EXEC, request)
+    (SIG_IO | SIG_EXEC, request)
 }
 
 /// Send a signal to a subprocess.

--- a/src/primitives/unix.rs
+++ b/src/primitives/unix.rs
@@ -5,7 +5,7 @@ use crate::port::{Direction, Port, PortKind};
 use crate::primitives::def::RegionEffect;
 use crate::primitives::kwarg::extract_connect_kwargs;
 use crate::signals::Signal;
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::Value;
 use std::os::unix::io::{FromRawFd, OwnedFd};
@@ -108,7 +108,7 @@ pub(crate) fn prim_unix_accept(
     };
     let encoding = kwargs.encoding.unwrap_or(crate::port::Encoding::Binary);
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(
             ctx,
             PortOp::Accept {
@@ -160,7 +160,7 @@ pub(crate) fn prim_unix_connect(
         ),
     );
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::with_timeout(
             ctx,
             IoOp::Connect {
@@ -191,7 +191,7 @@ pub(crate) fn prim_unix_shutdown(
         Err(e) => return e,
     };
     (
-        SIG_YIELD | SIG_IO,
+        SIG_IO,
         IoRequest::new(ctx, PortOp::Shutdown { how }.into(), port_val),
     )
 }

--- a/src/primitives/unix/tests.rs
+++ b/src/primitives/unix/tests.rs
@@ -1,7 +1,7 @@
 //! Unit tests (`super` is the parent impl module).
 
 use super::*;
-use crate::value::fiber::{SIG_IO, SIG_YIELD};
+use crate::value::fiber::SIG_IO;
 
 /// A short socket path under the platform temp root.
 ///
@@ -51,7 +51,7 @@ fn test_unix_accept_returns_sig_io() {
             listener.as_external::<Port>().unwrap().close();
             bits
         });
-        assert_eq!(bits, SIG_YIELD | SIG_IO);
+        assert_eq!(bits, SIG_IO);
         std::fs::remove_file(&path).ok();
     });
 }
@@ -63,7 +63,7 @@ fn test_unix_connect_returns_sig_io() {
             let arg = ctx.string(&*sock_path("nonexistent"));
             prim_unix_connect(ctx, &[arg])
         });
-        assert_eq!(bits, SIG_YIELD | SIG_IO);
+        assert_eq!(bits, SIG_IO);
     });
 }
 
@@ -79,6 +79,6 @@ fn test_unix_shutdown_returns_sig_io() {
         let (bits, _) = crate::primitives::ctx::with_test_ctx(|ctx| {
             prim_unix_shutdown(ctx, &[stream_port, Value::keyword("read-write")])
         });
-        assert_eq!(bits, SIG_YIELD | SIG_IO);
+        assert_eq!(bits, SIG_IO);
     });
 }

--- a/src/primitives/watch.rs
+++ b/src/primitives/watch.rs
@@ -4,7 +4,7 @@ use crate::io::request::{IoOp, IoRequest};
 use crate::io::watch::FsWatcher;
 use crate::primitives::def::RegionEffect;
 use crate::signals::Signal;
-use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK, SIG_YIELD};
+use crate::value::fiber::{SignalBits, SIG_ERROR, SIG_IO, SIG_OK};
 use crate::value::types::Arity;
 use crate::value::{sorted_struct_get, Value};
 
@@ -113,10 +113,7 @@ fn prim_watch_next(
             ctx.error("type-error", "watch-next: argument must be a watcher"),
         );
     }
-    (
-        SIG_YIELD | SIG_IO,
-        IoRequest::new(ctx, IoOp::WatchNext, args[0]),
-    )
+    (SIG_IO, IoRequest::new(ctx, IoOp::WatchNext, args[0]))
 }
 
 /// (watch-close watcher)

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -74,10 +74,16 @@ pub const SIG_OS_SIGNAL: SignalBits = SignalBits::new(1 << 16); // POSIX signal 
 pub const SIG_FS: SignalBits = SignalBits::new(1 << 17); // filesystem access (capability bit, not dispatch)
 
 /// The scheduler round trip: the dispatch bit that routes a request to the
-/// I/O backend, the suspension it implies, and the error it may come back
-/// with. Every async primitive carries these three; a capability-gated one
-/// adds its own bit on top, so the base cannot drift between them.
-const IO_ROUND_TRIP: SignalBits = SIG_IO.union(SIG_YIELD).union(SIG_ERROR);
+/// I/O backend, and the error it may come back with. Every async primitive
+/// carries these two; a capability-gated one adds its own bit on top, so the
+/// base cannot drift between them.
+///
+/// `SIG_YIELD` is deliberately absent. The request does suspend its fiber, but
+/// suspension follows from raising a signal at all — see
+/// [`dispatch::is_suspending`] — not from that bit. `:yield` is the keyword a
+/// generator's mask names, and a request that carried it would be caught by
+/// every such mask on its way to the scheduler.
+const IO_ROUND_TRIP: SignalBits = SIG_IO.union(SIG_ERROR);
 
 /// VM-internal signal bits: infrastructure signals that user code cannot
 /// produce. These are emitted exclusively by the VM's own dispatch machinery.
@@ -215,12 +221,13 @@ impl Signal {
         }
     }
 
-    /// Performs asynchronous I/O: suspends on the request and may error
-    /// (SIG_IO | SIG_YIELD | SIG_ERROR).
+    /// Performs asynchronous I/O: raises a request and may error
+    /// (SIG_IO | SIG_ERROR).
     ///
     /// The signal of every port, socket, and file primitive that reaches the
-    /// scheduler. `SIG_YIELD` belongs with `SIG_IO` because the request
-    /// suspends the calling fiber until the backend completes it.
+    /// scheduler. The request suspends the calling fiber until the backend
+    /// completes it, but that is true of any signal and needs no bit of its own
+    /// — see the `IO_ROUND_TRIP` constant.
     pub const fn io_yields_errors() -> Self {
         Signal {
             bits: IO_ROUND_TRIP,
@@ -244,7 +251,7 @@ impl Signal {
     }
 
     /// Opens a filesystem path through the I/O scheduler
-    /// (SIG_FS | SIG_IO | SIG_YIELD | SIG_ERROR).
+    /// (SIG_FS | SIG_IO | SIG_ERROR).
     ///
     /// Both capabilities apply and either denial blocks the call: `SIG_FS` for
     /// the path the primitive resolves, `SIG_IO` for the scheduler round trip
@@ -259,7 +266,7 @@ impl Signal {
     }
 
     /// Runs a subprocess: asynchronous I/O under the exec capability
-    /// (SIG_EXEC | SIG_IO | SIG_YIELD | SIG_ERROR).
+    /// (SIG_EXEC | SIG_IO | SIG_ERROR).
     ///
     /// Both `SIG_EXEC` and `SIG_IO` are emitted, and they do different jobs.
     /// `SIG_IO` is the dispatch bit that routes the request through the I/O
@@ -434,6 +441,11 @@ impl fmt::Display for Signal {
             write!(f, "polymorphic({})", indices.join(","))?;
         } else if self.bits.intersects(SIG_YIELD) {
             write!(f, "yields")?;
+        } else if self.bits.intersects(SIG_IO) {
+            // An async primitive raises `:io` and no longer claims `:yield`, so
+            // without this arm every port and socket signal would print as
+            // "silent" — the one word it is not.
+            write!(f, "io")?;
         } else {
             write!(f, "silent")?;
         }

--- a/src/signals/registry.rs
+++ b/src/signals/registry.rs
@@ -1,13 +1,15 @@
+//! Signal registry for mapping signal keywords to bit positions.
+//!
+//! The registry maintains a global mapping of signal keywords (`:error`,
+//! `:yield`, etc.) to their corresponding bit positions. Built-in signals
+//! occupy bits 0-17, bits 18-31 are runtime-reserved, and user-defined signals
+//! are allocated from bits 32-63.
+
 use super::{
     SIG_DEBUG, SIG_ERROR, SIG_EXEC, SIG_FFI, SIG_FS, SIG_FUEL, SIG_GPU, SIG_HALT, SIG_IO,
     SIG_OS_SIGNAL, SIG_WAIT, SIG_YIELD,
 };
-/// Signal registry for mapping signal keywords to bit positions.
-///
-/// The registry maintains a global mapping of signal keywords (`:error`, `:yield`, etc.)
-/// to their corresponding bit positions. Built-in signals occupy bits 0-17,
-/// bits 18-31 are runtime-reserved, and user-defined signals are allocated
-/// from bits 32-63.
+use crate::value::fiber::SignalBits;
 use std::sync::{Mutex, OnceLock};
 
 /// An entry in the signal registry mapping a keyword name to its bit position.
@@ -149,19 +151,15 @@ impl SignalRegistry {
     /// Convert an signal keyword to its signal bits representation.
     ///
     /// Returns `Some(SignalBits)` if the signal is registered, `None` otherwise.
-    pub fn to_signal_bits(&self, name: &str) -> Option<crate::value::fiber::SignalBits> {
-        self.lookup(name)
-            .map(crate::value::fiber::SignalBits::from_bit)
+    pub fn to_signal_bits(&self, name: &str) -> Option<SignalBits> {
+        self.lookup(name).map(SignalBits::from_bit)
     }
 
     /// Convert signal bits to a Vec of keyword Values.
     ///
     /// Used by `fiber/caps` and capability denial payloads to produce
     /// keyword sets from signal bitmasks.
-    pub fn bits_to_keywords(
-        &self,
-        bits: crate::value::fiber::SignalBits,
-    ) -> Vec<crate::value::Value> {
+    pub fn bits_to_keywords(&self, bits: SignalBits) -> Vec<crate::value::Value> {
         self.entries
             .iter()
             .filter(|e| bits.has_bit(e.bit_position))
@@ -171,13 +169,22 @@ impl SignalRegistry {
 
     /// Format signal bits as a human-readable string.
     ///
-    /// Returns a string like `"{:error, :yield}"` for multiple bits, or `"{}"` for empty.
-    pub fn format_signal_bits(&self, bits: crate::value::fiber::SignalBits) -> String {
+    /// Returns a string like `"{:error, :yield}"` for multiple bits, or `"{}"`
+    /// for empty. A bit the registry does not carry — the VM-internal ones,
+    /// which no program declares — is reported as a raw mask alongside the
+    /// names, because a signal that is not empty must not read as `{}`.
+    pub fn format_signal_bits(&self, bits: SignalBits) -> String {
         let mut names = Vec::new();
+        let mut named = SignalBits::EMPTY;
         for entry in &self.entries {
             if bits.has_bit(entry.bit_position) {
                 names.push(format!(":{}", entry.name));
+                named = named.union(SignalBits::from_bit(entry.bit_position));
             }
+        }
+        let unnamed = bits.subtract(named);
+        if !unnamed.is_empty() {
+            names.push(unnamed.to_string());
         }
 
         if names.is_empty() {
@@ -186,6 +193,18 @@ impl SignalRegistry {
             format!("{{{}}}", names.join(", "))
         }
     }
+}
+
+/// Format signal bits through the global registry — the one way an error
+/// message names a signal.
+///
+/// Every diagnostic that mentions signal bits reaches for the same two steps:
+/// take the process-global registry, then format. Sharing them keeps one
+/// rendering of a signal across the interpreter, the JIT, and signal
+/// inference, and takes the registry the poison-tolerant way
+/// ([`with_registry`]).
+pub fn format_bits(bits: SignalBits) -> String {
+    with_registry(|registry| registry.format_signal_bits(bits))
 }
 
 impl Default for SignalRegistry {

--- a/src/signals/registry/tests.rs
+++ b/src/signals/registry/tests.rs
@@ -102,6 +102,40 @@ fn test_format_signal_bits_empty() {
 }
 
 #[test]
+fn format_signal_bits_reports_a_bit_the_registry_does_not_carry() {
+    // The trap: the formatter walks the registry's entries, and the VM-internal
+    // bits are deliberately never registered. Reporting only what it walks
+    // renders a signal that is demonstrably not empty as `{}` — the string
+    // reserved for no signal at all. The counter-factual: assert `:error` alone
+    // and the dropped bit passes unseen.
+    let registry = SignalRegistry::with_builtins();
+    let internal = crate::signals::SIG_RESUME;
+    assert_eq!(
+        registry.lookup("resume"),
+        None,
+        "the premise: :resume is VM-internal and carries no registry entry"
+    );
+
+    let alone = registry.format_signal_bits(internal);
+    assert_ne!(
+        alone, "{}",
+        "an unnamed bit must not render as the empty set"
+    );
+    assert!(
+        alone.contains(&internal.to_string()),
+        "an unnamed bit is reported as its raw mask, got: {}",
+        alone
+    );
+
+    let beside_a_name = registry.format_signal_bits(SIG_ERROR.union(internal));
+    assert!(
+        beside_a_name.contains(":error") && beside_a_name.contains(&internal.to_string()),
+        "a named bit and an unnamed one are reported together, got: {}",
+        beside_a_name
+    );
+}
+
+#[test]
 fn test_global_registry_returns_same_instance() {
     let reg1 = global_registry();
     let reg2 = global_registry();

--- a/src/signals/tests.rs
+++ b/src/signals/tests.rs
@@ -265,14 +265,15 @@ fn test_squelch_all_bits_leaves_error() {
 // primitive that uses it.
 
 #[test]
-fn io_yields_errors_names_all_three_bits() {
+fn io_yields_errors_names_io_and_error_only() {
     let sig = Signal::io_yields_errors();
     assert!(sig.bits.intersects(SIG_IO), "must name :io");
-    assert!(
-        sig.bits.intersects(SIG_YIELD),
-        "an I/O request suspends its fiber, so it must name :yield"
-    );
     assert!(sig.bits.intersects(SIG_ERROR), "must name :error");
+    assert!(
+        !sig.bits.intersects(SIG_YIELD),
+        "the request suspends its fiber, but suspension follows from raising \
+         any signal — :yield is the keyword a generator's mask names"
+    );
     assert_eq!(sig.propagates, 0);
 }
 
@@ -301,8 +302,8 @@ fn subprocess_names_the_dispatch_bit_and_the_capability_bit() {
         sig.bits.intersects(SIG_EXEC),
         ":exec is what a fiber mask denies to forbid spawning"
     );
-    assert!(sig.bits.intersects(SIG_YIELD));
     assert!(sig.bits.intersects(SIG_ERROR));
+    assert!(!sig.bits.intersects(SIG_YIELD), "and it claims no :yield");
 }
 
 // ── squelched_bits: what a squelch/attune boundary enforces ─────────
@@ -390,8 +391,8 @@ fn fs_io_yields_errors_is_deniable_from_either_side() {
     let s = Signal::fs_io_yields_errors();
     assert!(s.bits.intersects(SIG_FS));
     assert!(s.may_io());
-    assert!(s.may_yield());
     assert!(s.may_error());
+    assert!(!s.may_yield(), "a request does not claim :yield");
 }
 
 /// The three async constructors share one base, so a change to what a
@@ -401,6 +402,36 @@ fn capability_gated_io_constructors_extend_the_same_base() {
     let base = Signal::io_yields_errors().bits;
     assert_eq!(Signal::subprocess().bits, base.union(SIG_EXEC));
     assert_eq!(Signal::fs_io_yields_errors().bits, base.union(SIG_FS));
+}
+
+/// A scheduler round trip does not claim `:yield`.
+///
+/// `:yield` is the cooperative suspension `(yield v)` raises and a `|:yield|`
+/// mask catches. An I/O request suspends too, but suspension follows from
+/// raising any signal (`signals::dispatch::is_suspending`), not from that bit —
+/// so carrying it here would make one keyword mean two things, and a mask
+/// naming it could not say which it wanted.
+///
+/// The counter-factual is a generator: `port/lines` masks `|:yield|` around a
+/// body that calls `port/read-line`. With `:yield` on the request, that mask
+/// swallows the read and it never reaches the scheduler
+/// (tests/elle/io-request-carries-no-yield.lisp).
+#[test]
+fn a_scheduler_round_trip_does_not_carry_yield() {
+    for sig in [
+        Signal::io_yields_errors(),
+        Signal::fs_io_yields_errors(),
+        Signal::subprocess(),
+    ] {
+        assert!(
+            !sig.bits.intersects(SIG_YIELD),
+            "an async signal must not carry :yield — got {}",
+            sig.bits
+        );
+        assert!(sig.bits.intersects(SIG_IO), "but it must carry :io");
+    }
+    // `(yield v)` still does, and is the only constructor that should.
+    assert!(Signal::yields().bits.intersects(SIG_YIELD));
 }
 
 /// Every signal bit is a capability bit: a fiber mask can withhold `:fs`

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -360,7 +360,7 @@ impl VM {
             self.fiber.signal.take();
             Err(format!(
                 "Unexpected signal from macro transformer: {}",
-                bits
+                crate::signals::registry::format_bits(bits)
             ))
         }
     }

--- a/src/vm/call/inner.rs
+++ b/src/vm/call/inner.rs
@@ -346,11 +346,13 @@ impl VM {
             {
                 let (sig_bits, sig_val) = self.fiber.signal.take().unwrap();
                 let name = closure.template.name.as_deref().unwrap_or("<anonymous>");
-                let reg = crate::signals::registry::global_registry().lock().unwrap();
                 eprintln!("panic: silence violation in '{}'", name);
                 eprintln!("  A (silence)'d function signaled at runtime.");
                 eprintln!("  silence asserts purity — any signal is a programmer bug.");
-                eprintln!("  signal: {}", reg.format_signal_bits(sig_bits));
+                eprintln!(
+                    "  signal: {}",
+                    crate::signals::registry::format_bits(sig_bits)
+                );
                 eprintln!("  value:  {}", sig_val);
                 if let Some(loc) = self.error_loc.as_ref() {
                     eprintln!("  at {}", loc);

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -382,10 +382,7 @@ impl VM {
     /// `compile/run-on` entry returns it as the call's result. `squelched` must
     /// be non-empty, the answer `signals::squelched_bits` gives.
     pub(crate) fn squelch_violation(&mut self, squelched: SignalBits) -> Value {
-        let squelched_str = {
-            let registry = crate::signals::registry::global_registry().lock().unwrap();
-            registry.format_signal_bits(squelched)
-        };
+        let squelched_str = crate::signals::registry::format_bits(squelched);
         let err = self.escaping_error(
             "signal-violation",
             format!("squelch: signal {} caught at boundary", squelched_str),

--- a/src/vm/dispatch/interp/signals.rs
+++ b/src/vm/dispatch/interp/signals.rs
@@ -20,9 +20,8 @@ impl VM {
             let signal_bits = closure.signal().bits;
             let excess = signal_bits.subtract(allowed_bits);
             if !excess.is_empty() {
-                let registry = crate::signals::registry::global_registry().lock().unwrap();
-                let excess_str = registry.format_signal_bits(excess);
-                let allowed_str = registry.format_signal_bits(allowed_bits);
+                let excess_str = crate::signals::registry::format_bits(excess);
+                let allowed_str = crate::signals::registry::format_bits(allowed_bits);
                 let err = self.escaping_error(
                     "signal-violation",
                     format!(

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -33,7 +33,7 @@ use crate::compiler::bytecode::{Bytecode, Instruction};
 use crate::error::LocationMap;
 use crate::pipeline::CompileCtx;
 use crate::symbol::SymbolTable;
-use crate::value::{SignalBits, SuspendedFrame, Value, SIG_ERROR, SIG_HALT, SIG_SWITCH, SIG_YIELD};
+use crate::value::{SignalBits, SuspendedFrame, Value, SIG_ERROR, SIG_HALT, SIG_SWITCH};
 use std::rc::Rc;
 
 impl VM {
@@ -266,11 +266,18 @@ impl VM {
                 break Err(self.format_error_with_location(err_value));
             } else if bits == SIG_SWITCH {
                 bits = self.handle_sig_switch();
-            } else if bits.intersects(SIG_YIELD) {
-                break Err("Unexpected yield outside fiber context".to_string());
             } else {
+                // Everything that is not an error, a halt, or the switch
+                // trampoline arrives here with no handler left to run, and one
+                // report answers for all of it: `:yield` is not privileged
+                // among the bits that reach the root (docs/signals/protocol.md
+                // § "Reaching the root"). The keywords are what the author of
+                // the emitting call can act on; the mask alone is not.
                 self.fiber.signal.take();
-                break Err(format!("Unexpected signal outside fiber context: {}", bits));
+                break Err(format!(
+                    "Unhandled signal {} outside fiber context",
+                    crate::signals::registry::format_bits(bits)
+                ));
             }
         };
         // The root activation's clean break: release the base slot's owner node

--- a/tests/elle/caps-thread.lisp
+++ b/tests/elle/caps-thread.lisp
@@ -7,12 +7,12 @@
 # so unless the spawning fiber's withheld travels with the closure, a
 # sandboxed fiber escapes every denial by spawning a thread.
 #
-# The trap: `file/write` is synchronous. An earlier attempt to settle this
-# with `:exec` saw `{:error :thread-error :message "Unexpected yield
-# outside fiber context"}` and read it as enforcement. It was not — the
-# subprocess primitive tried to suspend and found no fiber context. A
-# synchronous primitive never hits that wall, so the escape was real and
-# invisible.
+# The trap: `file/write` is synchronous. Settle this with `:exec` instead
+# and the worker fails with a `:thread-error` whose message reports an
+# unhandled signal — which reads as enforcement and is not. The subprocess
+# primitive suspends, and a worker has no fiber context to suspend into. A
+# synchronous primitive never hits that wall, so the escape it hides is
+# real and invisible.
 #
 # A worker has no parent to suspend into, so a denial there cannot be
 # mediated. The thread ends and the join reports it.

--- a/tests/elle/io-request-carries-no-yield.lisp
+++ b/tests/elle/io-request-carries-no-yield.lisp
@@ -1,0 +1,42 @@
+(elle/epoch 12)
+## signals/io-request-carries-no-yield — an I/O request raises `|:io|` alone,
+## so a `|:yield|` mask does not catch it.
+##
+## `:yield` means one thing: the cooperative suspension `(yield v)` raises. It
+## used to be OR-ed onto every scheduler-bound request as well, which made a
+## mask naming it unable to say which of the two it wanted.
+##
+## THE TRAP: an I/O request suspends its fiber, so it looks like it ought to
+## carry `:yield`. Suspension does not come from that bit — it comes from
+## raising any signal at all (`signals::dispatch::is_suspending`). The bit is
+## what a mask matches on, and nothing else.
+##
+## COUNTER-FACTUAL: `fiber/bits` is asserted rather than just the fiber's value,
+## because a stray `:yield` on the request changes nothing a program can see
+## until some mask names `:yield` and starts swallowing scheduler traffic. The
+## generator case below is that failure made observable.
+
+# A fiber whose body does I/O, masked to catch ONLY the request.
+(let [f (fiber/new (fn []
+                     (ev/sleep 0.001)
+                     :done) |:io :error|)]
+  (fiber/resume f)
+  (assert (= (fiber/bits f) 512)
+          (string "an io request raises |:io| alone — got " (fiber/bits f))))
+
+# The generator shape the whole rule exists to protect: `port/lines`,
+# `tls/lines`, and the SSE streams in lib/http.lisp all mask `|:yield|` around a
+# body that does I/O. The `(yield v)` must be caught here; the I/O must not be,
+# or it never reaches the scheduler and the read never completes.
+(let [g (fiber/new (fn []
+                     (ev/sleep 0.001)
+                     (yield :from-generator)
+                     :done) |:yield|)]
+  (fiber/resume g)
+  (assert (= (fiber/bits g) 2)
+          (string "a |:yield| mask catches the yield, not the io — got "
+                  (fiber/bits g)))
+  (assert (= (fiber/value g) :from-generator)
+          "the value the generator yielded reaches its consumer"))
+
+(println "io-request-carries-no-yield: ok")

--- a/tests/integration/error_reporting.rs
+++ b/tests/integration/error_reporting.rs
@@ -400,6 +400,30 @@ fn an_unjoined_fibers_error_names_the_form_that_raised_it() {
     );
 }
 
+// ============================================================================
+// A signal that reaches the root — which signal the report names
+// ============================================================================
+
+#[test]
+fn an_unhandled_signal_at_the_root_is_named_by_its_keyword() {
+    // A signal no fiber masks travels to the root of the program, where the
+    // report is all the author gets. The trap: the root holds `SignalBits`,
+    // whose `Display` is hex — and a user signal's bit is above 32, so the
+    // report reads `0x100000000`. The counter-factual: assert only `is_err()`,
+    // and that hex passes for a signal the author named `:root-unhandled`.
+    crate::common::eval_source_unscheduled(
+        "(signal :root-unhandled) (emit :root-unhandled 1)",
+        |result| {
+            let err = result.expect_err("nothing masks the signal, so it reaches the root");
+            assert!(
+                err.contains(":root-unhandled"),
+                "the root must name the unhandled signal, got: {}",
+                err
+            );
+        },
+    );
+}
+
 #[test]
 fn test_closure_has_location_map() {
 

--- a/tests/integration/io.rs
+++ b/tests/integration/io.rs
@@ -1,24 +1,33 @@
 use crate::common::{eval_source, eval_source_unscheduled};
 
+// An I/O primitive raises `:io` and nothing else names the scheduler round
+// trip, so both tests below read the reported keyword rather than the fact of
+// failure. The counter-factual: assert only `is_err()`, and the two pass
+// unchanged when the request arrives at the root as an unreadable bitmask.
+
 #[test]
 fn test_stream_write_outside_scheduler_errors() {
-    // port/write yields SIG_IO, which can't be caught by protect in Elle.
-    // Run WITHOUT a scheduler (eval_source now wraps in ev/run) so the yield
-    // has nothing to service it and errors at top level.
+    // Run WITHOUT a scheduler (eval_source wraps in ev/run) so the request has
+    // nothing to service it and reaches the root.
     eval_source_unscheduled("(port/write (port/stdout) \"hello\")", |result| {
         assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains(":io"),
+            "an unserviced port/write must report :io, got: {}",
+            err
+        );
     });
 }
 
 #[test]
 fn test_stream_read_line_outside_scheduler_errors() {
-    // port/read-line yields SIG_IO, which should error at top level (no scheduler).
     eval_source_unscheduled("(port/read-line (port/open \"/dev/null\" :read))", |result| {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            err.contains("SIG_IO") || err.contains("outside scheduler") || err.contains("yield"),
-            "expected SIG_IO error, got: {}",
+            err.contains(":io"),
+            "an unserviced port/read-line must report :io, got: {}",
             err
         );
     });


### PR DESCRIPTION
Stacked below #929 (`mask-overlap`). Base: `main`.

Every scheduler-bound request carried `SIG_YIELD` alongside `SIG_IO`, so `:yield` named two different things: the cooperative suspension `(yield v)` raises, and "this request suspends". A mask naming it could not say which one it wanted.

The request does suspend its fiber. That follows from raising a signal **at all** — `signals::dispatch::is_suspending` — not from any particular bit. The bit is what a mask matches on, and nothing else.

`IO_ROUND_TRIP` drops `SIG_YIELD`, and so do the 27 runtime emission sites across `stream`, `io`, `net/tcp`, `net/udp`, `unix`, `ports`, `subprocess`, `posix`, `watch`, and `chan`. `fiber/bits` on an I/O request now reports `|:io|` where it reported `|:io :yield|`.

This is what lets a generator masked `|:yield|` do I/O in its body — `port/lines` (`src/stdlib.lisp`), `tls/lines` (`lib/tls.lisp`), the SSE streams in `lib/http.lisp`. Their `(yield line)` is caught by the consumer; their `port/read-line` raises `|:io|`, which the mask does not name, so it travels out to the scheduler. Pinned by `tests/elle/io-request-carries-no-yield.lisp`.

`elle-plugin`'s `yield_io` helper returned the pair too, so it changes with the rest — a plugin using it would otherwise put the bit straight back on the request.

Three unit tests asserted the old contract, one of them arguing *"an I/O request suspends its fiber, so it must name :yield"*. That is the claim being reversed, so they now assert the new rule and say why.

`Display for Signal` grows an `:io` arm: without it every port and socket signal would print as "silent", the one word it is not.

The `SIG_YIELD` that `hir/analyze/call.rs` unions onto `(emit :kw v)` stays, and its comment now says what it is for. The LIR lowering's suspending-call test is `SIG_YIELD|SIG_DEBUG|SIG_IO|SIG_WAIT` and contains no user bit, so without it the code after `(emit :my-signal v)` is dropped on resume. It is compile-time only and never reaches `fiber/bits`.

## The VM root had the same gap

The root's readable message for an unserviced request came from an arm that tested `SIG_YIELD`. A request that no longer carries the bit fell through to the generic case and reported a raw mask:

```
Unexpected signal outside fiber context: 0x200
```

One arm now answers for every bit, naming the signal through the registry:

```
Unhandled signal {:io} outside fiber context
```

`format_signal_bits` reports an unregistered bit as a raw mask beside the names, so a VM-internal bit cannot read as `{}`. The six diagnostics that name a signal share one `registry::format_bits`, which also takes the process-global registry the poison-tolerant way. The argument lives in `docs/signals/protocol.md` § "Reaching the root".

Pinned by `tests/integration/io.rs` (both port tests now read the reported keyword, not the fact of failure), `an_unhandled_signal_at_the_root_is_named_by_its_keyword` (a user signal, which reported `0x100000000`), and `format_signal_bits_reports_a_bit_the_registry_does_not_carry`.

**Verification:** corpus 1429 files, 0 fail / 0 diverge / 0 timeout; Rust unit 2208 and integration 1220 green; `cargo fmt`, clippy, and `make fmt-check` clean.
