### PR TITLE
regions: a terminal dynamic emit mints its payload's delivery

### DIFF
--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1412,6 +1412,33 @@ That exemption is what carries a **dynamic** `emit` in tail position, whose non-
 first argument makes it an ordinary native call rather than the `Emit` terminator: the
 borrowed-argument retain is the body reference the park owes, and there is no second mint.
 
+**A terminal `:error` mints instead of exempting.** The same operation raising a terminal
+signal hands its payload to a **catcher**, whose read of the signal consumes one reference —
+the payload's **delivery** (§ "An abandoned frame runs the releases it still owes"). The
+suspend exemption cannot supply that one. An `:error` fiber is resumable, so a restart replays
+this block too, and the stash release then reaches a retain the catcher has already consumed.
+So the exit consumes its retains like any other — the nil stamp makes the replay a no-op — and
+mints the delivery itself, exactly as `handle_emit` mints it on the literal path, recording it
+in the same `Fiber::emit_delivery`.
+
+The mint is taken only where the payload is one of the call's **own arguments**. A payload the
+native BUILT funds the delivery with its birth reference, so an ordinary native raise — a fresh
+error struct — must not receive one. The identity test is what tells the two apart, and the
+`emit` primitive handing back its second argument is the shape that needs it.
+
+**The record travels with the mint**, as it does on the literal path. Once the mint funds the
+delivery, every reference the frame holds is owed to the frame's own routes, so the walk and
+the discharge must stop exempting the payload's region. Two references are reclaimed that way:
+a payload the body ALLOCATED, whose owned-argument release sits in the abandoned block, and the
+second name of a payload that reaches the call twice — the first occurrence moves the frame's
+reference and the second takes a retain of its own (rules.md Rule 5), as `(emit s s)` does.
+Where the fiber is restarted rather than discharged, the replayed block runs that same release,
+so the accounting is the same either way.
+
+A **halt** takes neither mint nor record, for the reason `handle_emit` withholds its own retain
+there: the fiber is promoted to `:dead` and never resumed, so that delivery has no consumer and
+a reference taken for it is stranded (owner.md § "Park/unpark symmetry").
+
 **Every OTHER release in that block stays.** They divide in two and neither half has that
 argument. An **argument's** own release is the ownership move, and a signal exit is exactly
 where the payload may BE that argument — a fiber carrier returns its fiber argument, a
@@ -1456,10 +1483,16 @@ an_owned_tail_argument_is_not_named_on_the_call}` (the naming pins, both faces),
 `tests/elle/region-tail-signal-exit-uaf.lisp` (the soundness complement — a value the signal
 payload carries, a restarted `:error` fiber that replays the block, a suspending handoff, and
 a caught error whose handler reads the released value's holder must all survive the exit's
-release). The payload exemption is pinned by
+release). The suspend half of the payload exemption is pinned by
 `tests/elle/region-dynamic-emit-borrow-uaf.lisp` (a tail dynamic `emit` of a borrowed value,
 driven past an abandoned park) and gauged by the `emit-dyn-tail` probe in
-`tests/elle/oracle.lisp`.
+`tests/elle/oracle.lisp`; the terminal half by
+`tests/elle/region-dynamic-emit-terminal-uaf.lisp` (a tail dynamic `(emit sig v)` raise of a
+borrowed value, read back through every holder that outlives the fiber) and gauged by the
+`emit-dyn-*-error*` probes there, whose `emit-dyn-error-fresh` and `emit-dyn-error-repeat`
+faces are the ones that read the RECORD — a payload the body allocated, and one region named
+through both arguments, each holding a frame reference the walk must stop exempting once the
+mint funds the delivery.
 
 ### A carrier that comes back with a result never left the frame
 
@@ -1579,6 +1612,11 @@ walk may release, and the two raise paths differ:
   would strand one region per raised-and-caught error whose payload the raise chain
   owns. The raise records the mint (`Fiber::emit_delivery`), and a walk whose live
   signal payload matches it skips nothing.
+- A **dynamic `emit` in tail position** reads like the `Emit` case with the mint moved to
+  the exit: the raise is an ordinary native call, so the signal exit mints the delivery of
+  a payload the call received as an argument and records it there (§ "What the fall-through
+  owes, a signal exit owes too"). What the walk then reclaims is the frame's own reference,
+  wherever the payload is one the body allocated.
 - An **injected** `fiber/abort` / `fiber/refuse` payload reads like the `Emit` case,
   for the same reason: the injection mints the delivery
   ([effects.md](effects.md) § `Delivers`) and records it on every fiber whose frames

--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -252,8 +252,14 @@ parked fiber's accounting symmetric with its unpark:
   literal path gates it. It is taken whatever the signal turns out to be, and a TERMINAL one
   reaches the same consumer by another route: the raise leaves through the mask that catches
   it, which delivers the payload as the resumer's result, and the resumer's release of that
-  result consumes one reference exactly as it consumes the delivery of a park. Pinned by
-  `tests/elle/region-dynamic-emit-borrow-uaf.lisp`, and gauged per op by the `emit-dyn-*`
+  result consumes one reference exactly as it consumes the delivery of a park. What supplies
+  that reference in TAIL position is not the borrowed-argument retain, which a restart's
+  replay of the post-`TailCall` block still claims: the exit consumes the retain and mints the
+  delivery itself, recording it so the frames' owed releases stop standing in for a delivery
+  this call now funds ([mechanism.md](mechanism.md) § "What the fall-through owes, a signal
+  exit owes too"). Pinned by
+  `tests/elle/region-dynamic-emit-borrow-uaf.lisp` and
+  `tests/elle/region-dynamic-emit-terminal-uaf.lisp`, and gauged per op by the `emit-dyn-*`
   probes in `tests/elle/oracle.lisp`.
 - **A delivery into a replayed frame carries one owning reference.** A parked
   `BytecodeFrame` re-enters at its suspending call's continuation, whose

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -141,10 +141,13 @@ pub struct Fiber {
     /// same value is `signal`'s.
     pub error_loc: Option<(Value, crate::error::SourceLoc)>,
     /// The `SIG_ERROR` payload whose DELIVERY reference something OTHER than this
-    /// fiber's frames minted. Two raises record here, for one reason:
+    /// fiber's frames minted. Three raises record here, for one reason:
     ///
     /// - an `emit` raise — the `EmitEscape` retain `handle_emit` (and its JIT
     ///   mirror) takes, which the resumer's release of the resume result consumes;
+    /// - the same raise leaving the emit PRIMITIVE in tail position, where the
+    ///   signal exit takes that retain in `handle_emit`'s place
+    ///   (`VM::mint_raised_argument_delivery`);
     /// - an injected `fiber/abort` / `fiber/refuse` payload — the `AbortDelivery`
     ///   retain the injection takes, recorded on the aborted fiber
     ///   (`do_fiber_abort`) and on the aborting one where the error escapes it

--- a/src/vm/call/inner/tail.rs
+++ b/src/vm/call/inner/tail.rs
@@ -56,6 +56,43 @@ impl VM {
         regions
     }
 
+    /// Mint the DELIVERY reference of a payload this tail call is RAISING, where
+    /// the payload is one of the call's own arguments — the shape a dynamic
+    /// `emit` takes, its non-literal first argument making the raise an ordinary
+    /// native call (docs/impl/region/mechanism.md § "What the fall-through owes,
+    /// a signal exit owes too").
+    ///
+    /// The catcher's read of the signal consumes exactly one reference, and every
+    /// reference this frame holds answers to the frame's own release routes: the
+    /// borrowed-argument retain is consumed by the exit (and no-oped at a
+    /// restart's replay by its nil stamp), an owned argument's release sits in the
+    /// abandoned block for the walk or that same replay to run. So the delivery is
+    /// minted here, exactly as `handle_emit` mints it on the literal path — and
+    /// recorded with it (`Fiber::emit_delivery`), so the abandoned-frame walk and
+    /// the parked frame's discharge stop exempting the payload's region and
+    /// reclaim the frame's own reference to a payload it allocated.
+    ///
+    /// A payload the native BUILT — a fresh error struct — is nobody's argument
+    /// and funds the delivery with its birth reference, so the identity test is
+    /// what keeps this off every ordinary native raise.
+    fn mint_raised_argument_delivery(&mut self, args: &[Value], payload: Value) {
+        if !args.iter().any(|a| a.bit_identical(payload)) {
+            return;
+        }
+        let heap = unsafe { &mut *self.heap_ptr };
+        // An immediate payload crosses no region, so there is nothing to fund and
+        // nothing for the record to say stands.
+        let Some(region) = crate::value::arena::region_of(heap, payload) else {
+            return;
+        };
+        crate::value::arena::incref_for_escape(
+            heap,
+            Some(region),
+            crate::value::arena::EscapeSite::EmitEscape,
+        );
+        self.fiber.emit_delivery = Some(payload);
+    }
+
     /// Release the regions [`Self::take_borrowed_arg_retains`] resolved. Split
     /// from the resolution so the signal handler runs between the two — see that
     /// method for why.
@@ -93,7 +130,9 @@ impl VM {
     /// continuation at the post-`TailCall` ip, so the block does run on resume and
     /// the retain naming the parked payload is the reference that park owes the
     /// body (docs/impl/region/mechanism.md § "What the fall-through owes, a signal
-    /// exit owes too").
+    /// exit owes too"). A terminal `:error` consumes them like any other exit and
+    /// mints the payload's delivery instead
+    /// ([`Self::mint_raised_argument_delivery`]).
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn tail_call_inner(
         &mut self,
@@ -198,12 +237,20 @@ impl VM {
             // suspended, by the discard discharge that stands in for it. Only that
             // one: a park delivers ONE payload and the discharge releases ONE
             // reference of it, so a retain on any other region has no stand-in.
-            let spare = matches!(
-                crate::signals::dispatch::classify(bits, &value),
-                crate::signals::dispatch::SignalAction::Suspend
-            )
-            .then_some(value);
+            let action = crate::signals::dispatch::classify(bits, &value);
+            let spare =
+                matches!(action, crate::signals::dispatch::SignalAction::Suspend).then_some(value);
             let owed = self.take_borrowed_arg_retains(borrowed_arg_slots, spare);
+            // A terminal :error hands the payload to a catcher, whose read
+            // consumes one reference the frame's own routes do not fund — so the
+            // raise mints it here where the payload is an argument of this call.
+            // A HALT takes none for the reason `handle_emit` takes none: the
+            // fiber is promoted to `:dead`, so that delivery has no consumer.
+            // Minted before the handler, which is where this fiber stops being
+            // the one whose frames hold the payload.
+            if action == crate::signals::dispatch::SignalAction::Error {
+                self.mint_raised_argument_delivery(&args, value);
+            }
             let bits = self.handle_primitive_signal_tail(bits, value);
             self.run_borrowed_arg_retains(owed);
             // A fiber CARRIER (`fiber/resume`/`fiber/abort`/`fiber/propagate`/

--- a/tests/elle/oracle.lisp
+++ b/tests/elle/oracle.lisp
@@ -974,6 +974,7 @@
 # A signal the compiler cannot read as a keyword set, and a payload no fiber body
 # allocates — the two ingredients a dynamic emit's borrowed park needs.
 (def emit-sig :yield)
+(def emit-error-sig :error)
 (def emit-subject (string "emit-subject"))
 
 # Direct-loop class. Each entry: [label (fn [j] body) rate].
@@ -1521,6 +1522,54 @@
       (let [f (fiber/new (fn []
                            (emit emit-sig (string "v" j))
                            9) |:yield|)]
+        (fiber/resume f))) 0]  # The same operation raising a TERMINAL signal, where
+   # the reference the tail call holds answers to a different consumer: the payload's
+   # DELIVERY, released by whoever catches the signal. The exit consumes its
+   # borrowed-argument retains — the block that would have consumed them is abandoned,
+   # and an `:error` fiber's restart replays it — so it mints the delivery and records
+   # it, the pair `handle_emit` performs on the literal path
+   # (docs/impl/region/mechanism.md § "What the fall-through owes, a signal exit owes
+   # too"). CLOSED controls (undeclared, like `rest-array-copy`), so a regression to
+   # open trips the completeness gate loudly rather than being absorbed under F2.
+   # Each reads the mint's ARITY: withholding it over-frees, which no leak gauge sees
+   # and tests/elle/region-dynamic-emit-terminal-uaf.lisp reports. The six must stay
+   # together, because only the gaps between them separate the mint from the record.
+   # `emit-dyn-error-fresh` allocates its payload in the body, so the frame's own
+   # reference is what the record reclaims and a mint per reference reads 1;
+   # `emit-dyn-error-repeat` names one region through BOTH arguments, so the frame
+   # holds a moved reference and a retain and the walk must run the release the
+   # exemption used to skip; `emit-dyn-error-restart` resumes the raised fiber, so the
+   # replayed block releases the frame's reference where the discharge otherwise
+   # would. `emit-dyn-error-discard` and `emit-lit-tail-error` remove one ingredient
+   # each — the tail position, and the primitive itself.
+   ["emit-dyn-tail-error"
+    (fn [j]
+      (let [f (fiber/new (fn [] (emit emit-error-sig emit-subject)) |:error|)]
+        (fiber/resume f))) 0]
+   ["emit-dyn-error-discard"
+    (fn [j]
+      (let [f (fiber/new (fn []
+                           (emit emit-error-sig emit-subject)
+                           9) |:error|)]
+        (fiber/resume f))) 0]
+   ["emit-lit-tail-error"
+    (fn [j]
+      (let [f (fiber/new (fn [] (emit :error emit-subject)) |:error|)]
+        (fiber/resume f))) 0]
+   ["emit-dyn-error-fresh"
+    (fn [j]
+      (let [f (fiber/new (fn [] (emit emit-error-sig (string "v" j))) |:error|)]
+        (fiber/resume f))) 0]
+   ["emit-dyn-error-repeat"
+    (fn [j]
+      (let [f (fiber/new (fn []
+                           (let [t (set :error)]
+                             (emit t t))) |:error|)]
+        (fiber/resume f))) 0]
+   ["emit-dyn-error-restart"
+    (fn [j]
+      (let [f (fiber/new (fn [] (emit emit-error-sig (string "v" j))) |:error|)]
+        (fiber/resume f)
         (fiber/resume f))) 0]  # An emit-raised error's payload keeps
    # every frame-owed release: `(error v)` mints the payload's delivery itself (the
    # `EmitEscape` retain the resumer's release of the resume result consumes), so the

--- a/tests/elle/region-dynamic-emit-terminal-uaf.lisp
+++ b/tests/elle/region-dynamic-emit-terminal-uaf.lisp
@@ -1,0 +1,230 @@
+(elle/epoch 12)
+# A raised payload's DELIVERY reference is the one the catcher's read consumes,
+# and what raises here is the emit OPERATION rather than the `Emit` node
+# (docs/impl/region/owner.md § "What yields is the emit OPERATION, not the
+# `Emit` node").
+#
+# A first argument the compiler cannot read as a keyword set falls through to the
+# `emit` primitive (docs/signals/emit.md § "Dynamic emit"), so a raise in TAIL
+# position is an ordinary native call that leaves by a signal. That exit consumes
+# the call's borrowed-argument retains, because the block that would have consumed
+# them is abandoned — so the delivery is minted at the exit and recorded, exactly as
+# `handle_emit` mints and records it on the literal path
+# (docs/impl/region/mechanism.md § "What the fall-through owes, a signal exit owes
+# too"). The record is what lets the abandoned-frame walk and the parked frame's
+# discharge reclaim the frame's OWN reference to a payload it allocated, so the two
+# references stay one per consumer.
+#
+# Every witness reads its payload after the raise has left the fiber — through the
+# resume result, through `fiber/value`, through the borrow's own holder, and through
+# a container — so an over-free faults at the deref (guardfree) or trips the
+# generation check rather than reading stale but mapped bytes. A fresh subject per
+# iteration keeps region ids churning, so a recycled id detonates on its stamp.
+#
+# The trap the restart faces guard: an `:error` fiber is resumable, so the parked
+# frame replays the post-`TailCall` block and reaches the very release the exit
+# already ran. The exit's nil stamp is what makes that second arrival a no-op —
+# leaving the retain standing instead of minting the delivery reads correct until a
+# restart claims it twice.
+#
+# Run under `--trace=guardfree` by the subprocess pin
+# `region_dynamic_emit_terminal_uaf` in tests/integration/elle_scripts.rs.
+
+(def sig :error)
+
+# ── (a) a module-level borrow, raised from tail position ─────────────────────
+# Nothing in the body releases `shared`, so the frame's only reference to it is
+# the borrowed-argument retain the tail call minted.
+(def shared (string "shared-subject"))
+(defn w-module-tail []
+  (let [f (fiber/new (fn () (emit sig shared)) |:error|)]
+    (length (fiber/resume f))))
+
+# ── (b) a captured `let`-local ───────────────────────────────────────────────
+(defn w-local-tail [n]
+  (let [s (string "local" n)]
+    (let [f (fiber/new (fn () (emit sig s)) |:error|)]
+      (let [m (length (fiber/resume f))]
+        (%add m (length s))))))
+
+# ── (c) a captured PARAMETER of the enclosing frame ──────────────────────────
+(defn w-param-tail [s]
+  (let [f (fiber/new (fn () (emit sig s)) |:error|)]
+    (let [n (length (fiber/resume f))]
+      (%add n (length s)))))
+
+# ── (d) the payload read through `fiber/value` ───────────────────────────────
+(defn w-fiber-value [s]
+  (let [f (fiber/new (fn () (emit sig s)) |:error|)]
+    (fiber/resume f)
+    (let [n (length (fiber/value f))]
+      (%add n (length s)))))
+
+# ── (e) the borrow outlives the fiber in a container ─────────────────────────
+(def @sink @[])
+(defn w-stored [s]
+  (push sink s)
+  (let [f (fiber/new (fn () (emit sig s)) |:error|)]
+    (length (fiber/resume f))))
+
+# ── (f) the raise the fiber's mask does NOT catch ────────────────────────────
+# The signal propagates out of the fiber and the caller's `catch` binds the
+# payload, so the delivery is consumed one frontier further out.
+(defn w-propagated [s]
+  (let [f (fiber/new (fn () (emit sig s)) 0)]
+    (try
+      (fiber/resume f)
+      (catch e (%add (length e) (length s))))))
+
+# ── (g) a body-ALLOCATED payload, then a RESTART ─────────────────────────────
+# Two references, two consumers: the delivery the caller's read consumes, and the
+# frame's own, which the replayed block releases.
+(defn w-owned-restart [n]
+  (let [f (fiber/new (fn () (emit sig (string "owned" n))) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [m (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add m (length v))))))
+
+# ── (h) a BORROWED payload, then a restart ───────────────────────────────────
+(defn w-borrow-restart [s]
+  (let [f (fiber/new (fn () (emit sig s)) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [m (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add m (length s))))))
+
+# ── controls — remove one ingredient each; correct with no delivery mint ─────
+
+# (i) the LITERAL path, which the `Emit` terminator already mints for.
+(defn c-literal-tail [s]
+  (let [f (fiber/new (fn () (emit :error s)) |:error|)]
+    (let [n (length (fiber/resume f))]
+      (%add n (length s)))))
+
+# (j) STATEMENT position: the raise leaves a call whose own site mints the
+# reference the park owes, and the exit under test is never reached.
+(defn c-stmt [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (let [n (length (fiber/resume f))]
+      (%add n (length s)))))
+
+# (k) an immediate payload crosses no region at all.
+(defn c-immediate [s]
+  (let [f (fiber/new (fn () (emit sig (length s))) |:error|)]
+    (fiber/resume f)
+    (length s)))
+
+# (l) a body-allocated payload with no restart: the frame's own reference is the
+# only one the walk reclaims, and the read must still find the value.
+(defn c-allocated [n]
+  (let [f (fiber/new (fn () (emit sig (string "alloc" n))) |:error|)]
+    (length (fiber/resume f))))
+
+# (m) one region named through BOTH arguments: the first occurrence moves the
+# frame's reference and the second takes a retain of its own, so the payload is
+# delivered once out of two names for it.
+(defn c-repeat []
+  (let [f (fiber/new (fn ()
+                       (let [t (set :error)]
+                         (emit t t))) |:error|)]
+    (length (fiber/resume f))))
+
+# (n) the SUSPENDING half of the same retain: a park, whose reference the
+# replayed block releases rather than the catcher.
+(defn c-yield-tail [s]
+  (let [f (fiber/new (fn () (emit :yield s)) |:yield|)]
+    (let [n (length (fiber/resume f))]
+      (%add n (length s)))))
+
+# ── drive: a fresh subject per iteration; an over-free faults on the read ─────
+
+(defn drive [reps]
+  (var i 0)
+  (var a 0)
+  (var b 0)
+  (var c 0)
+  (var d 0)
+  (var e 0)
+  (var f 0)
+  (var g 0)
+  (var h 0)
+  (var k 0)
+  (var l 0)
+  (var m 0)
+  (var n 0)
+  (var o 0)
+  (var p 0)
+  (while (%lt i reps)
+    (assign a (w-module-tail))
+    (assign b (w-local-tail i))
+    (assign c (w-param-tail (string "param" i)))
+    (assign d (w-fiber-value (string "value" i)))
+    (assign e (w-stored (string "stored" i)))
+    (assign f (w-propagated (string "prop" i)))
+    (assign g (w-owned-restart i))
+    (assign h (w-borrow-restart (string "restart" i)))
+    (assign k (c-literal-tail (string "lit" i)))
+    (assign l (c-stmt (string "stmt" i)))
+    (assign m (c-immediate (string "imm" i)))
+    (assign n (c-allocated i))
+    (assign o (c-repeat))
+    (assign p (c-yield-tail (string "yield" i)))
+    # The (e) sink is a module-level container by design: read the stored borrow
+    # back out — it must still be alive — then drain, so the driver's own
+    # retention stays flat.
+    (assert (%gt (length (get sink (%sub (length sink) 1))) 0)
+            "stored borrow freed by the raising fiber")
+    (assign sink @[])
+    (assign i (%add i 1)))
+  (list a b c d e f g h k l m n o p))
+
+(let [r (drive 400)]
+  (assert (> (get r 8) 0)
+          "control: literal tail raise mis-read (harness broken)")
+  (assert (> (get r 9) 0) "control: statement-position raise mis-read")
+  (assert (> (get r 10) 0) "control: immediate payload mis-read")
+  (assert (> (get r 11) 0) "control: body-allocated payload mis-read")
+  (assert (> (get r 12) 0) "control: two-name payload mis-read")
+  (assert (> (get r 13) 0) "control: suspending tail emit mis-read")
+  (assert (> (get r 0) 0)
+          "dynamic tail raise: module-level borrow freed under the caller's read")
+  (assert (> (get r 1) 0)
+          "dynamic tail raise: captured local freed under the emitting frame")
+  (assert (> (get r 2) 0)
+          "dynamic tail raise: captured parameter freed under the caller")
+  (assert (> (get r 3) 0)
+          "dynamic tail raise: payload freed under a `fiber/value` read")
+  (assert (> (get r 4) 0)
+          "dynamic tail raise: stored borrow freed under the container read")
+  (assert (> (get r 5) 0)
+          "dynamic tail raise: propagated payload freed under the catcher")
+  (assert (> (get r 6) 0)
+          "dynamic tail raise: allocated payload freed by the restart's replay")
+  (assert (> (get r 7) 0)
+          "dynamic tail raise: borrowed payload freed by the restart's replay"))
+
+# The module-level subject must survive every fiber that raised it.
+(assert (%gt (length shared) 0)
+        "module-level borrow freed by a dynamic tail raise")
+
+# ── the leak face: one delivery per raise, not one per reference ─────────────
+# The mint answers to the catcher's single release, and the frame's own reference
+# to the frames' own release tables, so steady-state region growth stays flat
+# across the whole witness set.
+(drive 100)
+(let [before (arena/region-count)]
+  (drive 400)
+  (let [growth (%sub (arena/region-count) before)]
+    (assert (%lt growth 40)
+            (string "terminal dynamic-emit delivery strands regions: live count "
+                    "grew by " growth " over 400 iterations of fourteen raises "
+                    "each (expected flat)"))))
+
+(println "region-dynamic-emit-terminal-uaf: ok")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -532,6 +532,27 @@ fn region_dynamic_emit_borrow_uaf() {
     );
 }
 
+// Guard — a raised payload's delivery reference, where the raise leaves the emit
+// PRIMITIVE in tail position (docs/impl/region/mechanism.md § "What the fall-through
+// owes, a signal exit owes too"). The exit consumes the call's borrowed-argument
+// retains, the block that would have consumed them being abandoned, so it mints the
+// payload's delivery and records it — the same pair `handle_emit` performs on the
+// literal path. Withhold the mint and the catcher's read of the delivered payload
+// frees it under every holder that outlives the fiber; withhold the record and the
+// frame's own reference to a payload it allocated is stranded. This drives every
+// holder shape past a raise — a module-level binding, a captured local, a captured
+// parameter, a `fiber/value` read, a container, an uncaught propagation, and a
+// restarted fiber that replays the abandoned block — and reads each afterwards, so
+// an over-free faults under guardfree. Six controls must stay clean with no mint,
+// and a growth gauge refuses a mint-per-reference fix.
+#[test]
+fn region_dynamic_emit_terminal_uaf() {
+    run_elle_script_with_args(
+        "region-dynamic-emit-terminal-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — a resume value delivered into a frame parked at a suspending PRIMITIVE
 // call carries one owning reference (docs/impl/region/owner.md § "A delivery into
 // a replayed frame carries one owning reference"). The replayed frame re-enters at


### PR DESCRIPTION
## What was wrong

A first argument the compiler cannot read as a keyword set falls through to the `emit`
primitive ([docs/signals/emit.md](docs/signals/emit.md) § "Dynamic emit"), so a raise in
**tail** position is an ordinary native call that leaves by a signal. That exit consumes the
call's borrowed-argument retains, because the post-`TailCall` block which would have consumed
them never runs, and `handle_primitive_signal_tail`'s error arm installs the payload with no
retain of its own. The payload therefore reached `fiber.signal` carrying no reference at all,
and the catcher's release of the delivered value freed it under every holder that outlived the
fiber. Three iterations of the issue's shape detonate the generation check.

The literal path differs at exactly one point: `handle_emit` mints the delivery itself and
records it in `Fiber::emit_delivery`.

## What the change does

The tail signal exit mints that delivery where the payload is one of the call's **own
arguments**, and records it — the pair `handle_emit` performs, moved to the seam the primitive
raise leaves through (`VM::mint_raised_argument_delivery`).

Minting is what the exit does rather than leaving a retain standing, because an `:error` fiber
is resumable: a restart replays the post-`TailCall` block and reaches the stash release, which
the exit's nil stamp turns into a no-op. A standing retain would be claimed twice — once by the
catcher and once by the replay.

The record travels with the mint for the same reason it does on the literal path. With the
delivery funded, every reference the frame holds is owed to the frame's own release routes, so
the abandoned-frame walk and the parked frame's discharge stop exempting the payload's region.
That reclaims a payload the body ALLOCATED, and the second name of a payload that reaches the
call twice.

The gate is the identity test against the call's arguments. A payload the native BUILT — a
fresh error struct — funds its delivery with its own birth reference and must not receive a
second. A halt takes neither mint nor record, for the reason `handle_emit` withholds its retain
there: the fiber is promoted to `:dead`, so that delivery has no consumer.

The rule reaches one more shape the same way: a fiber restarted after a tail raise of a
body-allocated payload, where the replayed block used to release a reference the catcher had
already consumed (witness (g) below).

## How it was measured

The issue's reproduction faulted at iteration 3 and now prints `done, shared=14`.

Counterfactuals, each against a build with one half disabled:

| disabled | result |
|---|---|
| the mint | `region-dynamic-emit-terminal-uaf.lisp` faults on a stale region deref |
| the record | `emit-dyn-error-fresh` and `emit-dyn-error-repeat` strand one region per op (801 live regions over 800 iterations, against 1 with the record) |
| the argument gate (mint on every error payload) | an ordinary native raise strands one region per op — the shape `error-payload-native` gauges |

All three gauges green on this branch: `oracle: ok` on all three passes (default, `--jit=off`,
`--jit=eager`) with the split unchanged (`open defects: 1 across 1 roots; by-design: 3`) and
every `emit-dyn*` probe — the four that were there and the six added here — at 0; the 91
`region_*` guardfree pins pass, including the new `region_dynamic_emit_terminal_uaf`, and the
new fixture is clean under `--jit=off`, `--jit=eager` and `--jit=adaptive`;
`cargo test -p elle --lib` is 2228 pass; `make smoke-elle ELLE=./target/release/elle` is 986
pass, 15 skip, 0 fail, 0 diverge, 0 timeout; `cargo clippy -p elle --all-targets` is clean.

The issue's leak table did not reproduce here. Each pairing I could build — a literal `:error`
statement raise, and a dynamic `:yield` statement raise, each beside the tail dynamic raise, in
one loop and again in one frame — reads 0 region growth over 800 iterations both before and
after the change, with `arena/count` flat beside it. What reproduced is the over-free above.

## Tests

- `tests/elle/region-dynamic-emit-terminal-uaf.lisp` — eight witnesses driven past a raise and
  read afterwards (a module-level binding, a captured local, a captured parameter, a
  `fiber/value` read, a container that outlives the fiber, an uncaught propagation, and the two
  restart faces), six controls that must stay clean with no mint (the literal path, statement
  position, an immediate payload, a body-allocated payload, one region named through both
  arguments, and the suspending twin), and a growth gate that refuses a mint-per-reference fix.
  Registered guardfree as `region_dynamic_emit_terminal_uaf`.
- `tests/elle/oracle.lisp` — `emit-dyn-tail-error` and its five companions, each a closed
  control at 0: `emit-dyn-error-discard` and `emit-lit-tail-error` remove one ingredient each
  (the tail position, the primitive), while `emit-dyn-error-fresh`, `emit-dyn-error-repeat` and
  `emit-dyn-error-restart` are the faces that read the record.
- `docs/impl/region/mechanism.md` § "What the fall-through owes, a signal exit owes too" gains
  the terminal half of the rule, and § "An abandoned frame runs the releases it still owes"
  gains the third raise that records a minted delivery; `docs/impl/region/owner.md` states
  where a tail dynamic raise's reference comes from.

Closes #949.
