### PR TITLE
stdlib: flatten walks a cursor stack instead of recursing per element

### DIFF
--- a/src/stdlib.lisp
+++ b/src/stdlib.lisp
@@ -846,26 +846,41 @@
                                        (reverse acc)
                                        (loop (+ i 1) (pair (get c i) acc))))]
                        (loop 0 ())))
-           flat (fn (lst)
-                  (if (empty? lst)
-                    ()
-                    (let [x (first lst)]
-                      (cond
-                        (pair? x)
-                          (append (flat x) (flat (rest lst)))
-                        (or (array? x) (array? x))
-                          (append (flat (to-list x)) (flat (rest lst)))
-                        true
-                          (pair x (flat (rest lst)))))))]
+           ## Deep flatten over an explicit cursor stack.
+           ##
+           ## `stack` is a list of cursors, innermost first; each cursor is the
+           ## not-yet-visited tail of one open sequence. `acc` collects output in
+           ## reverse. Descending into a nested sequence pushes a cursor, and
+           ## exhausting one pops it.
+           ##
+           ## The shape buys two properties. Every `walk` call sits in tail
+           ## position, so the trampoline in `execute_bytecode_saving_stack`
+           ## reuses a single frame and the native stack stays flat however long
+           ## the input is. And carrying the remaining work as a stack keeps the
+           ## whole walk O(n) — appending each expansion onto that work instead
+           ## would copy the tail once per nested sequence.
+           walk (fn (stack acc)
+                  (if (empty? stack)
+                    (reverse acc)
+                    (let [cur (first stack)]
+                      (if (empty? cur)
+                        (walk (rest stack) acc)
+                        (let [x (first cur)
+                              rest-stack (pair (rest cur) (rest stack))]
+                          (cond
+                            (pair? x) (walk (pair x rest-stack) acc)
+                            (array? x)
+                              (walk (pair (to-list x) rest-stack) acc)
+                            true (walk rest-stack (pair x acc))))))))]
     (cond
-      (or (pair? coll) (empty? coll)) (flat coll)
+      (or (pair? coll) (empty? coll)) (walk (pair coll ()) ())
+      ## An `@[]` literal filled by `push`, so an array input yields a
+      ## *mutable* array. `->array` would hand back an immutable one.
       (array? coll)
         (let [result @[]]
-          (each x in (flat (to-list coll))
+          (each x in (walk (pair (to-list coll) ()) ())
             (push result x))
           result)
-      (array? coll)
-        (apply array (flat (to-list coll)))
       true (error {:error :type-error
                    :reason :not-a-sequence
                    :message "not a sequence"}))))

--- a/tests/elle/functional.lisp
+++ b/tests/elle/functional.lisp
@@ -191,6 +191,24 @@
 (let [f (flatten @[1 @[2 3] @[4]])]
   (assert (array? f) "flatten: array returns array")
   (assert (= (length f) 4) "flatten: array length"))
+## Length and depth are the two axes that can drive `flatten` past the
+## call-depth limit. Every case above stays under five elements, so these
+## are the ones that pin the flat native stack.
+(let [long-list (reduce (fn (acc i) (pair i acc)) () (range 1000))]
+  (assert (= (length (flatten long-list)) 1000)
+          "flatten: 1000-element list does not exhaust the call stack"))
+(assert (= (length (flatten (range 1000))) 1000)
+        "flatten: 1000-element array does not exhaust the call stack")
+## Depth: one cursor per nested sequence.
+(let [deep (reduce (fn (acc i) (list acc)) (list 42) (range 500))]
+  (assert (= (flatten deep) (list 42)) "flatten: 500 levels of nesting"))
+## Arrays nested inside a list expand too.
+(assert (= (flatten (list 1 @[2 3] (list 4 @[5]))) (list 1 2 3 4 5))
+        "flatten: arrays nested in a list")
+## An array result accepts `push`, which `->array` would not allow.
+(let [f (flatten @[1 @[2 3]])]
+  (push f 99)
+  (assert (= (length f) 4) "flatten: array result is mutable"))
 
 ## ── take-while ──────────────────────────────────────────────────────
 (assert (= (take-while even? (list 2 4 5 6)) (list 2 4)) "take-while: list")


### PR DESCRIPTION
## What was wrong

`flatten` raised

```
{:error :stack-overflow :message "call depth exceeded maximum (200)"}
```

on any sequence of roughly 200 items or more. Its inner helper `flat` recursed
non-tail:

```elle
(pair x (flat (rest lst)))
```

so it spent one native frame per element and hit `MAX_CALL_DEPTH` (200) on
length alone — nesting was never needed to trigger it. Every existing `flatten`
test in `tests/elle/functional.lisp` uses fewer than five elements, so none of
them reached the recursion.

## What the change does

`walk` carries an explicit cursor stack. `stack` is a list holding the
not-yet-visited tail of each open sequence, innermost first; `acc` collects the
output in reverse. Descending into a nested sequence pushes a cursor, and
exhausting one pops it. Every `walk` call sits in tail position, so the
trampoline reuses a single frame and the native stack stays flat.

Cursors also keep it O(n). Re-appending each expansion onto the remaining work —
the shape the old `append`-based version used — copies the tail at every nested
sequence.

Two dead branches go with the rewrite. Neither was reachable, so neither is a
behaviour change:

- the inner `cond` tested `(or (array? x) (array? x))` — the same predicate
  twice, so the `or` could never decide anything;
- the outer `cond` listed `(array? coll)` twice. The first arm won every time,
  leaving `(apply array (flat (to-list coll)))` unreachable — and the two arms
  did not agree, since the dead one built an immutable array.

Array input still yields a **mutable** array: the surviving arm keeps the
`@[]`-plus-`push` construction rather than `->array`.

## How it was measured

The assertions now in `tests/elle/functional.lisp` were run against the
pre-change stdlib. A 1000-element list reproduces the failure at
`<stdlib>:854`, inside `flat`:

```
✗ Runtime error: {:error :stack-overflow :message "call depth exceeded maximum (200)"}
```

They pass against the rewritten `flatten`. `tests/elle/functional.lisp` as it
stood before this change passes on both versions, which is what shows the
existing coverage never reached the recursion.

`elle fmt --check --no-epoch` is clean on both changed files.

## Tests

Added to the `flatten` section of `tests/elle/functional.lisp`:

- a 1000-element list — the case that regressed
- a 1000-element array — the array entry point
- 500 levels of nesting — depth, the other axis
- arrays nested inside a list
- an array result still accepts `push`, pinning the mutable-array guarantee
