### PR TITLE
regions: a carrier that comes back with a result never left the frame

### DIFF
--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1461,6 +1461,64 @@ release). The payload exemption is pinned by
 driven past an abandoned park) and gauged by the `emit-dyn-tail` probe in
 `tests/elle/oracle.lisp`.
 
+### A carrier that comes back with a result never left the frame
+
+The section above divides a native tail call's outcomes into normal completion, which
+runs the post-`TailCall` block, and a signal exit, which abandons it. A **fiber
+carrier** — `fiber/resume`, `fiber/abort`, `fiber/propagate`, `fiber/refuse` —
+belongs to neither
+half until the VM has driven the child. It leaves the primitive as a signal because it
+is a *request*: the VM is asked to run another fiber and report what happened. Where
+this fiber's own mask **absorbs** the child's outcome, the request is answered here,
+the value is the call's result, and nothing has left. So the carrier takes the
+fall-through — push the result, continue into the post-`TailCall` block — exactly as a
+native that returned `SIG_OK` does.
+
+Reading the absorbed outcome as an exit instead is what strands the block. The block
+holds every release the frame still owes for this call: one `DecrefValueRegion` per
+**owned argument** (the ownership move a native callee never runs in the caller's
+place), the return mint, and the result's own release. Handing the value out through
+`fiber.signal` and returning `SIG_OK` reaches none of them, and no other path runs them
+either — an absorbed outcome is not an error, so the abandoned-frame walk does not
+fire, and it is not a suspend, so no replay arrives.
+
+The count argument the exemptions in the section above make is *why the fall-through
+is the answer rather than a walk*. That section keeps an argument's release in the
+dead block because a signal exit is where the payload may BE that argument, and keeps
+the result's release because it names a local the fall-through would have stored.
+Absorption removes both premises at once: the frame runs on, so the block stores its
+own result before releasing anything, and it runs the compiler's exact per-argument
+ownership rather than a runtime guess about which argument the signal took.
+
+The **other two positions already read it this way**, so this is one rule stated in
+three places rather than a new one. In Call position `handle_fiber_abort_signal` pushes
+the absorbed result and returns `None`, and the compiler's post-call code runs. On the
+JIT tier `handle_fiber_abort_signal_jit` hands it back in the return register and the
+compiled caller's post-`TailCall` block runs. The interpreter's tail position was the
+one that treated the answer as an exit.
+
+What funds the result's release is unchanged by the position. `dispatch_native_call`
+withholds the pass-through retain from a value a native returns as a signal payload
+(effects.md § "The dispatch pass-through retain"), and for an absorbed carrier the seam that
+produced the value has already counted one: the injection's `AbortDelivery` where an
+abort's mask catches (effects.md § `Delivers`), and for a resume the reference the
+crossing itself counted — the park's `EmitEscape` retain for a yielded value, the
+child's `Return` mint for a terminal one. That is the same reference the Call position
+consumes, so the two positions cannot drift apart.
+
+Where the payload is *also* an owned argument — a literal materialized straight into
+`(fiber/abort f "boom")` whose caller reads the result back — the frame owes **two**
+releases on one region, and holds two references to fund them: the one its allocation
+minted and the one the delivery did. Running one is what a skipped block looks like
+from the outside: a rate of one region per abort, flat in the payload's size.
+
+Pinned by the `abort-tail-result`, `abort-mask-caught-literal` and
+`refuse-tail-result` probes in `tests/elle/oracle.lisp` (the per-op rates, each beside
+the control that removes the tail position), and by
+`tests/elle/region-fiber-abort-delivery-uaf.lisp` (the soundness complement — the block
+frees the fiber and the payload at the call the carrier returned through, so every
+reader that outlives it must still find them).
+
 ## An abandoned frame runs the releases it still owes
 
 The section above places one release in the block a signal exit skips. That block is

--- a/src/vm/call/inner/tail.rs
+++ b/src/vm/call/inner/tail.rs
@@ -206,6 +206,34 @@ impl VM {
             let owed = self.take_borrowed_arg_retains(borrowed_arg_slots, spare);
             let bits = self.handle_primitive_signal_tail(bits, value);
             self.run_borrowed_arg_retains(owed);
+            // A fiber CARRIER (`fiber/resume`/`fiber/abort`/`fiber/propagate`/
+            // `fiber/refuse`)
+            // leaves the primitive as a signal because it is a request: drive
+            // this child fiber and report what happened. Where this fiber's own
+            // mask ABSORBS the child's outcome the request is answered here, so
+            // the value is the call's result and the frame never left — it takes
+            // the fall-through, exactly as a native that completed normally does
+            // (docs/impl/region/mechanism.md § "A carrier that comes back with a
+            // result never left the frame"). The post-`TailCall` block then runs
+            // the releases it holds for this call: one per owned argument, plus
+            // the result's own, plus the return mint. Handing the value out
+            // through `fiber.signal` instead reaches none of them, and no other
+            // path does either — an absorbed outcome is not an error, so the
+            // abandoned-frame walk does not fire, and not a suspend, so no replay
+            // arrives. The Call position and the JIT tier already read it this
+            // way (`handle_fiber_abort_signal`, `handle_fiber_abort_signal_jit`).
+            //
+            // The borrowed-argument retains are consumed above on this path too,
+            // and the block's own `DecrefValueRegion` for each then loads the
+            // `nil` the take stamped and no-ops: one release either way.
+            if bits.is_empty() {
+                let (_, result) =
+                    self.fiber.signal.take().expect(
+                        "VM bug: a tail signal handler that answers SIG_OK sets fiber.signal",
+                    );
+                self.fiber.stack.push(result);
+                return None;
+            }
             return Some(bits);
         }
 

--- a/tests/elle/oracle.lisp
+++ b/tests/elle/oracle.lisp
@@ -262,8 +262,16 @@
                     "del-wrapper" "set-del-wrapper" "set-add"])
 (declare-root :f2 ["fiber-nested" "multi-resume" "yield-discard"
                    "yield-multimut" "protect-while" "denied-discard"
-                   "cancel-discard" "abort-tail-result"
-                   "abort-mask-caught-literal"])
+                   "cancel-discard"])
+# `abort-tail-result` and `abort-mask-caught-literal` are CLOSED controls now
+# (undeclared, like `rest-array-copy`, so a regression to open trips the
+# completeness gate loudly rather than being absorbed back under F2). What they
+# measured was a fiber carrier in TAIL position whose outcome this fiber's mask
+# absorbs: the request is answered here, so the value is the call's result and the
+# frame never left — it takes the fall-through into the post-`TailCall` block, which
+# runs the compiler's owned-argument releases and the return mint, exactly as the
+# Call position and the JIT tier already did (docs/impl/region/mechanism.md § "A
+# carrier that comes back with a result never left the frame").
 # `abort-discard` is a CLOSED control now (undeclared, like `rest-array-copy`, so a
 # regression to open trips the completeness gate loudly rather than being absorbed
 # back under F2): what it measured was the borrowed-argument
@@ -2266,59 +2274,54 @@
                                      nil)
                                    (catch e nil))
                                  nil))) count-gauge 100 6 60 0.4 0.5) 0)
-# The TAIL-position face of the same abort, and the one that reads open. The
-# nine controls above all discard the abort's result; this one RETURNS it, which
-# is the whole difference — `abort-tail-discarded` is the identical body with a
-# `nil` after the call, so the gap between the pair isolates the tail position
-# rather than the abort. `fiber/abort` in tail position is a NATIVE tail call
-# that leaves by a signal, so the post-`TailCall` block holding the call's
-# compiler-emitted result release is reached on no path, and the delivery the
-# injection minted keeps a whole fiber alive behind it
-# (docs/impl/region/mechanism.md § "What the fall-through owes, a signal exit
-# owes too" states the rule for the borrowed-argument retain; a native tail
-# call's own RESULT release is the obligation this measures and it names a local
-# the fall-through would have stored). Declared under F2 — the dead
-# continuation's residual — and shrink-only, so a fix lowers it. An IMMEDIATE
-# payload, which has no region at all, still strands two regions here, and a
-# payload an enclosing binding owns changes nothing: what this counts is not the
-# payload. That is the discriminator against `abort-mask-caught-literal` below,
-# which the same two controls take to 0. Tracked as issue #945.
+# The TAIL-position face of the same abort. The nine controls above all discard
+# the abort's result; this one RETURNS it, which is the whole difference —
+# `abort-tail-discarded` is the identical body with a `nil` after the call, so
+# the gap between the pair isolates the tail position rather than the abort.
+# `fiber/abort` in tail position is a NATIVE tail call that leaves by a signal,
+# but an ABSORBED outcome is the carrier's answer rather than an exit: the frame
+# is still there, so it falls through to the post-`TailCall` block and runs the
+# owned-argument releases that block holds (docs/impl/region/mechanism.md § "A
+# carrier that comes back with a result never left the frame"). A closed control
+# now. The counter-factual — reading the answer as an exit — strands the fiber
+# argument, the closure behind it, and the payload: three regions, of which an
+# IMMEDIATE payload removes one and a payload an enclosing binding owns removes
+# none. That is the discriminator against `abort-mask-caught-literal` below,
+# whose whole strand IS the payload, and it is why the two must stay a pair.
 #
-# The pin is a cross-tier RANGE because the strand is interpreter machinery: the
-# post-`TailCall` block is what the interpreter never reaches, and a compiled
-# frame reaches the same release by another route. So the shape measures 0 under
-# `--jit=eager` and the whole strand under `--jit=off`, and the pinned range is
-# that gap's gauge. Closing the interpreter side collapses it to 0.
+# It reads 0 on every tier, and did so under `--jit=eager` before the fall-through
+# landed: a compiled frame reaches the same releases through its own
+# post-`TailCall` block, so the strand was interpreter machinery alone.
 (pin (measure-core "abort-tail-result"
                    (stmt-run (fn []
                                (let [f (ab-mk-caught)]
                                  (fiber/resume f)
                                  (fiber/abort f [1 2 3])))) count-gauge 100 6 60
-                   0.4 0.5) [0 4])
+                   0.4 0.5) 0)
 (pin (measure-core "abort-tail-discarded"
                    (stmt-run (fn []
                                (let [f (ab-mk-caught)]
                                  (fiber/resume f)
                                  (fiber/abort f [1 2 3])
                                  nil))) count-gauge 100 6 60 0.4 0.5) 0)
-# The payload's OWN region, stranded where one frame both allocates it and
-# consumes the abort's result: the two releases the frame owes land in one region
-# slot and it emits one. `abort-mask-caught-literal` needs all three — the
-# fiber's MASK catches (so the caller receives the payload back), the payload is a
-# literal materialized in the aborting frame, and that frame consumes the result —
-# and `abort-mask-caught-bound` is the pair-control that removes the second, the
-# same abort over a payload an enclosing binding owns, whose own release then
-# covers it. Open, declared under F2, tracked as issue #942.
+# The payload's OWN region, where one frame both allocates it and consumes the
+# abort's result. The frame owes TWO releases on that one region — the argument
+# and the result — and holds two references to fund them: its allocation's, and
+# the injection's delivery mint. The post-`TailCall` block carries both, which is
+# what a skipped block costs one region per abort. This probe needs all three
+# ingredients — the fiber's MASK catches (so the caller receives the payload
+# back), the payload is a literal materialized in the aborting frame, and that
+# frame consumes the result — and `abort-mask-caught-bound` is the pair-control
+# that removes the second, the same abort over a payload an enclosing binding
+# owns, whose own release then covers it. A closed control now.
 #
 # It is NOT `abort-tail-result` seen smaller, and the two must stay a pair because
 # resemblance is all there is to go on otherwise: both need the result in tail
-# position and both flatten when it is bound. What separates them is an IMMEDIATE
-# payload, which has no region at all — this probe reads 0 there, since the
-# payload's region is the whole strand, while `abort-tail-result` still strands
-# two regions, since its strand is not the payload. So neither fix closes the
-# other. `abort-discard` above sits one mask bit away from this shape: with
-# `|:yield|` the injected error escapes the fiber instead of being caught by the
-# mask, and that route reclaims.
+# position and both flatten when it is bound. An IMMEDIATE payload separates them
+# — it has no region at all, so this shape reads 0 there while
+# `abort-tail-result` still counts the fiber. `abort-discard` above sits one mask
+# bit away: with `|:yield|` the injected error escapes the fiber instead of being
+# caught by the mask, and that route reclaims.
 (defn ab-mk-mask-caught []
   (fiber/new (fn []
                (yield 1)
@@ -2328,7 +2331,7 @@
                                (let [f (ab-mk-mask-caught)]
                                  (fiber/resume f)
                                  (protect (fiber/abort f "boom"))))) count-gauge
-                   100 6 60 0.4 0.5) 1)
+                   100 6 60 0.4 0.5) 0)
 (pin (measure-core "abort-mask-caught-bound"
                    (stmt-run (fn []
                                (let [p "boom"
@@ -2336,6 +2339,24 @@
                                  (fiber/resume f)
                                  (protect (fiber/abort f p))))) count-gauge 100
                    6 60 0.4 0.5) 0)
+# `fiber/refuse` shares the injection seam with `fiber/abort`
+# (`inject_error_at_suspension`) and leaves by the same `SIG_ABORT`, so it reaches
+# the absorbed-carrier fall-through by the same route and needs its own reading:
+# nothing about the seam distinguishes the two, so a change that reintroduces the
+# strand for one reintroduces it for both. The pair is the same as the abort's —
+# the result RETURNED, and the identical body with a `nil` after the call.
+(pin (measure-core "refuse-tail-result"
+                   (stmt-run (fn []
+                               (let [f (ab-mk-caught)]
+                                 (fiber/resume f)
+                                 (fiber/refuse f [1 2 3])))) count-gauge 100 6
+                   60 0.4 0.5) 0)
+(pin (measure-core "refuse-tail-discarded"
+                   (stmt-run (fn []
+                               (let [f (ab-mk-caught)]
+                                 (fiber/resume f)
+                                 (fiber/refuse f [1 2 3])
+                                 nil))) count-gauge 100 6 60 0.4 0.5) 0)
 
 # ── The physical-id dimension ─────────────────────────────────────────
 # What a CALL costs in physical region ids, the dimension every probe above is

--- a/tests/elle/region-fiber-abort-delivery-uaf.lisp
+++ b/tests/elle/region-fiber-abort-delivery-uaf.lisp
@@ -181,6 +181,101 @@
               "the literal materialized into the abort argument reaches the catch")))
   (assign i (%add i 1)))
 
+# ── Route 1 in TAIL position: the frame releases at the call it returned through
+# An absorbed carrier answers its request in this frame, so the frame falls
+# through to the post-`TailCall` block and runs the releases that block holds —
+# the fiber argument's, the payload argument's, and the result's
+# (docs/impl/region/mechanism.md § "A carrier that comes back with a result never
+# left the frame"). Those frees never ran before, so each face below reads a value
+# the block has just released a reference of.
+#
+# The trap: the payload is BOTH an owned argument and the result here, so the
+# block releases the same region twice on one path. It survives because the frame
+# holds two references — its allocation's and the injection's delivery mint — and
+# the counter-factual is one release short of that, which reads as a per-abort
+# leak rather than a fault.
+(defn tail-abort-literal [f]
+  (fiber/abort f "boom"))
+
+(defn tail-abort-payload [f p]
+  (fiber/abort f p))
+
+(def @i 0)
+(while (%lt i 200)
+  (let [f (fiber/new (fn []
+                       (yield 1)
+                       2) |:yield :error|)]
+    (fiber/resume f)
+    (assert (= (length (tail-abort-literal f)) 4)
+            "a tail abort's caller reads the payload the block released"))
+  (assign i (%add i 1)))
+
+# The payload is a heap value the caller keeps naming after the tail abort
+# returns, so the argument release must leave the enclosing binding's reference
+# standing.
+(def @i 0)
+(while (%lt i 200)
+  (let [payload [1 2 3]
+        f (fiber/new (fn []
+                       (yield 1)
+                       2) |:yield :error|)]
+    (fiber/resume f)
+    (assert (= (get (tail-abort-payload f payload) 2) 3)
+            "the tail abort hands back a payload an outer binding still owns")
+    (assert (= (get payload 0) 1)
+            "the outer binding reads its payload after the tail abort"))
+  (assign i (%add i 1)))
+
+# The fiber ARGUMENT is what the block releases first, and the aborted fiber is
+# still readable through the caller's own binding afterwards.
+(def @i 0)
+(while (%lt i 200)
+  (let [f (fiber/new (fn []
+                       (yield 1)
+                       2) |:yield :error|)]
+    (fiber/resume f)
+    (tail-abort-literal f)
+    (assert (= (fiber/status f) :error)
+            "the aborted fiber survives the tail block's release of its argument")
+    (assert (= (length (fiber/value f)) 4)
+            "the aborted fiber's terminal value survives with it"))
+  (assign i (%add i 1)))
+
+# The RESUME carrier reaches the same fall-through: a tail `fiber/resume` whose
+# child yields a value this fiber's mask absorbs.
+(defn tail-resume [f]
+  (fiber/resume f))
+
+(def @i 0)
+(while (%lt i 200)
+  (let [f (fiber/new (fn []
+                       (yield [7 8 9])
+                       2) |:yield|)]
+    (assert (= (get (tail-resume f) 1) 8)
+            "a tail resume's caller reads the value the block released")
+    (assert (= (fiber/status f) :paused)
+            "the resumed fiber survives the tail block's release of its argument"))
+  (assign i (%add i 1)))
+
+# `fiber/refuse` shares the injection seam and the `SIG_ABORT` exit, so it reaches
+# the same fall-through. A refused fiber that catches keeps running, so its own
+# binding reads it after the block released the argument.
+(defn tail-refuse [f p]
+  (fiber/refuse f p))
+
+(def @i 0)
+(while (%lt i 200)
+  (let [payload {:denied 1}
+        f (fiber/new (fn []
+                       (let [r (protect (yield 1))]
+                         (get (get r 1) :denied))) |:yield :error|)]
+    (fiber/resume f)
+    (assert (= (tail-refuse f payload) 1)
+            "a tail refusal's caller reads the value the block released")
+    (assert (= (get payload :denied) 1)
+            "the outer binding reads its payload after the tail refusal"))
+  (assign i (%add i 1)))
+
 # ── Churn: repeated abort delivery must not accumulate stale pages ───────
 (def @i 0)
 (while (%lt i 200)


### PR DESCRIPTION
## What was wrong

A fiber carrier — `fiber/resume`, `fiber/abort`, `fiber/propagate`, `fiber/refuse` —
leaves its primitive as a signal because it is a *request*: drive this child fiber and
report what happened. Where the calling fiber's own mask **absorbs** the child's
outcome, that request is answered in the frame, so the value is the call's result and
nothing has left.

In **tail** position the interpreter read the answer as an exit instead: it handed the
value out through `fiber.signal` and returned `SIG_OK`. That skips the post-`TailCall`
block, which holds every release the frame still owes for the call — one
`DecrefValueRegion` per owned argument, the result's own release, and the return mint.
Nothing else runs them: an absorbed outcome is not an error, so the abandoned-frame
walk does not fire, and it is not a suspend, so no replay arrives.

Two shapes measured it.

- **#945** — a function whose tail is `(fiber/abort f [1 2 3])` stranded 3 regions per
  call: the fiber argument, the closure behind it, and the payload. An immediate
  payload dropped one; a payload an enclosing binding owns dropped none.
- **#942** — `(protect (fiber/abort f "boom"))`, where the payload is *both* an owned
  argument and the result, stranded 1 region per abort. The frame owes two releases on
  that one region and holds two references to fund them: its allocation's, and the
  injection's `AbortDelivery` mint.

## What the change does

`tail_call_inner` falls through when the tail signal handler answers with empty bits —
it pushes the result and returns `None`, so the dispatch loop continues into the
post-`TailCall` block, exactly as a native that completed normally does. The block then
runs the compiler's exact per-argument ownership rather than a runtime guess about
which argument the signal took.

This is one rule stated in three places rather than a new one. The Call position
(`handle_fiber_abort_signal`) pushes the absorbed result and returns `None`; the JIT
tier (`handle_fiber_abort_signal_jit`) hands it back in the return register and the
compiled caller's own post-`TailCall` block runs. The interpreter's tail position was
the outlier, which is why `--jit=adaptive` measured 0 while `--jit=off` measured the
strand.

The two exemptions in mechanism.md § "What the fall-through owes, a signal exit owes
too" do not reach this case, and absorption is why: that section keeps an argument's
release in the dead block because a signal exit is where the payload may BE that
argument, and keeps the result's release because it names a local the fall-through
would have stored. An absorbed carrier removes both premises at once — the frame runs
on, so the block stores its own result before releasing anything.

## Measurement

`tests/elle/oracle.lisp`, per-op regions:

| probe | before | after |
| --- | --- | --- |
| `abort-tail-result` (#945) | 4.0 | 0.0 |
| `abort-mask-caught-literal` (#942) | 1.0 | 0.0 |
| split headline | `open defects: 3 across 1 roots` | `open defects: 1 across 1 roots` |

Counterfactual: re-pinning both to 0 before the code change failed with
`pinned 0, measured 4.0` and `pinned 0, measured 1.0`, plus the completeness gate
reporting them unclassified.

`make test ELLE=./target/release/elle CARGO_PROFILE=--release` is green end to end, and
the oracle reads `open defects: 1 across 1 roots; by-design: 3` on all four of its
passes (default, `--jit=off`, `--jit=eager`, doctest).

## Tests

- `tests/elle/oracle.lisp` — `abort-tail-result` re-pinned from the cross-tier range
  `[0 4]` to `0` and `abort-mask-caught-literal` from `1` to `0`; both leave
  `declare-root :f2` and become closed controls, so a regression trips the completeness
  gate rather than being absorbed back under F2. New `refuse-tail-result` /
  `refuse-tail-discarded` pair: `fiber/refuse` shares `inject_error_at_suspension` and
  the `SIG_ABORT` exit, so nothing about the seam distinguishes the two.
- `tests/elle/region-fiber-abort-delivery-uaf.lisp` — the soundness complement for a
  free path that never ran before. Five tail-position faces under `--trace=guardfree`:
  an abort with a frame-local literal (payload released twice on one path), an abort
  with a payload an outer binding still names, the fiber argument read back through the
  caller's binding, a tail `fiber/resume`, and a tail `fiber/refuse`.
- `docs/impl/region/mechanism.md` — new section "A carrier that comes back with a result
  never left the frame", beside the signal-exit rule it bounds.

Closes #942.
Closes #945.
