### PR TITLE
docs: the integer bytecodes have no emitter, and W001 has no rule

### DIFF
--- a/docs/cookbook/lint-rules.md
+++ b/docs/cookbook/lint-rules.md
@@ -6,82 +6,116 @@ tree walker lives in `src/hir/lint.rs`.
 
 ### Files to modify (in order)
 
-1. **`src/lint/rules.rs`** — Implement the rule function.
+1. **`src/lint/diagnostics.rs`** — Claim a code: add a `LintCode` const and
+   list it in `WARNINGS`.
 
-2. **`src/hir/lint.rs`** — Call the rule from the appropriate `HirKind`
+2. **`src/lint/rules.rs`** — Implement the rule function.
+
+3. **`src/hir/lint.rs`** — Call the rule from the appropriate `HirKind`
    arm in `HirLinter::check()`.
 
-3. **`src/lint/mod.rs`** — Re-export if the rule is public.
+4. **This file** — Add the code to the table below.
 
 ### Step by step
 
-**Step 1: `src/lint/rules.rs`** — Write the rule. Rules take context and
+**Step 1: `src/lint/diagnostics.rs`** — Claim a code. The const binds the
+code to the rule name, and `WARNINGS` is what the table below is checked
+against:
+
+```rust
+pub const MY_RULE: LintCode = LintCode::new("W006", "my-rule-name");
+
+pub const WARNINGS: &[LintCode] = &[
+    ARITY_MISMATCH,
+    MUTABLE_BINDING_NEVER_ASSIGNED,
+    UNUSED_BINDING,
+    NON_TAIL_SELF_RECURSION,
+    MY_RULE,
+];
+```
+
+**Step 2: `src/lint/rules.rs`** — Write the rule. Rules take context and
 push `Diagnostic`s:
 
 ```rust
-use super::diagnostics::{Diagnostic, Severity};
+use super::diagnostics::{Diagnostic, MY_RULE};
 use crate::reader::SourceLoc;
 
-pub fn check_my_rule(
+pub(crate) fn check_my_rule(
     context_data: &str,
     location: &Option<SourceLoc>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     if /* violation detected */ {
-        diagnostics.push(Diagnostic::new(
-            Severity::Warning,
-            "W004",                    // unique code
-            "my-rule-name",            // kebab-case rule name
+        let mut diag = Diagnostic::warn(
+            MY_RULE,
             "description of the issue",
             location.clone(),
-        ).with_suggestions(vec![
-            "how to fix it".to_string(),
-        ]));
+        );
+        diag.suggestions.push("how to fix it".to_string());
+        diagnostics.push(diag);
     }
 }
 ```
 
-**Step 2: `src/hir/lint.rs`** — Call the rule from the tree walker. Find
-the appropriate `HirKind` match arm in `check()`:
+**Step 3: `src/hir/lint.rs`** — Call the rule from the tree walker. A rule
+about a binding goes in `check_binding_site`, which `Let`, `Letrec`, and
+`Define` all route through; a rule about any other form goes in that form's
+`HirKind` arm in `check()`:
 
 ```rust
-// Example: check all let bindings for some property
-HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
-    for (binding, init) in bindings {
-        // Call your rule here:
-        if let Some(sym_name) = symbols.name(binding.name()) {
-            rules::check_my_rule(sym_name, &loc, &mut self.diagnostics);
-        }
-        self.check(init, symbols);
+fn check_binding_site(
+    &mut self,
+    binding: crate::hir::Binding,
+    init: &Hir,
+    loc: &Option<SourceLoc>,
+    symbols: &SymbolTable,
+    arena: &BindingArena,
+) {
+    // Call your rule here:
+    if let Some(sym_name) = symbols.name(arena.get(binding).name) {
+        rules::check_my_rule(sym_name, loc, &mut self.diagnostics);
     }
-    self.check(body, symbols);
+    // ...existing rules and the descent into `init`
 }
 ```
+
+Loop, match, and pattern bindings never reach `check_binding_site`, so a
+rule placed there does not see them.
 
 ### Key types
 
 | Type | Location | Purpose |
 |------|----------|---------|
 | `Diagnostic` | `src/lint/diagnostics.rs` | Finding with severity, code, message, location |
+| `LintCode` | `src/lint/diagnostics.rs` | A code and the rule name it travels with |
 | `Severity` | `src/lint/diagnostics.rs` | `Info`, `Warning`, `Error` |
 | `HirLinter` | `src/hir/lint.rs` | Tree walker that calls rules |
 | `Linter` | `src/lint/cli.rs` | CLI wrapper that runs `HirLinter` |
 
 ### Diagnostic codes
 
+The linter raises these warnings:
+
 | Code | Rule | Fires on |
 |------|------|----------|
-| `W001` | — | Unclaimed. |
 | `W002` | `arity-mismatch` | A call to a built-in with the wrong argument count. |
 | `W003` | `mutable-binding-never-assigned` | A `var`/`@` binding that no `assign` targets. |
 | `W004` | `unused-binding` | A `def`/`let`/`letrec` binding with zero uses. |
 | `W005` | `non-tail-self-recursion` | A function whose self-call is not in tail position. |
 
-Use `W006+` for new warnings, `E00x` for errors, `I00x` for info.
+`diagnostics::WARNINGS` (`src/lint/diagnostics.rs`) is the source of this
+table, and a test in `src/lint/diagnostics/tests.rs` compares the two. A rule
+that lands without its row here fails that test.
 
 `W004` reads the def-use chains `src/hir/defuse.rs` builds, and `W005`
 reads the `is_tail` flag `src/hir/tailcall.rs` sets. Neither rule tracks
 its own state, and neither adds a field to `BindingInner`.
+
+`W001` is unclaimed and no rule raises it, so the table has no row for it.
+Use `W006+` for new warnings. `E000`–`E005` are analysis failures the lint
+CLI reports (`src/lint/cli.rs`), not rules; take `E006` for a new error and
+`I001` for the first info diagnostic.
 
 ### How linting runs
 

--- a/docs/impl/bytecode.md
+++ b/docs/impl/bytecode.md
@@ -29,6 +29,15 @@ Add, Sub, Mul, Div              generic arithmetic (any numeric type)
 Rem                             remainder
 AddInt, SubInt, MulInt, DivInt  integer-specialized arithmetic
 ```
+The integer-only forms are implemented but unemitted. The interpreter runs
+them (`src/vm/arithmetic.rs`), and nothing produces them: the emitter maps
+every LIR `BinOp` to the polymorphic bytecode
+(`src/lir/emit/instr/ops.rs`), so a program never reaches an `AddInt`.
+Wiring them up is tracked as issue #957, which carries the compiler's
+operand-type proofs across the HIR→LIR boundary and spends them here.
+
+There is no negation instruction, and no modulo instruction. The emitter
+lowers unary minus to a `Mul` by the constant `-1`.
 
 ### Comparison
 ```text

--- a/docs/impl/vm.md
+++ b/docs/impl/vm.md
@@ -37,8 +37,13 @@ The main loop in `execute.rs`:
 5. Push result
 6. Advance instruction pointer
 
-Specialized fast paths exist for common sequences (e.g., `LoadLocal` +
-`AddInt` + `StoreLocal` for counter increments).
+The loop dispatches one instruction at a time; no fused sequences exist.
+Specialization lives inside the handlers instead. The polymorphic
+arithmetic ops test their two operands for integers and take a wrapping
+integer path before falling back to the general one
+(`src/vm/arithmetic.rs`). The integer-only `AddInt`/`SubInt`/`MulInt`/
+`DivInt` handlers skip even that test, but no emitter produces those
+bytecodes — see [impl/bytecode.md](bytecode.md) § Arithmetic.
 
 ## Fiber integration
 

--- a/src/compiler/bytecode/instruction.rs
+++ b/src/compiler/bytecode/instruction.rs
@@ -69,13 +69,13 @@ pub enum Instruction {
     /// Array set (index)
     ArrayMutSet,
 
-    /// Specialized arithmetic operations
+    /// Integer-only arithmetic (`docs/impl/bytecode.md` § Arithmetic)
     AddInt,
     SubInt,
     MulInt,
     DivInt,
 
-    /// Generic arithmetic (handles floats)
+    /// Polymorphic arithmetic (int or float operands)
     Add,
     Sub,
     Mul,

--- a/src/lint/AGENTS.md
+++ b/src/lint/AGENTS.md
@@ -14,7 +14,11 @@ provides the shared types and rule implementations.
 |------|---------|
 | `Diagnostic` | Lint finding with severity, code, message, location |
 | `Severity` | `Info`, `Warning`, `Error` |
-| `DiagnosticContext` | Optional source text for context display |
+| `LintCode` | A warning code and the rule name it travels with |
+
+| Constant | Purpose |
+|----------|---------|
+| `WARNINGS` | Every warning code the linter raises, in code order |
 
 | Function | Code | Purpose |
 |----------|------|---------|
@@ -23,8 +27,13 @@ provides the shared types and rule implementations.
 | `check_unused_binding` | `W004` | Warns on a `def`/`let`/`letrec` binding with zero uses |
 | `check_non_tail_self_recursion` | `W005` | Warns on a self-call outside tail position |
 
+Each code above names a `LintCode` in `diagnostics::WARNINGS`, which the
+emission site passes to `Diagnostic::warn` rather than spelling out.
+
 Every binding rule shares one exemption set — synthetic, primitive, and
 `_`-prefixed names — through `reportable_name`.
+
+Adding a rule: see [`docs/cookbook/lint-rules.md`](../../docs/cookbook/lint-rules.md).
 
 ## Dependents
 

--- a/src/lint/diagnostics.rs
+++ b/src/lint/diagnostics.rs
@@ -21,6 +21,41 @@ impl fmt::Display for Severity {
     }
 }
 
+/// A warning the linter can raise: its code and the rule name that always
+/// travels with it.
+///
+/// The pair has one home, so a rule cannot pick up a second code — or a code a
+/// second name — by being spelled out again at a new emission site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LintCode {
+    pub code: &'static str,
+    pub rule: &'static str,
+}
+
+impl LintCode {
+    pub const fn new(code: &'static str, rule: &'static str) -> Self {
+        Self { code, rule }
+    }
+}
+
+pub const ARITY_MISMATCH: LintCode = LintCode::new("W002", "arity-mismatch");
+pub const MUTABLE_BINDING_NEVER_ASSIGNED: LintCode =
+    LintCode::new("W003", "mutable-binding-never-assigned");
+pub const UNUSED_BINDING: LintCode = LintCode::new("W004", "unused-binding");
+pub const NON_TAIL_SELF_RECURSION: LintCode = LintCode::new("W005", "non-tail-self-recursion");
+
+/// Every warning the linter raises, in code order.
+///
+/// `docs/cookbook/lint-rules.md` publishes this table to rule authors as the
+/// index of codes already taken, and `diagnostics/tests.rs` holds the two in
+/// step. A rule that lands without its row in the cookbook fails that test.
+pub const WARNINGS: &[LintCode] = &[
+    ARITY_MISMATCH,
+    MUTABLE_BINDING_NEVER_ASSIGNED,
+    UNUSED_BINDING,
+    NON_TAIL_SELF_RECURSION,
+];
+
 /// A linter diagnostic with source location
 #[derive(Debug, Clone)]
 pub struct Diagnostic {
@@ -54,6 +89,12 @@ impl Diagnostic {
             suggestions: Vec::new(),
             function: None,
         }
+    }
+
+    /// A warning built from its registry entry, which is how every rule raises
+    /// one: the code and the rule name arrive together and cannot disagree.
+    pub fn warn(lint: LintCode, message: impl Into<String>, location: Option<SourceLoc>) -> Self {
+        Self::new(Severity::Warning, lint.code, lint.rule, message, location)
     }
 
     /// Format as human-readable output

--- a/src/lint/diagnostics/tests.rs
+++ b/src/lint/diagnostics/tests.rs
@@ -30,3 +30,43 @@ fn test_diagnostic_without_location() {
     assert_eq!(diag.severity, Severity::Info);
     assert!(diag.location.is_none());
 }
+
+/// Read a row of the cookbook's code table as `(code, rule)`.
+///
+/// Only a row whose first cell holds a code — one of `W`/`E`/`I` and three
+/// digits — qualifies. The cookbook has other two-column tables with backticked
+/// cells, the key-types table among them, and none of those are code rows.
+fn code_row(line: &str) -> Option<(&str, &str)> {
+    let mut cells = line.strip_prefix('|')?.split('|').map(str::trim);
+    let code = cells.next()?.strip_prefix('`')?.strip_suffix('`')?;
+    if code.len() != 4
+        || !matches!(code.as_bytes()[0], b'W' | b'E' | b'I')
+        || !code[1..].bytes().all(|b| b.is_ascii_digit())
+    {
+        return None;
+    }
+    let rule = cells.next()?.strip_prefix('`')?.strip_suffix('`')?;
+    Some((code, rule))
+}
+
+#[test]
+fn the_cookbook_code_table_names_exactly_the_warnings_the_linter_raises() {
+    // The cookbook's table is a rule author's index of codes already taken, and
+    // it is prose: nothing but this test stops it drifting from `WARNINGS`.
+    //
+    // The trap: drift is silent in both directions and neither is cosmetic. A
+    // code the table lists but no rule raises gets skipped as taken, so the
+    // next rule takes a further code and the numbering grows holes. A code a
+    // rule raises but the table omits gets handed to a second rule, and two
+    // rules then answer to one code.
+    const COOKBOOK: &str = include_str!("../../../docs/cookbook/lint-rules.md");
+
+    let documented: Vec<(&str, &str)> = COOKBOOK.lines().filter_map(code_row).collect();
+    let raised: Vec<(&str, &str)> = WARNINGS.iter().map(|w| (w.code, w.rule)).collect();
+
+    assert_eq!(
+        documented, raised,
+        "docs/cookbook/lint-rules.md § Diagnostic codes disagrees with \
+         diagnostics::WARNINGS"
+    );
+}

--- a/src/lint/rules.rs
+++ b/src/lint/rules.rs
@@ -1,6 +1,9 @@
 //! Linting rules for Elle code
 
-use super::diagnostics::{Diagnostic, Severity};
+use super::diagnostics::{
+    Diagnostic, ARITY_MISMATCH, MUTABLE_BINDING_NEVER_ASSIGNED, NON_TAIL_SELF_RECURSION,
+    UNUSED_BINDING,
+};
 use crate::primitives::registration::ALL_TABLES;
 use crate::reader::SourceLoc;
 use crate::value::types::Arity;
@@ -17,10 +20,8 @@ pub(crate) fn check_call_arity(
     if let Some(func_name) = symbol_table.name(func_sym) {
         if let Some(arity) = builtin_arity(func_name) {
             if !arity.matches(arg_count) {
-                let diag = Diagnostic::new(
-                    Severity::Warning,
-                    "W002",
-                    "arity-mismatch",
+                let diag = Diagnostic::warn(
+                    ARITY_MISMATCH,
                     format!(
                         "function '{}' expects {} argument(s) but got {}",
                         func_name, arity, arg_count
@@ -87,10 +88,8 @@ pub(crate) fn check_unused_binding(
     let Some(name) = reportable_name(arena.get(binding), symbol_table) else {
         return;
     };
-    let mut diag = Diagnostic::new(
-        Severity::Warning,
-        "W004",
-        "unused-binding",
+    let mut diag = Diagnostic::warn(
+        UNUSED_BINDING,
         format!("binding '{name}' is never used"),
         location.clone(),
     );
@@ -127,10 +126,8 @@ pub(crate) fn check_non_tail_self_recursion(
     let Some(name) = reportable_name(arena.get(enclosing), symbol_table) else {
         return;
     };
-    let mut diag = Diagnostic::new(
-        Severity::Warning,
-        "W005",
-        "non-tail-self-recursion",
+    let mut diag = Diagnostic::warn(
+        NON_TAIL_SELF_RECURSION,
         format!("'{name}' calls itself outside tail position, so the stack grows with the recursion depth"),
         location.clone(),
     );
@@ -174,10 +171,8 @@ pub(crate) fn check_mutable_never_assigned(
     let Some(name) = reportable_name(inner, symbol_table) else {
         return;
     };
-    let mut diag = Diagnostic::new(
-        Severity::Warning,
-        "W003",
-        "mutable-binding-never-assigned",
+    let mut diag = Diagnostic::warn(
+        MUTABLE_BINDING_NEVER_ASSIGNED,
         format!("mutable binding '{name}' is never reassigned"),
         location.clone(),
     );

--- a/src/lir/emit/tests.rs
+++ b/src/lir/emit/tests.rs
@@ -341,3 +341,66 @@ fn emit_terminator_carries_a_user_signal_bit_whole() {
         "got: {emit_line}"
     );
 }
+
+/// LIR `BinOp` names an operation, never an operand type, so it can only mean
+/// the polymorphic bytecode. The integer-only family stays unemitted until a
+/// typed LIR variant carries a proof of integer operands
+/// (docs/impl/bytecode.md § Arithmetic).
+#[test]
+fn arithmetic_binops_emit_the_polymorphic_bytecodes() {
+    // The trap: every integer opcode name contains its polymorphic one, so a
+    // substring search for "Add" also matches an emitted `AddInt` and passes
+    // under the very mapping it exists to reject. Compare the opcode token
+    // whole.
+    //
+    // The counter-factual: without the negative half, mapping `BinOp::Add` to
+    // `AddInt` still satisfies "some arithmetic opcode was emitted", and float
+    // operands would silently take integer wrapping arithmetic.
+    use crate::compiler::bytecode::disassemble_lines;
+
+    for (op, polymorphic, integer) in [
+        (BinOp::Add, "Add", "AddInt"),
+        (BinOp::Sub, "Sub", "SubInt"),
+        (BinOp::Mul, "Mul", "MulInt"),
+        (BinOp::Div, "Div", "DivInt"),
+    ] {
+        let func = LirFixture::new(Arity::Exact(0))
+            .block(
+                0,
+                vec![
+                    LirInstr::Const {
+                        dst: Reg(0),
+                        value: LirConst::Int(6),
+                    },
+                    LirInstr::Const {
+                        dst: Reg(1),
+                        value: LirConst::Int(7),
+                    },
+                    LirInstr::BinOp {
+                        dst: Reg(2),
+                        op,
+                        lhs: Reg(0),
+                        rhs: Reg(1),
+                    },
+                ],
+                Terminator::Return(Reg(2)),
+            )
+            .build();
+
+        let (bytecode, _, _) = Emitter::new().emit(&func);
+        let opcodes: Vec<String> = disassemble_lines(&bytecode.instructions)
+            .iter()
+            .filter_map(|line| line.split_once("] "))
+            .map(|(_, rest)| rest.split(' ').next().unwrap_or_default().to_string())
+            .collect();
+
+        assert!(
+            opcodes.iter().any(|name| name == polymorphic),
+            "{polymorphic}: BinOp must emit the polymorphic opcode; got {opcodes:?}"
+        );
+        assert!(
+            !opcodes.iter().any(|name| name == integer),
+            "{integer}: BinOp must not emit the integer-only opcode; got {opcodes:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #958.

Two documents described machinery the source does not have.

## The `AddInt` family was presented as a live specialization

`AddInt`/`SubInt`/`MulInt`/`DivInt` are in the instruction set and have
interpreter handlers (`src/vm/arithmetic.rs`), but nothing produces them:
`src/lir/emit/instr/ops.rs` maps every LIR `BinOp` to the polymorphic
bytecode. `docs/impl/bytecode.md` § Arithmetic now states that, and links #957.

The block that named `Mod` and `Neg` — neither is in the enum — was rewritten
by #968 while this branch was open, so what remains here is the paragraph
saying the integer forms are unemitted, and the note that the emitter lowers
unary minus to a `Mul` by `-1`.

`docs/impl/vm.md` § Dispatch loop claimed a fused `LoadLocal` + `AddInt` +
`StoreLocal` fast path. No fused sequence exists. The specialization that does
live there is inside the handlers: the polymorphic arithmetic ops test for two
integer operands and take a wrapping path before the general one.

## The lint-rules code table did not match the linter

`docs/cookbook/lint-rules.md` listed `W001` (naming-kebab-case), which no rule
raises, and called `W003` retired while `src/lint/rules.rs` raises it. The
table now names exactly the codes the linter raises, and says in prose that
`W001` is unclaimed rather than giving it a row.

The recipe around the table was stale the same way: its example called
`Diagnostic::with_suggestions`, which does not exist, and routed new rules at a
`HirKind` arm rather than `check_binding_site`, which is the site `Let`,
`Letrec`, and `Define` actually share. `src/lint/AGENTS.md` listed
`check_naming_convention` and `DiagnosticContext`, neither of which is in the
source.

## The table now has a source

`diagnostics::WARNINGS` holds each code as a `LintCode` carrying its rule name,
`Diagnostic::warn` builds a warning from an entry, and every emission site in
`src/lint/rules.rs` names an entry instead of writing the pair out again. This
is what makes the drift testable. No diagnostic changes.

#974 landed `W004` (`unused-binding`) and `W005` (`non-tail-self-recursion`)
while this branch was open, so `WARNINGS` and the four emission sites cover
those two as well, and the recipe's example claims `W006`.

## Tests

`the_cookbook_code_table_names_exactly_the_warnings_the_linter_raises`
(`src/lint/diagnostics/tests.rs`) parses the cookbook's table and compares it
to `WARNINGS`. Against the table this PR replaces it fails with `left: []`,
`right: [("W002", "arity-mismatch"), ("W003", "mutable-binding-never-assigned")]`.

`arithmetic_binops_emit_the_polymorphic_bytecodes` (`src/lir/emit/tests.rs`)
asserts each arithmetic `BinOp` emits its polymorphic opcode and never the
integer one. Mapping `BinOp::Add` to `Instruction::AddInt` fails it; I ran that
edit to confirm. The negative half matters because every integer opcode name
contains its polymorphic one, so a substring check passes under exactly that
bug.

`make test ELLE=./target/release/elle CARGO_PROFILE=--release` passed before
the rebase over #968 and #974. Since the rebase: `cargo test -p elle --lib` is
2261 pass, `cargo fmt --check` and `cargo clippy -p elle --all-targets` are
clean.
