### PR TITLE
vm: a parked primitive call's resume value arrives counted

### DIFF
--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -245,6 +245,21 @@ parked fiber's accounting symmetric with its unpark:
   theft invisible). Pinned by `region_fiber_abort_io_protect_uaf`
   (`tests/integration/fixtures/region-fiber-abort-io-protect-uaf.lisp`);
   `tests/elle/grpc.lisp`'s `with-server` teardown is the full-scheduler witness.
+  A **primitive** that suspends is the other frame with no `Return` to fund it, and
+  it is the general case rather than an exit path: the resume value takes the place
+  of the primitive's result, and the continuation past the call releases that result
+  like any other. Two parks have that shape — a dynamic `emit`, whose non-literal
+  first argument falls through to the runtime primitive instead of compiling to the
+  `Emit` terminator, and a capability denial, which parks a denied primitive call
+  for the parent to mediate — and neither can be told from an `Emit` park at the
+  delivery, where the frame is already built and, for a tail suspend, was built by a
+  driver that never saw the primitive. So the classifier records the shape on the
+  fiber (`Fiber::resume_value_unfunded`) and `do_fiber_resume_single` takes it with
+  the parked signal, minting one `ResumeDelivery` retain on every route into the
+  fiber. What needs no mint is an `Emit` park, whose resume block mints in bytecode
+  (above), and an io completion, which the scheduler allocates fresh and hands over
+  carrying its own birth reference. Pinned by
+  `tests/elle/region-primitive-resume-uaf.lisp`.
 - **A propagated signal is a fresh park, and owes its own delivery reference.**
   `fiber/propagate` installs the child's parked payload as the propagating fiber's own
   `signal`. That fiber's resumer then reads the payload as its resume result and runs the

--- a/docs/signals/emit.md
+++ b/docs/signals/emit.md
@@ -108,6 +108,12 @@ through to the runtime primitive. This supports dynamic signal selection:
 (emit some-variable value)   # runtime dispatch, not compile-time
 ```
 
+The dynamic form suspends, routes, and resumes exactly as the literal one
+does, and the resume value is its result the way a return value is any
+call's result. What differs is the shape of the compiled code: the literal
+`emit` ends a basic block and resumes in the next one, while the dynamic
+`emit` is an ordinary call the fiber parks inside of.
+
 This is rare. Prefer literal keywords for compile-time signal inference.
 
 ## Capability interaction

--- a/src/jit/calls.rs
+++ b/src/jit/calls.rs
@@ -107,6 +107,12 @@ fn jit_handle_primitive_signal(vm: &mut crate::vm::VM, bits: SignalBits, value: 
                 r,
                 crate::value::arena::EscapeSite::SuspendEscape,
             );
+            // …and the same arm's park classification: this primitive never
+            // returns, so the resume value stands in for its result and the
+            // delivery owes the reference the missing `Return` mint would have
+            // carried (docs/impl/region/owner.md § "A delivery into a replayed
+            // frame carries one owning reference").
+            vm.fiber.resume_value_unfunded = true;
             vm.fiber.signal = Some((bits, value));
             YIELD_SENTINEL
         }
@@ -143,6 +149,10 @@ pub(crate) fn jit_capability_denial(
     let heap = unsafe { &mut *vm.heap_ptr };
     let r = crate::value::arena::region_of(heap, payload);
     crate::value::arena::incref_for_escape(heap, r, crate::value::arena::EscapeSite::SuspendEscape);
+    // The denied primitive never runs, so the mediating parent's resume value
+    // stands in for its result — the same park classification the interpreter's
+    // `handle_capability_denial` records.
+    vm.fiber.resume_value_unfunded = true;
     vm.fiber.signal = Some((blocked, payload));
     YIELD_SENTINEL
 }

--- a/src/runtime/tests/ownership/fnode.rs
+++ b/src/runtime/tests/ownership/fnode.rs
@@ -802,3 +802,95 @@ fn a_parked_terminal_payload_is_worth_one_retain_at_every_stage() {
         rc!("after the test's own release — nothing holds it", 0);
     }
 }
+
+/// A resume value delivered into a frame parked at a suspending PRIMITIVE call
+/// arrives carrying one owning reference (docs/impl/region/owner.md § "A delivery
+/// into a replayed frame carries one owning reference").
+///
+/// The replayed frame re-enters at the parked call's continuation, which runs
+/// that call's compiler-emitted result release. A bytecode callee funds the
+/// reference that release consumes with its `Return` mint; a primitive that
+/// suspends never returns, so the delivery mints it instead. Which shape a park
+/// has is the classifier's answer, recorded on the fiber, so the two arms below
+/// park IDENTICAL frames and differ only in `Fiber::resume_value_unfunded` — the
+/// flag is the counter-factual. Both arms then complete and park the same value
+/// as their terminal result, which is worth its own single retain
+/// (`a_parked_terminal_payload_is_worth_one_retain_at_every_stage`), so the whole
+/// difference between the arms is the delivery's one reference.
+#[test]
+fn a_primitive_park_delivery_is_worth_one_retain() {
+    use crate::compiler::bytecode::{Bytecode, Instruction};
+    use crate::value::fiber::FiberStatus;
+    use crate::value::{BytecodeFrame, SuspendedFrame};
+    use std::rc::Rc;
+
+    for unfunded in [false, true] {
+        let mut vm = crate::vm::VM::new();
+        let heap_ptr = vm.heap_ptr;
+        let (payload, rid) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
+        macro_rules! rc {
+            ($stage:expr, $want:expr) => {
+                assert_eq!(
+                    unsafe { &*heap_ptr }.region_rc(rid),
+                    $want,
+                    "unfunded={unfunded}: delivered region rc {}",
+                    $stage
+                )
+            };
+        }
+        rc!("as allocated — the test's own reference", 1);
+
+        // The parked continuation: the resume value is pushed as the suspended
+        // call's result and returned, exactly as a body that binds nothing else
+        // would.
+        let mut body = Bytecode::new();
+        body.emit(Instruction::Return);
+        let (handle, fiber_value) =
+            child_fiber(unsafe { &mut *heap_ptr }, fiber_body_closure(body));
+        let mut parked = Bytecode::new();
+        parked.emit(Instruction::Return);
+        let code = crate::value::Code::new(
+            Rc::new(parked.instructions),
+            Rc::new(parked.constants),
+            Rc::new(crate::error::LocationMap::new()),
+            Rc::new(vec![]),
+        );
+        let frame = BytecodeFrame::suspend(
+            code,
+            Rc::new(vec![]),
+            0,
+            vec![],
+            true,
+            rustc_hash::FxHashMap::default(),
+            None,
+            crate::value::Value::NIL,
+            unsafe { &*heap_ptr },
+        );
+        handle.with_mut(|f| {
+            f.status = FiberStatus::Paused;
+            f.suspended = Some(vec![SuspendedFrame::Bytecode(frame)]);
+            // What `prim_fiber_resume` installs: the value to deliver, plus the
+            // park shape the classifier recorded when the fiber suspended.
+            f.signal = Some((crate::value::fiber::SIG_OK, payload));
+            f.resume_value_unfunded = unfunded;
+        });
+        rc!("after the park is installed — the delivery has not run", 1);
+
+        let (result_bits, v) = vm.do_fiber_resume(&handle, fiber_value);
+        assert!(result_bits.is_empty(), "the replayed frame completes");
+        assert_eq!(v, payload, "the resumed frame returns what it was handed");
+        rc!(
+            "after the resume — the terminal park retain, plus the delivery's \
+             reference where the park owed one",
+            if unfunded { 3 } else { 2 }
+        );
+
+        release_fiber_value(unsafe { &mut *heap_ptr }, fiber_value);
+        drop(handle);
+        unsafe { &mut *heap_ptr }.decref_region_if_present(rid);
+        rc!(
+            "after every holder releases — only an unconsumed delivery is left",
+            if unfunded { 1 } else { 0 }
+        );
+    }
+}

--- a/src/value/arena.rs
+++ b/src/value/arena.rs
@@ -191,6 +191,13 @@ pub enum EscapeSite {
     /// A child fiber's set-once terminal result, park-retained until the fiber
     /// is freed (released by the signal scan — asymmetric by Rule 7).
     TerminalSignal,
+    /// A resume value delivered into a frame parked at a suspending PRIMITIVE
+    /// call. The primitive never returns, so its `Return` mint never runs and
+    /// the resume value takes the place of the result the continuation's
+    /// compiler-emitted release consumes — this retain is that missing mint
+    /// (docs/impl/region/owner.md § "A delivery into a replayed frame carries
+    /// one owning reference").
+    ResumeDelivery,
     /// A heap value in a child fiber's inherited dynamic-parameter baseline,
     /// retained at the seed until the fiber is freed (released by the Fiber
     /// content scan's baseline walk — the terminal-signal shape;
@@ -215,6 +222,7 @@ impl EscapeSite {
             EscapeSite::EmitEscape => "emit-escape",
             EscapeSite::PropagateEscape => "propagate-escape",
             EscapeSite::TerminalSignal => "terminal-signal",
+            EscapeSite::ResumeDelivery => "resume-delivery",
             EscapeSite::ParamBaseline => "param-baseline",
         }
     }

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -153,6 +153,23 @@ pub struct Fiber {
     /// exemption preserves. Cleared where the delivery is consumed: the resume's
     /// signal take, and an abort's injection.
     pub emit_delivery: Option<Value>,
+    /// Whether this fiber's innermost suspension is a PRIMITIVE call, whose
+    /// resume value therefore arrives owing one reference.
+    ///
+    /// A parked frame re-enters at its suspending call's continuation, which
+    /// runs that call's compiler-emitted result release. A bytecode callee funds
+    /// the reference that release consumes with its `Return` mint; a primitive
+    /// that suspends never returns, so the delivery mints it instead
+    /// (docs/impl/region/owner.md § "A delivery into a replayed frame carries one
+    /// owning reference"). The classifier — `handle_primitive_signal` and the
+    /// capability-denial path, in call and tail position and in their JIT twins
+    /// (`src/jit/calls.rs`) — is the only place that knows which shape a park has,
+    /// and the park itself may be built later
+    /// and elsewhere (a tail suspend leaves no frame of its own), so the answer
+    /// rides the fiber rather than the frame. `do_fiber_resume_single` takes it
+    /// with the parked signal, so every delivery route consumes it exactly once
+    /// and a later park of a different shape starts from `false`.
+    pub resume_value_unfunded: bool,
     /// Suspended execution frames. Set when the fiber suspends; consumed
     /// when it resumes.
     ///
@@ -431,6 +448,7 @@ impl Fiber {
             signal: None,
             error_loc: None,
             emit_delivery: None,
+            resume_value_unfunded: false,
             suspended: None,
             activation_region_maps: vec![rustc_hash::FxHashMap::default()],
             activation_owner_nodes: vec![None],
@@ -467,6 +485,7 @@ impl Fiber {
             signal: None,
             error_loc: None,
             emit_delivery: None,
+            resume_value_unfunded: false,
             suspended: None,
             activation_region_maps: vec![rustc_hash::FxHashMap::default()],
             activation_owner_nodes: vec![None],

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -175,6 +175,7 @@ On resume, the VM wires up the parent/child chain (Janet semantics):
 | `signal` | `Option<(SignalBits, Value)>` | Signal from execution (errors, yields) |
 | `error_loc` | `Option<(Value, SourceLoc)>` | The parked `SIG_ERROR` payload and where it was raised. Parked by `absorbs`, read back by `fiber/propagate` so a re-raised error keeps its raising form |
 | `suspended` | `Option<Vec<SuspendedFrame>>` | Suspended execution frames (for yield/signal resumption) |
+| `resume_value_unfunded` | `bool` | Whether the innermost suspension is a PRIMITIVE call, so the next delivery owes its resume value one reference (docs/impl/region/owner.md § "A delivery into a replayed frame carries one owning reference") |
 | `signal_mask` | `SignalBits` | Which signals this fiber catches |
 | `param_frames` | `Vec<Vec<(Value, Value)>>` | Parameter binding frames (stack of frames, each frame is vec of (param, value) pairs) |
 | `parent` | `Option<WeakFiberHandle>` | Weak back-pointer to parent fiber |
@@ -225,6 +226,12 @@ When a fiber suspends (via yield instruction or `emit`):
    (caller) at last index.
 5. **Resume** (`resume_suspended`): iterates frames forward, calling
    `execute_bytecode_from_ip` for each. Handles re-yields and errors.
+
+A park at a suspending PRIMITIVE call — a dynamic `emit`, a capability denial —
+resumes into that call's continuation, which releases the call's result. The
+primitive never returns, so nothing mints the reference that release consumes:
+`handle_primitive_signal` and the denial path record the shape on the fiber
+(`resume_value_unfunded`) and `do_fiber_resume_single` mints it as it delivers.
 
 Key methods:
 - `execute_bytecode_from_ip`: Executes from a given IP with Rc bytecode/constants

--- a/src/vm/fiber/resume.rs
+++ b/src/vm/fiber/resume.rs
@@ -35,15 +35,39 @@ impl VM {
         }
 
         // Extract resume value and status before taking the fiber
-        let (resume_value, is_first_resume, child_params_seeded) = child_handle.with_mut(|child| {
-            let rv = child.signal.take().map(|(_, v)| v).unwrap_or(Value::NIL);
-            // The resume consumes the parked signal, and with it any recorded
-            // emit-minted delivery: the payload this record named is gone from
-            // the slot, and a later raise records its own.
-            child.emit_delivery = None;
-            let first = child.status == FiberStatus::New;
-            (rv, first, !child.param_frames.is_empty())
-        });
+        let (resume_value, is_first_resume, child_params_seeded, unfunded) =
+            child_handle.with_mut(|child| {
+                let rv = child.signal.take().map(|(_, v)| v).unwrap_or(Value::NIL);
+                // The resume consumes the parked signal, and with it any recorded
+                // emit-minted delivery: the payload this record named is gone from
+                // the slot, and a later raise records its own.
+                child.emit_delivery = None;
+                // …and with it the park's delivery obligation, so a park of a
+                // different shape later starts from `false`.
+                let unfunded = std::mem::take(&mut child.resume_value_unfunded);
+                let first = child.status == FiberStatus::New;
+                (rv, first, !child.param_frames.is_empty(), unfunded)
+            });
+
+        // Fund the crossing into a frame parked at a suspending PRIMITIVE call.
+        // The replayed frame re-enters at that call's continuation and runs the
+        // call's compiler-emitted result release; a bytecode callee funds that
+        // release with its `Return` mint, but a primitive that suspends never
+        // returns and the resume value stands in for its result. Without the
+        // retain the continuation consumes a reference the resumer still owns,
+        // and the value is freed under every holder that outlives the resume
+        // (docs/impl/region/owner.md § "A delivery into a replayed frame carries
+        // one owning reference"; `tests/elle/region-primitive-resume-uaf.lisp`).
+        // `region_of` no-ops an immediate.
+        if unfunded {
+            let heap = unsafe { &mut *self.heap_ptr };
+            let r = crate::value::arena::region_of(heap, resume_value);
+            crate::value::arena::incref_for_escape(
+                heap,
+                r,
+                crate::value::arena::EscapeSite::ResumeDelivery,
+            );
+        }
 
         // Inherit parent's parameter bindings on first resume.
         // Flatten all frames into a single frame so the child starts
@@ -299,6 +323,13 @@ impl VM {
             // error minted no delivery, so any recorded one goes with it.
             vm.fiber.signal = None;
             vm.fiber.emit_delivery = None;
+            // An abort delivers no resume value — the replayed frame re-enters
+            // with `SIG_ERROR` set and leaves before the parked call's result
+            // release — so the park's delivery obligation goes with the signal it
+            // rode in on. Each arm below funds what it does hand over
+            // (docs/impl/region/owner.md § "A delivery into a replayed frame
+            // carries one owning reference").
+            vm.fiber.resume_value_unfunded = false;
 
             let frames = match vm.fiber.suspended.take() {
                 Some(frames) => frames,

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -90,6 +90,12 @@ impl VM {
                     r,
                     crate::value::arena::EscapeSite::SuspendEscape,
                 );
+                // This primitive never returns, so the frame's continuation —
+                // the code after the Call, including the call's own result
+                // release — is funded by the delivery instead of by a `Return`
+                // mint (docs/impl/region/owner.md § "A delivery into a replayed
+                // frame carries one owning reference").
+                self.fiber.resume_value_unfunded = true;
                 let saved_stack: Vec<Value> = self.fiber.stack.drain(..).collect();
                 let activation_region_map = self
                     .fiber
@@ -173,6 +179,13 @@ impl VM {
                     r,
                     crate::value::arena::EscapeSite::SuspendEscape,
                 );
+                // Tail-position mirror of the Call-position park classification.
+                // A tail suspend builds no frame of its own — the driver it
+                // unwinds to parks one — so the obligation rides the fiber until
+                // the delivery. The frame that driver parks resumes into the
+                // post-`TailCall` block, whose result release the missing `Return`
+                // mint would have funded.
+                self.fiber.resume_value_unfunded = true;
                 self.fiber.signal = Some((bits, value));
                 bits
             }
@@ -220,6 +233,11 @@ impl VM {
             r,
             crate::value::arena::EscapeSite::SuspendEscape,
         );
+
+        // The denied primitive never runs, let alone returns, so the mediating
+        // parent's resume value takes the place of its result — and the frame's
+        // continuation releases that result (see the `SignalAction::Suspend` arm).
+        self.fiber.resume_value_unfunded = true;
 
         // Save the stack and build a suspended frame (same as suspending signals)
         let saved_stack: Vec<Value> = self.fiber.stack.drain(..).collect();
@@ -273,6 +291,9 @@ impl VM {
             r,
             crate::value::arena::EscapeSite::SuspendEscape,
         );
+        // Tail-position mirror of the Call-position denial park (see
+        // `handle_capability_denial`).
+        self.fiber.resume_value_unfunded = true;
         self.fiber.signal = Some((blocked, payload));
         blocked
     }

--- a/src/vm/signal/tests.rs
+++ b/src/vm/signal/tests.rs
@@ -150,3 +150,71 @@ fn dispatch_query_answer_is_born_in_the_ctx_region() {
         "the SIG_QUERY answer is born in the ctx's region, not the region TLS",
     );
 }
+
+// -- which parks owe their resume value a reference --
+
+/// A suspending primitive's park owes its resume value one reference: the
+/// primitive never returns, so the `Return` mint that would fund the parked
+/// call's compiler-emitted result release never runs, and the resume value
+/// stands in for that result (docs/impl/region/owner.md § "A delivery into a
+/// replayed frame carries one owning reference"). The classifier is the only
+/// place that can tell — by the delivery the frame is built and, for a tail
+/// suspend, was built by a driver that never saw the primitive — so it records
+/// the answer on the fiber for `do_fiber_resume_single` to take.
+#[test]
+fn a_suspending_primitive_park_owes_its_resume_value_a_reference() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        let (code, env) = test_fixtures();
+        let mut ip = 0usize;
+
+        let result = vm.handle_primitive_signal(SIG_YIELD, Value::int(1), &code, &env, &mut ip);
+
+        assert_eq!(result, Some(SIG_YIELD));
+        assert!(
+            vm.fiber.resume_value_unfunded,
+            "the park at a suspending primitive call owes its resume value a reference",
+        );
+    })
+}
+
+/// The tail-position mirror: the suspend leaves no frame of its own, so the
+/// obligation must survive on the fiber until whichever driver parks the frame
+/// and, later, whichever route delivers into it.
+#[test]
+fn a_tail_suspending_primitive_park_owes_its_resume_value_a_reference() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+
+        let result = vm.handle_primitive_signal_tail(SIG_YIELD, Value::int(1));
+
+        assert_eq!(result, SIG_YIELD);
+        assert!(
+            vm.fiber.resume_value_unfunded,
+            "a tail suspend at a primitive owes its resume value a reference too",
+        );
+    })
+}
+
+/// A primitive that COMPLETES parks nothing, so nothing is owed. The
+/// counter-factual for the two above: a classifier that set the flag on every
+/// primitive result would mint against a resume the fiber never waits for.
+#[test]
+fn a_completing_primitive_owes_its_resume_value_nothing() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        let (code, env) = test_fixtures();
+        let mut ip = 0usize;
+
+        let result = vm.handle_primitive_signal(SIG_OK, Value::int(1), &code, &env, &mut ip);
+
+        assert!(
+            result.is_none(),
+            "a completing primitive continues dispatch"
+        );
+        assert!(
+            !vm.fiber.resume_value_unfunded,
+            "a primitive that returns funds its own result — nothing is owed",
+        );
+    })
+}

--- a/src/wasm/resume.rs
+++ b/src/wasm/resume.rs
@@ -400,11 +400,15 @@ pub(super) fn handle_fiber_resume(
         }
     };
 
-    let (closure, resume_value, status) = fiber_handle.with_mut(|fiber| {
+    let (closure, resume_value, status, unfunded) = fiber_handle.with_mut(|fiber| {
         let closure = fiber.closure.clone();
         let resume_value = fiber.signal.take().map(|(_, v)| v).unwrap_or(Value::NIL);
         let status = fiber.status;
-        (closure, resume_value, status)
+        // The park's delivery obligation travels with the parked signal, exactly
+        // as it does in the VM's fiber driver (`do_fiber_resume_single`), so every
+        // delivery route consumes it once.
+        let unfunded = std::mem::take(&mut fiber.resume_value_unfunded);
+        (closure, resume_value, status, unfunded)
     });
 
     let wasm_idx = match closure.template.wasm_func_idx {
@@ -418,6 +422,23 @@ pub(super) fn handle_fiber_resume(
             return (tag, payload, SIG_ERROR.raw() as i64);
         }
     };
+
+    // Fund the crossing into a frame parked at a suspending PRIMITIVE call: that
+    // frame resumes into the parked call's continuation, which runs the call's
+    // compiler-emitted result release, and the primitive that never returned
+    // minted nothing for it (docs/impl/region/owner.md § "A delivery into a
+    // replayed frame carries one owning reference"). Emitted past the guards
+    // above, so a resume that never reaches the body mints nothing; `region_of`
+    // no-ops an immediate.
+    if unfunded {
+        let heap = unsafe { &mut *caller.data().heap_ptr() };
+        let r = crate::value::arena::region_of(heap, resume_value);
+        crate::value::arena::incref_for_escape(
+            heap,
+            r,
+            crate::value::arena::EscapeSite::ResumeDelivery,
+        );
+    }
 
     let yield_signal = SIG_YIELD.raw() as i64;
     let fiber_id = fiber_handle.id();

--- a/tests/elle/emit-user-signal.lisp
+++ b/tests/elle/emit-user-signal.lisp
@@ -38,11 +38,8 @@
 #
 # A non-literal first argument falls through to the runtime primitive,
 # which reads the registry and keeps all 64 bits. Both paths emit the
-# same signal, so both must report the same bits and the same status.
-#
-# This stops at the first resume. A second one — resuming a fiber parked
-# through the dynamic path, whatever the signal — reads the fiber's freed
-# activation region; see issue #915.
+# same signal, so both must report the same bits and the same status —
+# and both must run the resumed body over the value they were handed.
 
 (let [s :user_sig_893
       f (fiber/new (fn []
@@ -51,7 +48,9 @@
   (assert (= (fiber/resume f) {:p 1}) "dynamic emit delivers its payload")
   (assert (= (fiber/status f) :paused) "dynamic emit suspends the fiber")
   (assert (= (fiber/bits f) user-bits)
-          "dynamic emit reports the same bit as the literal emit"))
+          "dynamic emit reports the same bit as the literal emit")
+  (assert (= (fiber/resume f "MEDIATED") [:resumed "MEDIATED"])
+          "the resume value is the result of the dynamic emit"))
 
 # ── A compound literal emit keeps both halves ────────────────────────
 #

--- a/tests/elle/emit.lisp
+++ b/tests/elle/emit.lisp
@@ -58,6 +58,25 @@
 (let [f (fiber/new (fn [] (emit 2 :dynamic)) |:yield|)]
   (assert (= (fiber/resume f) :dynamic) "dynamic emit still works"))
 
+# The resume value flows back through a dynamic emit too, and the body
+# runs on over it. The dynamic emit is an ordinary call, so its result is
+# the resume value the way any call's result is its return value.
+(let [s :yield
+      f (fiber/new (fn []
+                     (let [r (emit s {:p 1})]
+                       [:resumed r])) |:yield|)]
+  (assert (= (fiber/resume f) {:p 1}) "dynamic emit: payload delivered")
+  (assert (= (fiber/resume f "MEDIATED") [:resumed "MEDIATED"])
+          "dynamic emit: the resumed body reads the value it was handed"))
+
+# …including from tail position, where the resume value becomes the
+# body's own result.
+(let [s :yield
+      f (fiber/new (fn [] (emit s 7)) |:yield|)]
+  (assert (= (fiber/resume f) 7) "dynamic tail emit: payload delivered")
+  (assert (= (fiber/resume f "MEDIATED") "MEDIATED")
+          "dynamic tail emit: the resume value is the body's result"))
+
 # ── Resume value flows back through emit ─────────────────────────────
 
 (let [f (fiber/new (fn []

--- a/tests/elle/region-primitive-resume-uaf.lisp
+++ b/tests/elle/region-primitive-resume-uaf.lisp
@@ -1,0 +1,144 @@
+(elle/epoch 12)
+# A resume value delivered into a parked PRIMITIVE call carries one owning
+# reference (docs/impl/region/owner.md § "A delivery into a replayed frame
+# carries one owning reference").
+#
+# A parked frame re-enters at its suspending call's continuation, and that
+# continuation runs the call's compiler-emitted result release. An ordinary
+# callee funds the reference that release consumes with its `Return` mint. A
+# primitive that SUSPENDS never returns at all: the resume value takes the place
+# of its result, so unless the delivery mints one, the continuation releases a
+# reference the resumer still owns and the value dies under every holder that
+# outlives the resume.
+#
+# Two parks land in that continuation. A dynamic `emit` — a non-literal first
+# argument, which falls through to the runtime primitive — and a capability
+# denial, which parks any denied primitive call for the parent to mediate. The
+# literal `emit` is a block terminator whose resume block mints the reference in
+# bytecode, so it is the control each witness is paired against: the same
+# program, the same reads, one path already correct.
+#
+# Each witness hands the resume a FRESH string the resumer releases as soon as
+# the call returns, then compares the delivered content against an equal string
+# built afterwards. Where the freed page has already been recycled the compare
+# reports the corruption on any run; where it has not, the read is stale but
+# still mapped — so this file is also pinned under `--trace=guardfree`
+# (`region_primitive_resume_uaf`), which unmaps the page and faults on it. A
+# fresh subject per iteration keeps region ids churning under both oracles.
+
+(def sig :yield)
+
+# ── (a) the body binds the resume value and builds from it ───────────────────
+# The array the body returns points into the resumer's region, so the resumer's
+# own release of the delivered string must not be the last one.
+(defn w-bind (i)
+  (let [f (fiber/new (fn ()
+                       (let [r (emit sig 7)]
+                         [:resumed r])) |:yield|)]
+    (fiber/resume f)
+    (let [out (fiber/resume f (string "bind" i))]
+      (if (= (get out 1) (string "bind" i)) 1 0))))
+
+# ── (b) the body RETURNS the resume value from tail position ─────────────────
+# The dynamic emit is the body's tail call, so the delivered value becomes the
+# fiber's terminal result and is read back out of the resume.
+(defn w-tail (i)
+  (let [f (fiber/new (fn () (emit sig 7)) |:yield|)]
+    (fiber/resume f)
+    (if (= (fiber/resume f (string "tail" i)) (string "tail" i)) 1 0)))
+
+# ── (c) the body keeps the resume value across a FURTHER park ────────────────
+# The resumer's release has run by the time the second read happens, so only the
+# delivery's own reference can still be holding the value.
+(defn w-keep (i)
+  (let [f (fiber/new (fn ()
+                       (let [r (emit sig 0)]
+                         (emit sig (length r))
+                         (first r))) |:yield|)]
+    (fiber/resume f)
+    (fiber/resume f (string "keep" i))
+    (if (= (fiber/resume f) (first (string "keep" i))) 1 0)))
+
+# ── (d) a CAPABILITY DENIAL parks the call the parent mediates ───────────────
+# `:deny |:fs|` suspends `file/read` before it runs; the parent answers the read
+# itself and resumes with the answer, which the child then reads back.
+(defn w-denied (i)
+  (let [f (fiber/new (fn ()
+                       (let [r (file/read "/nonexistent-mediated")]
+                         [:mediated r])) |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (let [out (fiber/resume f (string "denied" i))]
+      (if (= (get out 1) (string "denied" i)) 1 0))))
+
+# ── controls: the literal path, which mints the reference in bytecode ────────
+(defn c-bind (i)
+  (let [f (fiber/new (fn ()
+                       (let [r (emit :yield 7)]
+                         [:resumed r])) |:yield|)]
+    (fiber/resume f)
+    (let [out (fiber/resume f (string "cbind" i))]
+      (if (= (get out 1) (string "cbind" i)) 1 0))))
+
+(defn c-tail (i)
+  (let [f (fiber/new (fn () (emit :yield 7)) |:yield|)]
+    (fiber/resume f)
+    (if (= (fiber/resume f (string "ctail" i)) (string "ctail" i)) 1 0)))
+
+# ── drive: a fresh subject each iteration; an over-early free faults on it ───
+
+(defn drive (reps)
+  (var i 0)
+  (var a 0)
+  (var b 0)
+  (var c 0)
+  (var d 0)
+  (var e 0)
+  (var f 0)
+  (while (%lt i reps)
+    (assign a (w-bind i))
+    (assign b (w-tail i))
+    (assign c (w-keep i))
+    (assign d (w-denied i))
+    (assign e (c-bind i))
+    (assign f (c-tail i))
+    (assign i (%add i 1)))
+  (list a b c d e f))
+
+(let [r (drive 800)]
+  (assert (= (get r 4) 1) "control: literal emit bind mis-read (harness broken)")
+  (assert (= (get r 5) 1) "control: literal emit tail mis-read (harness broken)")
+  (assert (= (get r 0) 1)
+          "dynamic emit: resume value freed under the body that bound it")
+  (assert (= (get r 1) 1)
+          "dynamic emit: resume value freed under the tail result it became")
+  (assert (= (get r 2) 1)
+          "dynamic emit: resume value freed under the body that kept it past a park")
+  (assert (= (get r 3) 1)
+          "capability denial: mediated value freed under the resumed body"))
+
+# ── the leak face: the delivery mints exactly one reference ──────────────────
+# One reference per park, balanced by the continuation's own result release, so
+# steady-state region growth over the emit witnesses stays flat.
+
+(defn drive-emit (reps)
+  (var i 0)
+  (var a 0)
+  (while (%lt i reps)
+    (assign a (w-bind i))
+    (assign a (w-tail i))
+    (assign a (w-keep i))
+    (assign a (c-bind i))
+    (assign a (c-tail i))
+    (assign i (%add i 1)))
+  a)
+
+(drive-emit 100)
+(let [before (arena/region-count)]
+  (drive-emit 400)
+  (let [growth (%sub (arena/region-count) before)]
+    (assert (%lt growth 40)
+            (string "primitive-park resume accounting strands regions: live count "
+                    "grew by " growth " over 400 iterations of five parks each "
+                    "(expected flat)"))))
+
+(println "region-primitive-resume-uaf: ok")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -510,6 +510,26 @@ fn region_fiber_yield_borrow_uaf() {
     );
 }
 
+// Guard — a resume value delivered into a frame parked at a suspending PRIMITIVE
+// call carries one owning reference (docs/impl/region/owner.md § "A delivery into
+// a replayed frame carries one owning reference"). The replayed frame re-enters at
+// that call's continuation and runs the call's compiler-emitted result release; a
+// bytecode callee funds that release with its `Return` mint, but a primitive that
+// suspends never returns, so the delivery owes it. This drives both parks that
+// land in such a continuation — a dynamic `emit`, in bound and tail position and
+// held across a further park, and a mediated capability denial — each paired with
+// the literal `Emit`, whose resume block mints the reference in bytecode and is
+// therefore correct without the delivery's. Freeing the delivered value early
+// faults on the read below — SIGSEGV under guardfree — and a growth gauge over the
+// emit witnesses refuses a delivery that mints more than one.
+#[test]
+fn region_primitive_resume_uaf() {
+    run_elle_script_with_args(
+        "region-primitive-resume-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — an inlined callee's body regions name the CALLEE's activation, so the
 // caller names the call's own region for the result (docs/impl/region/mechanism.md
 // § "A call's result is named by the call's own region"). The result therefore


### PR DESCRIPTION
Closes #915.

## The defect

A parked `BytecodeFrame` re-enters at its suspending call's continuation, and
that continuation runs the call's compiler-emitted result release. A bytecode
callee funds the reference that release consumes with its `Return` mint. A
**primitive** that suspends never returns at all: the resume value takes the
place of its result. Nothing minted a reference for it, so the continuation
consumes one the resumer still owns and the value is freed under every holder
that outlives the resume.

Two parks have that shape:

- a **dynamic** `emit` — a non-literal first argument, which falls through to the
  runtime primitive instead of compiling to the `Emit` terminator;
- a **capability denial**, which parks any denied primitive call for the parent
  to mediate.

```lisp
(let [s :yield
      f (fiber/new (fn [] (let [r (emit s {:p 1})] [:resumed r])) |:yield|)]
  (println "1:" (fiber/resume f))
  (println "3:" (fiber/resume f "MEDIATED")))
```

```
1:{:p 1}
3:[resumed ]
```

The same program with a literal `(emit :yield {:p 1})` prints
`3:[resumed MEDIATED]`. The literal path is a block terminator, so `lower_emit`
mints the reference in the resume block's bytecode; the dynamic path is a call,
and had nothing.

The mediated-denial shape fails identically:

```lisp
(let [f (fiber/new (fn [] (let [r (file/read "/nonexistent")] [:resumed r]))
                   |:fs :error| :deny |:fs|)]
  (fiber/resume f)
  (println (fiber/resume f "MEDIATED")))   # => [resumed ]
```

As #915 reports, a debug-assertions build catches these programs earlier — the
uncounted-borrow check at `src/vm/core/resume.rs:186` panics at the resume
boundary instead of letting the body read the freed region. Both faces are gone;
the reproductions above run clean on `--jit=off`, `--jit=eager`, and a
debug-assertions build.

## The fix

The delivery mints the reference the missing `Return` would have carried, at the
one funnel every resume route passes through.

Which shape a park has is only knowable at the park: by delivery time the frame
is already built and, for a tail suspend, was built by a driver that never saw
the primitive. So the classifier records it on the fiber
(`Fiber::resume_value_unfunded`) and `do_fiber_resume_single` takes it together
with the parked signal, minting one `EscapeSite::ResumeDelivery` retain. Taking
it with the signal is what keeps it exact: every delivery consumes the obligation
once, and a later park of a different shape starts from `false`.

Four sites set it — `handle_primitive_signal`'s `Suspend` arm and
`handle_capability_denial`, in call and tail position — plus their JIT twins in
`src/jit/calls.rs`, which install the same signals without going through the
interpreter's handlers. The WASM tier's own fiber driver takes and honours the
same flag, and `do_fiber_abort` clears it: an abort hands over no resume value,
and each of its arms funds what it does hand over.

Two deliveries need no mint and get none. An `Emit` park mints in bytecode
already (`RegionInfo::unfunded_resume_values`, `lower_emit`). An io completion is
allocated fresh by the scheduler and arrives carrying its own birth reference —
`release_parked_signal` is the arm that balances that side, and it is untouched.

## Docs

- `docs/impl/region/owner.md` § "A delivery into a replayed frame carries one
  owning reference" gains the primitive-park case, why the answer rides the fiber
  rather than the frame, and what does not need the mint.
- `docs/signals/emit.md` states that the dynamic form resumes like the literal
  one and differs only in the shape of the compiled code.
- `src/vm/AGENTS.md` records the field and the classification.

## Tests

- `tests/elle/region-primitive-resume-uaf.lisp` — the dynamic emit bound, in tail
  position, and held across a further park; a mediated capability denial; each
  paired with the literal `Emit` control that is correct without the delivery's
  mint. Plus a growth gauge over the emit witnesses, which refuses a delivery
  that mints more than one. Pinned under `--trace=guardfree` as
  `region_primitive_resume_uaf`; the tail witness also fails on a plain run.
- `runtime::tests::ownership::fnode::a_primitive_park_delivery_is_worth_one_retain`
  — two arms parking identical frames and differing only in the flag, walking the
  region RC through the delivery. The flag is the counter-factual.
- `vm::signal::tests` — which parks owe their resume value a reference, in call
  and tail position, with a completing primitive as the control.
- `tests/elle/emit.lisp` and `tests/elle/emit-user-signal.lisp` now resume PAST
  the dynamic emit. The latter's dynamic case stopped one resume short with a
  comment pointing at this issue; it runs to completion now.

Each fails before the fix.

## Verification

`cargo test -p elle --lib`, `cargo test --test lib --release`, `make smoke-elle`
over the full corpus on both tiers, `cargo clippy --all-targets`,
`cargo fmt --check`, `make fmt-check`, `make crosscheck`.

## Adjacent, not fixed here

Two further defects on the same seam turned up while reproducing this one. Both
are independent of the delivery reference and neither is touched by this change:

- #933 — a dynamic emit's BORROWED payload gets no body reference, so an
  abandoned park over-releases it (the other direction of the same crossing).
- #934 — a mediated capability denial strands its denial payload's regions,
  because the balancing release is gated on `SIG_IO`.
