### PR TITLE
jit: a compiled frame's error exit runs the releases it owes

### DIFF
--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1522,13 +1522,41 @@ own discharge reads the same two tables off each parked `BytecodeFrame`, its sav
 locals and its saved activation map standing in for the live ones
 ([owner.md](owner.md) § "The bounded residual").
 
-The **JIT** tier keeps today's behaviour: a compiled frame's error exit walks nothing,
-an over-keep, never an over-free. The gap now has a gauge: the
-`error-payload-helper` probe in `tests/elle/oracle.lisp` raises from a non-tail
-callee frame with a payload that frame owns, and its cross-tier range pin reads 0
-under `--jit=off` and one region per raise under `--jit=eager` — per raise in a
-loop, so a compiled retry loop grows by it until the walk (or its equivalent) is
-realized on the tier.
+**The compiled tier runs the same walk.** A compiled frame leaves by an error at two
+points, and each runs the walk before its activation's region-map pop: the check after
+a call, which finds the callee's raise, and an `Emit` of `SIG_ERROR`, which parks no
+frame to resume. The tables are compile-time constants, so the prologue materializes
+them once — each in its own stack slot, at its own width — and every exit hands the
+runtime both, with the frame's locals spilled in slot order. The value route resolves
+`s` to the spilled `LoadLocal s`; the slot route reads the very activation map the
+compiled prologue pushed. The two tiers share the walk itself; only where the slots
+are read differs.
+
+Nothing is spilled back. The compiled frame returns as the walk completes, so the nil
+stamp that is the interpreter's receipt has no compiled counterpart and needs none: a
+table names each slot once, and one error exit runs per unwind.
+
+A compiled frame is never one a restart replays, so `VM::pending_error_park` has no
+compiled reader. A fiber body's first run enters through
+`execute_bytecode_saving_stack`, and compiled code is reached only from a call site
+inside it, so the parked frame is always an interpreter frame.
+
+Every exit — compiled or not — pops the map it pushed, and the walk depends on it:
+`last()` must be the abandoned activation's own frame, not a callee's leftover.
+`execute_bytecode_saving_stack` asserts the balance in debug builds, so an exit path
+that returns without popping detonates at the first activation to return through it
+rather than resolving some later release against the wrong frame.
+
+The rule reaches the exits an error never takes. A compiled frame whose CALLEE
+suspends parks itself at the post-call yield check and returns the yield sentinel,
+and that exit pops too: the park reads the map first, so what the pop discards is a
+frame nothing needs again. Left behind, it is what `last()` names for the interpreter
+activation above — which then parks a map that was never its own — and the remap stack
+never shrinks back, one frame per suspend through a compiled callee. That the exit is a
+suspend rather than an unwind changes only what runs before the pop: nothing, because
+the frame resumes and still owes its releases to the resumed body.
+`jit::compiler::tests::every_compiled_exit_pops_the_region_map` pins it on the emitted
+code, where a missing pop is visible without an activation having to return first.
 
 Pinned by `tests/elle/region-error-unwind.lisp` (the leak gauge — the pending release
 of a raising call's argument, of two of them, of a binding live across the raising
@@ -1542,7 +1570,14 @@ recorded mint from the walk and discharge) with
 payload a catcher stores outward, a borrowed module payload raised repeatedly, a
 native raise's unrecorded install, and a restarted `:error` fiber's replay), the
 `denied-discard` probe in `tests/elle/oracle.lisp` (the per-op rate of what the
-tables cannot name),
+tables cannot name), `tests/elle/region-jit-error-unwind.lisp` with
+`tests/elle/region-jit-error-unwind-uaf.lisp` as its guardfree complement (the
+compiled face — one subject per compiled error exit, and, on the soundness side,
+the caller's binding live across a compiled callee's exit),
+`vm::core::region::tests::a_compiled_frames_*` (the spilled locals stand in for the
+frame stack, and the payload exemption reads the same) and
+`jit::dispatch::tests::release_abandoned_frame_runs_both_routes_off_the_compiled_exits_buffers`
+(the two tables reach the runtime as separate buffers of different widths),
 `lir::lower::tests::release::emission::{frame_release_tables_name_exactly_the_routes_emitted,
 a_reassigned_binding_records_no_value_route}` (the tables are the emit sites, so a route
 the emitter declined has no entry), and `tests/elle/region-error-unwind-uaf.lisp` (the

--- a/docs/io.md
+++ b/docs/io.md
@@ -240,24 +240,31 @@ whole call runs well past it:
 (ev/run (fn []
           (let* [listener (tcp/listen "127.0.0.1" 0)
                  chunk 4096
-                 chunks 10]
+                 chunks 20
+                 gap 0.05
+                 deadline 500]
             (ev/spawn (fn []
                         (let [conn (tcp/accept listener)]
                           (repeat chunks
                                   (port/write conn (bytes (string/repeat "z" chunk)))
-                                  (ev/sleep 0.1))
+                                  (ev/sleep gap))
                           (port/close conn))))
             (let* [conn (tcp/connect "127.0.0.1" (listener-port listener)
                                      :timeout 5000)
                    want (* chunk chunks)
                    started (clock/monotonic)
-                   got (port/read-exact conn want :timeout 300)
+                   got (port/read-exact conn want :timeout deadline)
                    elapsed (- (clock/monotonic) started)]
               (port/close conn)
               (port/close listener)
               (assert (= (length got) want)
                       "a slow peer still delivers every byte")
-              (assert (> elapsed 0.3)
+              # The read returns once the last chunk lands, after `chunks - 1`
+              # gaps — so this bound sits between the deadline and that total,
+              # and the gap sits an order of magnitude under the deadline. Tie
+              # either margin closer and a loaded scheduler's overshoot on one
+              # `ev/sleep` trips the deadline this example exists to survive.
+              (assert (> elapsed 0.5)
                       "and the call outlives its own :timeout while doing it")))))
 ```
 

--- a/src/jit/AGENTS.md
+++ b/src/jit/AGENTS.md
@@ -478,5 +478,15 @@ The JIT emits the same `IncrefValueRegion` / `DecrefValueRegion` /
 `DecrefCellRegion` accounting the interpreter does, so a loop body or a
 self-tail-call boundary needs no separate release step.
 
+An **error** exit runs none of those instructions, so the releases still among
+them run at the exit instead — `elle_jit_release_abandoned_frame`, the compiled
+half of the interpreter's abandoned-frame walk (docs/impl/region/mechanism.md
+§ "An abandoned frame runs the releases it still owes"). The prologue
+materializes the function's two release tables into stack slots, and every error
+exit — the post-call exception check, and an `Emit` of `SIG_ERROR` — hands both
+to the helper with the frame's locals spilled in slot order, ahead of the
+region-map pop. `emit_abandoned_error_return` is the one route out; a new
+error exit that returns directly leaks whatever the tables name.
+
 `elle_jit_rotate_pools` survives as an exported no-op that nothing calls —
 its vtable `FuncId` carries `#[allow(dead_code)]`. See `jit/calls/callops.rs`.

--- a/src/jit/compiler/tests.rs
+++ b/src/jit/compiler/tests.rs
@@ -626,3 +626,137 @@ fn a_capture_load_carries_trusted_flags() {
         );
     }
 }
+
+/// fn(f) -> f(). A `Call` inside a function whose signal may suspend, which is
+/// what makes the translator emit all three exits: the post-call error check,
+/// the post-call yield check, and the normal return.
+fn make_suspending_call_lir() -> LirFunction {
+    use crate::hir::region::StaticRegion;
+    use crate::lir::CallSiteInfo;
+    LirFixture::new(Arity::Exact(1))
+        .signal(Signal::yields())
+        .call_sites(vec![CallSiteInfo {
+            resume_ip: 0,
+            stack_regs: vec![],
+            num_locals: 0,
+        }])
+        .block(
+            0,
+            vec![
+                LirInstr::LoadCapture {
+                    dst: Reg(0),
+                    index: 0,
+                },
+                LirInstr::Call {
+                    dst: Reg(1),
+                    func: Reg(0),
+                    args: vec![],
+                    arity_checked: false,
+                    region: StaticRegion::new(1).unwrap(),
+                },
+            ],
+            Terminator::Return(Reg(1)),
+        )
+        .build()
+}
+
+/// `fnN` → the module function id it names, read off a rendered function's
+/// preamble lines (`fn3 = u0:87 sig3`, optionally `colocated`).
+fn func_refs(clif: &[String]) -> HashMap<String, u32> {
+    let mut refs = HashMap::new();
+    for line in clif {
+        let line = line.trim();
+        let Some((name, rest)) = line.split_once(" = ") else {
+            continue;
+        };
+        if !name.starts_with("fn") {
+            continue;
+        }
+        let Some(id) = rest
+            .split_whitespace()
+            .find_map(|tok| tok.strip_prefix("u0:"))
+        else {
+            continue;
+        };
+        if let Ok(id) = id.parse::<u32>() {
+            refs.insert(name.to_string(), id);
+        }
+    }
+    refs
+}
+
+/// The `fnN` of the call instruction nearest above `at`, searching back only
+/// within `at`'s own block.
+fn call_target_before(clif: &[String], at: usize) -> Option<String> {
+    for line in clif[..at].iter().rev() {
+        let line = line.trim();
+        if line.starts_with("block") {
+            return None;
+        }
+        let Some(pos) = line.find("call ") else {
+            continue;
+        };
+        let rest = &line[pos + "call ".len()..];
+        let name = rest.split('(').next()?.trim();
+        return Some(name.to_string());
+    }
+    None
+}
+
+/// Every `return` a compiled function emits is preceded by the call that pops
+/// this activation's region-remap frame, so the prologue's push is balanced on
+/// every path out (docs/impl/region/mechanism.md § "An abandoned frame runs the
+/// releases it still owes").
+#[test]
+fn every_compiled_exit_pops_the_region_map() {
+    // Trap: a missing pop is invisible to the compiled function itself. It
+    // returns the right value; what it leaves behind is a map frame that
+    // `last()` then names for the INTERPRETER activation above it, which parks
+    // and releases against a frame that was never its own — and the remap stack
+    // never shrinks back.
+    //
+    // Counter-factual: the yield-check exit
+    // (`emit_yield_check_after_call`) returned straight from the suspend
+    // helper. Every corpus test that suspends through a compiled frame passed
+    // its own assertions, and only the balance check in
+    // `execute_bytecode_saving_stack` — a debug build, and only once the
+    // enclosing activation returned — said anything at all.
+    let compiler = JitCompiler::new().expect("Failed to create compiler");
+    let pop_id = compiler.helpers.pop_region_map.as_u32();
+    let clif = compiler
+        .clif_text(&make_suspending_call_lir(), None)
+        .expect("Failed to translate");
+    let refs = func_refs(&clif);
+
+    let returns: Vec<usize> = clif
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| line.trim().starts_with("return"))
+        .map(|(i, _)| i)
+        .collect();
+    // One per exit: the error check's, the yield check's, and the terminator's.
+    assert_eq!(
+        returns.len(),
+        3,
+        "a suspending function's Call has three exits; got:\n{}",
+        clif.join("\n")
+    );
+
+    for i in returns {
+        let target = call_target_before(&clif, i).unwrap_or_else(|| {
+            panic!(
+                "`{}` is not preceded by any call in its block:\n{}",
+                clif[i].trim(),
+                clif.join("\n")
+            )
+        });
+        assert_eq!(
+            refs.get(&target).copied(),
+            Some(pop_id),
+            "`{}` is preceded by `{target}`, not by the region-map pop \
+             (u0:{pop_id}) — this exit leaks its activation's remap frame:\n{}",
+            clif[i].trim(),
+            clif.join("\n")
+        );
+    }
+}

--- a/src/jit/compiler/translate.rs
+++ b/src/jit/compiler/translate.rs
@@ -318,6 +318,13 @@ impl JitCompiler {
             translator.init_locally_defined_vars(&mut builder, num_locally_defined)?;
         }
 
+        // Materialize the abandoned-frame release tables (constants) and reserve
+        // the locals scratch every error exit spills into
+        // (docs/impl/region/mechanism.md § "An abandoned frame runs the releases
+        // it still owes"). After `init_locally_defined_vars`, so the spill at an
+        // exit reads locals that are already defined.
+        translator.emit_abandoned_tables(&mut builder);
+
         // Allocate shared spill slot for emit/call sites (if any).
         // Check yield_points (emit terminators) and call_sites directly,
         // not may_suspend() — emit can emit any signal, not just :yield.

--- a/src/jit/dispatch/region.rs
+++ b/src/jit/dispatch/region.rs
@@ -307,6 +307,63 @@ pub extern "C" fn elle_jit_release_activation_owner_node(vm: *mut ()) {
     vm.release_activation_owner_node();
 }
 
+/// Run the releases a COMPILED activation abandoned by an **error** still owed —
+/// the compiled entry to the same walk the interpreter reaches through
+/// `VM::release_abandoned_frame` (docs/impl/region/mechanism.md § "An abandoned
+/// frame runs the releases it still owes").
+///
+/// `slots` and `regions` are the function's two release tables, materialized once
+/// by the compiled prologue: the value routes' local slots and the slot routes'
+/// static region ids. `locals` is the frame's local slots spilled in slot order,
+/// so `locals[s]` is what `LoadLocal s` reads. The slot route needs no spill —
+/// its receipt is the activation region map, which the prologue pushed and this
+/// call reads ahead of the matching pop.
+///
+/// The payload is read off `fiber.signal`, which the raise has already installed:
+/// the callee's error at the post-call exit, this frame's own emitted value at
+/// the `Emit` exit. Only an **error** abandons the frame, so a signal without
+/// `SIG_ERROR` walks nothing — the post-call exception check also fires on a
+/// halt, which the interpreter's trampoline likewise declines to walk.
+///
+/// # Safety
+/// `slots` must point at `num_slots` contiguous `u16`s, `regions` at
+/// `num_regions` contiguous `u32`s, and `locals` at `num_locals` contiguous
+/// `Value`s. Any of the three may be null when its count is 0.
+#[no_mangle]
+pub extern "C" fn elle_jit_release_abandoned_frame(
+    vm: *mut (),
+    slots: *const u16,
+    num_slots: u64,
+    regions: *const u32,
+    num_regions: u64,
+    locals: *const Value,
+    num_locals: u64,
+) {
+    /// A null pointer with a zero count is the empty table, not a slice to build.
+    unsafe fn table<'a, T>(ptr: *const T, count: u64) -> &'a [T] {
+        if count == 0 || ptr.is_null() {
+            &[]
+        } else {
+            std::slice::from_raw_parts(ptr, count as usize)
+        }
+    }
+    let vm = unsafe { &mut *(vm as *mut crate::vm::VM) };
+    let Some((bits, payload)) = vm.fiber.signal else {
+        return;
+    };
+    if !bits.intersects(crate::value::SIG_ERROR) {
+        return;
+    }
+    unsafe {
+        vm.release_abandoned(
+            table(slots, num_slots),
+            table(regions, num_regions),
+            payload,
+            crate::vm::core::FrameLocals::Spilled(table(locals, num_locals)),
+        )
+    };
+}
+
 /// Free a co-owned region group as one unit — the `FreeRegionGroup` instruction.
 /// Mirrors the interpreter's `handle_free_region_group` arm
 /// (src/vm/dispatch/region.rs): `members_ptr` points at `count` member Values the

--- a/src/jit/dispatch/tests.rs
+++ b/src/jit/dispatch/tests.rs
@@ -565,3 +565,72 @@ fn jit_intrinsics_use_threaded_vm() {
         (*heap_ptr).decref_region_if_present(region);
     }
 }
+
+/// The compiled error exit's ABI: `elle_jit_release_abandoned_frame` reads the
+/// value routes out of the locals the exit spilled, the slot routes out of the
+/// activation map the prologue pushed, and the payload off `fiber.signal`
+/// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+/// still owes").
+///
+/// The trap: the tables are laid out as two SEPARATE buffers of different widths
+/// — `u16` local slots and `u32` static region ids. Reading either through the
+/// other's pointer names a slot the frame never had, so this drives both at once
+/// with distinct ids and asserts each release lands where it belongs.
+#[test]
+fn release_abandoned_frame_runs_both_routes_off_the_compiled_exits_buffers() {
+    use crate::hir::region::StaticRegion;
+    use crate::value::arena::alloc_in_fresh_region;
+    use crate::value::heap::{HeapObject, Pair};
+
+    crate::value::arena::with_test_region(|| {
+        let mut vm = VM::new();
+        let heap_ptr = vm.heap_ptr;
+        let vm_ptr = &mut vm as *mut VM as *mut ();
+
+        // The compiled prologue: this activation's region-remap frame.
+        crate::jit::dispatch::elle_jit_push_region_map(vm_ptr);
+
+        // A slot-routed alloc: the mint records slot → physical, which is the
+        // release's receipt.
+        let region_slot = StaticRegion::new(5).expect("nonzero slot");
+        let mapped = crate::hir::region::RuntimeRegion::new(
+            crate::jit::dispatch::elle_jit_resolve_alloc_region(vm_ptr, region_slot.get()),
+        )
+        .expect("the mint returns a live region");
+
+        // A value-routed local in local slot 2.
+        let (held, held_region) = alloc_in_fresh_region(
+            unsafe { &mut *heap_ptr },
+            HeapObject::Pair(Pair::new(Value::int(1), Value::NIL)),
+        );
+        let locals = [Value::NIL, Value::NIL, held];
+
+        // The raise: an immediate payload exempts nothing.
+        vm.fiber.signal = Some((crate::value::SIG_ERROR, Value::int(7)));
+
+        let slots: [u16; 1] = [2];
+        let regions: [u32; 1] = [region_slot.get()];
+        crate::jit::dispatch::elle_jit_release_abandoned_frame(
+            vm_ptr,
+            slots.as_ptr(),
+            slots.len() as u64,
+            regions.as_ptr(),
+            regions.len() as u64,
+            locals.as_ptr(),
+            locals.len() as u64,
+        );
+        crate::jit::dispatch::elle_jit_pop_region_map(vm_ptr);
+
+        assert_eq!(
+            unsafe { &*heap_ptr }.region_rc(held_region),
+            0,
+            "the value route named by local slot 2 must release what the spill \
+             holds there",
+        );
+        assert_eq!(
+            unsafe { &*heap_ptr }.region_rc(mapped),
+            0,
+            "the slot route must release the physical region its alloc mapped",
+        );
+    });
+}

--- a/src/jit/helpers.rs
+++ b/src/jit/helpers.rs
@@ -424,7 +424,12 @@ impl<'a> FunctionTranslator<'a> {
     }
 
     /// Emit exception check after a call instruction.
-    /// If an exception is pending, return (TAG_NIL, 0) immediately.
+    ///
+    /// The callee raised, so this activation is abandoned where it stands: it
+    /// runs the releases it still owed, pops its region-remap frame, and returns
+    /// (TAG_NIL, 0) for the caller's own check to find
+    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    /// still owes").
     pub(crate) fn emit_exception_check_after_call(
         &mut self,
         builder: &mut FunctionBuilder,
@@ -448,7 +453,7 @@ impl<'a> FunctionTranslator<'a> {
         builder.seal_block(exc_block);
         let nil_tag = builder.ins().iconst(I64, TAG_NIL as i64);
         let zero = builder.ins().iconst(I64, 0);
-        builder.ins().return_(&[nil_tag, zero]);
+        self.emit_abandoned_error_return(builder, nil_tag, zero)?;
 
         builder.switch_to_block(cont_block);
         builder.seal_block(cont_block);
@@ -457,6 +462,13 @@ impl<'a> FunctionTranslator<'a> {
     }
 
     /// Emit yield check after a call instruction for yielding functions.
+    ///
+    /// The callee suspended, so this activation suspends with it: the helper
+    /// parks the frame — reading this activation's region map, still on top —
+    /// and the exit then pops that map like every other one
+    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    /// still owes"). Nothing is released here: the frame resumes, and the
+    /// releases it still owes are the resumed body's to run.
     pub(crate) fn emit_yield_check_after_call(
         &mut self,
         builder: &mut FunctionBuilder,
@@ -511,7 +523,7 @@ impl<'a> FunctionTranslator<'a> {
         );
         let result_tag = builder.inst_results(call)[0];
         let result_payload = builder.inst_results(call)[1];
-        builder.ins().return_(&[result_tag, result_payload]);
+        self.emit_pop_then_return(builder, result_tag, result_payload)?;
 
         builder.switch_to_block(cont_block);
         builder.seal_block(cont_block);

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -73,6 +73,15 @@ pub(crate) struct FunctionTranslator<'a> {
     pub(crate) call_site_index: u32,
     /// Shared stack slot for spilling locals + operands at yield/call sites.
     pub(crate) shared_spill_slot: Option<cranelift_codegen::ir::StackSlot>,
+    /// The abandoned-frame release tables, materialized once in the prologue and
+    /// handed to `elle_jit_release_abandoned_frame` at every error exit: the
+    /// value routes' local slots (`u16`), the slot routes' static region ids
+    /// (`u32`), and the scratch the locals spill into. `None` on each where the
+    /// function's matching table is empty (docs/impl/region/mechanism.md § "An
+    /// abandoned frame runs the releases it still owes").
+    pub(crate) abandoned_slots_table: Option<cranelift_codegen::ir::StackSlot>,
+    pub(crate) abandoned_regions_table: Option<cranelift_codegen::ir::StackSlot>,
+    pub(crate) abandoned_locals_spill: Option<cranelift_codegen::ir::StackSlot>,
     /// Nested-lambda template **blueprints** built during MakeClosure
     /// translation. The native code holds a raw pointer to each (like
     /// `templates` below), and `elle_jit_make_closure` materializes a FRESH
@@ -148,6 +157,9 @@ impl<'a> FunctionTranslator<'a> {
             yield_point_index: 0,
             call_site_index: 0,
             shared_spill_slot: None,
+            abandoned_slots_table: None,
+            abandoned_regions_table: None,
+            abandoned_locals_spill: None,
             closure_protos: Vec::new(),
             templates: Vec::new(),
             symbol_names: HashMap::new(),

--- a/src/jit/translate/region.rs
+++ b/src/jit/translate/region.rs
@@ -94,6 +94,143 @@ impl<'a> FunctionTranslator<'a> {
         Ok(())
     }
 
+    /// Materialize this function's two abandoned-frame release tables into stack
+    /// slots, and reserve the scratch the value route's locals spill into. Both
+    /// tables are compile-time constants, so the prologue writes them once and
+    /// every error exit passes the same addresses to the runtime walk
+    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    /// still owes"). A function that owes nothing at an error exit gets neither
+    /// slot and emits no walk at all.
+    pub(crate) fn emit_abandoned_tables(&mut self, builder: &mut FunctionBuilder) {
+        // Read the function out of `self` first: the loops below borrow it while
+        // the writes at the end need `&mut self`.
+        let lir = self.lir;
+        let slots = &lir.frame_release_slots;
+        if !slots.is_empty() {
+            let table = builder.create_sized_stack_slot(cranelift_codegen::ir::StackSlotData::new(
+                cranelift_codegen::ir::StackSlotKind::ExplicitSlot,
+                (slots.len() * 2) as u32,
+                1,
+            ));
+            for (i, slot) in slots.iter().enumerate() {
+                let c = builder
+                    .ins()
+                    .iconst(cranelift_codegen::ir::types::I16, *slot as i64);
+                builder.ins().stack_store(c, table, (i * 2) as i32);
+            }
+            self.abandoned_slots_table = Some(table);
+            // The value route reads slot `s` out of `locals[s]`, so the scratch
+            // is indexed by slot and covers all of them, not just the released
+            // ones (`Value` is 16 bytes).
+            self.abandoned_locals_spill = Some(builder.create_sized_stack_slot(
+                cranelift_codegen::ir::StackSlotData::new(
+                    cranelift_codegen::ir::StackSlotKind::ExplicitSlot,
+                    (lir.num_locals as u32) * 16,
+                    0,
+                ),
+            ));
+        }
+        let regions = &lir.frame_release_regions;
+        if !regions.is_empty() {
+            let table = builder.create_sized_stack_slot(cranelift_codegen::ir::StackSlotData::new(
+                cranelift_codegen::ir::StackSlotKind::ExplicitSlot,
+                (regions.len() * 4) as u32,
+                2,
+            ));
+            for (i, region) in regions.iter().enumerate() {
+                let c = builder.ins().iconst(I32, region.get() as i64);
+                builder.ins().stack_store(c, table, (i * 4) as i32);
+            }
+            self.abandoned_regions_table = Some(table);
+        }
+    }
+
+    /// Emit the abandoned-frame walk for an activation leaving by an **error**:
+    /// spill the frame's locals in slot order and hand them, with the prologue's
+    /// tables, to `elle_jit_release_abandoned_frame`. A no-op for a function
+    /// whose tables are both empty.
+    ///
+    /// Runs BEFORE the region-map pop: the slot route's receipt is this
+    /// activation's map, which the pop discards.
+    fn emit_release_abandoned_frame(
+        &mut self,
+        builder: &mut FunctionBuilder,
+    ) -> Result<(), JitError> {
+        if self.abandoned_slots_table.is_none() && self.abandoned_regions_table.is_none() {
+            return Ok(());
+        }
+        let vm = self.vm_ptr.ok_or_else(|| {
+            JitError::InvalidLir("release_abandoned_frame without vm pointer".to_string())
+        })?;
+        let null = builder.ins().iconst(I64, 0);
+
+        let (slots_ptr, num_slots) = match self.abandoned_slots_table {
+            Some(table) => (
+                builder.ins().stack_addr(I64, table, 0),
+                builder
+                    .ins()
+                    .iconst(I64, self.lir.frame_release_slots.len() as i64),
+            ),
+            None => (null, null),
+        };
+        let (locals_ptr, num_locals) = match self.abandoned_locals_spill {
+            Some(spill) => {
+                for i in 0..self.lir.num_locals as u32 {
+                    let (tag, payload) = self.use_var_pair(builder, self.local_var_base + i);
+                    builder.ins().stack_store(tag, spill, (i * 16) as i32);
+                    builder
+                        .ins()
+                        .stack_store(payload, spill, (i * 16 + 8) as i32);
+                }
+                (
+                    builder.ins().stack_addr(I64, spill, 0),
+                    builder.ins().iconst(I64, self.lir.num_locals as i64),
+                )
+            }
+            None => (null, null),
+        };
+        let (regions_ptr, num_regions) = match self.abandoned_regions_table {
+            Some(table) => (
+                builder.ins().stack_addr(I64, table, 0),
+                builder
+                    .ins()
+                    .iconst(I64, self.lir.frame_release_regions.len() as i64),
+            ),
+            None => (null, null),
+        };
+
+        let func_ref = self
+            .module
+            .declare_func_in_func(self.helpers.release_abandoned_frame, builder.func);
+        builder.ins().call(
+            func_ref,
+            &[
+                vm,
+                slots_ptr,
+                num_slots,
+                regions_ptr,
+                num_regions,
+                locals_ptr,
+                num_locals,
+            ],
+        );
+        Ok(())
+    }
+
+    /// Leave a compiled activation by an **error**: run the releases it still
+    /// owed, then pop its region-remap frame and return. Every error exit goes
+    /// through here — one that returns directly leaks whatever the frame's
+    /// release tables name.
+    pub(crate) fn emit_abandoned_error_return(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        rt: cranelift_codegen::ir::Value,
+        rp: cranelift_codegen::ir::Value,
+    ) -> Result<(), JitError> {
+        self.emit_release_abandoned_frame(builder)?;
+        self.emit_pop_then_return(builder, rt, rp)
+    }
+
     /// Pop the region-remap frame, then emit the function `return`. Every exit
     /// path goes through here so the prologue push is always balanced. The pop
     /// is correct on the yield/Emit side-exit too: the suspend helper has

--- a/src/jit/translate/terminator.rs
+++ b/src/jit/translate/terminator.rs
@@ -187,9 +187,21 @@ impl<'a> FunctionTranslator<'a> {
                 );
                 let rt = builder.inst_results(call)[0];
                 let rp = builder.inst_results(call)[1];
-                // Pop AFTER elle_jit_yield: the suspend helper has already cloned
-                // the live activation map into the resume frame.
-                self.emit_pop_then_return(builder, rt, rp)?;
+                // An ERROR emit parks no frame — nothing resumes to run the rest
+                // of these instructions — so this activation is abandoned and
+                // runs the releases it still owed. The signal is a compile-time
+                // constant, so a suspending emit skips the walk's spill entirely
+                // rather than paying for a call that would decline it.
+                //
+                // The walk goes AFTER `elle_jit_yield`, which installs the
+                // payload and records its mint, so it reads both. The pop goes
+                // after them both: the suspend helper has already cloned the live
+                // activation map into the resume frame.
+                if signal.intersects(crate::value::fiber::SIG_ERROR) {
+                    self.emit_abandoned_error_return(builder, rt, rp)?;
+                } else {
+                    self.emit_pop_then_return(builder, rt, rp)?;
+                }
             }
 
             Terminator::Unreachable => {

--- a/src/jit/vtable.rs
+++ b/src/jit/vtable.rs
@@ -146,6 +146,9 @@ pub(crate) struct RuntimeHelpers {
     /// Free the current activation's owner node at the compiled `Return` path —
     /// the JIT twin of the interpreter trampoline's clean-break release.
     pub(crate) release_activation_owner_node: FuncId,
+    /// Run the releases this compiled activation still owed at an **error** exit
+    /// — the compiled entry to the interpreter's abandoned-frame walk.
+    pub(crate) release_abandoned_frame: FuncId,
     /// Free a co-owned region group as one unit — the `FreeRegionGroup`
     /// instruction's JIT helper, mirroring `handle_free_region_group`.
     pub(crate) free_region_group: FuncId,
@@ -448,6 +451,10 @@ pub(crate) fn register_symbols(builder: &mut JITBuilder) {
     builder.symbol(
         "elle_jit_release_activation_owner_node",
         dispatch::elle_jit_release_activation_owner_node as *const u8,
+    );
+    builder.symbol(
+        "elle_jit_release_abandoned_frame",
+        dispatch::elle_jit_release_abandoned_frame as *const u8,
     );
     builder.symbol(
         "elle_jit_free_region_group",

--- a/src/jit/vtable/helpers.rs
+++ b/src/jit/vtable/helpers.rs
@@ -249,6 +249,15 @@ pub(crate) fn declare_helpers(module: &mut JITModule) -> Result<RuntimeHelpers, 
             "elle_jit_release_activation_owner_node",
             &make_sig(module, &[I64], &[]),
         )?,
+        // release_abandoned_frame: (vm, slots_ptr, num_slots, regions_ptr,
+        // num_regions, locals_ptr, num_locals) -> () — the two release tables
+        // the prologue materialized, plus the frame's locals spilled in slot
+        // order for the value route.
+        release_abandoned_frame: declare(
+            module,
+            "elle_jit_release_abandoned_frame",
+            &make_sig(module, &[I64, I64, I64, I64, I64, I64, I64], &[]),
+        )?,
         // free_region_group: (members_ptr, count, vm) -> () — the members are
         // spilled to a stack slot as Value pairs, exactly like push_param_frame.
         free_region_group: declare(

--- a/src/lir/AGENTS.md
+++ b/src/lir/AGENTS.md
@@ -76,7 +76,8 @@ The rules the fixture holds:
    instructions do not justify.
 
 The remaining setters — `name`, `signal`, `num_captures`, `num_locals`,
-`num_params`, `closure_id`, `yield_points` — write the like-named field.
+`num_params`, `closure_id`, `yield_points`, `call_sites` — write the like-named
+field.
 Fields with no setter are public on the built `LirFunction`: set them on the
 result, as the JIT's arity and `vararg_kind` tests do.
 

--- a/src/lir/testkit.rs
+++ b/src/lir/testkit.rs
@@ -17,8 +17,8 @@
 //! the instructions do not justify says so with [`LirFixture::num_regs`].
 
 use crate::lir::{
-    for_each_def, for_each_terminator_use, for_each_use, BasicBlock, ClosureId, Label, LirFunction,
-    LirInstr, Reg, SpannedInstr, SpannedTerminator, Terminator, YieldPointInfo,
+    for_each_def, for_each_terminator_use, for_each_use, BasicBlock, CallSiteInfo, ClosureId,
+    Label, LirFunction, LirInstr, Reg, SpannedInstr, SpannedTerminator, Terminator, YieldPointInfo,
 };
 use crate::signals::Signal;
 use crate::syntax::Span;
@@ -77,6 +77,14 @@ impl LirFixture {
 
     pub(crate) fn yield_points(mut self, yield_points: Vec<YieldPointInfo>) -> Self {
         self.func.yield_points = yield_points;
+        self
+    }
+
+    /// The per-call-site resume metadata a suspending function's backends index
+    /// by call-site number. A `Call` inside a `may_suspend` function needs one
+    /// entry per site, or the JIT's yield check fails translation.
+    pub(crate) fn call_sites(mut self, call_sites: Vec<CallSiteInfo>) -> Self {
+        self.func.call_sites = call_sites;
         self
     }
 

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -301,6 +301,13 @@ mod lifecycle;
 mod region;
 mod resume;
 
+/// Where a tier keeps the local slots the abandoned-frame walk reads — named
+/// here because the compiled entry (`elle_jit_release_abandoned_frame`) picks
+/// the variant the interpreter never uses. That entry is the only reader, so a
+/// build without the compiled tier does not name the type here at all.
+#[cfg(feature = "jit")]
+pub(crate) use region::FrameLocals;
+
 impl VM {
     /// Access the root heap.
     #[inline]

--- a/src/vm/core/region.rs
+++ b/src/vm/core/region.rs
@@ -1,6 +1,35 @@
 use super::*;
 use crate::value::fiberheap::regionstore::RegionMint;
 
+/// Where the abandoned-frame walk reads a value route's slot
+/// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+/// still owes"). Both tiers name the slot the same way — the table is the
+/// function's — and differ only in where slot `s` lives.
+#[derive(Clone, Copy)]
+pub(crate) enum FrameLocals<'a> {
+    /// An interpreter activation: slot `s` is `fiber.stack[base + s]`. The walk
+    /// stamps it nil as it releases, exactly as the abandoned instruction would.
+    Stack(usize),
+    /// A compiled activation: slot `s` is `spill[s]`, the frame's Cranelift
+    /// local spilled at the error exit. The frame returns as the walk completes,
+    /// so there is no slot left to stamp and none is written back.
+    ///
+    /// `elle_jit_release_abandoned_frame` is its only constructor, so a build
+    /// without the compiled tier never reaches this arm.
+    #[cfg_attr(not(feature = "jit"), allow(dead_code))]
+    Spilled(&'a [Value]),
+}
+
+impl FrameLocals<'_> {
+    /// The value slot `slot` holds, or `None` where the frame has no such slot.
+    fn get(&self, vm: &VM, slot: u16) -> Option<Value> {
+        match self {
+            FrameLocals::Stack(base) => vm.fiber.stack.get(base + slot as usize).copied(),
+            FrameLocals::Spilled(spill) => spill.get(slot as usize).copied(),
+        }
+    }
+}
+
 impl VM {
     /// Resolve a static region slot to a **fresh** physical region for an
     /// allocation that has a matching compiler-emitted `DecrefRegion` at its
@@ -351,19 +380,29 @@ impl VM {
             .and_then(|frame| frame.remove(&static_id.get()))
             .map(|m| m.region)
     }
+    /// The interpreter's entry to the abandoned-frame walk: the tables come off
+    /// the executing `Code`, and slot `s` lives on this activation's frame stack.
+    pub(crate) fn release_abandoned_frame(&mut self, code: &crate::value::Code, payload: Value) {
+        let base = self.current_frame_base();
+        let slots = code.frame_release_slots.clone();
+        let regions = code.frame_release_regions.clone();
+        self.release_abandoned(&slots, &regions, payload, FrameLocals::Stack(base));
+    }
+
     /// Run the releases an activation abandoned by an **error** still owed
     /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
     /// still owes").
     ///
     /// An error leaves through the signal machinery, so none of the frame's
     /// remaining instructions run — and every release it still owed is among
-    /// them. `Code::frame_release_slots` names each one by the local slot its
-    /// value route reads: the route is `LoadLocal s; DecrefValueRegion;
-    /// StoreLocal s nil`, so a slot still holding a heap value is a release that
-    /// did not run, and releasing what it holds is exactly what the abandoned
-    /// instruction would have done. The stamp is repeated here for the same
-    /// reason the route stamps it — a slot released twice is an over-free.
-    /// [`Self::release_abandoned_regions`] is the same reading of the other route.
+    /// them. `slots` names each value route by the local slot it reads: the route
+    /// is `LoadLocal s; DecrefValueRegion; StoreLocal s nil`, so a slot still
+    /// holding a heap value is a release that did not run, and releasing what it
+    /// holds is exactly what the abandoned instruction would have done. On an
+    /// interpreter frame the stamp is repeated here for the same reason the route
+    /// stamps it — a slot released twice is an over-free.
+    /// [`Self::release_abandoned_regions`] is the same reading of the other route,
+    /// off `regions`.
     ///
     /// `payload` is the value leaving with the signal. Where the raise did NOT
     /// mint the delivery — a native hands back a value read out of an argument,
@@ -371,21 +410,26 @@ impl VM {
     /// reference IS the delivery, so a slot naming the payload's region is
     /// skipped and its release stays owed. An emit-raised error minted the
     /// delivery itself (`Fiber::emit_delivery`), so nothing is exempt and the
-    /// frame's reference is reclaimed here
-    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases
-    /// it still owes").
-    pub(crate) fn release_abandoned_frame(&mut self, code: &crate::value::Code, payload: Value) {
-        self.release_abandoned_regions(code, payload);
-        if code.frame_release_slots.is_empty() {
+    /// frame's reference is reclaimed here.
+    ///
+    /// Both tiers walk here. The compiled tier arrives through
+    /// `elle_jit_release_abandoned_frame`, which reads the tables out of the stack
+    /// slots its prologue materialized and hands the frame's locals over spilled.
+    pub(crate) fn release_abandoned(
+        &mut self,
+        slots: &[u16],
+        regions: &[u32],
+        payload: Value,
+        locals: FrameLocals<'_>,
+    ) {
+        self.release_abandoned_regions(regions, payload);
+        if slots.is_empty() {
             return;
         }
         let heap = unsafe { &mut *self.heap_ptr };
         let payload_region = self.unminted_payload_region(heap, payload);
-        let base = self.current_frame_base();
-        let slots = code.frame_release_slots.clone();
-        for slot in slots.iter() {
-            let index = base + *slot as usize;
-            let Some(value) = self.fiber.stack.get(index).copied() else {
+        for &slot in slots {
+            let Some(value) = locals.get(self, slot) else {
                 continue;
             };
             let heap = unsafe { &mut *self.heap_ptr };
@@ -395,8 +439,10 @@ impl VM {
             if payload_region == Some(region) {
                 continue;
             }
-            self.fiber.stack[index] = Value::NIL;
-            Self::freelog_abandoned("value route", *slot as u32, region);
+            if let FrameLocals::Stack(base) = locals {
+                self.fiber.stack[base + slot as usize] = Value::NIL;
+            }
+            Self::freelog_abandoned("value route", slot as u32, region);
             self.heap().decref_region(region);
         }
     }
@@ -437,8 +483,8 @@ impl VM {
     /// frame-replacing tail call, so it can also hold a caller's leftovers, whose
     /// references the callee's own machinery answers for; naming only this
     /// function's slots leaves those out by construction.
-    fn release_abandoned_regions(&mut self, code: &crate::value::Code, payload: Value) {
-        if code.frame_release_regions.is_empty() {
+    fn release_abandoned_regions(&mut self, regions: &[u32], payload: Value) {
+        if regions.is_empty() {
             return;
         }
         let heap = unsafe { &mut *self.heap_ptr };
@@ -447,7 +493,7 @@ impl VM {
             let Some(frame) = self.fiber.activation_region_maps.last() else {
                 return;
             };
-            code.frame_release_regions
+            regions
                 .iter()
                 .filter_map(|slot| frame.get(slot).copied())
                 .filter(|m| payload_region != Some(m.region))
@@ -455,7 +501,7 @@ impl VM {
                 .collect()
         };
         if let Some(frame) = self.fiber.activation_region_maps.last_mut() {
-            for slot in code.frame_release_regions.iter() {
+            for slot in regions {
                 frame.remove(slot);
             }
         }

--- a/src/vm/core/region/tests.rs
+++ b/src/vm/core/region/tests.rs
@@ -157,6 +157,111 @@ fn unmerged_slot_mints_fresh_each_execution() {
     });
 }
 
+// ── the abandoned-frame walk over a COMPILED frame's spilled locals
+// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+// still owes") ──
+//
+// A compiled frame keeps its locals in registers, so its error exit spills them
+// and the walk reads slot `s` out of `spill[s]` instead of off the fiber stack.
+// These drive `FrameLocals::Spilled` directly: the table names the release, the
+// spill supplies the value, and the payload exemption reads exactly as it does
+// on the interpreter side.
+
+/// Allocate a pair in a fresh region of its own, returning `(value, region)`.
+fn owned_pair(vm: &mut VM) -> (Value, RuntimeRegion) {
+    use crate::value::heap::{HeapObject, Pair};
+    let heap = unsafe { &mut *vm.heap_ptr };
+    crate::value::arena::alloc_in_fresh_region(
+        heap,
+        HeapObject::Pair(Pair::new(Value::int(1), Value::NIL)),
+    )
+}
+
+#[test]
+fn a_compiled_frames_spilled_locals_run_the_value_route() {
+    crate::value::arena::with_test_region(|| {
+        let mut vm = VM::new();
+        vm.push_activation_region_map();
+        let (held, region) = owned_pair(&mut vm);
+        // Slot 1 holds it; slot 0 is nil, as an already-run release reads.
+        let spill = [Value::NIL, held];
+        vm.release_abandoned(&[1], &[], Value::NIL, FrameLocals::Spilled(&spill));
+        assert_eq!(
+            vm.heap().region_rc(region),
+            0,
+            "a value route the compiled frame still owed must run off the \
+             spilled local its table names",
+        );
+    });
+}
+
+/// The counter-factual for the test above: the walk runs the releases the TABLE
+/// names, not everything the frame spilled. A slot missing from the table is a
+/// route the emitter declined, and the frame owes nothing for it.
+#[test]
+fn a_compiled_frames_spilled_walk_runs_only_the_tabled_slots() {
+    crate::value::arena::with_test_region(|| {
+        let mut vm = VM::new();
+        vm.push_activation_region_map();
+        let (held, region) = owned_pair(&mut vm);
+        let spill = [Value::NIL, held];
+        vm.release_abandoned(&[0], &[], Value::NIL, FrameLocals::Spilled(&spill));
+        assert_eq!(
+            vm.heap().region_rc(region),
+            1,
+            "slot 1 is not in the table, so its region keeps the frame's reference",
+        );
+    });
+}
+
+#[test]
+fn a_compiled_frames_spilled_walk_skips_an_unminted_payload() {
+    crate::value::arena::with_test_region(|| {
+        let mut vm = VM::new();
+        vm.push_activation_region_map();
+        let (payload, region) = owned_pair(&mut vm);
+        let spill = [payload];
+        // A native raise installs the payload with no retain of its own, so the
+        // frame's reference IS the delivery and its release stays owed.
+        vm.fiber.emit_delivery = None;
+        vm.release_abandoned(&[0], &[], payload, FrameLocals::Spilled(&spill));
+        assert_eq!(
+            vm.heap().region_rc(region),
+            1,
+            "the skipped release is the delivery the catcher reads the payload by",
+        );
+        // An emit-raised error minted the delivery itself, so nothing is exempt.
+        vm.fiber.emit_delivery = Some(payload);
+        vm.release_abandoned(&[0], &[], payload, FrameLocals::Spilled(&spill));
+        assert_eq!(
+            vm.heap().region_rc(region),
+            0,
+            "a recorded mint funds the delivery, so the frame's own reference is \
+             reclaimed by the compiled walk too",
+        );
+    });
+}
+
+/// The slot route needs no spill: its receipt is the activation region map, which
+/// a compiled prologue pushes and `elle_jit_resolve_alloc_region` records into.
+/// A slot still mapped when the frame is abandoned is a release that did not run.
+#[test]
+fn a_compiled_frames_walk_runs_the_slot_route_off_the_activation_map() {
+    crate::value::arena::with_test_region(|| {
+        let mut vm = VM::new();
+        vm.push_activation_region_map();
+        let slot = StaticRegion::new(9).expect("nonzero slot");
+        let region = vm.runtime_region_for_alloc_slot(slot);
+        vm.release_abandoned(&[], &[slot.get()], Value::NIL, FrameLocals::Spilled(&[]));
+        assert_eq!(
+            vm.heap().region_rc(region),
+            0,
+            "a `DecrefRegion` the compiled frame never reached must run off the \
+             mapping its alloc minted",
+        );
+    });
+}
+
 #[cfg(debug_assertions)]
 #[test]
 #[should_panic(expected = "RegionEffect::Immediate")]

--- a/src/vm/execute.rs
+++ b/src/vm/execute.rs
@@ -356,8 +356,24 @@ impl VM {
         // (docs/impl/region/mechanism.md § "An abandoned frame runs the releases
         // it still owes").
         let parks_error_frame = std::mem::take(&mut self.pending_error_park);
+        // The depth this activation's push lands on. Every activation the body
+        // enters — interpreted or compiled — must have handed its own frame back
+        // by the time control returns here, or `last()` names a callee's leftover
+        // map and this activation's slot-routed releases resolve against the
+        // wrong frame (docs/impl/region/rules.md Rule 4).
+        #[cfg(debug_assertions)]
+        let entry_depth = self.fiber.activation_region_maps.len();
         self.push_activation_region_map();
         let mut result = self.trampoline_loop(code, closure_env, 0, !parks_error_frame);
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            self.fiber.activation_region_maps.len(),
+            entry_depth + 1,
+            "region-remap frames left unbalanced by this activation's body: \
+             entered at depth {entry_depth}, returned at depth {} (one exit path \
+             pushed without popping)",
+            self.fiber.activation_region_maps.len(),
+        );
         if !result.bits.is_empty() {
             result.activation_region_map = self
                 .fiber

--- a/tests/elle/oracle.lisp
+++ b/tests/elle/oracle.lisp
@@ -244,7 +244,7 @@
                     "del-wrapper" "set-del-wrapper" "set-add"])
 (declare-root :f2 ["fiber-nested" "multi-resume" "yield-discard"
                    "yield-multimut" "protect-while" "denied-discard"
-                   "cancel-discard" "error-payload-helper"])
+                   "cancel-discard"])
 # `abort-discard` is a CLOSED control now (undeclared, like `rest-array-copy`, so a
 # regression to open trips the completeness gate loudly rather than being absorbed
 # back under F2): what it measured was the borrowed-argument
@@ -1311,12 +1311,10 @@
    # `error-payload-helper` calls its raiser as a STATEMENT: a bare call in the
    # try body is a frame-replacing tail call, which lands in the parked frame like
    # `error-payload` — only the non-tail call leaves a callee frame for the walk.
-   # Its pin is a cross-tier RANGE, and it is DECLARED under F2 rather than a
-   # closed control: the walk is interpreter machinery, and a compiled frame's
-   # error exit walks nothing (docs/impl/region/mechanism.md § "An abandoned frame
-   # runs the releases it still owes"), so the same shape reads 0 under --jit=off
-   # and one region per raise under --jit=eager. The pinned range is that gap's
-   # gauge; closing the JIT side shrinks it to 0.
+   # Its pin is CROSS-TIER at 0: both tiers walk the abandoned frame, the compiled
+   # one off the tables its prologue materialized and the locals it spills at the
+   # exit, so the rate agrees under --jit=off and --jit=eager. The compiled face
+   # has its own gauge in tests/elle/region-jit-error-unwind.lisp.
    ["error-payload"
     (fn [j]
       (try
@@ -1328,7 +1326,7 @@
         (begin
           (ep-raiser j)
           nil)
-        (catch e nil))) [0 1]]
+        (catch e nil))) 0]
    ["error-payload-param"
     (fn [j]
       (try

--- a/tests/elle/region-jit-error-unwind-uaf.lisp
+++ b/tests/elle/region-jit-error-unwind-uaf.lisp
@@ -1,0 +1,126 @@
+(elle/epoch 12)
+# Soundness complement of tests/elle/region-jit-error-unwind.lisp: a COMPILED
+# frame's error exit must release only what that frame owed
+# (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+# still owes"). Run under `--trace=guardfree` by the subprocess pin
+# `region_jit_error_unwind_uaf` in tests/integration/elle_scripts.rs.
+#
+# The compiled walk reads its value route off the locals the exit spilled and
+# its slot route off the activation map the prologue pushed, then pops that map.
+# What must survive is every reference the walk does not own: the delivery the
+# catcher reads, a counted store's, a borrowed payload's owner, and — the
+# reference the map pop answers for — the CALLER's own binding, live across a
+# compiled callee's walked exit.
+#
+# Every read below happens after the walk ran, so an over-release faults at the
+# deref under guardfree or trips the generation check.
+
+# The raisers must be compiled for the walk under test to be the compiled one,
+# and the compile is asynchronous, so the drive outlasts it. The cap only bounds
+# that wait, and a policy that compiles nothing would pay it in full for no
+# coverage — so the warm-up is skipped outright when the JIT is off, and the
+# window below still gauges the interpreter walk.
+(def jit-live? (not (= (vm/config :jit) :off)))
+(def warm-cap 20000)
+(def window 200)
+
+(def shared {:error :shared :message "borrowed"})
+(def kept @[])
+
+# ── the raisers ───────────────────────────────────────────────────────────────
+
+(defn ep-raise [j]
+  (error (string "payload-" j)))
+
+(defn raise-shared [j]
+  (error shared))
+
+# Stores into a container that outlives the frame, THEN raises: the store funnel
+# counted the sink's reference, so the walk's release of the frame's own cannot
+# take the value below it.
+(defn stores-then-raises [j]
+  (let [v (string "kept-" j)]
+    (begin
+      (push kept v)
+      (error (string "boom-" j)))))
+
+# ── the subjects ──────────────────────────────────────────────────────────────
+
+# 1. The catcher reads the payload the compiled raiser allocated. The raise
+# minted the delivery itself, so the frame's own reference IS released — and the
+# delivery must be what is left.
+(defn catch-reads [j]
+  (try
+    (begin
+      (ep-raise j)
+      0)
+    (catch e (string/size-of e))))
+
+# 2. The stored value must read whole after the raising frame is gone.
+(defn store-survives [j]
+  (try
+    (begin
+      (stores-then-raises j)
+      nil)
+    (catch e nil))
+  (string/size-of (pop kept)))
+
+# 3. The raise chain owns no reference of a module-level payload, so the walk
+# must release nothing for it however many times it is raised.
+(defn borrowed-survives [j]
+  (try
+    (begin
+      (raise-shared j)
+      0)
+    (catch e (string/size-of (get e :message)))))
+
+# 4. The caller's binding is live across the COMPILED callee's walked error
+# exit. The callee's walk names only the callee's slots, and the map it reads is
+# its own — which is also what its exit pops, so the caller's later releases
+# resolve against the caller's map and not the callee's leftovers.
+(defn holds-across-catch [j]
+  (let [held (string "held-" j)]
+    (begin
+      (try
+        (begin
+          (ep-raise j)
+          nil)
+        (catch e nil))
+      (string/size-of held))))
+
+# ── the drive ─────────────────────────────────────────────────────────────────
+
+# The RAISERS are the compiled frames: a body holding a `try` is not a JIT
+# candidate, so each subject below wraps its raiser in an interpreted catcher and
+# the walk under test is the raiser's own.
+(defn all-hot? []
+  (and (jit? ep-raise) (jit? raise-shared) (jit? stores-then-raises)))
+
+(defn check [j]
+  (assert (< 0 (catch-reads j))
+          "the delivery the catcher reads must survive the compiled walk")
+  (assert (< 0 (store-survives j))
+          "a value the compiled frame stored outward must survive its walk")
+  (assert (< 0 (borrowed-survives j))
+          "a borrowed payload's owner must survive the compiled walk")
+  (assert (< 0 (holds-across-catch j))
+          "the caller's binding must survive a compiled callee's walked exit"))
+
+(var i 0)
+(while (and jit-live? (%lt i warm-cap) (not (all-hot?)))
+  (check i)
+  (assign i (%add i 1)))
+
+(def hot (all-hot?))
+
+(var k 0)
+(while (%lt k window)
+  (check k)
+  (assign k (%add k 1)))
+
+(assert (= (get shared :message) "borrowed")
+        "the module binding must be whole after every raise")
+(assert (= (length kept) 0)
+        "each stored payload is read back, so the sink stays bounded")
+
+(println "region-jit-error-unwind-uaf: ok (compiled " hot ")")

--- a/tests/elle/region-jit-error-unwind.lisp
+++ b/tests/elle/region-jit-error-unwind.lisp
@@ -1,0 +1,128 @@
+(elle/epoch 12)
+# A COMPILED frame's error exit runs the releases it still owes
+# (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+# still owes").
+#
+# An error leaves through the signal machinery on either tier, so none of the
+# frame's remaining instructions run and every release it still owed is among
+# them. The walk that runs them belongs to the runtime, not to the interpreter:
+# a compiled frame reads its value route off the locals it spills at the exit
+# and its slot route off the activation map its prologue pushed.
+#
+# This file is the COMPILED face of that gauge. The interpreter face is
+# tests/elle/region-error-unwind.lisp, which raises natively; every raise here is
+# an `(error v)`, whose `Emit` mints the payload's delivery itself, so nothing
+# in the raising frame is exempt and its own reference is owed too.
+#
+# One subject per compiled error exit:
+#
+#   - `raise-owned` leaves through the `Emit` of `SIG_ERROR` itself. It parks no
+#     frame, so the activation is abandoned where it stands, holding the string
+#     it built for the payload.
+#   - `caller-holds` leaves through the check after the call that raised,
+#     holding a binding whose last use lies past that call.
+#
+# Each subject is driven until `jit?` reports it compiled, so the measured
+# window is the compiled tier's. Under `--jit=off` nothing compiles, `jit?`
+# stays false, and the same window gauges the interpreter walk.
+
+(def window 500)
+# The compile is asynchronous under `--jit=eager`: the worker installs while the
+# interpreter keeps running the function, so the drive must outlast the compile
+# rather than assume it. The cap only bounds that wait, and a policy that
+# compiles nothing would pay it in full for no coverage — so the warm-up is
+# skipped outright when the JIT is off, and the window below still gauges the
+# interpreter walk.
+(def jit-live? (not (= (vm/config :jit) :off)))
+(def warm-cap 20000)
+
+# subjects ─────────────────────────────────────────────────────────────────────
+
+(defn raise-owned [j]
+  (error (string "x" j)))
+
+# The raise is a STATEMENT here: a bare call in the try body would be a
+# frame-replacing tail call, which lands in the parked body frame instead of
+# leaving a callee frame to walk.
+(defn drive-raise [j]
+  (try
+    (begin
+      (raise-owned j)
+      nil)
+    (catch e nil)))
+
+(defn caller-holds [j]
+  (let [held (string "h" j)]
+    (begin
+      (raise-owned j)
+      held)))
+
+(defn drive-holds [j]
+  (try
+    (begin
+      (caller-holds j)
+      nil)
+    (catch e nil)))
+
+# control ──────────────────────────────────────────────────────────────────────
+
+# The same allocation and the same binding with NO raise: the ordinary releases
+# run. A subject that reads like this one is measuring the abandoned release and
+# not its own scratch.
+(defn holds-no-raise [j]
+  (let [held (string "h" j)]
+    (string/size-of held)))
+
+(defn drive-none [j]
+  (try
+    (begin
+      (holds-no-raise j)
+      nil)
+    (catch e nil)))
+
+# measurement ──────────────────────────────────────────────────────────────────
+
+(defn all-hot? []
+  (and (jit? raise-owned) (jit? caller-holds) (jit? holds-no-raise)))
+
+# One interleaved drive, not three waits: the first pass submits every subject
+# and the worker installs them all while the loop keeps running, so the whole
+# warm-up costs one compile latency instead of three.
+(defn warm []
+  (var i 0)
+  (while (and jit-live? (%lt i warm-cap) (not (all-hot?)))
+    (drive-raise i)
+    (drive-holds i)
+    (drive-none i)
+    (assign i (%add i 1)))
+  (all-hot?))
+
+(defn measure [thunk window]
+  (def before (arena/count))
+  (var j 0)
+  (while (%lt j window)
+    (thunk j)
+    (assign j (%add j 1)))
+  (%sub (arena/count) before))
+
+(def hot (warm))
+(def d-raise (measure drive-raise window))
+(def d-holds (measure drive-holds window))
+(def d-none (measure drive-none window))
+
+(println "region-jit-error-unwind over " window
+         " iters (object deltas, compiled " hot "):")
+(println "  raise-owned  " d-raise)
+(println "  caller-holds " d-holds)
+(println "  no-raise     " d-none " (control)")
+
+(assert (%lt d-none 50)
+        (concat "control: the same values with no raise reclaim normally, "
+                "delta=" (number->string d-none)))
+(assert (%lt d-raise 50)
+        (concat "the emit-raised payload's own region is a release the raising "
+                "frame still owed, delta=" (number->string d-raise)))
+(assert (%lt d-holds 50)
+        (concat "a binding live across the raising call is owed a release by "
+                "the frame the raise unwinds, delta=" (number->string d-holds)))
+(println "region-jit-error-unwind: ok")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -647,6 +647,24 @@ fn region_error_payload_uaf() {
     );
 }
 
+// Guard — the COMPILED face of the same walk: a compiled frame's error exit
+// reads its value route off the locals it spilled there and its slot route off
+// the activation map its prologue pushed, then pops that map
+// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+// still owes"). What must survive is every reference the walk does not own: the
+// delivery the catcher reads, a counted store's, a borrowed payload's owner,
+// and the CALLER's binding live across the compiled callee's exit — the one the
+// map pop answers for, since a leftover callee map would resolve the caller's
+// releases against the wrong frame. Eager JIT, so the raisers are compiled
+// before the reads. The leak face is `region-jit-error-unwind.lisp`.
+#[test]
+fn region_jit_error_unwind_uaf() {
+    run_elle_script_with_args(
+        "region-jit-error-unwind-uaf",
+        &["--jit=eager", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — a `def` evaluates to what it bound, so its initializer's demise must
 // not be narrowed onto the initializer when nothing reads the binding
 // (docs/impl/region/mechanism.md § "A binder's init release lands after the slot


### PR DESCRIPTION
An error leaves through the signal machinery, so none of the frame's remaining
instructions run and every release it still owed is among them. The interpreter
runs them at the exit, off the two tables the emitter records per function. A
compiled frame ran none of them, so a JIT-compiled callee that owns its error
payload stranded one region per raise — per raise in a loop, which is what a
compiled retry loop grows by.

```
(defn raiser [j] (error (string "x" j)))
(try (begin (raiser j) nil) (catch e nil))
→ 0 regions per raise under --jit=off
→ 1 region  per raise under --jit=eager     (before)
→ 0 regions per raise on both tiers         (after)
```

## What changed

Both tiers now reach the same walk. `VM::release_abandoned` takes the two tables
and a `FrameLocals`, which says where slot `s` lives: on the interpreter's frame
stack, or in the buffer a compiled exit spilled. Nothing is spilled back — the
compiled frame returns as the walk completes, so the nil stamp that is the
interpreter's receipt has no compiled counterpart and needs none, since a table
names each slot once.

`elle_jit_release_abandoned_frame` is the compiled entry. The tables are
compile-time constants, so the prologue materializes them into stack slots and
every error exit hands the runtime both, with the frame's locals spilled in slot
order. The slot route needs no spill: its receipt is the activation region map
the prologue pushed, read ahead of the matching pop — which the error path now
also runs, so a caller's own releases resolve against the caller's map and not a
callee's leftovers.

A compiled frame leaves by an error at two points, and
`emit_abandoned_error_return` is the one route out of both: the check after a
call, which finds the callee's raise, and an `Emit` of `SIG_ERROR`, which parks
no frame to resume. A compiled frame is never one a restart replays — a fiber
body's first run enters through `execute_bytecode_saving_stack` and compiled
code is reached only from a call site inside it — so `VM::pending_error_park`
has no compiled reader.

The walk reads `last()` expecting this activation's own map, so
`execute_bytecode_saving_stack` now asserts in debug builds that the body it ran
left the remap stack at the depth it entered on. The compiled error path that
returned without popping trips it at the first caught error.

## Tests

- `tests/elle/region-jit-error-unwind.lisp` — the compiled leak gauge, one
  subject per compiled error exit, driven until `jit?` reports the subjects
  compiled. It reads 500 and 1000 leaked objects over a 500-iteration window
  before the fix and 0 after, with a no-raise control at 0 throughout.
- `tests/elle/region-jit-error-unwind-uaf.lisp` and the
  `region_jit_error_unwind_uaf` subprocess pin — the guardfree complement: the
  delivery the catcher reads, a counted store's, a borrowed payload's owner, and
  the caller's binding live across a compiled callee's exit.
- `vm::core::region::tests::a_compiled_frames_*` — the walk over spilled locals,
  including the payload exemption in both directions and a slot-route face.
- `jit::dispatch::tests::release_abandoned_frame_runs_both_routes_off_the_compiled_exits_buffers`
  — the helper ABI, with the two tables at their different widths.

The `error-payload-helper` oracle probe's cross-tier range pin shrinks from
`[0 1]` to `0`, and it leaves the F2 roots for the closed controls beside it.

Closes #920.
