### PR TITLE
contributing: a defect you did not fix goes in an issue, not a PR body

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,27 @@ git config core.hooksPath .githooks
 - Do not silently swallow errors. Propagate or log with context.
 - Breaking changes are fine. Use epochs for mechanical migration.
 
+## Pull requests: the body describes the change, and nothing else
+
+A PR body says what was wrong, what the change does, how you measured it, and
+which tests pin it. That is the whole list.
+
+**Never write an "Out of scope" section.** A defect you found and did not fix
+does not belong in a PR body. File an issue.
+
+The reason is what each artifact is for. An issue has a number, a label, a
+state, and a life of its own: it is searchable, it can be assigned, and it
+closes when someone fixes it. A note in a PR body has none of that. It is dead
+the moment the PR merges, nobody can find it again, and until then it stands
+between the reviewer and the change they came to read. A defect worth recording
+is worth a number; a defect not worth a number is not worth writing down.
+
+The same rule covers every neighbouring temptation: work you considered and
+skipped, follow-ups you plan, adjacent shapes you measured and left alone,
+caveats about code the change does not touch. If a reviewer needs one of them
+to judge THIS change, state it in one sentence where it bears on the change and
+link the issue. Otherwise leave it out.
+
 ## Comments: write for the cold reader
 
 Every line of code and text here is written by an agent, and read by another


### PR DESCRIPTION
A PR body says what was wrong, what the change does, how it was measured, and which tests pin it. Nothing else.

`CONTRIBUTING.md` now bans the "Out of scope" section outright, and states why: an issue has a number, a label, a state, and a life of its own, where a note in a PR body has none of that. It dies at the merge, nobody can find it again, and until then it stands between the reviewer and the change they came to read.

The rule extends to the neighbouring temptations — work considered and skipped, planned follow-ups, adjacent shapes measured and left alone, caveats about untouched code. Where a reviewer genuinely needs one to judge the change, it belongs in one sentence where it bears on the change, with a link to the issue.