### PR TITLE
regions: fiber/propagate wires the child chain, and wiring is not storing

### DIFF
--- a/docs/impl/region/effects.md
+++ b/docs/impl/region/effects.md
@@ -167,6 +167,33 @@ Every primitive declares its region behavior in its `PrimitiveDef` as a
   declaration costs a read like this is that seed: a fiber named in one arm of a
   branch and read in another loses the branch-arm release window and strands per
   call (`tests/elle/region-fiber-child-effect.lisp`).
+
+  **The child-chain WIRING is `Opaque` too — that write holds nothing.**
+  `fiber/propagate` returns `SIG_PROPAGATE` carrying its fiber argument, and
+  `handle_fiber_propagate_signal` writes that value into the propagating fiber's
+  own `child`/`child_value` fields. The `Mixed` rule below asks whether a handler's
+  write creates a **holder**, and this pair is not one. The free-time walk's Fiber
+  arm enumerates the closure, its env and template, the terminal `signal`,
+  `closure_value` and the seeded parameter baseline — never the child chain
+  (`find_object_cross_refs`). A field no walk consults owes no reference, so
+  nothing is under-counted by leaving it undeclared.
+
+  `fiber/resume` settles the same question the same way. Its handler performs the
+  identical two writes on every resume — `with_child_fiber` step 2 when it
+  descends, `seed_child_inheritance` when it suspends instead — and its
+  `Delivers { args: &[1] }` lists the resume value alone. The fiber argument has
+  never been a store there, and the two wiring natives agree. What keeps the
+  cache honest is not a reference but its consumer: `fiber/child` reads it only
+  while the wiring call's own frame is live or parked, and absorbing the child's
+  signal clears both fields (`VM::absorbs`'s callers).
+
+  The cost of `Mixed` here is the branch-arm seed the read rule above describes,
+  and `defer` is where it lands. `defer` reads its fiber with `fiber/status`, with
+  `fiber/value` in one arm and with `fiber/propagate` in the other, so a store
+  facet on the propagate argument leaves the branch's only release in the arm the
+  success path never takes. Every evaluation then strands the fiber value and its
+  body closure, and a loop whose body is wrapped in `defer` grows without bound
+  (the `defer-while` and `defer-error` probes in `tests/elle/oracle.lisp`).
 - **`Delivers { args }`** — the listed (0-based) arguments are handed to
   **another fiber** by installing them in its signal slot, and the result is
   unbounded. The fiber value installers are the declarants: `fiber/resume`'s
@@ -257,17 +284,18 @@ Every primitive declares its region behavior in its `PrimitiveDef` as a
 
   **A signal a handler stores for is a store.** A primitive whose work is done by
   the VM's handler for its signal is judged on what that handler does with the
-  argument. `fiber/propagate` returns `SIG_PROPAGATE` carrying its fiber argument,
-  and `handle_fiber_propagate_signal` writes that value into the propagating
-  fiber's own `child`/`child_value` fields — a fiber field, not a fiber frontier,
-  and with no counting seam of its own. So the store is real and uncounted, which
-  is `Mixed`'s property, and the argument stays a store-facet escape seed. The
-  clique is empty either way (one heap argument), so that seed is the whole content
-  of the declaration here — and nothing else would catch its loss: a `PassThrough`
-  claim reads true on the result side (the result IS arg0) and the oracle exempts
-  a signal-carrying return anyway, so the store side is the only thing the
-  declaration is deciding. Pinned solver-side by
-  `fiber_child_declares_opaque_and_propagate_keeps_the_hard_edge`.
+  argument. `git` returns `SIG_QUERY` carrying the closure it is asked to compile,
+  and the handler caches the SPIR-V on that closure's template — a retention that
+  outlives the call, shared by every closure over that template, and recorded by no
+  seam. So the store is real and uncounted, which is `Mixed`'s property, and the
+  argument stays a store-facet escape seed.
+
+  The rule asks for a **holder**, not merely for a write. A handler that writes an
+  argument into a field the free-time walk never enumerates creates no second
+  holder of the region and can under-count nothing, so the strongest true claim is
+  the one that says so — `Opaque`, the child-chain wiring's answer (§ `Opaque`,
+  "The child-chain WIRING is `Opaque` too"). Both halves are pinned solver-side by
+  `fiber_graph_natives_declare_opaque_and_git_keeps_the_hard_edge`.
 - **`Unknown`** — nobody has looked. The default for unexamined
   primitives, every plugin-supplied definition (the plugin ABI cannot
   carry a claim yet), and the standing classification of user-supplied

--- a/src/hir/escape/tests/flow.rs
+++ b/src/hir/escape/tests/flow.rs
@@ -332,23 +332,26 @@ fn a_sequence_read_does_not_seed_the_store_facet() {
     );
 }
 
-/// The fiber-graph reads are the same claim on a different subject: `fiber/child`
-/// hands back the cached child-fiber `Value` its argument carries and stores
-/// nothing, so its argument is not a store-facet seed. `fiber/propagate` is the
-/// contrast that keeps the seed honest — it hands its argument to the
-/// `SIG_PROPAGATE` handler, which writes it into the propagating fiber's own
-/// `child`/`child_value` fields with no counting seam, the uncounted store `Mixed`
-/// exists to cover (docs/impl/region/effects.md § `Opaque`, § `Mixed`).
+/// The fiber-graph natives are the same claim on a different subject, and the
+/// WRITE side answers it the same way the read side does. `fiber/child` hands back
+/// the cached child-fiber `Value` its argument carries; `fiber/propagate` hands its
+/// argument to the `SIG_PROPAGATE` handler, which writes it into the propagating
+/// fiber's `child`/`child_value` pair. That pair is not enumerated by the free-time
+/// walk, so neither call creates a holder and neither argument is a store-facet
+/// seed (docs/impl/region/effects.md § `Opaque`, "The child-chain WIRING is
+/// `Opaque` too"). The counter-factual is `Mixed` on `fiber/propagate`, and this
+/// seed is the only thing that catches it: `Mixed` reads true on the result side
+/// (the SIG_PROPAGATE payload IS arg0) and the declaration oracle exempts a
+/// signal-carrying return, so no result check can. What it costs is `defer`'s
+/// success path, which names its fiber in the arm this call does not take.
 #[test]
-fn a_fiber_graph_read_does_not_seed_the_store_facet() {
-    assert_binding_escape(
-        "(let [f (fiber/new (fn () 1) |:error|)] (fiber? (fiber/child f)))",
-        &[("f", false, false)],
-    );
-    assert_binding_escape(
-        "(let [f (fiber/new (fn () 1) |:error|)] (fiber? (fiber/propagate f)))",
-        &[("f", true, false)],
-    );
+fn a_fiber_graph_write_does_not_seed_the_store_facet() {
+    for op in ["fiber/child", "fiber/propagate"] {
+        assert_binding_escape(
+            &format!("(let [f (fiber/new (fn () 1) |:error|)] (fiber? ({op} f)))"),
+            &[("f", false, false)],
+        );
+    }
 }
 
 /// `import` copies its specifier out to a Rust `String` to resolve it and stores

--- a/src/hir/region/infer/tests/effects.rs
+++ b/src/hir/region/infer/tests/effects.rs
@@ -371,36 +371,40 @@ fn has_declares_opaque_no_arg_clique() {
 }
 
 #[test]
-fn fiber_child_declares_opaque_and_propagate_keeps_the_hard_edge() {
-    // The two fiber-graph natives split on the STORE side, and the split is what
-    // their declarations record. `fiber/child` reads the cached child-fiber `Value`
-    // out of its argument and returns it — no store, and a result living in whatever
-    // region the resume minted the cache in, so `Opaque`: no hard-edge site, and no
-    // store-facet escape seed on the argument (the escape half is
-    // `a_fiber_graph_read_does_not_seed_the_store_facet`). `fiber/propagate` returns
-    // SIG_PROPAGATE, which drives the VM to write its argument into the propagating
-    // fiber's own `child`/`child_value` fields with no counting seam — the uncounted
-    // store the clique covers — so it stays `Mixed` and stays a hard-edge site.
-    // Both are single-heap-arg, so the clique edge set is empty either way and
-    // `hard_edge_sites` is what distinguishes them (docs/impl/region/effects.md
-    // § `Opaque`, § `Mixed`).
-    let (hir, arena, symbols, info) = analyze_with_class("(fiber/child \"f\")");
-    let calls = find_calls_to_primitive(&hir, "fiber/child", &arena, &symbols);
-    assert_eq!(calls.len(), 1, "expected one (fiber/child ...) call");
-    assert!(
-        !info.hard_edge_sites.contains(&calls[0]),
-        "fiber/child declares Opaque — it stores nothing — so its call site must \
-         NOT be a hard-edge site (a regression to Mixed re-seeds the store facet \
-         on every fiber it reads)"
-    );
+fn fiber_graph_natives_declare_opaque_and_git_keeps_the_hard_edge() {
+    // Both fiber-graph natives touch the same `child`/`child_value` pair and both
+    // declare `Opaque`. `fiber/child` READS the cached child-fiber `Value` out of
+    // its argument; `fiber/propagate` returns SIG_PROPAGATE, which drives the VM to
+    // WRITE its argument into that pair. Neither is a store: the free-time walk's
+    // Fiber arm does not enumerate the child chain, so the field creates no holder
+    // of the region and can under-count nothing (docs/impl/region/effects.md
+    // § `Opaque`, "The child-chain WIRING is `Opaque` too"). The escape half is
+    // `a_fiber_graph_write_does_not_seed_the_store_facet`.
+    for name in ["fiber/child", "fiber/propagate"] {
+        let (hir, arena, symbols, info) = analyze_with_class(&format!("({name} \"f\")"));
+        let calls = find_calls_to_primitive(&hir, name, &arena, &symbols);
+        assert_eq!(calls.len(), 1, "expected one ({name} ...) call");
+        assert!(
+            !info.hard_edge_sites.contains(&calls[0]),
+            "{name} declares Opaque — it stores nothing — so its call site must NOT \
+             be a hard-edge site (a regression to Mixed re-seeds the store facet on \
+             every fiber it names)"
+        );
+    }
 
-    let (hir, arena, symbols, info) = analyze_with_class("(fiber/propagate \"f\")");
-    let calls = find_calls_to_primitive(&hir, "fiber/propagate", &arena, &symbols);
-    assert_eq!(calls.len(), 1, "expected one (fiber/propagate ...) call");
+    // The contrast that keeps the handler-store rule honest. `git` also does its
+    // work through a signal handler, and that handler caches the compiled SPIR-V on
+    // its closure argument's template — a retention outliving the call that no seam
+    // records. Real, uncounted store: `Mixed`, and a hard-edge site. All three are
+    // single-heap-arg, so the clique edge set is empty for each and `hard_edge_sites`
+    // is the only thing that separates them.
+    let (hir, arena, symbols, info) = analyze_with_class("(git \"f\")");
+    let calls = find_calls_to_primitive(&hir, "git", &arena, &symbols);
+    assert_eq!(calls.len(), 1, "expected one (git ...) call");
     assert!(
         info.hard_edge_sites.contains(&calls[0]),
-        "fiber/propagate's argument is stored uncounted into the propagating \
-         fiber's child field, so it must stay a Mixed hard-edge site"
+        "git's argument keeps compiled SPIR-V cached on its template past the call, \
+         so it must stay a Mixed hard-edge site"
     );
 }
 

--- a/src/primitives/fiber_introspect.rs
+++ b/src/primitives/fiber_introspect.rs
@@ -406,15 +406,19 @@ primitive! {
         doc: "Propagate a caught signal from a child fiber, preserving the child chain",
         params: &["fiber"],
         category: "fiber",
-        // Mixed: the SIG_PROPAGATE return drives the VM to write the fiber
-        // argument into the propagating fiber's own `child`/`child_value` fields
-        // (`handle_fiber_propagate_signal`), with no counting seam — the uncounted
-        // store the clique exists to cover. The clique is empty either way (one
-        // heap argument), so what the declaration carries here is escape's store
-        // facet on the argument, which that write earns
-        // (docs/impl/region/effects.md § "A signal a handler stores for is a
-        // store").
-        effect: RegionEffect::Mixed,
+        // Opaque, not Mixed: the SIG_PROPAGATE return drives the VM to write the
+        // fiber argument into the propagating fiber's own `child`/`child_value`
+        // pair (`handle_fiber_propagate_signal`) — the child-chain WIRING, the
+        // same write `fiber/resume`'s handler performs and does not declare. The
+        // free-time walk's Fiber arm never enumerates that pair, so it holds no
+        // reference and the call stores nothing; the result leaves by signal, so
+        // it is unbounded. The clique is empty either way (one heap argument), so
+        // what the declaration decides is escape's store facet on the argument,
+        // and `Mixed` would cost every branch that names a live-in fiber here its
+        // release window — `defer`'s success path first
+        // (docs/impl/region/effects.md § "The child-chain WIRING is `Opaque`
+        // too").
+        effect: RegionEffect::Opaque,
     }
     "fiber/caps" => prim_fiber_caps {
         signal: Signal::query_errors(),

--- a/src/primitives/meta.rs
+++ b/src/primitives/meta.rs
@@ -399,6 +399,11 @@ primitive! {
         params: &["f", "workgroup-size"],
         category: "fn",
         example: "(git (fn [a b] (+ a b)))",
+        // Mixed: the SIG_QUERY return hands the closure to the VM's handler, which
+        // caches the compiled SPIR-V on that closure's TEMPLATE — a retention that
+        // outlives the call, is shared by every closure over the template, and is
+        // recorded by no seam. Real, uncounted store (docs/impl/region/effects.md
+        // § "A signal a handler stores for is a store").
         effect: RegionEffect::Mixed,
     }
     "fn/git?" => prim_fn_git {

--- a/src/wasm/instruction/calls.rs
+++ b/src/wasm/instruction/calls.rs
@@ -141,7 +141,7 @@ impl WasmEmitter {
     /// rather than branched on.
     ///
     /// Only `rt_call` returns four words. `rt_data_op` and `call_primitive`
-    /// return three and use [`store_result_with_signal`] directly.
+    /// return three and use [`Self::store_result_with_signal`] directly.
     pub(in crate::wasm) fn store_call_result(&self, f: &mut Function, dst: Reg) {
         f.instruction(&Instruction::LocalSet(self.suspended_local()));
         self.store_result_with_signal(f, dst);

--- a/tests/elle/oracle.lisp
+++ b/tests/elle/oracle.lisp
@@ -1219,7 +1219,36 @@
    ["protect-while"
     (fn [j]
       (let [[ok v] (protect ((fn [] j)))]
-        v)) 0]
+        v)) 0]  # `defer` on its ordinary SUCCESS path — the twin of `protect-while`
+   # above. Same inner fiber, same resume; the whole difference is the trailing
+   # `if`, which reads the fiber with `fiber/value` in the arm taken here and with
+   # `fiber/propagate` in the arm that is not. Declaring `fiber/propagate` `Mixed`
+   # seeds that fiber on escape's store facet, the branch-arm release window
+   # declines, and the branch's only release stays in the untaken arm — 2 regions
+   # and 3 objects stranded per evaluation, so a loop whose body is wrapped in
+   # `defer` grows without bound (docs/impl/region/effects.md § `Opaque`, "The
+   # child-chain WIRING is `Opaque` too"). `protect-while` has no such arm and reads
+   # 0 whatever the declaration says, which is what makes it the pair-control here
+   # and not the gauge. Both are CLOSED controls (undeclared, like
+   # `rest-array-copy`), so a regression to open trips the completeness gate loudly
+   # instead of being absorbed under F2.
+   ["defer-while"
+    (fn [j]
+      (defer
+        (length [1 2])
+        ((fn [] j)))) 0]  # The other arm, and the control.
+   # `defer-error` raises in the body, so the arm it drives is the PROPAGATE arm —
+   # the one that held the branch's only release under `Mixed`, and so the one that
+   # correctly stays closed under `defer-while`'s counterfactual. It is what tells a
+   # real fix from a moved strand: a change that only re-anchored the release onto
+   # the other arm closes `defer-while` and opens this. The arm also leaves by
+   # SIG_PROPAGATE rather than falling through, so a release the window replicates
+   # into it must survive a signal exit to read 0 here.
+   ["defer-error"
+    (fn [j]
+      (protect (defer
+                 (length [1 2])
+                 (error j)))) 0]
    ["one-shot"
     (fn [j]
       (let [f (fiber/new (fn [] j) 1)]


### PR DESCRIPTION
`defer` stranded two regions and three objects on every evaluation of its
ordinary success path — no fiber, no yield, no error in the shape. A loop whose
body is wrapped in `defer`, and so every `with` and `with-temp-dir`, grew
without bound.

`fiber/propagate` declared `RegionEffect::Mixed`, on the reading that the VM's
SIG_PROPAGATE handler writes the fiber argument into the propagating fiber's own
`child`/`child_value` pair with no counting seam. `Mixed` seeds every argument on
escape's store facet, and a region escaping by a facet other than return keeps
the conservative baseline at every mechanism gated on `frame_held_regions` — the
branch-arm release window among them. `defer`'s expansion reads its fiber with
`fiber/status`, with `fiber/value` in one arm and with `fiber/propagate` in the
other, so the branch's only release stayed in the arm the success path never
takes, and the fiber value and its body closure stranded per call.

That write holds nothing. The free-time walk's Fiber arm enumerates the closure,
its env and template, the terminal `signal`, `closure_value` and the seeded
parameter baseline, and never the child chain (`find_object_cross_refs`), so the
pair owes no reference. It is the child-chain **wiring**, and `fiber/resume`'s
handler performs the identical writes on every resume — `with_child_fiber` step 2
when it descends, `seed_child_inheritance` when it suspends — under a
`Delivers { args: &[1] }` declaration that lists the resume value alone. The
fiber argument has never been a store there; `fiber/propagate` was the outlier.
It now declares `Opaque`, beside `fiber/child`: unbounded result, no store.

`git` becomes the sole `Mixed` declarant and the handler-store rule's declarant
with it — its handler caches compiled SPIR-V on the argument's template, a
retention that outlives the call and that no seam records. The rule now says what
it always meant: a handler's write is a store when it creates a **holder**.

## Measurement

The gauge is the oracle. Two probes join the direct-loop class, run at both
`--jit=off` and `--jit=eager`:

| probe | shape | declared `Mixed` | declared `Opaque` |
|---|---|---|---|
| `defer-while` | `(defer (length [1 2]) ((fn [] j)))` | 3.0 objects/op, **open** | 0.0, closed |
| `defer-error` | `(protect (defer (length [1 2]) (error j)))` | 0.0, closed | 0.0, closed |

`defer-while` is the counterfactual: with the declaration restored to `Mixed` it
reads 3.0/op and trips the completeness gate as an unclassified open probe.

`defer-error` correctly stays closed under that same counterfactual, and that is
why it is here. It drives the PROPAGATE arm — the one that held the branch's only
release under `Mixed` — so a change that merely re-anchored the release onto the
other arm would close `defer-while` and open this. The arm also leaves by
SIG_PROPAGATE rather than falling through, so a release the window replicates
into it must survive a signal exit to read 0.

`protect-while` is the pair-control: the same inner fiber and resume with no
propagate arm, 0.0 either way, which is what makes it a control and not a gauge.
Both new probes are CLOSED controls (undeclared), so a regression to open trips
the completeness gate rather than being absorbed under F2.

## Pins

- `fiber_graph_natives_declare_opaque_and_git_keeps_the_hard_edge` — neither
  fiber-graph native is a hard-edge site; `git` is.
- `a_fiber_graph_write_does_not_seed_the_store_facet` — the escape half. Nothing
  else catches the wrong declaration: `Mixed` reads true on the result side (the
  SIG_PROPAGATE payload IS arg0) and the declaration oracle exempts a
  signal-carrying return.
- `tests/elle/region-fiber-propagate-uaf.lisp` — the soundness face, green with
  the fiber, error, unwind and abort UAF files under `--trace=guardfree`.

The first commit is unrelated and one word long: a bare-name doc link into a
`pub(in crate::wasm)` method failed `make test`'s `--document-private-items`
rustdoc pass under `-D warnings`.

Closes #941.