### PR TITLE
regions: what yields is the emit operation, not the `Emit` node

### DIFF
--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1379,8 +1379,8 @@ cannot decide is whether the block ever runs. The block belongs to the native
 fall-through, and a native reaches it on exactly one outcome: **normal completion**
 (`bits.is_empty()`, the `SignalAction::Ok` classification). Every other outcome — an
 error, a suspend, a fiber carrier (`fiber/resume`/`fiber/abort`/`fiber/propagate`), a
-capability denial — leaves through the signal machinery, which abandons this frame's
-continuation.
+capability denial — leaves through the signal machinery, which does not run the block
+before returning to the dispatch loop.
 
 One release in that block is the frame's own **extra** reference, and it is the one the
 signal exit runs. A tail call hands its callee one fresh owning reference per **borrowed**
@@ -1392,6 +1392,25 @@ not being replaced by a native, the fall-through block's own `DecrefValueRegion`
 exit reaches neither, so it consumes the retain itself. The count argument is the
 borrowedness: the value has a holder that is not this frame, by the definition of the
 class, so dropping the extra reference frees nothing.
+
+**Except the retain that names the parked payload.** A SUSPEND does not abandon the
+continuation: the driver the tail suspend unwinds to parks it at the post-`TailCall` ip and
+the resume replays the block (owner.md § "A suspending native tail call parks its
+continuation"). So on that exit the fall-through's `DecrefValueRegion` is still a consumer,
+and the retain it consumes is exactly what the park owes — a fiber body owns one reference
+of every value it yields, and a borrowed payload has no other (owner.md § "A fiber body owns
+one reference of every value it yields"). The suspending exit therefore leaves standing each
+retain whose region is the payload's, and consumes the rest as before: a park delivers ONE
+payload and the discharge of an abandoned fiber releases ONE reference of it, so a retain on
+any other region has no such stand-in and would be stranded once per abandoned park. The
+test is the payload's region against the stash's, the same reading the abandoned-frame walk
+makes of its own tables (§ "An abandoned frame runs the releases it still owes"). A
+capability denial parks too, but its payload is a struct the denial built, which names no
+argument — so its retains keep the ordinary consume.
+
+That exemption is what carries a **dynamic** `emit` in tail position, whose non-literal
+first argument makes it an ordinary native call rather than the `Emit` terminator: the
+borrowed-argument retain is the body reference the park owes, and there is no second mint.
 
 **Every OTHER release in that block stays.** They divide in two and neither half has that
 argument. An **argument's** own release is the ownership move, and a signal exit is exactly
@@ -1437,7 +1456,10 @@ an_owned_tail_argument_is_not_named_on_the_call}` (the naming pins, both faces),
 `tests/elle/region-tail-signal-exit-uaf.lisp` (the soundness complement — a value the signal
 payload carries, a restarted `:error` fiber that replays the block, a suspending handoff, and
 a caught error whose handler reads the released value's holder must all survive the exit's
-release).
+release). The payload exemption is pinned by
+`tests/elle/region-dynamic-emit-borrow-uaf.lisp` (a tail dynamic `emit` of a borrowed value,
+driven past an abandoned park) and gauged by the `emit-dyn-tail` probe in
+`tests/elle/oracle.lisp`.
 
 ## An abandoned frame runs the releases it still owes
 

--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -232,6 +232,29 @@ parked fiber's accounting symmetric with its unpark:
   region where the record matches ([mechanism.md](mechanism.md) § "An abandoned frame runs
   the releases it still owes"). A halt takes neither the retain nor the record — a halted
   fiber is promoted to `:dead` and never resumed, so its delivery has no consumer.
+- **What yields is the emit OPERATION, not the `Emit` node.** A first argument the compiler
+  cannot read as a keyword set falls through to the `emit` primitive
+  ([../../signals/emit.md](../../signals/emit.md) § "Dynamic emit"), which parks the same way
+  and owes the same body reference — so the question above is asked of the operation. The
+  walk records the payload argument's regions against a call whose callee is the emit
+  primitive exactly as its `Emit` arm records them against the node
+  (`CallClassification::emit_natives` names that primitive under each of its names), and
+  `borrowed_emit_payloads` answers over both.
+  What supplies the reference differs by position, because a call already mints one for an
+  argument the frame does not own. In **tail** position that borrowed-argument retain IS the
+  body reference: it is taken before the `TailCall` and released by the post-`TailCall`
+  block, which the resume replays ([mechanism.md](mechanism.md) § "What the fall-through
+  owes, a signal exit owes too"). In **non-tail** position no such retain exists, so
+  `lower_call` takes one at the payload argument — the same `IncrefValueRegion`, private
+  stash slot, and `DecrefValueRegion` shape `lower_emit` uses, the resume landing at the
+  instruction after the call.
+  The signal is a runtime value here, so the mint cannot be gated on `suspends` the way the
+  literal path gates it. It is taken whatever the signal turns out to be, and a TERMINAL one
+  reaches the same consumer by another route: the raise leaves through the mask that catches
+  it, which delivers the payload as the resumer's result, and the resumer's release of that
+  result consumes one reference exactly as it consumes the delivery of a park. Pinned by
+  `tests/elle/region-dynamic-emit-borrow-uaf.lisp`, and gauged per op by the `emit-dyn-*`
+  probes in `tests/elle/oracle.lisp`.
 - **A delivery into a replayed frame carries one owning reference.** A parked
   `BytecodeFrame` re-enters at its suspending call's continuation, whose
   compiler-emitted result release consumes one owning reference of the value the

--- a/src/hir/region.rs
+++ b/src/hir/region.rs
@@ -23,7 +23,7 @@ mod stats;
 // Re-export at the crate::hir::region root so every path that resolved as
 // `crate::hir::region::<Item>` before the split still resolves, and so the
 // test module's `use super::*;` keeps seeing these names.
-pub use classify::CallClassification;
+pub use classify::{CallClassification, EMIT_PAYLOAD_ARG};
 pub use data::{OutlivesConstraint, Region, RegionData};
 pub use id::{MappedRegion, RuntimeRegion, StaticRegion};
 pub use info::{CellContainer, CellStore, CellStores, RegionInfo, TailCalleeFacts};

--- a/src/hir/region/classify.rs
+++ b/src/hir/region/classify.rs
@@ -7,6 +7,13 @@ use crate::value::SymbolId;
 
 use rustc_hash::FxHashSet;
 
+/// The 0-based index of the emit primitive's **payload** argument. `(emit bits
+/// value)` takes its signal first and the value it yields second, so this is the
+/// one position both the region walk — which records the payload's regions
+/// against a dynamic emit's call node — and the lowerer — which mints the body
+/// reference the park owes for it — have to name.
+pub const EMIT_PAYLOAD_ARG: usize = 1;
+
 /// Call classification data for region inference.
 ///
 /// Tells the region inference walk which calls return immediates
@@ -98,4 +105,14 @@ pub struct CallClassification {
     /// completing resume hands back the body's terminal value). `None` under
     /// the default empty classification.
     pub fiber_resume: Option<SymbolId>,
+    /// The SymbolIds the **emit primitive** answers to. A first argument the
+    /// compiler cannot read as a keyword set compiles to an ordinary call on it
+    /// rather than to the `Emit` terminator (docs/signals/emit.md § "Dynamic
+    /// emit"), and such a call parks and yields exactly as the terminator does —
+    /// so the borrowed-payload reading must recognize it structurally
+    /// (docs/impl/region/owner.md § "What yields is the emit OPERATION, not the
+    /// `Emit` node"). A set rather than one id because the primitive is reachable
+    /// under its canonical name and its alias, and ordinary code uses the alias.
+    /// Empty under the default classification, which disables the reading.
+    pub emit_natives: FxHashSet<SymbolId>,
 }

--- a/src/hir/region/infer/tests/emit.rs
+++ b/src/hir/region/infer/tests/emit.rs
@@ -137,6 +137,71 @@ fn own_parameter_yield_payload_is_not_borrowed() {
     );
 }
 
+// ── the same question, asked of the emit OPERATION ──────────────────────────
+//
+// A first argument the compiler cannot read as a keyword set falls through to the
+// `emit` primitive, so the park is an ordinary call and there is no `Emit` node to
+// key on. The walk records the payload argument's regions against the CALL, so the
+// borrowed-payload reading covers both shapes (docs/impl/region/owner.md
+// § "What yields is the emit OPERATION, not the `Emit` node"). Both need the real
+// classification: `emit_natives` is empty under the default one.
+
+#[test]
+fn dynamic_emit_of_a_captured_payload_is_borrowed() {
+    // `s` makes the signal a runtime value, so `(emit s x)` is a Call. `x` belongs
+    // to the enclosing lambda, so the emitting body releases it nowhere and the
+    // discharge would release the resumer's reference.
+    let (hir, arena, symbols, info) =
+        analyze_with_class("(let [s :yield] (fn () (let [x (string \"a\")] (fn () (emit s x)))))");
+    let calls = find_calls_to_primitive(&hir, "emit", &arena, &symbols);
+    assert_eq!(calls.len(), 1, "expected one dynamic (emit …) call");
+    assert!(
+        info.borrowed_emit_payloads.contains(&calls[0]),
+        "a dynamic emit of a captured value borrows it: the emitting body releases \
+         it nowhere, so the reference is owed; borrowed_emit_payloads = {:?}, call @{}",
+        info.borrowed_emit_payloads,
+        calls[0].0,
+    );
+}
+
+#[test]
+fn dynamic_emit_of_a_body_allocated_payload_is_not_borrowed() {
+    // The contrast that keeps the reading about the emitting BODY rather than about
+    // the call: the body allocates what it emits, so its `decref_point` sits in the
+    // emitting lambda and a second reference would be stranded at every abandoned
+    // park.
+    let (hir, arena, symbols, info) =
+        analyze_with_class("(let [s :yield] (fn () (let [x (string \"a\")] (emit s x))))");
+    let calls = find_calls_to_primitive(&hir, "emit", &arena, &symbols);
+    assert_eq!(calls.len(), 1, "expected one dynamic (emit …) call");
+    assert!(
+        !info.borrowed_emit_payloads.contains(&calls[0]),
+        "a body-allocated dynamic emit payload owns its own reference; \
+         borrowed_emit_payloads = {:?}, call @{}",
+        info.borrowed_emit_payloads,
+        calls[0].0,
+    );
+}
+
+#[test]
+fn a_non_emit_delivers_call_records_no_emit_payload() {
+    // The recording is keyed on the emit primitive, not on the `Delivers` effect it
+    // shares with the other fiber value installers: `fiber/resume` hands its value
+    // to a fiber that is already parked and yields nothing of its own, so naming its
+    // argument here would mint a reference no park consumes.
+    let (hir, arena, symbols, info) =
+        analyze_with_class("(fn () (let [x (string \"a\")] (fn (h) (fiber/resume h x))))");
+    let calls = find_calls_to_primitive(&hir, "fiber/resume", &arena, &symbols);
+    assert_eq!(calls.len(), 1, "expected one (fiber/resume …) call");
+    assert!(
+        !info.borrowed_emit_payloads.contains(&calls[0]),
+        "only the emit primitive delivers a value the emitting body yields; \
+         borrowed_emit_payloads = {:?}, call @{}",
+        info.borrowed_emit_payloads,
+        calls[0].0,
+    );
+}
+
 #[test]
 fn funnel_containment_recorded_for_push() {
     // `%array-push` compiles as a native funnel Call: the store is runtime-counted,

--- a/src/hir/region/infer/walk/call.rs
+++ b/src/hir/region/infer/walk/call.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::hir::region::infer::walk::inline::Inlined;
+use crate::hir::region::EMIT_PAYLOAD_ARG;
 
 impl RegionInference {
     pub(super) fn walk_call(&mut self, hir: &Hir) -> Vec<Region> {
@@ -25,6 +26,20 @@ impl RegionInference {
         }
         let _ = self.walk(func);
         let arg_regions: Vec<Vec<Region>> = args.iter().map(|a| self.walk(&a.expr)).collect();
+
+        // A dynamic `emit` — a first argument the compiler could not read as a
+        // keyword set — parks and yields exactly as the `Emit` terminator does, so
+        // its payload argument's regions are recorded against this call exactly as
+        // the `Emit` arm records them against the node. What reads them is the
+        // borrowed-payload pass, which asks whether the emitting body releases the
+        // payload anywhere (docs/impl/region/owner.md § "What yields is the emit
+        // OPERATION, not the `Emit` node"). The signal is arg0 and the payload arg1,
+        // the primitive's fixed arity.
+        if self.is_emit_native(func) {
+            if let Some(payload) = arg_regions.get(EMIT_PAYLOAD_ARG) {
+                self.emit_payload_regions.insert(hir.id, payload.clone());
+            }
+        }
 
         // Always register the Call node so the lowerer has a
         // region for the bytecode Call instruction.

--- a/src/hir/region/infer/walk/classify.rs
+++ b/src/hir/region/infer/walk/classify.rs
@@ -163,6 +163,26 @@ impl RegionInference {
         }
     }
 
+    /// Is the callee the **emit primitive** — the callee a dynamic `emit` falls
+    /// through to when its first argument is not a literal keyword set
+    /// (docs/signals/emit.md § "Dynamic emit")? Under the same
+    /// unshadowed-immutable-primitive condition as `call_effect`. Such a call parks
+    /// and yields exactly as the `Emit` terminator does, so the walk records its
+    /// payload argument's regions the same way and the borrowed-payload reading
+    /// covers both shapes (docs/impl/region/owner.md § "What yields is the emit
+    /// OPERATION, not the `Emit` node").
+    pub(super) fn is_emit_native(&self, func: &Hir) -> bool {
+        if let HirKind::Var(binding) = &func.kind {
+            let bi = self.arena().get(*binding);
+            if !bi.is_immutable || bi.is_mutated {
+                return false;
+            }
+            self.call_class.emit_natives.contains(&bi.name)
+        } else {
+            false
+        }
+    }
+
     /// May this callee's heap result BE one of its arguments, or a value living inside
     /// one? Only a declaration that the result lives in the call's OWN minted region
     /// answers no: [`Fresh`](crate::primitives::def::RegionEffect::Fresh),

--- a/src/lir/AGENTS.md
+++ b/src/lir/AGENTS.md
@@ -333,6 +333,13 @@ register is consumed by the `Emit`. That gives a fiber body one reference of eve
 value it yields, which is what a discarded fiber's discharge releases
 (docs/impl/region/owner.md § "Park/unpark symmetry").
 
+A **dynamic** emit has no `Emit` terminator to wrap — its first argument is not a
+literal keyword set, so it lowers as an ordinary call — and `lower_call` carries the
+same obligation there. In non-tail position it takes the mint at the payload
+argument and releases it after the call, which is where the resume lands; in tail
+position the borrowed-argument retain already is that reference (docs/impl/region/
+owner.md § "What yields is the emit OPERATION, not the `Emit` node").
+
 The emitter preserves stack state across the emit boundary via
 `yield_stack_state`. This ensures intermediate values computed before emit
 (e.g., the `1` in `(+ 1 (emit :yield 2) 3)`) survive into the resume block.

--- a/src/lir/intrinsics.rs
+++ b/src/lir/intrinsics.rs
@@ -141,6 +141,14 @@ impl PrimitiveClassification {
             // structurally: a fiber-body producer and its resume consumer.
             fiber_new: symbols.get("fiber/new"),
             fiber_resume: symbols.get("fiber/resume"),
+            // The emit primitive under each name it answers to: a dynamic `emit`
+            // compiles to a call on it, and that call parks and yields exactly as
+            // the `Emit` terminator does (`CallClassification::emit_natives`).
+            // Ordinary code reaches it through the alias, so both belong here.
+            emit_natives: ["fiber/emit", "emit"]
+                .iter()
+                .filter_map(|name| symbols.get(name))
+                .collect(),
             ..Default::default()
         };
         PrimitiveClassification {

--- a/src/lir/lower/control/call.rs
+++ b/src/lir/lower/control/call.rs
@@ -316,6 +316,20 @@ impl<'a> Lowerer<'a> {
                 .current_hir_id
                 .and_then(|id| self.region_info.tail_callee_facts.get(&id))
                 .map(|f| f.fixed_params);
+            // A dynamic `emit` whose payload this body releases nowhere. The park
+            // owes the body one reference of every value it yields, and the shape
+            // that carries it depends on position (docs/impl/region/owner.md
+            // § "What yields is the emit OPERATION, not the `Emit` node"): a TAIL
+            // call already mints one for a borrowed argument, which the suspending
+            // exit leaves standing and the replayed fall-through releases, so only
+            // a non-tail call owes a mint of its own. Routed through `borrowed`
+            // below, whose retain / private stash / post-call release is the exact
+            // shape `lower_emit` uses at the terminator.
+            let emit_payload_arg = (!is_tail
+                && self
+                    .current_hir_id
+                    .is_some_and(|id| self.region_info.borrowed_emit_payloads.contains(&id)))
+            .then_some(crate::hir::region::EMIT_PAYLOAD_ARG);
             for (index, arg) in args.iter().enumerate() {
                 // For a tail call, a BORROWED arg must be handed the callee a
                 // fresh owning reference (see the move-on-tail-call comment at
@@ -347,7 +361,7 @@ impl<'a> Lowerer<'a> {
                 if takes_the_move && !repeated {
                     moved_arg_regions.extend(leaf_regions);
                 }
-                let borrowed = borrowed_leaf || repeated;
+                let borrowed = borrowed_leaf || repeated || emit_payload_arg == Some(index);
                 if borrowed {
                     self.deferred_decref_points.insert(arg.expr.id);
                 }
@@ -649,6 +663,20 @@ impl<'a> Lowerer<'a> {
                         args: arg_regs,
                         arity_checked,
                     });
+                }
+                // The body reference a dynamic `emit` park owes, released here:
+                // the primitive parks at the instruction after this call, so this
+                // is the continuation past the suspend — the release a fiber
+                // abandoned while suspended never reaches and the discard discharge
+                // stands in for (docs/impl/region/owner.md § "Park/unpark
+                // symmetry"). The stash is private to this site, and the
+                // `LoadLocal`/`DecrefValueRegion` pair is push-pop-neutral around
+                // the result the call left on top. Empty for every other non-tail
+                // call: only the emit payload sets `borrowed` off tail position.
+                for &slot in &borrowed_arg_slots {
+                    let v = self.fresh_reg();
+                    self.emit(LirInstr::LoadLocal { dst: v, slot });
+                    self.emit(LirInstr::DecrefValueRegion { src: v });
                 }
                 // After ANF (`src/hir/anf.rs`), every consumer position
                 // for a Call has a synthetic `Let` binding owning the

--- a/src/lir/lower/tests/release/emission.rs
+++ b/src/lir/lower/tests/release/emission.rs
@@ -90,6 +90,72 @@ fn park_mints_nothing_for_a_body_allocated_payload() {
     );
 }
 
+/// The `(retains, releases)` a NON-TAIL dynamic emit is wrapped in — retains
+/// before the `SuspendingCall` in its block, releases after it. The park is an
+/// ordinary call here, so the resume lands at the next instruction rather than in
+/// a block of its own (docs/impl/region/owner.md § "What yields is the emit
+/// OPERATION, not the `Emit` node").
+fn dynamic_park_borrow_ops(module: &crate::lir::LirModule) -> (usize, usize) {
+    fn in_func(func: &LirFunction) -> Option<(usize, usize)> {
+        for b in &func.blocks {
+            let Some(at) = b
+                .instructions
+                .iter()
+                .position(|i| matches!(i.instr, LirInstr::SuspendingCall { .. }))
+            else {
+                continue;
+            };
+            let count = |r: &[crate::lir::types::SpannedInstr], f: fn(&LirInstr) -> bool| {
+                r.iter().filter(|i| f(&i.instr)).count()
+            };
+            return Some((
+                count(&b.instructions[..at], |i| {
+                    matches!(i, LirInstr::IncrefValueRegion { .. })
+                }),
+                count(&b.instructions[at + 1..], |i| {
+                    matches!(i, LirInstr::DecrefValueRegion { .. })
+                }),
+            ));
+        }
+        None
+    }
+    in_func(&module.entry)
+        .or_else(|| module.closures.iter().find_map(in_func))
+        .expect("a function containing a SuspendingCall")
+}
+
+#[test]
+fn dynamic_park_mints_a_body_reference_for_a_borrowed_payload() {
+    // A non-literal first argument makes the park an ordinary call, so there is no
+    // `Emit` terminator for `lower_emit` to mint at — and no borrowed-argument
+    // retain either, the call not being in tail position. The emitting lambda
+    // closes over a value the enclosing one allocates and releases, so `lower_call`
+    // owes the reference the discard discharge stands in for.
+    let module = compile_to_lir(
+        "(let [s :yield] (fn () (let [x (string \"a\")] (fn () (begin (emit s x) 0)))))",
+    );
+    let (retains, releases) = dynamic_park_borrow_ops(&module);
+    assert!(
+        retains >= 1 && releases >= 1,
+        "a borrowed dynamic-emit payload must be retained across the park and \
+         released after the call; got {retains} retain(s) and {releases} release(s)",
+    );
+}
+
+#[test]
+fn dynamic_park_mints_nothing_for_a_body_allocated_payload() {
+    // The contrast, exactly as for the literal park: the body allocates what it
+    // emits, so its own release is already the one the discharge stands in for.
+    let module =
+        compile_to_lir("(let [s :yield] (fn () (let [x (string \"a\")] (begin (emit s x) 0))))");
+    let (retains, _) = dynamic_park_borrow_ops(&module);
+    assert_eq!(
+        retains, 0,
+        "a body-allocated dynamic-emit payload already carries the body's \
+         reference; minting a second strands it per abandoned park",
+    );
+}
+
 #[test]
 fn release_emitted_for_unbound_call_result() {
     // An unbound Call result — `(f "a")` whose result flows

--- a/src/lir/lower/tests/release/frameexit.rs
+++ b/src/lir/lower/tests/release/frameexit.rs
@@ -951,3 +951,21 @@ fn an_owned_tail_argument_is_not_named_on_the_call() {
          releasing it at a signal exit drops the reference the move handed over",
     );
 }
+
+#[test]
+fn a_tail_dynamic_emit_names_its_payload_as_a_borrowed_argument() {
+    // A dynamic `emit` in tail position is an ordinary native tail call, and its
+    // borrowed payload takes the ordinary borrowed-argument retain. That retain is
+    // the body reference the park owes (docs/impl/region/owner.md § "What yields is
+    // the emit OPERATION, not the `Emit` node"), so no second mint is owed here —
+    // and the suspending exit's payload exemption has a slot to leave standing.
+    let module =
+        compile_to_lir("(let [s :yield] (fn () (let [x (string \"a\")] (fn () (emit s x)))))");
+    let slots = tail_call_borrowed_slots(&module);
+    assert!(
+        slots.iter().any(|s| !s.is_empty()),
+        "a tail dynamic emit must name its borrowed payload on the call \
+         (slots={slots:?}) — the suspending exit can spare only what the \
+         instruction names",
+    );
+}

--- a/src/vm/call/inner/tail.rs
+++ b/src/vm/call/inner/tail.rs
@@ -21,23 +21,37 @@ impl VM {
     /// handler: the handler may install the very value as the signal's payload
     /// (a fiber carrier hands over its own fiber argument) or swap the live
     /// fiber out from under the frame whose locals name it.
+    ///
+    /// `spare` is the value a SUSPENDING exit parks, and it is left standing: that
+    /// exit's continuation is parked at the post-`TailCall` ip, so the release the
+    /// retain answers to still runs on the resume, and the retain is the one
+    /// reference the park owes the body for what it yields (owner.md § "A fiber
+    /// body owns one reference of every value it yields"). Its slot keeps its
+    /// value, so the replay releases it rather than no-opping on a stamp. `None`
+    /// everywhere else, where nothing reaches the block again.
     fn take_borrowed_arg_retains(
         &mut self,
         slots: &[u16],
+        spare: Option<Value>,
     ) -> Vec<crate::hir::region::RuntimeRegion> {
         if slots.is_empty() {
             return Vec::new();
         }
         let frame_base = self.current_frame_base();
         let heap = unsafe { &mut *self.heap_ptr };
+        let spared = spare.and_then(|v| crate::value::arena::region_of(heap, v));
         let mut regions = Vec::with_capacity(slots.len());
         for &slot in slots {
             let Some(cell) = self.fiber.stack.get_mut(frame_base + slot as usize) else {
                 continue;
             };
             let value = *cell;
+            let region = crate::value::arena::result_region_of(heap, value);
+            if spared.is_some() && region == spared {
+                continue;
+            }
             *cell = Value::NIL;
-            regions.extend(crate::value::arena::result_region_of(heap, value));
+            regions.extend(region);
         }
         regions
     }
@@ -74,9 +88,12 @@ impl VM {
     /// borrowed-argument retains. That retain has exactly one consumer per path:
     /// a frame-replacing closure callee's owned-param release, or the
     /// post-`TailCall` fall-through block, which runs on one outcome only — the
-    /// native's normal completion. Every SIGNAL exit reaches neither, so it
-    /// consumes the retain here instead (docs/impl/region/mechanism.md § "What
-    /// the fall-through owes, a signal exit owes too").
+    /// native's normal completion. A SIGNAL exit reaches neither, so it consumes
+    /// the retain here instead — except at a SUSPEND, which parks the
+    /// continuation at the post-`TailCall` ip, so the block does run on resume and
+    /// the retain naming the parked payload is the reference that park owes the
+    /// body (docs/impl/region/mechanism.md § "What the fall-through owes, a signal
+    /// exit owes too").
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn tail_call_inner(
         &mut self,
@@ -97,13 +114,15 @@ impl VM {
             if !blocked.is_empty() {
                 // The denial never runs the native at all, so the fall-through
                 // block is abandoned exactly as it is on any other signal exit.
-                let owed = self.take_borrowed_arg_retains(borrowed_arg_slots);
+                // Its park spares nothing: the payload is a struct the denial
+                // built, which names no argument of this call.
+                let owed = self.take_borrowed_arg_retains(borrowed_arg_slots, None);
                 let bits = self.handle_capability_denial_tail(def, blocked, &args);
                 self.run_borrowed_arg_retains(owed);
                 return Some(bits);
             }
             if !checked && !def.arity.matches(args.len()) {
-                let owed = self.take_borrowed_arg_retains(borrowed_arg_slots);
+                let owed = self.take_borrowed_arg_retains(borrowed_arg_slots, None);
                 self.set_error(
                     "arity-error",
                     format!(
@@ -170,7 +189,21 @@ impl VM {
             // and the regions released after it, so a payload that carries one
             // of these values (a fiber carrier's own argument, an `IoRequest`
             // embedding a port) is still held while the handler installs it.
-            let owed = self.take_borrowed_arg_retains(borrowed_arg_slots);
+            //
+            // A SUSPEND is the exit that does not abandon the block: the driver it
+            // unwinds to parks the continuation at the post-`TailCall` ip and the
+            // resume replays it. So the retain naming the value this park delivers
+            // is spared — it is the one reference the body owes for what it yields,
+            // released by that replayed block or, for a fiber abandoned while
+            // suspended, by the discard discharge that stands in for it. Only that
+            // one: a park delivers ONE payload and the discharge releases ONE
+            // reference of it, so a retain on any other region has no stand-in.
+            let spare = matches!(
+                crate::signals::dispatch::classify(bits, &value),
+                crate::signals::dispatch::SignalAction::Suspend
+            )
+            .then_some(value);
+            let owed = self.take_borrowed_arg_retains(borrowed_arg_slots, spare);
             let bits = self.handle_primitive_signal_tail(bits, value);
             self.run_borrowed_arg_retains(owed);
             return Some(bits);

--- a/tests/elle/oracle.lisp
+++ b/tests/elle/oracle.lisp
@@ -811,6 +811,10 @@
 (def heap-mod (make-heap-module))
 (def @t19s @{:x 0})
 (def @t20c 0)
+# A signal the compiler cannot read as a keyword set, and a payload no fiber body
+# allocates — the two ingredients a dynamic emit's borrowed park needs.
+(def emit-sig :yield)
+(def emit-subject (string "emit-subject"))
 
 # Direct-loop class. Each entry: [label (fn [j] body) rate].
 # j varies the input (faithful to the originals' loop variable i). Pins are the
@@ -1289,7 +1293,46 @@
                            (yield j)
                            9) |:yield|)]
         (fiber/resume f)
-        (protect (fiber/abort f "boom")))) 0]  # An emit-raised error's payload keeps
+        (protect (fiber/abort f "boom")))) 0]  # An abandoned park through the DYNAMIC
+   # emit path: a first argument the compiler cannot read as a keyword set falls
+   # through to the `emit` primitive, so the park is an ordinary call rather than the
+   # `Emit` terminator and the body reference the discharge stands in for comes from
+   # the call rather than from `lower_emit` (docs/impl/region/owner.md § "What yields
+   # is the emit OPERATION, not the `Emit` node"). Each gauges the reference's ARITY,
+   # not its presence — withholding it over-frees, which no leak gauge sees and
+   # `tests/elle/region-dynamic-emit-borrow-uaf.lisp` reports. The four must stay
+   # together: the two witnesses differ only in POSITION, which decides where the
+   # reference comes from — a non-tail park mints one at the payload argument, a tail
+   # park already has the borrowed-argument retain and the suspending exit leaves it
+   # standing (docs/impl/region/mechanism.md § "What the fall-through owes, a signal
+   # exit owes too") — and each has a control that removes one ingredient:
+   # `emit-lit-discard` takes the literal path with the same borrow, and
+   # `emit-dyn-fresh` takes the dynamic path with a payload the body allocates, where
+   # nothing is owed and a mint would strand one per park. CLOSED controls
+   # (undeclared, like `rest-array-copy`), so a regression to open trips the
+   # completeness gate loudly rather than being absorbed under F2.
+   ["emit-dyn-discard"
+    (fn [j]
+      (let [f (fiber/new (fn []
+                           (emit emit-sig emit-subject)
+                           9) |:yield|)]
+        (fiber/resume f))) 0]
+   ["emit-dyn-tail"
+    (fn [j]
+      (let [f (fiber/new (fn [] (emit emit-sig emit-subject)) |:yield|)]
+        (fiber/resume f))) 0]
+   ["emit-lit-discard"
+    (fn [j]
+      (let [f (fiber/new (fn []
+                           (emit :yield emit-subject)
+                           9) |:yield|)]
+        (fiber/resume f))) 0]
+   ["emit-dyn-fresh"
+    (fn [j]
+      (let [f (fiber/new (fn []
+                           (emit emit-sig (string "v" j))
+                           9) |:yield|)]
+        (fiber/resume f))) 0]  # An emit-raised error's payload keeps
    # every frame-owed release: `(error v)` mints the payload's delivery itself (the
    # `EmitEscape` retain the resumer's release of the resume result consumes), so the
    # raise records the mint and the abandoned-frame walk and the parked frame's

--- a/tests/elle/region-dynamic-emit-borrow-uaf.lisp
+++ b/tests/elle/region-dynamic-emit-borrow-uaf.lisp
@@ -1,0 +1,216 @@
+(elle/epoch 12)
+# A fiber body owns one reference of every value it yields, and what yields is the
+# emit OPERATION rather than the `Emit` node (docs/impl/region/owner.md
+# § "Park/unpark symmetry").
+#
+# A park's escape retain is the DELIVERY reference: the resumer's compiler-emitted
+# release of the resume result consumes it. What a discarded fiber's discharge
+# stands in for is the body's SEPARATE reference, released by the continuation past
+# the suspend — a release a fiber abandoned while suspended never reaches. A
+# payload the body allocated carries that second reference itself; a payload it
+# merely BORROWS — a capture, a parameter, a module-level binding — carries none,
+# so without one the discharge releases the delivery reference the resumer already
+# consumed and the value dies under every holder that outlives the fiber.
+#
+# A first argument the compiler cannot read as a keyword set falls through to the
+# `emit` primitive (docs/signals/emit.md § "Dynamic emit"), so the park is an
+# ordinary call rather than the `Emit` terminator. Two positions, two references:
+# a TAIL emit's payload already carries the borrowed-argument retain the call mints
+# for the callee, which the post-`TailCall` block releases on resume, so the
+# suspending exit must leave it standing (docs/impl/region/mechanism.md § "What the
+# fall-through owes, a signal exit owes too"); a NON-TAIL emit has no such retain,
+# so the site mints one of its own.
+#
+# The fault needs both ingredients, and the controls at the bottom remove one each:
+# resume the fiber to completion, emit something the body allocated, or emit
+# through the literal path, and the same program is balanced without an extra
+# reference. So a fix that mints unconditionally trades this fault for a per-park
+# leak, which the growth gauge at the end refuses.
+#
+# Each witness reads its subject AFTER the abandoned fiber's region is gone —
+# through the borrow's own holder, through `fiber/value`, and through a container —
+# so an over-early free faults rather than reading stale but mapped bytes. A fresh
+# subject per iteration keeps region ids churning, so a recycled id detonates on its
+# generation stamp.
+
+(def sig :yield)
+
+# ── (a) STATEMENT position, a module-level borrow ────────────────────────────
+# The emit is a non-tail suspending call; nothing in the body releases `shared`.
+(def shared (string "shared-subject"))
+(defn w-module []
+  (let [inner (fiber/new (fn ()
+                           (emit sig shared)
+                           0) |:yield|)]
+    (length (fiber/resume inner))))
+
+# ── (b) TAIL position, a module-level borrow ─────────────────────────────────
+# Here the payload is a borrowed tail argument, so the call already mints the
+# reference — the suspending exit must not consume it.
+(defn w-module-tail []
+  (let [inner (fiber/new (fn () (emit sig shared)) |:yield|)]
+    (length (fiber/resume inner))))
+
+# ── (c) STATEMENT position, a captured `let`-local ───────────────────────────
+(defn w-local [n]
+  (let [s (string "local" n)]
+    (let [inner (fiber/new (fn ()
+                             (emit sig s)
+                             0) |:yield|)]
+      (let [m (length (fiber/resume inner))]
+        (%add m (length s))))))
+
+# ── (d) TAIL position, a captured PARAMETER of the enclosing frame ───────────
+(defn w-param-tail [s]
+  (let [inner (fiber/new (fn () (emit sig s)) |:yield|)]
+    (let [n (length (fiber/resume inner))]
+      (%add n (length s)))))
+
+# ── (e) the payload is read through `fiber/value`, not the resume ────────────
+(defn w-fiber-value [s]
+  (let [inner (fiber/new (fn ()
+                           (emit sig s)
+                           0) |:yield|)]
+    (fiber/resume inner)
+    (let [n (length (fiber/value inner))]
+      (%add n (length s)))))
+
+# ── (f) the borrow outlives the emitting frame in a container ────────────────
+# Nothing in the frame reads `s` after the resume; the holder that must still find
+# it alive is the array the caller reads back out.
+(def @sink @[])
+(defn w-stored [s]
+  (push sink s)
+  (let [inner (fiber/new (fn ()
+                           (emit sig s)
+                           0) |:yield|)]
+    (length (fiber/resume inner))))
+
+# ── (g) two dynamic parks of the same borrow, the second one abandoned ───────
+(defn w-twice [s]
+  (let [inner (fiber/new (fn ()
+                           (emit sig s)
+                           (emit sig s)
+                           0) |:yield|)]
+    (fiber/resume inner)
+    (let [n (length (fiber/resume inner))]
+      (%add n (length s)))))
+
+# ── controls — remove one ingredient each; correct without an extra reference ─
+
+# (h) the LITERAL path, which the `Emit` terminator already mints for.
+(defn c-literal [s]
+  (let [inner (fiber/new (fn ()
+                           (emit :yield s)
+                           0) |:yield|)]
+    (let [n (length (fiber/resume inner))]
+      (%add n (length s)))))
+
+# (i) the literal path in TAIL position, the pair-control for (b) and (d).
+(defn c-literal-tail [s]
+  (let [inner (fiber/new (fn () (emit :yield s)) |:yield|)]
+    (let [n (length (fiber/resume inner))]
+      (%add n (length s)))))
+
+# (j) the body ALLOCATES what it emits, so it owns the second reference.
+(defn c-allocated [s]
+  (let [inner (fiber/new (fn ()
+                           (emit sig (concat s "!"))
+                           0) |:yield|)]
+    (let [n (length (fiber/resume inner))]
+      (%add n (length s)))))
+
+# (k) the body emits only a READ of the borrow — an immediate crosses no region.
+(defn c-read [s]
+  (let [inner (fiber/new (fn ()
+                           (emit sig (length s))
+                           0) |:yield|)]
+    (fiber/resume inner)
+    (length s)))
+
+# (l) the fiber is RESUMED TO COMPLETION, so the body's continuation runs.
+(defn c-completed [s]
+  (let [inner (fiber/new (fn ()
+                           (emit sig s)
+                           0) |:yield|)]
+    (let [n (length (fiber/resume inner))]
+      (fiber/resume inner)
+      (%add n (length s)))))
+
+# ── drive: a fresh subject per iteration; an over-free faults on the read ─────
+
+(defn drive [reps]
+  (var i 0)
+  (var a 0)
+  (var b 0)
+  (var c 0)
+  (var d 0)
+  (var e 0)
+  (var f 0)
+  (var g 0)
+  (var h 0)
+  (var k 0)
+  (var l 0)
+  (var m 0)
+  (var n 0)
+  (while (%lt i reps)
+    (assign a (w-module))
+    (assign b (w-module-tail))
+    (assign c (w-local i))
+    (assign d (w-param-tail (string "param" i)))
+    (assign e (w-fiber-value (string "value" i)))
+    (assign f (w-stored (string "stored" i)))
+    (assign g (w-twice (string "twice" i)))
+    (assign h (c-literal (string "lit" i)))
+    (assign k (c-literal-tail (string "littail" i)))
+    (assign l (c-allocated (string "alloc" i)))
+    (assign m (c-read (string "read" i)))
+    (assign n (c-completed (string "done" i)))
+    # The witness (f) sink is a module-level container by design; read the stored
+    # borrow back out — it must still be alive — then drain so the driver's own
+    # retention stays flat.
+    (assert (%gt (length (get sink (%sub (length sink) 1))) 0)
+            "stored borrow freed by the abandoned fiber's discharge")
+    (assign sink @[])
+    (assign i (%add i 1)))
+  (list a b c d e f g h k l m n))
+
+(let [r (drive 800)]
+  (assert (> (get r 7) 0) "control: literal emit mis-read (harness broken)")
+  (assert (> (get r 8) 0) "control: literal tail emit mis-read (harness broken)")
+  (assert (> (get r 9) 0) "control: body-allocated payload mis-read")
+  (assert (> (get r 10) 0) "control: immediate payload mis-read")
+  (assert (> (get r 11) 0) "control: completed fiber mis-read")
+  (assert (> (get r 0) 0)
+          "dynamic emit: module-level borrow freed by an abandoned park")
+  (assert (> (get r 1) 0)
+          "dynamic tail emit: module-level borrow freed by an abandoned park")
+  (assert (> (get r 2) 0)
+          "dynamic emit: captured local freed under the emitting frame")
+  (assert (> (get r 3) 0)
+          "dynamic tail emit: captured parameter freed under the caller")
+  (assert (> (get r 4) 0)
+          "dynamic emit: borrow freed under a `fiber/value` read")
+  (assert (> (get r 5) 0)
+          "dynamic emit: stored borrow freed under the container read")
+  (assert (> (get r 6) 0)
+          "dynamic emit: borrow freed by the second of two parks"))
+
+# The module-level subject must survive every abandoned fiber that emitted it.
+(assert (%gt (length shared) 0)
+        "module-level borrow freed by an abandoned dynamic park")
+
+# ── the leak face: one reference per park, not two ───────────────────────────
+# The mint belongs only where the body owns none — and in tail position the
+# borrowed-argument retain is already it — so steady-state region growth stays flat
+# across the whole witness set.
+(drive 100)
+(let [before (arena/region-count)]
+  (drive 400)
+  (let [growth (%sub (arena/region-count) before)]
+    (assert (%lt growth 40)
+            (string "dynamic-emit borrow accounting strands regions: live count "
+                    "grew by " growth " over 400 iterations of thirteen parks "
+                    "each (expected flat)"))))
+
+(println "region-dynamic-emit-borrow-uaf: ok")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -510,6 +510,28 @@ fn region_fiber_yield_borrow_uaf() {
     );
 }
 
+// Guard — what yields is the emit OPERATION, not the `Emit` node
+// (docs/impl/region/owner.md § "What yields is the emit OPERATION, not the `Emit`
+// node"). A first argument the compiler cannot read as a keyword set falls through
+// to the `emit` primitive, so the park is an ordinary call and the body reference
+// the discard discharge stands in for has to come from the call: a NON-TAIL one
+// mints it at the payload argument, a TAIL one already holds the borrowed-argument
+// retain and the suspending exit leaves it standing. Withhold either and the
+// discharge releases the delivery reference the resumer already consumed, freeing
+// the payload under every holder that outlives the fiber. This drives each borrow
+// shape — a module-level binding in both positions, a captured local, a captured
+// parameter, a second park of the same value — past an abandoned fiber and reads it
+// afterwards, through the holder, through `fiber/value`, and through a container, so
+// an over-free faults under guardfree. Four controls must stay clean without an extra
+// reference, and a growth gauge refuses a mint-everywhere fix.
+#[test]
+fn region_dynamic_emit_borrow_uaf() {
+    run_elle_script_with_args(
+        "region-dynamic-emit-borrow-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — a resume value delivered into a frame parked at a suspending PRIMITIVE
 // call carries one owning reference (docs/impl/region/owner.md § "A delivery into
 // a replayed frame carries one owning reference"). The replayed frame re-enters at


### PR DESCRIPTION
A first argument the compiler cannot read as a keyword set falls through to the
`emit` primitive ([docs/signals/emit.md](docs/signals/emit.md) § "Dynamic emit"),
so the park is an ordinary call rather than the `Emit` terminator. The analysis
named no site there and the lowerer minted nothing. A fiber body that emitted a
value it merely **borrows** — a capture, a parameter, a module-level binding —
therefore held no reference of it across the suspend. A fiber abandoned while
parked then had its discharge release the delivery reference the resumer already
consumed, and the payload died under every holder that outlived the fiber.

## What the change does

The reading follows the emit **operation** rather than the `Emit` node.
`walk_call` records the payload argument's regions against a call whose callee is
the emit primitive, exactly as the `Emit` arm records them against the node, so
`RegionInfo::borrowed_emit_payloads` answers over both shapes.

What supplies the reference depends on position, because a call already mints one
for an argument the frame does not own.

- **Non-tail.** `lower_call` mints at the payload argument and releases after the
  call, which is where the resume lands — the retain, private stash slot, and
  release `lower_emit` uses at the terminator.
- **Tail.** The borrowed-argument retain already is that reference, and the
  post-`TailCall` block releases it. What was wrong is that the suspending exit
  consumed it first, on the premise that a signal exit abandons the block. A
  suspend does not: the driver parks the continuation at the post-`TailCall` ip
  and the resume replays it. So `tail_call_inner` now leaves standing the retain
  whose region is the parked payload's, and consumes the rest as before — a park
  delivers ONE payload and an abandoned fiber's discharge releases ONE reference
  of it, so a retain on any other region has no such stand-in.

## How it was measured

Four probes join `tests/elle/oracle.lisp`, all at 0. `emit-dyn-discard` and
`emit-dyn-tail` are the two positions; `emit-lit-discard` and `emit-dyn-fresh`
are the controls that remove one ingredient each — the literal path with the same
borrow, and the dynamic path with a payload the body allocates. Each reads the
reference's **arity**, not its presence: withholding it over-frees, which no leak
gauge can see.

Counterfactuals, each against a build with one mechanism disabled:

| disabled | result |
|---|---|
| the non-tail mint | `region-dynamic-emit-borrow-uaf.lisp` faults on a stale region deref |
| the suspending exit's payload exemption | same fixture faults on a stale region deref |
| the borrowed gate (mint at every dynamic emit) | `emit-dyn-fresh` reads 1.0 and the oracle's completeness gate fires |

All three gauges green on this branch: `oracle: ok` with the open/by-design split
unchanged (1 defect across 1 root, 2 by-design); the 89 `region_*` guardfree pins
pass, including the new `region_dynamic_emit_borrow_uaf`; `make smoke-elle` is
963 pass, 15 skip, 0 fail, 0 diverge. `cargo test -p elle --lib` is 2217 pass.

## Tests

- `tests/elle/region-dynamic-emit-borrow-uaf.lisp` — seven borrow shapes driven
  past an abandoned park (a module-level binding in both positions, a captured
  local, a captured parameter, a `fiber/value` read, a container that outlives
  the fiber, and a second park of the same value), five controls that must stay
  clean without an extra reference, and a growth gate that refuses a
  mint-everywhere fix. Registered guardfree as `region_dynamic_emit_borrow_uaf`.
- `hir::region::infer::tests::emit::{dynamic_emit_of_a_captured_payload_is_borrowed,
  dynamic_emit_of_a_body_allocated_payload_is_not_borrowed,
  a_non_emit_delivers_call_records_no_emit_payload}` — the analysis names the call
  site, and names only the emit primitive rather than every `Delivers` declarant.
- `lir::lower::tests::release::emission::{dynamic_park_mints_a_body_reference_for_a_borrowed_payload,
  dynamic_park_mints_nothing_for_a_body_allocated_payload}` and
  `lir::lower::tests::release::frameexit::a_tail_dynamic_emit_names_its_payload_as_a_borrowed_argument`
  — the emit pins for each position.

Closes #933.
