### PR TITLE
lir: a relocated release stays behind a read through the cell it frees

### DIFF
--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1164,6 +1164,57 @@ the box through `LoadCaptureRaw` + `DecrefCellRegion`, and it is already frame-h
 because the binding names its own region (§ "A mutated holder poisons its value
 route, not its cell box").
 
+### A move that crosses a read through the cell it frees is declined
+
+A captured binding's value and its env cell are addressed by one env index, and
+they are two **regions**. The relocation decides per region, so the pair can get
+different answers, and moving one of them alone inverts the order between them.
+The value release loads the box RAW and lets `result_region_of` unwrap it, so it
+READS the page the box's `DecrefCellRegion` frees ([bindings.md](bindings.md) § "A
+cell's release lands at or after every release routed through that cell"). Move
+the cell's release ahead of the `TailCall` while the value's stays behind, and the
+unwrap reads a reclaimed page.
+
+The everyday split is the admission's own holder rule. It judges a region through
+the bindings that name it, so a value region **no binding names** is refused for
+want of a holder, while the cell region is admitted on its binding's verdict (§ "A
+compiled capture cell is frame-held exactly as its binding is"). An
+`Immediate`-effect native's result is such a region: the walk records no result
+region for the call, and the lowerer still routes the binding's release through the
+env index.
+
+Neither reading the relocation already makes can see the inversion: the exemption
+asks what the CALL names and the admission asks whether the frame holds the region
+alone, and this obligation holds between two regions rather than between a region
+and the call. So the relocation asks one more question, of the window the move
+crosses rather than of the region: a run spliced from after the `TailCall` to
+before it crosses every instruction now between the two positions, and those
+instructions say whether the move inverts anything. A `DecrefCellRegion` naming an
+env index that some instruction in the window still reads — a `LoadCapture` or
+`LoadCaptureRaw` at that index — declines the move and stays where the lowerer put
+it.
+
+Reading the window is enough because the clamp already fixed the emission order:
+it puts the cell's `decref_point` at or after the value release's, and where both
+land on one point the release order sorts the deepest read first
+([rules.md](rules.md) Rule 4). So a value release that reads through the cell is
+already in the window when the cell release asks to move.
+
+Declining strands the box on the closure path — the bounded, always-legal fallback
+the relocation takes for every region it refuses, and one box per activation rather
+than a page freed under its own reader. The everyday shape is the closure-as-module
+whose last form is a struct literal over the closures its captured defs built:
+`(fn [] (def a (ptr/from-int 0)) (defn p [] a) {:p p})`. Pinned by
+`a_cell_release_declines_a_move_across_a_read_through_it`, beside the admitted face
+`reassigned_env_cell_release_precedes_the_frame_replacing_tail_call`, whose cell
+holds an immediate and so has no release routed through it at all.
+
+The order the clamp and this decline together hold is stated once more over the
+finished emission, as a debug-only walk of every block
+(`lir::lower::assert_cells_outlive_their_readers`). Each mechanism can only see its
+own half, so a block that frees a cell before a read through it names a gap in
+either.
+
 ### What the exemption keeps, a channel must still run
 
 The exemption states its reason positively: the callee's own region keeps its place

--- a/src/lir/lower/emitops.rs
+++ b/src/lir/lower/emitops.rs
@@ -494,7 +494,10 @@ impl<'a> Lowerer<'a> {
             let start = self.current_block.instructions.len();
             f(self);
             let moved: Vec<_> = self.current_block.instructions.drain(start..).collect();
-            if moved.is_empty() || !self.hoistable_run(0, &moved) {
+            if moved.is_empty()
+                || !self.hoistable_run(0, &moved)
+                || self.move_frees_a_cell_the_window_reads(at, &moved)
+            {
                 self.current_block.instructions.extend(moved);
                 return;
             }
@@ -588,6 +591,53 @@ impl<'a> Lowerer<'a> {
             }
         }
         stamped
+    }
+
+    /// Would moving `run` back to `at` free an env cell that the instructions it
+    /// crosses still read?
+    ///
+    /// The two refusals of [`Self::hoistable_run`] are about the region and the
+    /// call; this one is about two REGIONS. A captured binding's value and its box
+    /// share one env index, and the value's `DecrefValueRegion` loads the box RAW
+    /// and unwraps it — so it reads the page the box's `DecrefCellRegion` frees.
+    /// The relocation answers per region and can move one of the pair alone, which
+    /// inverts the order the `decref_point` clamp established
+    /// (docs/impl/region/bindings.md § "A cell's release lands at or after every
+    /// release routed through that cell").
+    ///
+    /// The window is everything from `at` to the end of the open block — the
+    /// `TailCall` and every release already emitted after it. Reading it is enough
+    /// because the clamp fixes the emission order: a release routed through the
+    /// cell is already in the window by the time the cell's own release asks to
+    /// move. Declining leaves the box release on the closure path, the same bounded
+    /// fallback every other refusal takes.
+    ///
+    /// The replica placement needs no such question: only a self-cancelling run is
+    /// replicated, and a cell release is not one ([`Self::self_cancelling_run`]).
+    fn move_frees_a_cell_the_window_reads(&self, at: usize, run: &[SpannedInstr]) -> bool {
+        let mut from_index: rustc_hash::FxHashMap<Reg, u16> = rustc_hash::FxHashMap::default();
+        let mut freed: rustc_hash::FxHashSet<u16> = rustc_hash::FxHashSet::default();
+        for i in run {
+            match &i.instr {
+                LirInstr::LoadCapture { dst, index } | LirInstr::LoadCaptureRaw { dst, index } => {
+                    from_index.insert(*dst, *index);
+                }
+                LirInstr::DecrefCellRegion { src } => {
+                    freed.extend(from_index.get(src).copied());
+                }
+                _ => {}
+            }
+        }
+        if freed.is_empty() {
+            return false;
+        }
+        self.current_block.instructions[at..].iter().any(|i| {
+            matches!(
+                &i.instr,
+                LirInstr::LoadCapture { index, .. } | LirInstr::LoadCaptureRaw { index, .. }
+                    if freed.contains(index)
+            )
+        })
     }
 
     /// May this just-emitted release run ahead of the tail call at point `index`?

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -778,7 +778,10 @@ impl<'a> Lowerer<'a> {
         let entry = std::mem::replace(&mut self.current_func, LirFunction::new(Arity::Exact(0)));
         let closures = std::mem::take(&mut self.closures);
 
-        Ok(LirModule { entry, closures })
+        let module = LirModule { entry, closures };
+        #[cfg(debug_assertions)]
+        assert_cells_outlive_their_readers(&module);
+        Ok(module)
     }
 
     /// Check if a HIR body is a tail call (or control flow where all result
@@ -828,6 +831,51 @@ impl<'a> Lowerer<'a> {
                 .iter()
                 .all(|(_, _, body)| Self::body_is_tail_call(body)),
             _ => false,
+        }
+    }
+}
+
+/// Debug-only: no block frees an env cell before an instruction that reads through
+/// that same cell.
+///
+/// A captured binding's value and its box are addressed by one env index, and the
+/// value's release loads the box RAW and unwraps it to the content — so it READS
+/// the page the box's `DecrefCellRegion` frees. Two mechanisms hold that order and
+/// neither can see the other: the `decref_point` clamp places the box release at or
+/// after every release routed through the cell (docs/impl/region/bindings.md § "A
+/// cell's release lands at or after every release routed through that cell"), and
+/// the frame-exit relocation declines a move that would carry the box release back
+/// across such a read (docs/impl/region/mechanism.md § "A move that crosses a read
+/// through the cell it frees is declined"). This states the property both exist to
+/// hold, over the finished emission where the two meet.
+#[cfg(debug_assertions)]
+fn assert_cells_outlive_their_readers(module: &LirModule) {
+    for f in std::iter::once(&module.entry).chain(module.closures.iter()) {
+        for b in &f.blocks {
+            let mut from_index: HashMap<Reg, u16> = HashMap::new();
+            let mut freed: HashMap<u16, usize> = HashMap::new();
+            for (idx, i) in b.instructions.iter().enumerate() {
+                match &i.instr {
+                    LirInstr::LoadCapture { dst, index }
+                    | LirInstr::LoadCaptureRaw { dst, index } => {
+                        from_index.insert(*dst, *index);
+                        if let Some(&at) = freed.get(index) {
+                            panic!(
+                                "env cell {index} is read at instruction {idx} of block \
+                                 {:?}, after the DecrefCellRegion at {at} freed the box \
+                                 — the read lands on a reclaimed page",
+                                b.label
+                            );
+                        }
+                    }
+                    LirInstr::DecrefCellRegion { src } => {
+                        if let Some(&index) = from_index.get(src) {
+                            freed.insert(index, idx);
+                        }
+                    }
+                    _ => {}
+                }
+            }
         }
     }
 }

--- a/src/lir/lower/tests/release/frameexit.rs
+++ b/src/lir/lower/tests/release/frameexit.rs
@@ -451,6 +451,90 @@ fn reassigned_env_cell_release_precedes_the_frame_replacing_tail_call() {
     );
 }
 
+/// Every place a block frees an env cell before something in that same block reads
+/// through it, as `(env index, release position, read position)`.
+///
+/// One reading serves both directions the pin needs: the release's own
+/// `LoadCaptureRaw` sits immediately BEFORE it, so a well-ordered block reports
+/// nothing, and any tuple here is a `DecrefCellRegion` that freed the box under a
+/// later unwrap of the same index.
+fn cell_release_inversions(module: &crate::lir::LirModule) -> Vec<(u16, usize, usize)> {
+    let funcs = std::iter::once(&module.entry).chain(module.closures.iter());
+    let mut out = Vec::new();
+    for f in funcs {
+        for b in &f.blocks {
+            let mut from_index: rustc_hash::FxHashMap<Reg, u16> = rustc_hash::FxHashMap::default();
+            let mut reads: Vec<(u16, usize)> = Vec::new();
+            let mut freed: Vec<(u16, usize)> = Vec::new();
+            for (idx, i) in b.instructions.iter().enumerate() {
+                match &i.instr {
+                    LirInstr::LoadCapture { dst, index }
+                    | LirInstr::LoadCaptureRaw { dst, index } => {
+                        from_index.insert(*dst, *index);
+                        reads.push((*index, idx));
+                    }
+                    LirInstr::DecrefCellRegion { src } => {
+                        freed.extend(from_index.get(src).map(|&index| (index, idx)));
+                    }
+                    _ => {}
+                }
+            }
+            for (index, at) in freed {
+                out.extend(
+                    reads
+                        .iter()
+                        .filter(|&&(i, r)| i == index && r > at)
+                        .map(|&(_, r)| (index, at, r)),
+                );
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn a_cell_release_declines_a_move_across_a_read_through_it() {
+    // The closure-as-module shape: `a` is a captured def, and the body's last form
+    // is a struct literal — a NATIVE tail call, so the dispatch loop falls through
+    // into the block after the `TailCall` and runs everything the lowerer put
+    // there.
+    //
+    // The trap is that `a`'s two releases are two REGIONS, and the relocation
+    // answers per region. `ptr/from-int` declares `RegionEffect::Immediate`, so the
+    // walk records no result region for the init and no binding names it — the
+    // frame-held admission refuses it for want of a holder, and its
+    // `DecrefValueRegion` keeps its place in the dead block. The env CELL is
+    // admitted on the binding's own verdict and moves ahead of the call. That value
+    // release loads the box RAW and unwraps it, so it reads the page the cell
+    // release frees (docs/impl/region/mechanism.md § "A move that crosses a read
+    // through the cell it frees is declined").
+    //
+    // The counter-factual: asserting only that some cell release precedes the
+    // `TailCall` passes on this witness while the box is freed under its own
+    // reader, because the move is exactly what the assertion asks for.
+    let module = compile_to_lir(
+        "(begin (def m (fn () \
+           (def a (ptr/from-int 0)) \
+           (def p (fn () a)) \
+           {:p p})) \
+         (m))",
+    );
+    let (at, releases) =
+        tail_call_cell_release_layout(&module).expect("the body lowers to a TailCall");
+    assert!(
+        releases.iter().all(|&r| r > at),
+        "the env cell's release was moved ahead of the TailCall \
+         (at={at}, releases={releases:?}) while the release routed through that \
+         cell stayed behind — the unwrap then reads a freed page",
+    );
+    let inversions = cell_release_inversions(&module);
+    assert!(
+        inversions.is_empty(),
+        "a cell is freed before a read through it; (env index, release, read) \
+         positions = {inversions:?}",
+    );
+}
+
 #[test]
 fn escaping_holder_env_cell_release_stays_after_the_tail_call() {
     // The decline face: the closure holding the cell is STORED into an aggregate


### PR DESCRIPTION
The frame-exit relocation decides per region. A captured binding's value and its
env cell are two regions, and they can get different answers.

An `Immediate` native's result is named by no binding, so the frame-held
admission has no holder to judge and refuses it: that `DecrefValueRegion` keeps
its place after the `TailCall`. The cell region is admitted on its binding's
verdict, so its `DecrefCellRegion` moves ahead of the call. The value release
loads the box raw and unwraps it, so it then reads the page the box release
already freed.

The witness is `lib/sqlite.lisp` — the closure-as-module shape whose last form is
a struct literal built by a native tail call. Before this change `cap[1]` and
`cap[2]` invert; every other index in the same block keeps the right order.

## The fix

Ask the window as well as the region. A run spliced from after the `TailCall` to
before it crosses every instruction between the two positions. A
`DecrefCellRegion` naming an env index that some instruction there still reads
declines the move and stays where the lowerer put it. Declining leaves the box
release on the closure path — the fallback the relocation already takes for every
region it refuses.

Reading the window is enough because the `decref_point` clamp already fixes the
emission order: a release routed through the cell is in the window by the time the
cell's own release asks to move.

## Tests

- `a_cell_release_declines_a_move_across_a_read_through_it` — a minimized
  closure-as-module witness. It fails before the fix (`the env cell's release was
  moved ahead of the TailCall (at=21, releases=[20])`) and passes after.
- `assert_cells_outlive_their_readers` — a debug-only walk of every finished
  block: no block frees an env cell before a read through that cell. The
  `decref_point` clamp and the relocation each hold one half of the order, and
  neither can see the other. Clean over the whole `.lisp` corpus.
- `docs/impl/region/mechanism.md` § "A move that crosses a read through the cell
  it frees is declined" owns the argument.

`make test ELLE=./target/release/elle CARGO_PROFILE=--release` exits 0.

Closes #905