### PR TITLE
regions: an injected abort payload arrives with its delivery minted

### DIFF
--- a/docs/impl/region/effects.md
+++ b/docs/impl/region/effects.md
@@ -208,18 +208,45 @@ Every primitive declares its region behavior in its `PrimitiveDef` as a
   balanced by the fiber's free-time signal scan, and a consumed one by the
   resumed frame's own accounting.
 
-  **What a delivered value still owes is owed by its RESULT.** A caught
-  `fiber/abort` hands the injected payload straight back to its caller, whose
-  `DecrefValueRegion` then fires on it alongside the separate release the caller
-  already owes it as an *argument* — and the unwinding child runs no `Return` to
-  fund the second. So the caught arm mints that reference
-  (`handle_fiber_abort_signal`), and only that arm: the uncaught arm pushes `nil`
-  and routes the payload through the signal, where no caller release targets it,
-  and an in-body handler that catches the error consumes the payload inside the
-  fiber and hands the caller a value of its own. Minting at the delivery instead
-  would strand a region per abort on both of those paths
-  (`tests/elle/region-fiber-abort-delivery-uaf.lisp` carries the over-free face
-  and the two placement faces).
+  **An injected error payload arrives unfunded, so the injection mints its
+  delivery.** Every other install of a terminal payload into a signal slot funds
+  itself: a raise mints (the `EmitEscape` retain, or a fresh error struct's birth
+  reference), and a re-park mints (`PropagateEscape`). `fiber/abort` and
+  `fiber/refuse` install a payload the CALLER owns, and the caller's one
+  reference answers the caller's *argument* release alone. Exactly one further
+  release fires on that payload as a RESULT, and which one depends on where the
+  injected error stops:
+
+  - the fiber's mask catches it, and the abort's caller releases the payload as
+    the call's result;
+  - a `protect` or `try` inside the fiber catches it, and that handler's release
+    of its own resume result consumes it;
+  - the error escapes the fiber, and the resume result of whichever ancestor
+    absorbs it consumes it;
+  - the unwinding replays a parked `defer`/`protect` frame, and that frame's
+    suspending call runs its compiler-emitted result release on it.
+
+  One reference, one consumer, four routes. So `inject_error_at_suspension` mints
+  it once at the seam all four leave through, and no route has to recognize
+  itself. Each route's own delivery mint is therefore absent: `do_fiber_abort`
+  hands the replayed frame the injection's reference rather than taking a
+  `ReturnValue` retain of its own, and the caught arm hands the caller the same
+  one.
+
+  The injection also RECORDS the mint, on both fibers whose frames the payload
+  travels through — the aborted fiber (`do_fiber_abort`) and, where the error
+  escapes, the aborting one (`VM::park_propagating_abort`). A frame holding the
+  payload then funds no delivery, so the abandoned-frame walk and the parked
+  frame's discharge stop exempting the payload's region, exactly as they do for
+  an emit raise ([mechanism.md](mechanism.md) § "An abandoned frame runs the
+  releases it still owes"). A literal materialized straight into the
+  `fiber/abort` argument lives in a frame slot and nowhere else, so without the
+  record its release stays owed forever (the `abort-discard` probe in
+  `tests/elle/oracle.lisp`).
+
+  `tests/elle/region-fiber-abort-delivery-uaf.lisp` carries a face per route: the
+  under-mint faults there under `--trace=guardfree`, and the over-mint shows as
+  region growth, since a spare reference never faults.
 - **`Mixed`** — examined, and the native stores arguments *uncounted*
   (the property the arg clique exists to cover) — and/or returns a result
   that is neither always-fresh nor always-pass-through (a trait-dispatching

--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1499,6 +1499,11 @@ walk may release, and the two raise paths differ:
   would strand one region per raised-and-caught error whose payload the raise chain
   owns. The raise records the mint (`Fiber::emit_delivery`), and a walk whose live
   signal payload matches it skips nothing.
+- An **injected** `fiber/abort` / `fiber/refuse` payload reads like the `Emit` case,
+  for the same reason: the injection mints the delivery
+  ([effects.md](effects.md) § `Delivers`) and records it on every fiber whose frames
+  the payload then travels through — the aborted one and, where the error escapes it,
+  the aborting one. A frame holding the payload owes its release like any other.
 
 The same reading governs the parked frame's discharge: `Fiber::take_parked_state`
 withholds its payload protection exactly where the mint is recorded, so the free-path

--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -238,11 +238,13 @@ parked fiber's accounting symmetric with its unpark:
   replay pushes. A normally-completing child funds it: its `Return` runs the
   ReturnValue retain before the result is handed up, and each frame of a replayed
   chain funds the next the same way. An **aborted** child's error exit runs no
-  `Return`, so `do_fiber_abort`'s delivery of the error payload into the remaining
-  parked frames takes that retain itself — without it the replay consumes a
-  reference the abort's caller still owns, and a fresh heap payload is freed under
-  the caller's read (a constant payload has no region, which is what kept the
-  theft invisible). Pinned by `region_fiber_abort_io_protect_uaf`
+  `Return`, and the reference the replay consumes is the one `fiber/abort`'s
+  injection minted for the payload — the replayed frame is one of the four
+  consumers that single mint answers for
+  ([effects.md](effects.md) § `Delivers`). Without a mint anywhere the replay
+  consumes a reference the abort's caller still owns, and a fresh heap payload is
+  freed under the caller's read (a constant payload has no region, which is what
+  kept the theft invisible). Pinned by `region_fiber_abort_io_protect_uaf`
   (`tests/integration/fixtures/region-fiber-abort-io-protect-uaf.lisp`);
   `tests/elle/grpc.lisp`'s `with-server` teardown is the full-scheduler witness.
   A **primitive** that suspends is the other frame with no `Return` to fund it, and

--- a/src/primitives/fiber_introspect.rs
+++ b/src/primitives/fiber_introspect.rs
@@ -201,6 +201,27 @@ fn inject_error_at_suspension(
     handle.with_mut(|fiber| {
         fiber.signal = Some((SIG_ERROR, error_value));
     });
+    // The DELIVERY reference. Every other install of a terminal payload into a
+    // signal slot funds itself — a raise mints, a re-park mints — but this one
+    // installs a payload the CALLER owns, and the caller's reference answers the
+    // caller's ARGUMENT release alone. Exactly one further release fires on the
+    // payload as a RESULT, and which one depends on where the injected error
+    // stops: the abort's caller when the fiber's mask catches it, an in-body
+    // `protect`'s resume result when the fiber catches it, the resume result of
+    // whichever ancestor absorbs it when it escapes, or a replayed cleanup
+    // frame's parked call when the unwinding runs one. One reference, one
+    // consumer, four routes — minting here, at the seam all four leave through,
+    // is what keeps any of them from having to recognize itself
+    // (docs/impl/region/effects.md § `Delivers`;
+    // `tests/elle/region-fiber-abort-delivery-uaf.lisp` carries a face per
+    // route). `region_of` no-ops an immediate payload.
+    let heap = ctx.heap_mut();
+    let region = crate::value::arena::region_of(heap, error_value);
+    crate::value::arena::incref_for_escape(
+        heap,
+        region,
+        crate::value::arena::EscapeSite::AbortDelivery,
+    );
     // The VM injects the error, resumes the fiber, and lets it unwind.
     (SIG_ABORT, fiber_value)
 }
@@ -415,11 +436,11 @@ primitive! {
         // The injected error is installed in the fiber's signal slot and taken
         // straight back out by `do_fiber_abort`; where the fiber was never
         // started, `kill_fiber` parks it under the park-retain instead. Either
-        // way the install counts its own reference — no clique. Where the value
-        // comes back OUT as the abort's result, `handle_fiber_abort_signal`
-        // mints the caller's reference (the unwinding exit runs no `Return` to
-        // mint it). Aborting an already-dead fiber hands back that fiber's
-        // terminal value, read out of the fiber argument: unbounded.
+        // way the install counts its own reference — no clique. The payload
+        // arrives owned by the CALLER and so with no delivery of its own, which
+        // `inject_error_at_suspension` mints once for whichever consumer the
+        // injected error reaches. Aborting an already-dead fiber hands back that
+        // fiber's terminal value, read out of the fiber argument: unbounded.
         effect: RegionEffect::Delivers { args: &[1] },
     }
     "fiber/refuse" => prim_fiber_refuse {
@@ -431,10 +452,11 @@ primitive! {
         example: "(fiber/refuse f)\n(fiber/refuse f :not-permitted)",
         // Same delivery accounting as `fiber/abort`: the injected error is
         // installed in the fiber's signal slot and taken straight back out by
-        // `do_fiber_abort`, and where it comes back OUT as the result,
-        // `handle_fiber_abort_signal` mints the caller's reference. Refusal
-        // accepts only a `:paused` fiber, so neither the `kill_fiber` park nor
-        // the dead-fiber terminal-value read applies.
+        // `do_fiber_abort`, and the injection mints the one delivery reference
+        // its consumer releases. A refused fiber that catches at its own call
+        // site is the in-body-handler route — that handler's resume result is
+        // the consumer. Refusal accepts only a `:paused` fiber, so neither the
+        // `kill_fiber` park nor the dead-fiber terminal-value read applies.
         effect: RegionEffect::Delivers { args: &[1] },
     }
 }

--- a/src/value/arena.rs
+++ b/src/value/arena.rs
@@ -188,6 +188,12 @@ pub enum EscapeSite {
     /// park funded its own resumer, not this one (docs/impl/region/owner.md
     /// § "Park/unpark symmetry").
     PropagateEscape,
+    /// An error payload injected into a paused fiber's `signal` by `fiber/abort`
+    /// or `fiber/refuse`. The payload belongs to the CALLER, whose own reference
+    /// answers the caller's argument release alone — no raise minted a delivery
+    /// for it. This retain is that delivery, and whichever consumer the injected
+    /// error reaches releases it (docs/impl/region/effects.md § `Delivers`).
+    AbortDelivery,
     /// A child fiber's set-once terminal result, park-retained until the fiber
     /// is freed (released by the signal scan — asymmetric by Rule 7).
     TerminalSignal,
@@ -221,6 +227,7 @@ impl EscapeSite {
             EscapeSite::SuspendEscape => "suspend-escape",
             EscapeSite::EmitEscape => "emit-escape",
             EscapeSite::PropagateEscape => "propagate-escape",
+            EscapeSite::AbortDelivery => "abort-delivery",
             EscapeSite::TerminalSignal => "terminal-signal",
             EscapeSite::ResumeDelivery => "resume-delivery",
             EscapeSite::ParamBaseline => "param-baseline",

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -140,18 +140,25 @@ pub struct Fiber {
     /// the Fiber content scan records no edge for it. The counted edge for the
     /// same value is `signal`'s.
     pub error_loc: Option<(Value, crate::error::SourceLoc)>,
-    /// The `SIG_ERROR` payload whose DELIVERY reference the raise itself minted
-    /// — the `EmitEscape` retain `handle_emit` (and its JIT mirror) takes, which
-    /// the resumer's release of the resume result consumes. While this matches
-    /// the live signal's payload (representation identity, never structural
-    /// equality), the payload exemption on the abandoned-frame walk and the
-    /// parked frame's discharge is withdrawn: the raise chain's own reference
-    /// funds no delivery, so every release the tables name is genuinely owed
-    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
-    /// still owes"). A native install leaves this untouched — its delivery is
+    /// The `SIG_ERROR` payload whose DELIVERY reference something OTHER than this
+    /// fiber's frames minted. Two raises record here, for one reason:
+    ///
+    /// - an `emit` raise — the `EmitEscape` retain `handle_emit` (and its JIT
+    ///   mirror) takes, which the resumer's release of the resume result consumes;
+    /// - an injected `fiber/abort` / `fiber/refuse` payload — the `AbortDelivery`
+    ///   retain the injection takes, recorded on the aborted fiber
+    ///   (`do_fiber_abort`) and on the aborting one where the error escapes it
+    ///   (`VM::park_propagating_abort`).
+    ///
+    /// While this matches the live signal's payload (representation identity,
+    /// never structural equality), the payload exemption on the abandoned-frame
+    /// walk and the parked frame's discharge is withdrawn: a frame's own
+    /// reference funds no delivery, so every release the tables name is genuinely
+    /// owed (docs/impl/region/mechanism.md § "An abandoned frame runs the releases
+    /// it still owes"). A native install leaves this untouched — its delivery is
     /// the payload's birth reference or the frame's left-standing one, which the
-    /// exemption preserves. Cleared where the delivery is consumed: the resume's
-    /// signal take, and an abort's injection.
+    /// exemption preserves. Cleared at the resume's signal take, where the parked
+    /// payload this record named leaves the slot.
     pub emit_delivery: Option<Value>,
     /// Whether this fiber's innermost suspension is a PRIMITIVE call, whose
     /// resume value therefore arrives owing one reference.

--- a/src/vm/fiber/abort.rs
+++ b/src/vm/fiber/abort.rs
@@ -9,33 +9,24 @@ use crate::value::{SignalBits, Value, SIG_ERROR, SIG_OK};
 use crate::vm::core::VM;
 
 impl VM {
-    /// Mint the caller's reference to an aborted child's ERROR result — the one
-    /// the missing `Return` would have taken.
+    /// Park an abort's outcome as this fiber's OWN propagating signal — the
+    /// uncaught arm, shared by all three positions so they cannot drift.
     ///
-    /// A caught abort hands `result_value` to the caller as the call's result, so
-    /// the caller's `DecrefValueRegion` fires on it. A normally-completing child
-    /// funds that release with its `Return`'s `IncrefValueRegion`; an unwinding
-    /// child runs no `Return` at all, and its payload is in general a value the
-    /// caller already owns and already releases — its own `fiber/abort` argument.
-    /// Without this mint the two releases run against one reference and the
-    /// payload is freed under the fiber that still parks it
-    /// (`region_fiber_abort_delivery_uaf`).
-    ///
-    /// Only the caught arm mints: the uncaught arm pushes `nil` and routes the
-    /// payload through the signal instead, where no caller release targets it.
-    /// The park-retain the child's own `signal` hold owes is separate and taken by
-    /// `with_child_fiber` (docs/impl/region/effects.md § `Delivers`).
-    ///
-    /// All three positions that drive an abort — call, tail, and JIT — share this,
-    /// so they cannot drift apart on the accounting.
-    pub(in crate::vm::fiber) fn mint_abort_error_result(&mut self, result_value: Value) {
-        let heap = unsafe { &mut *self.heap_ptr };
-        let r = crate::value::arena::region_of(heap, result_value);
-        crate::value::arena::incref_for_escape(
-            heap,
-            r,
-            crate::value::arena::EscapeSite::ReturnValue,
-        );
+    /// The payload's delivery is funded before it gets here, and never by this
+    /// frame: the injection minted it (`AbortDelivery`) where the fiber unwound
+    /// with the value it was aborted with, and the child's own raise minted it
+    /// where the fiber raised an error of its own instead. So a slot of this
+    /// frame that holds the payload owes a release like any other, and the
+    /// record is what stops the abandoned-frame walk exempting it
+    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    /// still owes"). A materialized literal handed straight to `fiber/abort` is
+    /// the shape that reaches this — it lives in a frame slot and in nothing
+    /// else (the `abort-discard` probe in `tests/elle/oracle.lisp`).
+    pub(in crate::vm::fiber) fn park_propagating_abort(&mut self, bits: SignalBits, value: Value) {
+        self.fiber.signal = Some((bits, value));
+        if bits.intersects(SIG_ERROR) {
+            self.fiber.emit_delivery = Some(value);
+        }
     }
 
     /// Handle SIG_ABORT from fiber/abort (Call position).
@@ -68,7 +59,6 @@ impl VM {
             // the aborted fiber is finished and must not stay :paused.
             if result_bits.intersects(SIG_ERROR) {
                 handle.with_mut(|f| f.status = FiberStatus::Error);
-                self.mint_abort_error_result(result_value);
             }
             self.fiber.child = None;
             self.fiber.child_value = None;
@@ -83,7 +73,7 @@ impl VM {
                 self.fiber.stack.push(Value::NIL);
                 None
             } else {
-                self.fiber.signal = Some((result_bits, result_value));
+                self.park_propagating_abort(result_bits, result_value);
                 if result_bits.intersects(SIG_ERROR) {
                     self.fiber.stack.push(Value::NIL);
                     None
@@ -115,7 +105,6 @@ impl VM {
             // Abort is terminal — set child to :error even when caught
             if result_bits.intersects(SIG_ERROR) {
                 handle.with_mut(|f| f.status = FiberStatus::Error);
-                self.mint_abort_error_result(result_value);
             }
             self.fiber.child = None;
             self.fiber.child_value = None;
@@ -128,7 +117,7 @@ impl VM {
             if self.reject_orphaned_signal(result_bits, "fiber/abort") {
                 SIG_ERROR
             } else {
-                self.fiber.signal = Some((result_bits, result_value));
+                self.park_propagating_abort(result_bits, result_value);
                 result_bits
             }
         }

--- a/src/vm/fiber/jit.rs
+++ b/src/vm/fiber/jit.rs
@@ -112,7 +112,6 @@ impl VM {
             // Abort is terminal — set child to :error even when caught
             if result_bits.intersects(SIG_ERROR) {
                 handle.with_mut(|f| f.status = FiberStatus::Error);
-                self.mint_abort_error_result(result_value);
             }
             self.fiber.child = None;
             self.fiber.child_value = None;
@@ -124,7 +123,7 @@ impl VM {
             if self.reject_orphaned_signal(result_bits, "fiber/abort") {
                 JitValue::nil()
             } else {
-                self.fiber.signal = Some((result_bits, result_value));
+                self.park_propagating_abort(result_bits, result_value);
                 if result_bits.intersects(SIG_ERROR) || result_bits.intersects(SIG_HALT) {
                     JitValue::nil()
                 } else {

--- a/src/vm/fiber/resume.rs
+++ b/src/vm/fiber/resume.rs
@@ -319,10 +319,18 @@ impl VM {
             // Clear the signal — prim_fiber_abort pre-set it with the error
             // value, which we already extracted above. If we leave it set,
             // the dispatch loop will see SIG_ERROR and bail immediately
-            // when we try to resume remaining bytecode frames. The injected
-            // error minted no delivery, so any recorded one goes with it.
+            // when we try to resume remaining bytecode frames.
             vm.fiber.signal = None;
-            vm.fiber.emit_delivery = None;
+            // The injection minted the payload's delivery (`AbortDelivery`), so
+            // record it the way a raise records its own: with the delivery funded
+            // independently, a frame of THIS fiber that owns a reference to the
+            // payload funds nothing, and the abandoned-frame walk and the parked
+            // frame's discharge must stop exempting the payload's region
+            // (docs/impl/region/mechanism.md § "An abandoned frame runs the
+            // releases it still owes"). A fiber handed the same value it is
+            // aborted with is the shape that reaches this — the record is what
+            // keeps its release owed.
+            vm.fiber.emit_delivery = Some(error_value);
             // An abort delivers no resume value — the replayed frame re-enters
             // with `SIG_ERROR` set and leaves before the parked call's result
             // release — so the park's delivery obligation goes with the signal it
@@ -394,20 +402,12 @@ impl VM {
                         // parked call's compiler-emitted result release). A
                         // normally-completing child funds that reference with
                         // its Return's ReturnValue retain; the aborted child's
-                        // ERROR exit runs no Return, so the delivery must take
-                        // the retain the missing Return would have — without
-                        // it the replay consumes a reference the abort's
-                        // caller still owns, and the payload is freed under
-                        // the caller's later read. Pinned by
+                        // ERROR exit runs no Return, and the injection's
+                        // `AbortDelivery` retain stands in — this replay is one
+                        // of the four consumers that mint answers for, and it
+                        // takes no retain of its own. Pinned by
                         // `region_fiber_abort_io_protect_uaf`;
                         // tests/elle/grpc.lisp is the full-scheduler witness.
-                        let heap = unsafe { &mut *vm.heap_ptr };
-                        let r = crate::value::arena::region_of(heap, inner_result);
-                        crate::value::arena::incref_for_escape(
-                            heap,
-                            r,
-                            crate::value::arena::EscapeSite::ReturnValue,
-                        );
                         vm.resume_suspended(remaining, inner_result)
                     }
                 }

--- a/tests/elle/region-fiber-abort-delivery-uaf.lisp
+++ b/tests/elle/region-fiber-abort-delivery-uaf.lisp
@@ -1,25 +1,26 @@
 (elle/epoch 12)
-# A caught `fiber/abort` mints the reference its result is released against.
+# `fiber/abort` injects a payload the CALLER owns, so the injection mints the one
+# delivery reference every route's consumer releases.
 #
-# Aborting a :paused fiber injects the caller's payload into the fiber and
-# resumes it to unwind. Where the mask catches, that payload comes straight back
-# out as the abort's RESULT, so the caller's `DecrefValueRegion` fires on it
-# alongside the separate one the caller already owes it as an ARGUMENT — and the
-# unwinding exit runs no `Return` to fund the second.
-# `handle_fiber_abort_signal` mints it, the same argument `do_fiber_abort` makes
-# for the value it hands to a replayed inner frame.
+# The caller's own reference answers the caller's ARGUMENT release and nothing
+# else. Exactly one further release fires on the payload as a RESULT, and which
+# one depends on where the injected error stops — the four faces below. One
+# reference, one consumer, four routes: `inject_error_at_suspension` mints it
+# once at the seam all four leave through
+# (docs/impl/region/effects.md § `Delivers`).
 #
-# Without the mint the payload's region is freed while the fiber (and the
-# reader below) still points into it. Run under `--trace=guardfree`, where every
-# freed page is PROT_NONE, each read below faults at the dereference.
+# Each face guards both counter-factuals. Where nothing mints, the payload's
+# region is freed while a fiber and the reader still point into it: run under
+# `--trace=guardfree`, where every freed page is PROT_NONE, and each read below
+# faults at the dereference. Where two things mint, the region strands once per
+# abort — that never faults, so the churn faces gauge it instead.
 #
-# The mint is owed by the result, so only the arm that hands one back takes it —
-# the placement face below pins that. `region-fiber-install-clique-leak.lisp` is
-# the bounded-growth face of the `Delivers` declaration this belongs to.
+# `region-fiber-install-clique-leak.lisp` is the bounded-growth face of the
+# `Delivers` declaration this belongs to.
 
-# ── The caught face: the abort's result IS the injected payload ──────────
-# The mask catches :error, so the abort's caller receives the payload back and
-# releases it as a result on top of releasing it as an argument.
+# ── Route 1: the fiber's mask catches, the caller reads the result ───────
+# The abort's caller receives the payload back and releases it as a result on
+# top of releasing it as an argument.
 (let [f (fiber/new (fn []
                      (yield 1)
                      2) |:yield :error|)]
@@ -39,24 +40,33 @@
   (assert (= (fiber/value f) [4 5 6])
           "the aborted fiber's terminal value is the injected payload"))
 
-# ── The unwound face: defer/protect runs before the payload comes back ───
-# The body's cleanup allocates and frees while the payload is in flight, so a
-# freed payload region is recycled under it before the caller reads it.
-(let [f (fiber/new (fn []
-                     (defer
-                       (length [1 2 3 4 5])
+# ── Route 2: the error escapes the fiber, an ancestor absorbs it ─────────
+# The mask names only `:yield`, so the injected error travels out of the fiber
+# to the enclosing `try`, which absorbs it and releases the payload as its
+# resume result. The caller still owns the payload across that whole trip and
+# reads it afterwards, so an unfunded escape frees it under both readers.
+(def @i 0)
+(while (%lt i 200)
+  (let [payload {:error :injected}
+        f (fiber/new (fn []
                        (yield 1)
-                       2)) |:yield :error|)]
-  (fiber/resume f)
-  (let [r (fiber/abort f [7 8 9])]
-    (assert (= (get r 0) 7)
-            "the payload survives the aborted body's defer cleanup")))
+                       2) |:yield|)]
+    (fiber/resume f)
+    (let [e (try
+              (begin
+                (fiber/abort f payload)
+                nil)
+              (catch e e))]
+      (assert (= (get e :error) :injected)
+              "the escaped abort payload reaches the catching try intact")
+      (assert (= (get payload :error) :injected)
+              "the abort's caller still reads the payload it injected")))
+  (assign i (%add i 1)))
 
-# ── Placement: only the arm that hands a result back mints ───────────────
-# The mint is owed by the RESULT, not by the delivery. An in-body handler that
-# catches the injected error consumes the payload inside the fiber and hands the
-# caller a value of its own, so no caller release targets the payload and a mint
-# taken at the delivery would strand it once per abort.
+# ── Route 3: a handler INSIDE the fiber catches the injected error ───────
+# The in-body handler's release of its own resume result consumes the delivery,
+# and the fiber hands the caller a value of its own — so no caller release
+# targets the payload and a second mint would strand it once per abort.
 (defn caught-churn [n]
   (def before (arena/region-count))
   (def @i 0)
@@ -72,7 +82,149 @@
 (let [d (caught-churn 200)]
   (assert (%lt d 30)
           (string "abort payload caught in body: 200 iters grew the region count by "
-                  d " (only the result arm owes the missing Return's mint)")))
+                  d
+                  " (the in-body handler's resume result is the only consumer)")))
+
+# The fiber catches the injected error and then raises an error of ITS OWN. That
+# raise mints its own delivery, so the abort owes the result nothing: a mint keyed
+# on "the abort ended in an error" rather than on the injection strands the second
+# payload once per abort.
+(defn own-error-churn [n]
+  (def before (arena/region-count))
+  (def @i 0)
+  (while (%lt i n)
+    (let [f (fiber/new (fn []
+                         (protect (yield 1))
+                         (error {:own 1})) |:yield :error|)]
+      (fiber/resume f)
+      (fiber/abort f [1 2 3]))
+    (assign i (%add i 1)))
+  (%sub (arena/region-count) before))
+
+(let [d (own-error-churn 200)]
+  (assert (%lt d 30)
+          (string "fiber raises its own error after catching the abort: 200 iters grew "
+                  "the region count by " d
+                  " (that raise minted its own delivery)")))
+
+# The same shape where the fiber re-raises the payload it caught. The value is
+# the injected one, so identity alone cannot tell this from an unwound abort —
+# but the `error` that re-raised it minted a delivery for it, and a second mint
+# strands the payload once per abort.
+(defn reraise-churn [n]
+  (def before (arena/region-count))
+  (def @i 0)
+  (while (%lt i n)
+    (let [f (fiber/new (fn []
+                         (let [r (protect (yield 1))]
+                           (error (get r 1)))) |:yield :error|)]
+      (fiber/resume f)
+      (fiber/abort f [1 2 3]))
+    (assign i (%add i 1)))
+  (%sub (arena/region-count) before))
+
+(let [d (reraise-churn 200)]
+  (assert (%lt d 30)
+          (string "fiber re-raises the injected payload: 200 iters grew the region "
+                  "count by " d " (the re-raise minted the delivery)")))
+
+# ── Route 4: a replayed `defer` frame is resumed with the payload ────────
+# The abort unwinds the deferred body, hands the payload to the parked
+# `fiber/resume` continuation — whose result release consumes the delivery —
+# and the cleanup's `fiber/propagate` mints afresh for the re-raise. Neither
+# the replay nor the abort's own result may mint on top of that.
+(defn defer-churn [n]
+  (def before (arena/region-count))
+  (def @i 0)
+  (while (%lt i n)
+    (let [f (fiber/new (fn []
+                         (defer
+                           (length [1 2 3 4 5])
+                           (yield 1)
+                           2)) |:yield :error|)]
+      (fiber/resume f)
+      (let [r (fiber/abort f [7 8 9])]
+        (assert (= (get r 0) 7)
+                "the payload survives the aborted body's defer cleanup")))
+    (assign i (%add i 1)))
+  (%sub (arena/region-count) before))
+
+(let [d (defer-churn 200)]
+  (assert (%lt d 30)
+          (string "abort unwound through defer: 200 iters grew the region count by "
+                  d " (the replay and the propagate each fund one consumer)")))
+
+# ── The record: the aborted fiber's own frame owes its release ───────────
+# The fiber holds the very value it is aborted with — handed to it as an owned
+# parameter — so its abandoned frame owes that value a release. With the
+# delivery minted at the injection the frame's reference funds nothing, so the
+# injection records the mint (`Fiber::emit_delivery`) and the abandoned-frame
+# walk stops exempting the payload's region. Without the record the frame's
+# release stays owed forever: one region per abort.
+(defn hold-then-yield [q]
+  (yield q)
+  2)
+
+(defn held-payload-churn [n]
+  (def before (arena/region-count))
+  (def @i 0)
+  (while (%lt i n)
+    (let [p {:a 1}
+          f (fiber/new hold-then-yield |:yield :error|)]
+      (fiber/resume f p)
+      (fiber/abort f p))
+    (assign i (%add i 1)))
+  (%sub (arena/region-count) before))
+
+(let [d (held-payload-churn 200)]
+  (assert (%lt d 30)
+          (string "fiber aborted with a value it already holds: 200 iters grew the "
+                  "region count by " d " (its frame's release is still owed)")))
+
+# The pair-control: the same frame, aborted with a DIFFERENT value. Nothing the
+# record could reach, so it isolates the record from the walk itself.
+(defn other-payload-churn [n]
+  (def before (arena/region-count))
+  (def @i 0)
+  (while (%lt i n)
+    (let [p {:a 1}
+          f (fiber/new hold-then-yield |:yield :error|)]
+      (fiber/resume f p)
+      (fiber/abort f {:b 2}))
+    (assign i (%add i 1)))
+  (%sub (arena/region-count) before))
+
+(let [d (other-payload-churn 200)]
+  (assert (%lt d 30)
+          (string "fiber aborted with a value it does not hold: 200 iters grew the "
+                  "region count by " d)))
+
+# The other side of the same record: the ABORTING frame. A literal materialized
+# straight into the `fiber/abort` argument lives in that frame's slot and nowhere
+# else, and the escaping error abandons the frame before its release runs. The
+# record travels with the propagating signal (`VM::park_propagating_abort`), so
+# the walk runs that release instead of exempting the payload's region.
+(defn aborting-frame-churn [n]
+  (def before (arena/region-count))
+  (def @i 0)
+  (while (%lt i n)
+    (let [f (fiber/new (fn []
+                         (yield 1)
+                         2) |:yield|)]
+      (fiber/resume f)
+      (try
+        (begin
+          (fiber/abort f {:e 1})
+          nil)
+        (catch e e)))
+    (assign i (%add i 1)))
+  (%sub (arena/region-count) before))
+
+(let [d (aborting-frame-churn 200)]
+  (assert (%lt d 30)
+          (string "payload materialized into the abort's argument: 200 iters grew the "
+                  "region count by " d
+                  " (the aborting frame's release is still owed)")))
 
 # ── Churn: repeated abort delivery must not accumulate stale pages ───────
 (def @i 0)

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -1273,10 +1273,11 @@ fn region_variadic_tail_forward_uaf() {
 // symmetry", the delivery rule). A replayed frame's pending release consumes
 // one owning reference of the value it is resumed with; a normally-completing
 // child funds it with its Return's ReturnValue retain, but an ABORTED child's
-// error exit runs no Return — so `do_fiber_abort`'s delivery of the error
-// payload into the remaining parked frames must take that retain itself, or
-// the replay steals a reference the abort's caller still owns and the payload
-// is freed under the caller's read (a stale-region deref once ids recycle).
+// error exit runs no Return — so the reference it consumes is the one
+// `fiber/abort`'s injection minted, and the replay is one of the four consumers
+// that single mint answers for. Without a mint anywhere the replay steals a
+// reference the abort's caller still owns and the payload is freed under the
+// caller's read (a stale-region deref once ids recycle).
 // The shape needs an io-parked protect child under the scheduler and a FRESH
 // heap payload (a constant payload has no region and masks the theft);
 // tests/elle/grpc.lisp's `with-server` teardown is the full-network witness.
@@ -1424,16 +1425,15 @@ fn region_squelch_fiber_uaf() {
     run_elle_script_with_args("region-squelch-fiber-uaf", &["--trace=guardfree"]);
 }
 
-// Guard — a caught `fiber/abort` hands its injected payload straight back to the
-// caller, whose `DecrefValueRegion` on the abort RESULT fires alongside the separate
-// one it already owes the payload as an ARGUMENT — and the unwinding child runs no
-// `Return` to fund the second. `handle_fiber_abort_signal` mints it on that arm.
-// Without the mint the payload's region is freed while the fiber and the caller still
-// point into it — a stale read the harness's ordinary vm/jit policies see as an intact
-// recycled page, and which only guardfree faults on deterministically. The file also
-// pins the mint's PLACEMENT: an in-body handler consumes the payload inside the fiber,
-// so minting at the delivery instead would strand a region per abort. The
-// bounded-growth face of the same declaration is
+// Guard — `fiber/abort` injects a payload the CALLER owns, whose one reference
+// answers the caller's ARGUMENT release alone; no raise minted a delivery for it.
+// Exactly one release then fires on it as a RESULT, and `inject_error_at_suspension`
+// mints that reference once for whichever of the four consumers the injected error
+// reaches (docs/impl/region/effects.md § `Delivers`). Under-mint and the payload's
+// region is freed while a fiber and the caller still point into it — a stale read the
+// harness's ordinary vm/jit policies see as an intact recycled page, and which only
+// guardfree faults on deterministically. Over-mint never faults, so the file carries a
+// churn face per route as well. The bounded-growth face of the same declaration is
 // tests/elle/region-fiber-install-clique-leak.lisp.
 #[test]
 fn region_fiber_abort_delivery_uaf() {

--- a/tests/integration/fixtures/region-fiber-abort-io-protect-uaf.lisp
+++ b/tests/integration/fixtures/region-fiber-abort-io-protect-uaf.lisp
@@ -11,8 +11,10 @@
 # § "Park/unpark symmetry", the delivery rule): a replayed frame's pending
 # release consumes one owning reference of the value it is resumed with. A
 # normally-completing child funds it with its Return's ReturnValue retain;
-# an ABORTED child's error exit runs no Return, so `do_fiber_abort`'s
-# delivery into the remaining parked frames takes that retain itself.
+# an ABORTED child's error exit runs no Return, so the reference the replay
+# consumes is the one `fiber/abort`'s injection minted — this replay is one
+# of the four consumers that single mint answers for
+# (docs/impl/region/effects.md § `Delivers`).
 #
 # The shape: a spawned fiber parks inside `(protect (ev/sleep …))` — an
 # io-parked protect child under a FiberResume frame — and the scheduler


### PR DESCRIPTION
Closes #919 — the guardfree fault reported as the abort complement to #917.

## The unfunded delivery

An uncaught `fiber/abort` of a suspended fiber double-freed the payload's
region under `--trace=guardfree`:

```
[guardfree] SIGSEGV — use-after-free at 0x7fcee402200c
    addr was freed by region 54245 via cascade(54250)
    held by: region 54249 (its contents were being cross-ref scanned at its own free)
```

The catcher's read of an error payload is funded by exactly one **delivery**
reference, and every install of a terminal payload into a `signal` slot funds
its own — except one. A raise mints (the `EmitEscape` retain, or a fresh error
struct's birth reference); a re-park mints (`PropagateEscape`). `fiber/abort`
and `fiber/refuse` install a payload the **caller** owns, whose one reference
answers the caller's *argument* release and nothing else.

Exactly one further release then fires on that payload as a RESULT, and which
one depends on where the injected error stops. Four routes:

- the fiber's mask catches it, and the abort's caller releases it as the call's
  result;
- a `protect` or `try` inside the fiber catches it, and that handler's release
  of its own resume result consumes it;
- the error escapes the fiber, and the resume result of whichever ancestor
  absorbs it consumes it;
- the unwinding replays a parked `defer`/`protect` frame, and that frame's
  suspending call runs its compiler-emitted result release on it.

Only two of the four were funded, each by a mint of its own that recognized its
own route: `handle_fiber_abort_signal`'s caught arm for the first, and
`do_fiber_abort`'s `ReturnValue` retain for the fourth. The escape route had
none, so the payload's count ran one short of the recorded `fiber → payload`
edges and the free cascade reclaimed it under the still-parked fiber. And the
two mints that did exist were keyed on the wrong thing — "the abort ended in an
error", not "the abort's payload arrived unfunded" — so a fiber that caught the
injection in its body and then raised an error of its own was minted for twice,
stranding a region per abort.

## The fix

The injection mints, once, at the seam all four routes leave through:
`inject_error_at_suspension` takes one `AbortDelivery` retain. The two
route-specific mints go away; a route no longer has to recognize itself.

The injection also RECORDS the mint, the way `#916` had an emit raise record
its own — on the aborted fiber (`do_fiber_abort`) and, where the error escapes
it, on the aborting one (`VM::park_propagating_abort`). A frame holding the
payload then funds no delivery, so the abandoned-frame walk and the parked
frame's discharge stop exempting the payload's region. Two shapes need that: a
fiber aborted with a value it was already handed, and a literal materialized
straight into the `fiber/abort` argument, which lives in the aborting frame's
slot and nowhere else.

`fiber/refuse` shares the injection, so it inherits the same accounting; a
refused fiber that catches at its own call site is the in-body-handler route.

## Measurements

Region-count delta over the churn named, `main` → this branch:

| shape | before | after |
| --- | --- | --- |
| the issue's reproducer (escaping abort, payload read after) | SIGSEGV | clean, +0 |
| fiber catches in body, then raises its own error (200 aborts) | +200 | +0 |
| fiber re-raises the injected payload (200) | +200 | +0 |
| abort unwound through `defer`, mask catches (200) | +200 | +0 |
| abort unwound through `defer`, error escapes (200) | +200 | +0 |
| fiber aborted with a value it already holds (300) | +300 | +0 |
| caught abort, payload read back as the result (400) | +0 | +0 |
| `fiber/refuse` caught at the fiber's own call site (300) | +0 | +0 |
| `(protect (fiber/abort f "boom"))`, `abort-discard` oracle probe | 0.0/op | 0.0/op |

## Tests

`tests/elle/region-fiber-abort-delivery-uaf.lisp` carries a face per route, and
each face carries both counter-factuals: an under-mint faults under
`--trace=guardfree` (the file's guardfree pin is
`region_fiber_abort_delivery_uaf`), and an over-mint never faults, so the churn
faces gauge it. Two further faces pin the record — one per fiber it is recorded
on. `region_fiber_abort_io_protect_uaf` is unchanged and still green: the replay
it pins now consumes the injection's reference instead of one of its own.
