### PR TITLE
hir: a binding nobody reads, a self-call that keeps its frame, and a call nobody sees

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,9 @@ See [docs/libraries.md](docs/libraries.md) for full documentation.
   (cons 1)                    # Error: cons expects 2 arguments, got 1
   (defn f [x] x)
   (f 1 2)                     # Error: f expects 1 argument, got 2
+  (let [reuslt 1] result)     # Warning: binding 'reuslt' is never used
+  (defn len [xs]              # Warning: 'len' calls itself outside tail position
+    (if (empty? xs) 0 (+ 1 (len (rest xs)))))
   ```
 
 - **Unreachable match arms are compile-time errors.** The compiler builds the decision tree for every `match` and rejects arms no value can reach — a duplicated literal, or anything after a guardless catch-all. The same analysis runs inside or-patterns at any depth: an alternative that earlier arms and alternatives already cover is rejected. A `match` that no arm covers raises a structured `:match-error` at runtime carrying the unmatched value; no mandatory wildcard arm.

--- a/docs/analysis/portrait.md
+++ b/docs/analysis/portrait.md
@@ -54,22 +54,33 @@ structured reports.
 ## Advisories
 
 A portrait reflects the compiler's lint diagnostics as advisories — it does not
-re-derive them. The relevant rule here is `mutable-binding-never-assigned`: a
-binding declared mutable (`var`/`@`) yet never reassigned via `assign`. This
-surfaces the common conflation of a mutable **binding** with a mutable
-**value**: `(let [buf @""] (push buf x))` mutates the *value* but the *binding*
-never changes, so `buf` should stay immutable. Because the advisory is read from
-`compile/diagnostics`, portrait and `elle lint` always agree.
+re-derive them. Three rules reach a portrait:
 
-The advisory appears at two granularities:
+| Rule | Advisory | What it says |
+|---|---|---|
+| `mutable-binding-never-assigned` | `:false-mutable` | A binding declared mutable (`var`/`@`) that no `assign` targets. |
+| `unused-binding` | `:unused-binding` | A `def`/`let`/`letrec` binding nothing reads. |
+| `non-tail-self-recursion` | `:non-tail-recursion` | A function whose self-call sits outside tail position. |
+
+The false-mutable advisory surfaces the common conflation of a mutable
+**binding** with a mutable **value**: `(let [buf @""] (push buf x))` mutates the
+*value* but the *binding* never changes, so `buf` should stay immutable. Because
+every advisory is read from `compile/diagnostics`, portrait and `elle lint`
+always agree.
+
+Each advisory appears at two granularities:
 
 - **Module** — `(get (portrait:module a) :false-mutable)` lists every flagged
-  binding across the module (including top-level ones).
-- **Function** — `(portrait:function a :f)` includes a `:false-mutable`
-  observation for each flag *inside* `f`. Per-function attribution is exact, not
-  by line range: the linter tags each diagnostic with its nearest enclosing
-  named function (the `:function` field on a diagnostic), and the observation
-  filters on it. A flag in a nested closure is attributed to the inner function.
+  binding across the module (including top-level ones). `:unused-binding` and
+  `:non-tail-recursion` list theirs the same way.
+- **Function** — `(portrait:function a :f)` includes one observation for each
+  flag *inside* `f`. Per-function attribution is exact, not by line range: the
+  linter tags each diagnostic with its nearest enclosing named function (the
+  `:function` field on a diagnostic), and the observation filters on it. A flag
+  in a nested closure is attributed to the inner function.
+
+Adding a rule to a portrait is one row in `lint-kinds` (`lib/portrait.lisp`),
+which both granularities read.
 
 ## Phases
 

--- a/docs/cookbook/lint-rules.md
+++ b/docs/cookbook/lint-rules.md
@@ -69,11 +69,19 @@ HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
 
 ### Diagnostic codes
 
-- `W001` — naming-kebab-case
-- `W002` — arity-mismatch
-- `W003` — retired (was reserved for non-exhaustive-match; unreachable
-  match arms are a compile error in the analyzer, not a lint)
-- Use `W004+` for new warnings, `E00x` for errors, `I00x` for info.
+| Code | Rule | Fires on |
+|------|------|----------|
+| `W001` | — | Unclaimed. |
+| `W002` | `arity-mismatch` | A call to a built-in with the wrong argument count. |
+| `W003` | `mutable-binding-never-assigned` | A `var`/`@` binding that no `assign` targets. |
+| `W004` | `unused-binding` | A `def`/`let`/`letrec` binding with zero uses. |
+| `W005` | `non-tail-self-recursion` | A function whose self-call is not in tail position. |
+
+Use `W006+` for new warnings, `E00x` for errors, `I00x` for info.
+
+`W004` reads the def-use chains `src/hir/defuse.rs` builds, and `W005`
+reads the `is_tail` flag `src/hir/tailcall.rs` sets. Neither rule tracks
+its own state, and neither adds a field to `BindingInner`.
 
 ### How linting runs
 

--- a/docs/impl/hir.md
+++ b/docs/impl/hir.md
@@ -34,8 +34,10 @@ signal profiles.
    [impl/escape.md](escape.md))
 3. **Signal inference** — interprocedural: traces call chains to
    determine whether a function can yield, error, or is silent
-4. **Tail position marking** — identifies calls in tail position for
-   TCO
+4. **Tail position marking** — sets `is_tail` on the calls in tail position,
+   for TCO. Analysis runs it, so every `AnalyzeResult` carries honest flags:
+   the linter and the call-graph builder both read `is_tail` off the analyzed
+   tree, and `regularize` marks again after map fusion introduces new nodes
 5. **Special form analysis** — `if`, `let`, `begin`, `block`,
    `match`, `defmacro`, etc. each have dedicated handlers
 
@@ -49,6 +51,59 @@ Three signal categories:
 
 `silence` constrains a parameter to be silent at compile time.
 The inference propagates through call chains interprocedurally.
+
+## Dead binding elimination
+
+`src/hir/dead.rs` removes a `let`/`letrec` binding when two facts hold: the
+binding has zero uses, and its initializer is provably effect-free. Removing
+the binding removes the initializer with it, so a dead call to an effect-free
+function never reaches LIR.
+
+The pass runs from `regularize`, after dead-arm pruning and map fusion, and
+before `functionalize`. That altitude is the same one `prune_typeof_match_arms`
+uses, for the same reason: the region solver runs after the HIR transforms, so
+a call deleted here never mints a region and strands no release obligation.
+
+### A silent function is not a pure function
+
+`Signal::silent()` says a function emits no signal bits. It does **not** say the
+function has no effect. Every `%`-intrinsic is registered silent, and
+`%push-array-mut` appends to its argument in place. A rule that eliminated any
+silent call would delete that append and change the program's output.
+
+So the pass proves effect-freedom, not silence, and it proves it from two
+facts that cannot lie:
+
+- **The node's signal is `Signal::silent()`.** The analyzer combines the callee
+  signal with every argument's signal, so a silent call node also means every
+  argument is silent, and that a polymorphic callee got silent arguments. A
+  yielding callback handed to an otherwise-silent higher-order function shows up
+  here and blocks elimination.
+- **The callee stores nothing.** For a primitive, `RegionEffect::Immediate` and
+  `RegionEffect::Fresh` are the two declarations that state no argument is
+  stored anywhere outliving the call, and `moves_out` marks the natives that
+  remove an element from a container argument. In-place mutation is a store into
+  an argument, so `Funnel`, `Stores`, `Sends`, `Mixed`, and `PassThrough` are all
+  rejected. For a user-defined callee, the same predicate runs over its lambda
+  body, to a fixpoint.
+
+The fixpoint starts with nothing proven pure and grows. A self-recursive
+function therefore never proves pure, which keeps the pass out of the
+termination question: it can only delete calls that provably return.
+
+### What the pass declines to touch
+
+- **File-scope bindings** (`is_file_scope`). A module's value is its body's last
+  expression, but the top-level names are also what `(environment)` reflects.
+- **`Define` nodes.** A `Define` evaluates to its own value, so it can be the
+  result of the enclosing body. Deleting one can change that result; deleting a
+  `let` binding cannot.
+- **Mutated, synthetic, primitive, and cell-materialized bindings.** An `assign`
+  records a def rather than a use, so a mutated binding can read as unused while
+  an `Assign` node still names it.
+- **Lambda initializers.** Binding an unused closure allocates and does nothing
+  else, so removing it would be sound. The pass leaves it for now; the win is
+  small and the blast radius across the corpus is not.
 
 ## Kernel and sugar (design target)
 
@@ -132,6 +187,8 @@ src/hir/analyze/mod.rs    Main analysis entry point
 src/hir/analyze/binding.rs  Binding resolution
 src/hir/analyze/forms.rs  Special form handlers
 src/hir/analyze/special.rs  More special forms
+src/hir/tailcall.rs       Tail position marking
+src/hir/dead.rs           Dead binding elimination
 ```
 
 ---

--- a/lib/portrait.lisp
+++ b/lib/portrait.lisp
@@ -24,6 +24,32 @@
       (assign result (pair x result)))
     result)
 
+  # ── Lint advisories ─────────────────────────────────────────────────────
+  #
+  # A portrait REFLECTS the linter's findings; it never re-derives them. Both
+  # granularities read compile/diagnostics through the one accessor below, so
+  # portrait and `elle lint` cannot disagree, and a new rule reaches both by
+  # gaining a row in `lint-kinds`.
+
+  (def lint-kinds
+    [["mutable-binding-never-assigned" :false-mutable]
+     ["unused-binding" :unused-binding]
+     ["non-tail-self-recursion" :non-tail-recursion]])
+
+  (defn diagnostics-for [analysis rule function]
+    "The linter's `rule` diagnostics. With a `function` name, only those the
+    linter attributed to that function; with nil, every one in the module."
+    (filter (fn [d]
+              (and (= (get d :rule) rule)
+                   (or (nil? function) (= (get d :function) function))))
+            (compile/diagnostics analysis)))
+
+  (defn advisories-for [analysis rule kind]
+    "Module-wide advisories for one rule, tagged with the portrait's `kind`."
+    (freeze (map (fn [d]
+                   {:kind kind :line (get d :line) :message (get d :message)})
+                 (diagnostics-for analysis rule nil))))
+
   # ── Phase classification ────────────────────────────────────────────────
 
   (defn classify-phase [sig]
@@ -153,14 +179,12 @@
                    :message (string/format "Captures '{}' by value, but '{}' is mutated elsewhere. This closure sees the value at capture time, not later mutations."
                    (get cap :name) (get cap :name))})))))
 
-    # 6. Mutable binding never reassigned (false-mutable), in THIS function.
-    # Reflects the linter's diagnostics, attributed by the :function the linter
-    # stamped — so a mutable BINDING that never changes is distinguished from a
-    # mutable VALUE held by an immutable binding.
-    (each d in (compile/diagnostics analysis)
-      (when (and (= (get d :rule) "mutable-binding-never-assigned")
-                 (= (get d :function) (string name)))
-        (push obs {:kind :false-mutable :message (get d :message)})))
+    # 6-8. Lint advisories raised inside THIS function. Attribution is by the
+    # :function the linter stamped on each diagnostic, so a finding in a nested
+    # closure belongs to the closure, not to its host.
+    (each pair in lint-kinds
+      (each d in (diagnostics-for analysis (get pair 0) (string name))
+        (push obs {:kind (get pair 1) :message (get d :message)})))
 
     (freeze obs))
 
@@ -186,20 +210,17 @@
        :callers callers
        :callees callees}))
 
-  # ── Lint advisories ─────────────────────────────────────────────────────
-
   (defn false-mutable-advisories [analysis]
-    "Reflect the linter's `mutable-binding-never-assigned` diagnostics — a
-    binding declared mutable (var/@) yet never reassigned via `assign`. Read
-    from compile/diagnostics so portrait and `elle lint` never disagree."
-    (def @out @[])
-    (each d in (compile/diagnostics analysis)
-      (when (= (get d :rule) "mutable-binding-never-assigned")
-        (push out
-              {:kind :false-mutable
-               :line (get d :line)
-               :message (get d :message)})))
-    (freeze out))
+    "A binding declared mutable (var/@) yet never reassigned via `assign`."
+    (advisories-for analysis "mutable-binding-never-assigned" :false-mutable))
+
+  (defn unused-binding-advisories [analysis]
+    "A binding that is defined and never read."
+    (advisories-for analysis "unused-binding" :unused-binding))
+
+  (defn non-tail-recursion-advisories [analysis]
+    "A function whose self-call sits outside tail position."
+    (advisories-for analysis "non-tail-self-recursion" :non-tail-recursion))
 
   # ── Module portrait ─────────────────────────────────────────────────────
 
@@ -253,6 +274,8 @@
        :yielding (freeze yielding)
        :boundaries (freeze boundaries)
        :false-mutable (false-mutable-advisories analysis)
+       :unused-binding (unused-binding-advisories analysis)
+       :non-tail-recursion (non-tail-recursion-advisories analysis)
        :graph (compile/call-graph analysis)}))
 
   # ── Text rendering ──────────────────────────────────────────────────────
@@ -348,11 +371,17 @@
               (string/format "    {} → {} ({})\n" (get b :caller)
                              (get b :callee) (get b :transition)))))
 
-    (when (not (empty? (get portrait :false-mutable)))
-      (push out "\n  Mutable bindings never reassigned:\n")
-      (each m in (get portrait :false-mutable)
-        (push out
-              (string/format "    line {}: {}\n" (get m :line) (get m :message)))))
+    (each section in [[:false-mutable "Mutable bindings never reassigned"]
+                      [:unused-binding "Bindings never used"]
+                      [:non-tail-recursion
+                       "Self-recursion outside tail position"]]
+      (let [advisories (get portrait (get section 0))]
+        (when (not (empty? advisories))
+          (push out (string/format "\n  {}:\n" (get section 1)))
+          (each m in advisories
+            (push out
+                  (string/format "    line {}: {}\n" (get m :line)
+                                 (get m :message)))))))
 
     (let [graph (get portrait :graph)]
       (when (not (empty? (get graph :roots)))
@@ -376,5 +405,7 @@
    :failures detect-failure-modes
    :composition assess-composition
    :observations find-observations
-   :false-mutable false-mutable-advisories})
+   :false-mutable false-mutable-advisories
+   :unused-binding unused-binding-advisories
+   :non-tail-recursion non-tail-recursion-advisories})
 # end closure

--- a/src/hir/AGENTS.md
+++ b/src/hir/AGENTS.md
@@ -209,3 +209,18 @@ Lowerer (&BindingArena) — read-only access to binding metadata
      set via the arena. File-level `def` bindings shadow primitives. The lowerer
      emits upvalue loads for both — compile-time checks (e.g., `(set + 42)` is
      an error) use the `Binding` identity.
+
+ 22. **Tail calls are marked on every `AnalyzeResult`.** `pipeline::analyze` and
+     `analyze_file` run `mark_tail_calls` before returning, so `is_tail` is a
+     fact on the analyzed tree rather than a default. The linter's
+     non-tail-self-recursion rule and the `compile/callees` call graph both read
+     it there. `regularize` marks again, because map fusion mints call nodes
+     after that point.
+
+ 23. **A dead binding takes its initializer with it.** `hir::dead` removes a
+     `let`/`letrec` binding with zero uses whose initializer is provably
+     effect-free, which deletes the initializer's call. It runs inside
+     `regularize`, before `functionalize`, so the region solver never sees the
+     deleted call. A silent callee is not enough: silence means no signal bits,
+     and `%push-array-mut` is silent and mutates. See
+     [docs/impl/hir.md](../../docs/impl/hir.md) § "Dead binding elimination".

--- a/src/hir/dead.rs
+++ b/src/hir/dead.rs
@@ -1,0 +1,283 @@
+//! Dead binding elimination for unused `let`/`letrec` bindings.
+//!
+//! A binding nothing reads, whose initializer nothing can observe, is removable
+//! along with the initializer. That deletes the dead call the initializer makes,
+//! so it never reaches LIR and never mints a region.
+//!
+//! The design argument — why an effect-free proof rather than a silence check,
+//! what the pass declines to touch, and why this altitude — lives in
+//! [docs/impl/hir.md](../../docs/impl/hir.md) § "Dead binding elimination". The
+//! comments here say only what a reader of this file would otherwise get wrong.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use super::arena::BindingArena;
+use super::binding::Binding;
+use super::defuse::DefUseBuilder;
+use super::expr::{Hir, HirKind};
+use crate::primitives::def::RegionEffect;
+use crate::signals::Signal;
+use crate::symbol::SymbolTable;
+
+/// Remove every `let`/`letrec` binding that has no use and an effect-free
+/// initializer.
+pub(crate) fn eliminate_dead_bindings(hir: &mut Hir, arena: &BindingArena, symbols: &SymbolTable) {
+    // Phase 1 (read-only): who is read, and which callees are proven pure.
+    let used: FxHashSet<Binding> = {
+        let mut defuse = DefUseBuilder::new();
+        defuse.walk(hir);
+        defuse.uses.into_keys().collect()
+    };
+    let pure = pure_functions(hir, arena, symbols);
+
+    // Phase 2 (mutating): drop the bindings.
+    strip(hir, arena, symbols, &used, &pure);
+}
+
+/// Drop the eliminable bindings of every `Let`/`Letrec` in the tree.
+///
+/// A binding is retained *before* the walk descends, so a dropped initializer's
+/// own subtree is never visited: whatever it bound went with it.
+///
+/// A node left with no bindings stays. Splicing its body in its place would
+/// retire one scope region, but the empty scope is already correct, and every
+/// downstream pass reads it as it reads any other `Let`.
+fn strip(
+    hir: &mut Hir,
+    arena: &BindingArena,
+    symbols: &SymbolTable,
+    used: &FxHashSet<Binding>,
+    pure: &FxHashSet<Binding>,
+) {
+    if let HirKind::Let { bindings, .. } | HirKind::Letrec { bindings, .. } = &mut hir.kind {
+        bindings.retain(|(b, init)| !eliminable(*b, init, arena, symbols, used, pure));
+    }
+    hir.for_each_child_mut(|c| strip(c, arena, symbols, used, pure));
+}
+
+/// Can this binding and its initializer both disappear?
+fn eliminable(
+    binding: Binding,
+    init: &Hir,
+    arena: &BindingArena,
+    symbols: &SymbolTable,
+    used: &FxHashSet<Binding>,
+    pure: &FxHashSet<Binding>,
+) -> bool {
+    if used.contains(&binding) {
+        return false;
+    }
+    let inner = arena.get(binding);
+    // `is_mutated` is the one flag that is not merely conservative: `assign`
+    // records a *definition* in the def-use walk, so a written-and-never-read
+    // binding reads as unused while an `Assign` node still names it. Removing
+    // the binding would leave that node pointing at nothing.
+    if inner.is_synthetic
+        || inner.is_primitive
+        || inner.is_mutated
+        || inner.is_file_scope
+        || inner.needs_capture()
+    {
+        return false;
+    }
+    if matches!(init.kind, HirKind::Lambda { .. }) {
+        return false;
+    }
+    is_effect_free(init, arena, symbols, pure)
+}
+
+/// Can evaluating this expression be observed?
+///
+/// `false` is always the safe answer, so every kind the walk does not recognize
+/// takes it. The recognized set is the value forms an initializer takes.
+fn is_effect_free(
+    hir: &Hir,
+    arena: &BindingArena,
+    symbols: &SymbolTable,
+    pure: &FxHashSet<Binding>,
+) -> bool {
+    let all = |exprs: &[Hir]| {
+        exprs
+            .iter()
+            .all(|e| is_effect_free(e, arena, symbols, pure))
+    };
+    match &hir.kind {
+        HirKind::Nil
+        | HirKind::EmptyList
+        | HirKind::Bool(_)
+        | HirKind::Int(_)
+        | HirKind::Float(_)
+        | HirKind::String(_)
+        | HirKind::Keyword(_)
+        | HirKind::Quote(_)
+        | HirKind::QuoteConst(_)
+        | HirKind::Var(_) => true,
+
+        HirKind::Return { value } => is_effect_free(value, arena, symbols, pure),
+
+        HirKind::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            is_effect_free(cond, arena, symbols, pure)
+                && is_effect_free(then_branch, arena, symbols, pure)
+                && is_effect_free(else_branch, arena, symbols, pure)
+        }
+
+        HirKind::Cond {
+            clauses,
+            else_branch,
+        } => {
+            clauses.iter().all(|(c, b)| {
+                is_effect_free(c, arena, symbols, pure) && is_effect_free(b, arena, symbols, pure)
+            }) && else_branch
+                .as_ref()
+                .is_none_or(|e| is_effect_free(e, arena, symbols, pure))
+        }
+
+        HirKind::Begin(exprs) | HirKind::And(exprs) | HirKind::Or(exprs) => all(exprs),
+
+        HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
+            bindings
+                .iter()
+                .all(|(_, init)| is_effect_free(init, arena, symbols, pure))
+                && is_effect_free(body, arena, symbols, pure)
+        }
+
+        // The node's own signal already folds in the callee's signal and every
+        // argument's, so a silent call node also proves the arguments silent and
+        // proves a polymorphic callee got silent arguments. What it does NOT
+        // prove is that the callee stores nothing — that is `callee_is_pure`.
+        HirKind::Call { func, args, .. } => {
+            hir.signal == Signal::silent()
+                && callee_is_pure(func, arena, symbols, pure)
+                && args
+                    .iter()
+                    .all(|a| is_effect_free(&a.expr, arena, symbols, pure))
+        }
+
+        // `routes_native_funnel` is the storing/removing/copying set, and the
+        // analyzer routes a call-position use of one of those to its NativeFn
+        // rather than to an opcode node. Testing it here anyway keeps the
+        // mutation gate on the op, not on which node shape the analyzer chose.
+        HirKind::Intrinsic { op, args } => {
+            hir.signal == Signal::silent() && !op.routes_native_funnel() && all(args)
+        }
+
+        _ => false,
+    }
+}
+
+/// Does calling this function position store nothing and reach nothing opaque?
+///
+/// A primitive answers from its own declaration. `RegionEffect::Immediate` and
+/// `RegionEffect::Fresh` are the two that state no argument is stored anywhere
+/// outliving the call — in-place mutation is such a store, so `Funnel`,
+/// `Stores`, `Sends`, `Mixed`, and `PassThrough` all fail here. `moves_out`
+/// marks the natives that remove an element from a container argument.
+///
+/// A user-defined function answers from `pure`, the fixpoint over lambda bodies.
+/// Anything else — a parameter, a dynamic expression, a mutable or reassigned
+/// binding — is opaque and fails.
+fn callee_is_pure(
+    func: &Hir,
+    arena: &BindingArena,
+    symbols: &SymbolTable,
+    pure: &FxHashSet<Binding>,
+) -> bool {
+    let HirKind::Var(binding) = &func.kind else {
+        return false;
+    };
+    let inner = arena.get(*binding);
+    if !inner.is_immutable || inner.is_mutated {
+        return false;
+    }
+    if !inner.is_primitive {
+        return pure.contains(binding);
+    }
+    let Some(name) = symbols.name(inner.name) else {
+        return false;
+    };
+    let Some(def) = crate::primitives::registration::def_by_name(name) else {
+        return false;
+    };
+    def.signal == Signal::silent()
+        && matches!(def.effect, RegionEffect::Immediate | RegionEffect::Fresh)
+        && !def.moves_out
+}
+
+/// The bindings whose lambda body is effect-free, to a fixpoint.
+///
+/// The fixpoint starts empty and grows, which is what keeps a self-recursive
+/// function out of it: proving `r` pure would need `r` already proven. That is
+/// the conservative direction — an unproven function's call survives.
+fn pure_functions(hir: &Hir, arena: &BindingArena, symbols: &SymbolTable) -> FxHashSet<Binding> {
+    let mut occurrences: FxHashMap<Binding, u32> = FxHashMap::default();
+    count_binding_sites(hir, &mut occurrences);
+
+    let mut pure: FxHashSet<Binding> = FxHashSet::default();
+    loop {
+        let mut grew = false;
+        admit_pure_lambdas(hir, arena, symbols, &occurrences, &mut pure, &mut grew);
+        if !grew {
+            return pure;
+        }
+    }
+}
+
+/// Admit each not-yet-proven lambda binding whose body is effect-free under what
+/// is proven so far. One round of the fixpoint.
+fn admit_pure_lambdas(
+    hir: &Hir,
+    arena: &BindingArena,
+    symbols: &SymbolTable,
+    occurrences: &FxHashMap<Binding, u32>,
+    pure: &mut FxHashSet<Binding>,
+    grew: &mut bool,
+) {
+    let mut consider = |b: Binding, value: &Hir, pure: &mut FxHashSet<Binding>| {
+        // Bound more than once means no single stable value, so the name proves
+        // nothing about what a call site reaches.
+        if occurrences.get(&b) != Some(&1) || pure.contains(&b) {
+            return;
+        }
+        let inner = arena.get(b);
+        if !inner.is_immutable || inner.is_mutated {
+            return;
+        }
+        if let HirKind::Lambda { body, .. } = &value.kind {
+            if is_effect_free(body, arena, symbols, pure) {
+                pure.insert(b);
+                *grew = true;
+            }
+        }
+    };
+    match &hir.kind {
+        HirKind::Let { bindings, .. } | HirKind::Letrec { bindings, .. } => {
+            for (b, value) in bindings {
+                consider(*b, value, pure);
+            }
+        }
+        HirKind::Define { binding, value } => consider(*binding, value, pure),
+        _ => {}
+    }
+    hir.for_each_child(|c| admit_pure_lambdas(c, arena, symbols, occurrences, pure, grew));
+}
+
+/// How many `let`/`letrec`/`def` sites introduce each binding.
+fn count_binding_sites(hir: &Hir, occurrences: &mut FxHashMap<Binding, u32>) {
+    match &hir.kind {
+        HirKind::Let { bindings, .. } | HirKind::Letrec { bindings, .. } => {
+            for (b, _) in bindings {
+                *occurrences.entry(*b).or_default() += 1;
+            }
+        }
+        HirKind::Define { binding, .. } => *occurrences.entry(*binding).or_default() += 1,
+        _ => {}
+    }
+    hir.for_each_child(|c| count_binding_sites(c, occurrences));
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/hir/dead/tests.rs
+++ b/src/hir/dead/tests.rs
@@ -1,0 +1,197 @@
+//! Unit tests (`super` is the parent impl module).
+
+use super::*;
+use crate::hir::expr::IntrinsicOp;
+use crate::hir::testkit::{HirFixture, Stage};
+use crate::symbol::SymbolTable;
+
+/// Analyze `source` and run the pass over it, with no surrounding stubs.
+fn eliminate(source: &str) -> (Hir, BindingArena, SymbolTable) {
+    let mut symbols = SymbolTable::new();
+    let mut arena = BindingArena::new();
+    let built = HirFixture::new().stage(Stage::Analyzed).bare().build_into(
+        source,
+        &mut arena,
+        &mut symbols,
+    );
+    let mut hir = built.hir;
+    eliminate_dead_bindings(&mut hir, &arena, &symbols);
+    (hir, arena, symbols)
+}
+
+/// How many calls to `name` survive in the tree.
+fn calls_to(hir: &Hir, arena: &BindingArena, symbols: &SymbolTable, name: &str) -> usize {
+    let mut count = 0;
+    if let HirKind::Call { func, .. } = &hir.kind {
+        if let HirKind::Var(b) = &func.kind {
+            if symbols.name(arena.get(*b).name) == Some(name) {
+                count += 1;
+            }
+        }
+    }
+    hir.for_each_child(|c| count += calls_to(c, arena, symbols, name));
+    count
+}
+
+/// How many `op` intrinsic nodes survive.
+///
+/// The trap: a call-position `%`-form is not always a `Call`. The analyzer
+/// routes the storing/removing/copying ops to their NativeFn (a `Call`) and
+/// turns everything else into an opcode node, so `(%add 1 2)` is an `Intrinsic`
+/// and `(%push-array-mut a 3)` is a `Call`. A test that counted only calls would
+/// pass for `%add` without observing anything.
+fn intrinsics_of(hir: &Hir, op: IntrinsicOp) -> usize {
+    let mut count = usize::from(matches!(&hir.kind, HirKind::Intrinsic { op: o, .. } if *o == op));
+    hir.for_each_child(|c| count += intrinsics_of(c, op));
+    count
+}
+
+/// Is `name` still introduced by a `let`/`letrec` binding in the tree?
+fn binds(hir: &Hir, arena: &BindingArena, symbols: &SymbolTable, name: &str) -> bool {
+    let here = match &hir.kind {
+        HirKind::Let { bindings, .. } | HirKind::Letrec { bindings, .. } => bindings
+            .iter()
+            .any(|(b, _)| symbols.name(arena.get(*b).name) == Some(name)),
+        _ => false,
+    };
+    let mut found = here;
+    hir.for_each_child(|c| found |= binds(c, arena, symbols, name));
+    found
+}
+
+// ── What goes ────────────────────────────────────────────────────────
+
+#[test]
+fn unused_binding_of_a_silent_call_takes_the_call_with_it() {
+    // `%add` is silent and declares `RegionEffect::Immediate`: it emits nothing
+    // and stores nothing. Nobody reads `x`, so neither the binding nor the call
+    // can be observed.
+    let (hir, arena, symbols) = eliminate("(let [x (%add 1 2) y 10] y)");
+    assert!(
+        !binds(&hir, &arena, &symbols, "x"),
+        "the binding is dropped"
+    );
+    assert_eq!(
+        intrinsics_of(&hir, IntrinsicOp::Add),
+        0,
+        "the operation goes with its binding"
+    );
+    assert!(binds(&hir, &arena, &symbols, "y"), "the used binding stays");
+}
+
+#[test]
+fn unused_binding_of_a_literal_goes() {
+    let (hir, arena, symbols) = eliminate("(let [x 1 y 10] y)");
+    assert!(!binds(&hir, &arena, &symbols, "x"));
+}
+
+#[test]
+fn unused_binding_of_a_variable_reference_goes() {
+    let (hir, arena, symbols) = eliminate("(let [y 10 alias y] y)");
+    assert!(!binds(&hir, &arena, &symbols, "alias"));
+    assert!(binds(&hir, &arena, &symbols, "y"), "the source stays");
+}
+
+#[test]
+fn a_user_function_proven_pure_is_eliminated_at_its_call_site() {
+    // `k`'s body is a silent call to a non-storing primitive over its own
+    // parameter, so the purity fixpoint proves `k` pure and the dead `(k 5)`
+    // goes.
+    let (hir, arena, symbols) = eliminate("(letrec [k (fn [a] (%add a 1)) x (k 5) y 10] y)");
+    assert!(!binds(&hir, &arena, &symbols, "x"));
+    assert_eq!(calls_to(&hir, &arena, &symbols, "k"), 0);
+    // `k` itself stays: an unused lambda binding is not eliminated.
+    assert!(binds(&hir, &arena, &symbols, "k"));
+}
+
+// ── What stays ───────────────────────────────────────────────────────
+
+#[test]
+fn a_silent_call_that_mutates_its_argument_is_preserved() {
+    // The trap: `Signal::silent()` says a callee emits no signal bits, NOT that
+    // it has no effect. `%push-array-mut` is silent and appends to its argument
+    // in place. Eliminating it because `x` is unused would delete the append.
+    // `RegionEffect::Funnel` is the declaration that stops it.
+    let (hir, arena, symbols) = eliminate("(let [arr @[1 2] x (%push-array-mut arr 3)] arr)");
+    assert_eq!(
+        calls_to(&hir, &arena, &symbols, "%push-array-mut"),
+        1,
+        "a store into an argument is an effect"
+    );
+    assert!(binds(&hir, &arena, &symbols, "x"), "so is its binding");
+}
+
+#[test]
+fn a_user_function_that_mutates_is_preserved() {
+    // Same trap one level up: `m` is silent, and the fixpoint must not prove it
+    // pure, because its body stores into its argument.
+    let (hir, arena, symbols) =
+        eliminate("(letrec [m (fn [a] (%push-array-mut a 3)) arr @[1] x (m arr)] arr)");
+    assert_eq!(calls_to(&hir, &arena, &symbols, "m"), 1);
+}
+
+#[test]
+fn an_io_initializer_is_preserved() {
+    // `port/read-all` declares `Signal::io_yields_errors()`: the scheduler round
+    // trip is observable whether or not anything reads the result.
+    let (hir, arena, symbols) = eliminate("(let [x (port/read-all 1) y 10] y)");
+    assert_eq!(calls_to(&hir, &arena, &symbols, "port/read-all"), 1);
+    assert!(binds(&hir, &arena, &symbols, "x"));
+}
+
+#[test]
+fn an_error_capable_initializer_is_preserved() {
+    // `length` declares `Signal::errors()`. The raise is observable, so the call
+    // stays even though nothing reads `x`.
+    let (hir, arena, symbols) = eliminate("(let [x (length [1 2]) y 10] y)");
+    assert_eq!(calls_to(&hir, &arena, &symbols, "length"), 1);
+}
+
+#[test]
+fn a_used_binding_is_preserved() {
+    let (hir, arena, symbols) = eliminate("(let [x (%add 1 2)] x)");
+    assert!(binds(&hir, &arena, &symbols, "x"));
+    assert_eq!(intrinsics_of(&hir, IntrinsicOp::Add), 1);
+}
+
+#[test]
+fn a_silent_higher_order_call_with_a_yielding_argument_is_preserved() {
+    // The callee is silent on its own and gets its effect from the callback.
+    // Signal inference folds the argument's signal into the call node, so the
+    // node is not silent and the call stays.
+    let (hir, arena, symbols) =
+        eliminate("(letrec [apply1 (fn [f] (f)) cb (fn [] (emit :yield 1)) x (apply1 cb) y 10] y)");
+    assert_eq!(calls_to(&hir, &arena, &symbols, "apply1"), 1);
+}
+
+#[test]
+fn a_self_recursive_function_never_proves_pure() {
+    // The fixpoint starts with nothing proven and grows, so a function whose
+    // body calls itself is never admitted. That keeps the pass out of the
+    // termination question: it deletes only calls that provably return.
+    let (hir, arena, symbols) = eliminate("(letrec [r (fn [n] (r n)) x (r 1) y 10] y)");
+    assert!(
+        binds(&hir, &arena, &symbols, "x"),
+        "the dead call stays bound"
+    );
+    // Both sites survive: the self-call in the body, and the initializer.
+    assert_eq!(calls_to(&hir, &arena, &symbols, "r"), 2);
+}
+
+#[test]
+fn an_unused_lambda_binding_is_preserved() {
+    // Binding an unused closure is effect-free, so removing it would be sound.
+    // The pass declines anyway — see docs/impl/hir.md. Changing that decision is
+    // what would change this assertion.
+    let (hir, arena, symbols) = eliminate("(let [f (fn [] 1) y 10] y)");
+    assert!(binds(&hir, &arena, &symbols, "f"));
+}
+
+#[test]
+fn a_mutated_binding_is_preserved() {
+    // `assign` records a definition, not a use, so a written-and-never-read
+    // binding reads as unused. Removing it would strand the `Assign` node that
+    // still names it.
+    let (hir, arena, symbols) = eliminate("(let [@n 1] (assign n 2) 10)");
+    assert!(binds(&hir, &arena, &symbols, "n"));
+}

--- a/src/hir/lint.rs
+++ b/src/hir/lint.rs
@@ -3,7 +3,11 @@
 //! Walks HIR trees and produces diagnostics. Uses the same rules as the
 //! legacy Expr-based linter but operates on the new pipeline's HIR.
 
+use std::collections::HashSet;
+
 use crate::hir::arena::BindingArena;
+use crate::hir::binding::Binding;
+use crate::hir::defuse::DefUseBuilder;
 use crate::hir::expr::{Hir, HirKind};
 use crate::lint::diagnostics::{Diagnostic, Severity};
 use crate::lint::rules;
@@ -18,6 +22,15 @@ pub struct HirLinter {
     /// each diagnostic (`Diagnostic::function`) so per-function consumers can
     /// attribute a finding exactly. `None` at module/top level.
     current_fn: Option<SymbolId>,
+    /// The binding `current_fn` names. Identity, where `current_fn` is only a
+    /// spelling: a self-call is a call whose function position resolves to this
+    /// binding, which no name comparison can decide once a name is shadowed.
+    current_fn_binding: Option<Binding>,
+    /// Every binding with at least one use, over the whole tree handed to
+    /// [`lint`](Self::lint). Read by the unused-binding rule. Collected up front
+    /// because a use may appear anywhere — including textually before the
+    /// binding, in a `letrec` — so the single-pass walk cannot decide it.
+    used: HashSet<Binding>,
 }
 
 impl HirLinter {
@@ -25,11 +38,21 @@ impl HirLinter {
         Self {
             diagnostics: Vec::new(),
             current_fn: None,
+            current_fn_binding: None,
+            used: HashSet::new(),
         }
     }
 
-    /// Lint a single HIR expression
+    /// Lint a whole HIR tree.
+    ///
+    /// `hir` must be a complete compilation unit: the def-use pass below runs
+    /// over it once, and a binding whose only use sits outside the subtree would
+    /// read as unused. Analysis marks tail calls (`pipeline::analyze`), so the
+    /// `is_tail` flags this reads are the same ones lowering acts on.
     pub fn lint(&mut self, hir: &Hir, symbols: &SymbolTable, arena: &BindingArena) {
+        let mut defuse = DefUseBuilder::new();
+        defuse.walk(hir);
+        self.used = defuse.uses.into_keys().collect();
         self.check(hir, symbols, arena);
     }
 
@@ -82,12 +105,22 @@ impl HirLinter {
             fname,
             &mut self.diagnostics,
         );
-        let prev = self.current_fn;
+        rules::check_unused_binding(
+            binding,
+            arena,
+            &self.used,
+            loc,
+            symbols,
+            fname,
+            &mut self.diagnostics,
+        );
+        let prev = (self.current_fn, self.current_fn_binding);
         if !arena.get(binding).is_synthetic && matches!(init.kind, HirKind::Lambda { .. }) {
             self.current_fn = Some(arena.get(binding).name);
+            self.current_fn_binding = Some(binding);
         }
         self.check(init, symbols, arena);
-        self.current_fn = prev;
+        (self.current_fn, self.current_fn_binding) = prev;
     }
 
     fn check(&mut self, hir: &Hir, symbols: &SymbolTable, arena: &BindingArena) {
@@ -163,7 +196,11 @@ impl HirLinter {
                 self.check(value, symbols, arena);
             }
 
-            HirKind::Call { func, args, .. } => {
+            HirKind::Call {
+                func,
+                args,
+                is_tail,
+            } => {
                 self.check(func, symbols, arena);
                 for arg in args {
                     self.check(&arg.expr, symbols, arena);
@@ -180,6 +217,19 @@ impl HirLinter {
                             &mut self.diagnostics,
                         );
                     }
+                }
+                if let (Some(enclosing), HirKind::Var(callee)) =
+                    (self.current_fn_binding, &func.kind)
+                {
+                    rules::check_non_tail_self_recursion(
+                        enclosing,
+                        *callee,
+                        *is_tail,
+                        arena,
+                        &loc,
+                        symbols,
+                        &mut self.diagnostics,
+                    );
                 }
             }
 

--- a/src/hir/lint/tests.rs
+++ b/src/hir/lint/tests.rs
@@ -50,6 +50,8 @@ fn test_hir_linter_arity_check() {
 }
 
 const MUTABLE_NEVER_ASSIGNED: &str = "mutable-binding-never-assigned";
+const UNUSED_BINDING: &str = "unused-binding";
+const NON_TAIL_SELF_RECURSION: &str = "non-tail-self-recursion";
 
 /// Analyze `source`, run the HIR linter, and return only the diagnostics whose
 /// rule matches `rule`.
@@ -64,6 +66,246 @@ fn lint_rule(source: &str, rule: &str) -> Vec<crate::lint::diagnostics::Diagnost
         .filter(|d| d.rule == rule)
         .cloned()
         .collect()
+}
+
+/// As [`lint_rule`], but through the file front-end, so `source` may hold more
+/// than one top-level form (a mutual-recursion pair needs two).
+fn lint_file_rule(source: &str, rule: &str) -> Vec<crate::lint::diagnostics::Diagnostic> {
+    let (mut symbols, mut vm) = setup();
+    let mut cctx = CompileCtx::new();
+    let analysis = crate::analyze_file(source, &mut symbols, &mut vm, &mut cctx, "<test>")
+        .expect("source should analyze");
+    let mut linter = HirLinter::new();
+    linter.lint(&analysis.hir, &symbols, &analysis.arena);
+    linter
+        .diagnostics()
+        .iter()
+        .filter(|d| d.rule == rule)
+        .cloned()
+        .collect()
+}
+
+/// The binding names a rule flagged, in the order the linter found them.
+fn flagged_names(diags: &[crate::lint::diagnostics::Diagnostic]) -> Vec<&str> {
+    diags
+        .iter()
+        .map(|d| {
+            let start = d.message.find('\'').expect("message quotes the name") + 1;
+            let rest = &d.message[start..];
+            &rest[..rest.find('\'').expect("message closes the quote")]
+        })
+        .collect()
+}
+
+// ── W004 unused-binding ──────────────────────────────────────────────
+
+#[test]
+fn unused_let_binding_warns() {
+    // `x` is bound and never read. This is the typo / dead-refactoring case the
+    // rule exists for.
+    let diags = lint_file_rule("(defn f [] (let [x 1] 2))\n(f)", UNUSED_BINDING);
+    assert_eq!(flagged_names(&diags), ["x"], "got {diags:?}");
+    assert_eq!(
+        diags[0].severity,
+        crate::lint::diagnostics::Severity::Warning
+    );
+}
+
+#[test]
+fn unused_def_binding_warns() {
+    // A `def` inside a function body is a letrec binding, and reaches the same
+    // checked site as a `let` binding.
+    let diags = lint_file_rule("(defn f [] (def x 1) 2)\n(f)", UNUSED_BINDING);
+    assert_eq!(flagged_names(&diags), ["x"], "got {diags:?}");
+}
+
+#[test]
+fn used_binding_no_warning() {
+    let diags = lint_file_rule("(defn f [] (let [x 1] x))\n(f)", UNUSED_BINDING);
+    assert!(diags.is_empty(), "a read binding must not warn: {diags:?}");
+}
+
+#[test]
+fn underscore_named_bindings_no_warning() {
+    // `_` and `_`-prefixed names are the "I know this is unused" convention, and
+    // the compiler's own temporaries (`__destructure_tmp`) share the spelling.
+    let diags = lint_file_rule("(defn f [] (let [_ 1 _spare 2] 3))\n(f)", UNUSED_BINDING);
+    assert!(diags.is_empty(), "throwaway names must not warn: {diags:?}");
+}
+
+#[test]
+fn binding_referenced_only_by_its_own_initializer_no_warning() {
+    // A self-recursive function references itself from its own body. That is a
+    // genuine use — def-use records the self-edge as a capture — so the binding
+    // is not unused even when nothing else calls it.
+    let diags = lint_file_rule("(defn f [n] (if (= n 0) 0 (f (- n 1))))", UNUSED_BINDING);
+    assert!(
+        diags.is_empty(),
+        "a self-referencing binding is referenced: {diags:?}"
+    );
+}
+
+#[test]
+fn capture_in_nested_closure_counts_as_use() {
+    // Counter-factual: were uses collected only from `Var` nodes in the same
+    // function, `x` would read as unused here and the rule would flag a binding
+    // the closure genuinely needs.
+    let diags = lint_file_rule("(defn f [] (let [x 1] (fn [] x)))\n(f)", UNUSED_BINDING);
+    assert!(diags.is_empty(), "a captured binding is used: {diags:?}");
+}
+
+#[test]
+fn destructure_and_primitive_bindings_no_warning() {
+    // The destructuring temporary is synthetic, and every primitive is bound
+    // into the compilation unit whether the program calls it or not. Neither is
+    // the user's dead code.
+    let diags = lint_file_rule(
+        "(defn f [] (let [(a b) (pair 1 2)] (+ a b)))\n(f)",
+        UNUSED_BINDING,
+    );
+    assert!(
+        diags.is_empty(),
+        "synthetic and primitive bindings must not warn: {diags:?}"
+    );
+}
+
+#[test]
+fn unused_function_parameter_is_not_reached() {
+    // The gap, pinned: `check_binding_site` runs at `let`/`letrec`/`def` sites
+    // only, so a lambda parameter never reaches the rule. `x` is unused here and
+    // is NOT flagged. Extending the walker to parameters is what would change
+    // this assertion.
+    let diags = lint_file_rule("(defn f [x] 1)\n(f 1)", UNUSED_BINDING);
+    assert!(
+        diags.is_empty(),
+        "parameters do not reach a checked site: {diags:?}"
+    );
+}
+
+#[test]
+fn mutual_recursion_leaves_both_referenced() {
+    let diags = lint_file_rule(
+        "(defn a [n] (b n))\n(defn b [n] (a n))\n(a 1)",
+        UNUSED_BINDING,
+    );
+    assert!(
+        diags.is_empty(),
+        "each function is referenced by the other: {diags:?}"
+    );
+}
+
+#[test]
+fn unused_top_level_definition_warns() {
+    let diags = lint_file_rule("(defn used [] 1)\n(defn dead [] 2)\n(used)", UNUSED_BINDING);
+    assert_eq!(flagged_names(&diags), ["dead"], "got {diags:?}");
+}
+
+#[test]
+fn unused_binding_diagnostic_carries_enclosing_function() {
+    let diags = lint_file_rule(
+        "(defn outer [] (defn inner [] (let [dead 1] 2)) (inner))\n(outer)",
+        UNUSED_BINDING,
+    );
+    assert_eq!(flagged_names(&diags), ["dead"], "got {diags:?}");
+    assert_eq!(
+        diags[0].function.as_deref(),
+        Some("inner"),
+        "attribution is to the nearest enclosing named function"
+    );
+}
+
+// ── W005 non-tail-self-recursion ─────────────────────────────────────
+
+#[test]
+fn non_tail_self_call_warns() {
+    // The self-call sits under `+`, so each level keeps a frame alive.
+    let diags = lint_rule(
+        "(defn f [n] (if (= n 0) 0 (+ 1 (f (- n 1)))))",
+        NON_TAIL_SELF_RECURSION,
+    );
+    assert_eq!(diags.len(), 1, "expected one warning, got {diags:?}");
+    assert!(
+        diags[0].message.contains("f"),
+        "message names the function: {}",
+        diags[0].message
+    );
+}
+
+#[test]
+fn tail_self_call_no_warning() {
+    // The accumulator form: the self-call is the whole `else` branch, so it
+    // replaces the frame.
+    let diags = lint_rule(
+        "(defn f [n acc] (if (= n 0) acc (f (- n 1) (+ acc 1))))",
+        NON_TAIL_SELF_RECURSION,
+    );
+    assert!(
+        diags.is_empty(),
+        "a tail self-call must not warn: {diags:?}"
+    );
+}
+
+#[test]
+fn self_call_in_both_tail_arms_no_warning() {
+    let diags = lint_rule(
+        "(defn f [n] (if (= n 0) (f 1) (f 2)))",
+        NON_TAIL_SELF_RECURSION,
+    );
+    assert!(
+        diags.is_empty(),
+        "both arms of a tail `if` are tail position: {diags:?}"
+    );
+}
+
+#[test]
+fn mutual_recursion_is_out_of_scope() {
+    // Two functions that only call each other, both outside tail position.
+    // Detecting this needs call-graph reasoning; the rule covers direct
+    // self-recursion only and must stay quiet here.
+    let diags = lint_file_rule(
+        "(defn a [n] (+ 1 (b n)))\n(defn b [n] (+ 1 (a n)))\n(a 1)",
+        NON_TAIL_SELF_RECURSION,
+    );
+    assert!(
+        diags.is_empty(),
+        "mutual recursion is out of scope: {diags:?}"
+    );
+}
+
+#[test]
+fn letrec_bound_anonymous_fn_self_recursion_warns() {
+    // The rule keys on the binding the enclosing lambda was bound to, not on a
+    // name in the source, so an anonymous `fn` under `letrec` is covered.
+    let diags = lint_rule(
+        "(letrec [g (fn [n] (if (= n 0) 0 (+ 1 (g (- n 1)))))] (g 3))",
+        NON_TAIL_SELF_RECURSION,
+    );
+    assert_eq!(diags.len(), 1, "expected one warning, got {diags:?}");
+}
+
+#[test]
+fn a_sibling_call_is_not_a_self_call() {
+    // Counter-factual for keying on the enclosing function rather than on any
+    // non-tail call: `g` calls `f` outside tail position and must not warn.
+    let diags = lint_file_rule(
+        "(defn f [n] n)\n(defn g [n] (+ 1 (f n)))\n(g 1)",
+        NON_TAIL_SELF_RECURSION,
+    );
+    assert!(diags.is_empty(), "a call to another function: {diags:?}");
+}
+
+#[test]
+fn a_call_from_a_nested_named_closure_is_not_the_outer_self_call() {
+    // `h` is bound to a lambda, so the linter's enclosing-function identity is
+    // `h` inside it. The `(f 1)` there is not a self-call of `f`.
+    let diags = lint_rule(
+        "(defn f [n] (let [h (fn [] (+ 1 (f 1)))] (h)))",
+        NON_TAIL_SELF_RECURSION,
+    );
+    assert!(
+        diags.is_empty(),
+        "the enclosing function inside `h` is `h`: {diags:?}"
+    );
 }
 
 #[test]

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -14,6 +14,7 @@ pub mod anf;
 pub mod arena;
 pub mod binding;
 pub mod dataflow;
+mod dead;
 pub(crate) mod decision;
 mod defuse;
 pub mod display;

--- a/src/hir/region/infer/tests/escape.rs
+++ b/src/hir/region/infer/tests/escape.rs
@@ -112,7 +112,11 @@ fn loop_with_pair_alloc_is_live() {
 fn let_with_pair_body_immediate_is_live() {
     // %pair allocates in the let scope; body returns 42 (immediate).
     // The pair stays local → the let scope is live.
-    let (hir, _, info) = pipeline("(let [x (%pair 1 2)] 42)");
+    //
+    // The body reads `x` so that the binding survives dead binding elimination
+    // (`hir::dead`), which would otherwise delete an unread `%pair` before the
+    // region solver ever sees the allocation this test is about.
+    let (hir, _, info) = pipeline("(let [x (%pair 1 2)] (if x 42 0))");
     let lets = find_lets(&hir);
     let any_live = lets.iter().any(|id| info.scope_has_local_allocs(*id));
     assert!(any_live, "let with %pair and immediate body should be live");

--- a/src/hir/regularize.rs
+++ b/src/hir/regularize.rs
@@ -40,6 +40,11 @@ pub(crate) fn regularize(
     // untouched) and before tail-call marking, so the fused loop's `freeze` tail
     // is marked in place of the collapsed `map` call.
     fuse_map_chains(hir, arena, symbols, fn_inline);
+    // Dead binding elimination runs after pruning and fusion, which both make
+    // bindings unused, and before functionalize, for the same reason pruning
+    // does: the region solver runs after these transforms, so a call deleted
+    // here mints no region and strands no release obligation.
+    crate::hir::dead::eliminate_dead_bindings(hir, arena, symbols);
     crate::hir::tailcall::mark_tail_calls(hir);
     crate::hir::functionalize::functionalize(hir, arena);
     crate::hir::anf::anf_lift(hir, arena);

--- a/src/lint/AGENTS.md
+++ b/src/lint/AGENTS.md
@@ -16,9 +16,15 @@ provides the shared types and rule implementations.
 | `Severity` | `Info`, `Warning`, `Error` |
 | `DiagnosticContext` | Optional source text for context display |
 
-| Function | Purpose |
-|----------|---------|
-| `check_naming_convention` | Warns on non-kebab-case identifiers |
+| Function | Code | Purpose |
+|----------|------|---------|
+| `check_call_arity` | `W002` | Warns on a built-in call with the wrong argument count |
+| `check_mutable_never_assigned` | `W003` | Warns on a `var`/`@` binding no `assign` targets |
+| `check_unused_binding` | `W004` | Warns on a `def`/`let`/`letrec` binding with zero uses |
+| `check_non_tail_self_recursion` | `W005` | Warns on a self-call outside tail position |
+
+Every binding rule shares one exemption set — synthetic, primitive, and
+`_`-prefixed names — through `reportable_name`.
 
 ## Dependents
 

--- a/src/lint/rules.rs
+++ b/src/lint/rules.rs
@@ -33,6 +33,115 @@ pub(crate) fn check_call_arity(
     }
 }
 
+/// The name a lint rule may report for `binding`, or `None` when the binding is
+/// not the user's to fix.
+///
+/// Three classes are silent for every binding rule. A `is_synthetic` binding is
+/// a compiler temporary the user never wrote (`__destructure_tmp`, the
+/// file-letrec statement wrappers). A `is_primitive` binding is injected into
+/// every compilation unit by `bind_primitives`, so its presence says nothing
+/// about the program. A `_`-prefixed name is the conventional "I know about
+/// this one" marker. A binding whose symbol the table cannot name has nothing
+/// to report.
+fn reportable_name<'a>(
+    inner: &crate::hir::BindingInner,
+    symbol_table: &'a crate::SymbolTable,
+) -> Option<&'a str> {
+    if inner.is_synthetic || inner.is_primitive {
+        return None;
+    }
+    let name = symbol_table.name(inner.name)?;
+    if name.starts_with('_') {
+        return None;
+    }
+    Some(name)
+}
+
+/// Warn when a binding is introduced and never read.
+///
+/// Zero uses is the shape shared by a misspelled reference (`reuslt` defined,
+/// `result` read), by a definition whose last reader a refactoring removed, and
+/// by an import nothing projects out of. The rule reads the def-use chains
+/// `src/hir/defuse.rs` already builds — `used` holds every binding with at least
+/// one use — so no binding carries a use counter of its own.
+///
+/// A use is any read: a `Var` node, or a closure capture. A self-recursive
+/// function reads its own binding from its own body, so it counts as used.
+/// Reassignment does not count: `assign` records a definition, so a binding that
+/// is written and never read is still reported.
+///
+/// Callers invoke this at binding-introduction sites (`def`/`let`/`letrec`).
+/// Lambda parameters, loop variables, and pattern bindings never reach it.
+pub(crate) fn check_unused_binding(
+    binding: crate::hir::Binding,
+    arena: &crate::hir::BindingArena,
+    used: &std::collections::HashSet<crate::hir::Binding>,
+    location: &Option<SourceLoc>,
+    symbol_table: &crate::SymbolTable,
+    function: Option<&str>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if used.contains(&binding) {
+        return;
+    }
+    let Some(name) = reportable_name(arena.get(binding), symbol_table) else {
+        return;
+    };
+    let mut diag = Diagnostic::new(
+        Severity::Warning,
+        "W004",
+        "unused-binding",
+        format!("binding '{name}' is never used"),
+        location.clone(),
+    );
+    diag.suggestions.push(format!(
+        "remove '{name}', or rename it to '_{name}' if the binding is deliberately unused"
+    ));
+    diag.function = function.map(str::to_string);
+    diagnostics.push(diag);
+}
+
+/// Warn when a function calls itself outside tail position.
+///
+/// Every such call keeps its caller's frame alive, so the recursion depth is
+/// bounded by the stack and deep input halts the program. A tail self-call
+/// replaces the frame and costs one frame at any depth, and the rewrite that
+/// gets there — an accumulator parameter, or `each`/`while` — is cheap while the
+/// code is being written.
+///
+/// Scope is direct self-recursion: the enclosing function's own binding stands
+/// in the call's function position. Mutual recursion needs call-graph reasoning
+/// and is not covered.
+pub(crate) fn check_non_tail_self_recursion(
+    enclosing: crate::hir::Binding,
+    callee: crate::hir::Binding,
+    is_tail: bool,
+    arena: &crate::hir::BindingArena,
+    location: &Option<SourceLoc>,
+    symbol_table: &crate::SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if is_tail || callee != enclosing {
+        return;
+    }
+    let Some(name) = reportable_name(arena.get(enclosing), symbol_table) else {
+        return;
+    };
+    let mut diag = Diagnostic::new(
+        Severity::Warning,
+        "W005",
+        "non-tail-self-recursion",
+        format!("'{name}' calls itself outside tail position, so the stack grows with the recursion depth"),
+        location.clone(),
+    );
+    diag.suggestions.push(format!(
+        "give '{name}' an accumulator parameter so the self-call is the whole result, \
+         or restate the recursion as `each`/`while`"
+    ));
+    diag.function = Some(name.to_string());
+    diagnostics.push(diag);
+}
+
 /// Recommend an immutable binding for a mutable one that is never reassigned.
 ///
 /// A binding declared mutable (`var`, or an `@`-prefixed `def`/`let` name) but
@@ -44,9 +153,9 @@ pub(crate) fn check_call_arity(
 /// mutable binding with a mutable value.
 ///
 /// Throwaway (`_`-prefixed), synthetic, primitive, and parameter bindings are
-/// exempt. Callers invoke this at binding-introduction sites (`def`/`let`/
-/// `letrec`); loop variables (rebound via `recur`, not `assign`) and pattern
-/// bindings are excluded by never being passed here.
+/// exempt ([`reportable_name`]). Callers invoke this at binding-introduction
+/// sites (`def`/`let`/`letrec`); loop variables (rebound via `recur`, not
+/// `assign`) and pattern bindings are excluded by never being passed here.
 pub(crate) fn check_mutable_never_assigned(
     binding: crate::hir::Binding,
     arena: &crate::hir::BindingArena,
@@ -59,20 +168,12 @@ pub(crate) fn check_mutable_never_assigned(
     if inner.scope != crate::hir::arena::BindingScope::Local
         || inner.is_immutable
         || inner.is_mutated
-        || inner.is_synthetic
-        || inner.is_primitive
     {
         return;
     }
-    let Some(name) = symbol_table.name(inner.name) else {
+    let Some(name) = reportable_name(inner, symbol_table) else {
         return;
     };
-    // `_`-prefixed names are the throwaway / compiler-temporary convention
-    // (e.g. the `__destructure_tmp` binder); a lint that recommends making them
-    // immutable is noise, not signal.
-    if name.starts_with('_') {
-        return;
-    }
     let mut diag = Diagnostic::new(
         Severity::Warning,
         "W003",

--- a/src/pipeline/analyze.rs
+++ b/src/pipeline/analyze.rs
@@ -35,11 +35,9 @@ pub fn analyze(
     let analysis = analyzer.analyze(&expanded)?;
     let errors = analysis.errors;
     drop(analyzer);
-    Ok(AnalyzeResult {
-        hir: analysis.hir,
-        arena,
-        errors,
-    })
+    let mut hir = analysis.hir;
+    crate::hir::tailcall::mark_tail_calls(&mut hir);
+    Ok(AnalyzeResult { hir, arena, errors })
 }
 
 /// Analyze a file as a single synthetic letrec (no bytecode).
@@ -88,9 +86,10 @@ pub fn analyze_file(
     );
     analyzer.set_compile_ctx(cctx);
     analyzer.bind_primitives(&meta);
-    let hir = analyzer.analyze_file_letrec(forms, span)?;
+    let mut hir = analyzer.analyze_file_letrec(forms, span)?;
     let errors = analyzer.take_errors();
     drop(analyzer);
 
+    crate::hir::tailcall::mark_tail_calls(&mut hir);
     Ok(AnalyzeResult { hir, arena, errors })
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -26,6 +26,11 @@ pub struct CompileResult {
 /// Used by linter and LSP which need HIR but not bytecode
 #[derive(Debug)]
 pub struct AnalyzeResult {
+    /// The analyzed tree, with tail calls already marked. Consumers that read
+    /// `is_tail` off an analysis — the linter's non-tail-self-recursion rule, the
+    /// `compile/callees` call-graph builder — read a flag the analysis set, not a
+    /// default. `regularize` marks again on the compile path, because map fusion
+    /// mints call nodes after this point.
     pub hir: crate::hir::Hir,
     pub arena: crate::hir::BindingArena,
     /// Accumulated non-fatal analysis errors

--- a/tests/elle/dead-binding.lisp
+++ b/tests/elle/dead-binding.lisp
@@ -1,0 +1,69 @@
+(elle/epoch 12)
+# ── Dead binding elimination: what it removes, and what it must not ─────
+#
+# The pass removes an unused let/letrec binding together with its initializer.
+# These run the compiled program, so they observe the only thing that matters
+# about the transform: the program's behavior is unchanged.
+
+# ── An unused binding over an effect-free initializer ───────────────────
+
+(assert (= (let [unread (%add 1 2)
+                 kept 10]
+             kept) 10)
+        "dropping a dead arithmetic binding leaves the result alone")
+
+(assert (= (let [alias 7
+                 unread alias
+                 kept alias]
+             kept) 7) "dropping a dead alias leaves its source alone")
+
+# ── A silent initializer that mutates ──────────────────────────────────
+#
+# The trap this pins: %push-array-mut emits no signal, so a rule that keyed on
+# silence alone would delete the append. `arr` would then still hold two
+# elements and the assertion below would read 2.
+
+(def arr @[1 2])
+(let [unread (%push-array-mut arr 3)
+      kept 10]
+  (assert (= kept 10) "the surrounding let still evaluates"))
+(assert (= (length arr) 3)
+        "an unused binding does not delete the append its initializer made")
+
+# ── Through a user-defined function ────────────────────────────────────
+
+(defn append-one [a]
+  (%push-array-mut a 9))
+(def arr2 @[1])
+(let [unread (append-one arr2)
+      kept 0]
+  (assert (= kept 0) "the surrounding let still evaluates"))
+(assert (= (length arr2) 2)
+        "purity is not inherited from a silent signal one call deep")
+
+# ── An observable initializer ──────────────────────────────────────────
+
+(def @writes 0)
+(defn note []
+  (assign writes (+ writes 1))
+  nil)
+(let [unread (note)
+      kept 5]
+  (assert (= kept 5) "the surrounding let still evaluates"))
+(assert (= writes 1) "an initializer that writes still runs")
+
+# ── A used binding is untouched ────────────────────────────────────────
+
+(assert (= (let [x (%add 20 22)]
+             x) 42) "a read binding keeps its value")
+
+# ── Recursion still terminates and still computes ──────────────────────
+#
+# A self-recursive function is never proven pure, so nothing about its call
+# sites changes.
+
+(defn total [n acc]
+  (if (= n 0) acc (total (- n 1) (+ acc n))))
+(assert (= (total 4 0) 10) "recursion is unaffected")
+
+(println "all dead binding tests passed")

--- a/tests/elle/lint-rules.lisp
+++ b/tests/elle/lint-rules.lisp
@@ -1,0 +1,64 @@
+(elle/epoch 12)
+# ── Lint rules, end to end through compile/diagnostics ──────────────────
+#
+# The rules run in `elle lint`, in the LSP, and here, because all three read
+# the same `HirLinter`. Asserting through `compile/diagnostics` pins the whole
+# path from source text to a rule name a consumer can filter on.
+
+(defn rule-hits [src rule]
+  "Every diagnostic `src` produces under `rule`."
+  (filter (fn [d] (= (get d :rule) rule))
+          (compile/diagnostics (compile/analyze src))))
+
+(defn names-in [diags]
+  "The quoted binding name each diagnostic message carries."
+  (map (fn [d] (get (string/split (get d :message) "'") 1)) diags))
+
+# ── W004 unused-binding ─────────────────────────────────────────────────
+
+(def unused (rule-hits "(defn f [] (let [x 1] 2))\n(f)" "unused-binding"))
+(assert (= (length unused) 1) "one unused binding in the let")
+(assert (= (first (names-in unused)) "x") "the unused binding is x")
+(assert (= (get (first unused) :code) "W004") "unused-binding is W004")
+(assert (= (get (first unused) :severity) :warning) "unused-binding warns")
+(assert (= (get (first unused) :function) "f")
+        "the finding is attributed to its enclosing function")
+
+(assert (empty? (rule-hits "(defn f [] (let [x 1] x))\n(f)" "unused-binding"))
+        "a binding that is read does not warn")
+
+(assert (empty? (rule-hits "(defn f [] (let [_scratch 1] 2))\n(f)"
+                           "unused-binding"))
+        "an _-prefixed name is a deliberate throwaway")
+
+# A misspelled reference leaves the definition unused and the use undefined.
+# The lint is the half that names the definition.
+(def typo (rule-hits "(defn f [] (let [reuslt 1] 2))\n(f)" "unused-binding"))
+(assert (= (first (names-in typo)) "reuslt") "the typo'd definition is flagged")
+
+# ── W005 non-tail-self-recursion ────────────────────────────────────────
+
+(def deep
+  (rule-hits "(defn f [n] (if (= n 0) 0 (+ 1 (f (- n 1)))))"
+             "non-tail-self-recursion"))
+(assert (= (length deep) 1) "the self-call under + is flagged")
+(assert (= (get (first deep) :code) "W005") "non-tail-self-recursion is W005")
+(assert (= (get (first deep) :function) "f") "the finding names f")
+
+(assert (empty? (rule-hits "(defn f [n acc] (if (= n 0) acc (f (- n 1) (+ acc 1))))"
+                           "non-tail-self-recursion"))
+        "the accumulator form recurses in tail position")
+
+# ── The tail flag the rule reads is the one callees report ──────────────
+#
+# Both read `is_tail` off the analyzed tree. Analysis marks it, so neither
+# reads a default that would call every call non-tail.
+
+(def a
+  (compile/analyze "(defn f [n acc] (if (= n 0) acc (f (- n 1) (+ acc 1))))"))
+(def self-calls (filter (fn [c] (= (get c :name) "f")) (compile/callees a :f)))
+(assert (= (length self-calls) 1) "f calls itself once")
+(assert (get (first self-calls) :tail)
+        "the self-call is reported in tail position")
+
+(println "all lint rule tests passed")

--- a/tests/elle/portrait.lisp
+++ b/tests/elle/portrait.lisp
@@ -168,4 +168,49 @@
 (assert (empty? (get (portrait:module a5) :false-mutable))
         "immutable binding of a mutable value is not a false-mutable")
 
+# ── Unused-binding advisory ─────────────────────────────────────────────
+
+# `spare` is bound and never read. The linter flags it and the portrait
+# reflects the flag, at both granularities.
+(def a7 (compile/analyze "
+(defn tidy [] (let [spare 1] 2))
+(tidy)
+"))
+(def ub (get (portrait:module a7) :unused-binding))
+(assert (array? ub) "module portrait has an unused-binding list")
+(assert (not (empty? ub)) "spare is flagged unused")
+(assert (contains? (get (first ub) :message) "'spare'")
+        "advisory names the binding spare")
+
+(def tidy-obs (get (portrait:function a7 :tidy) :observations))
+(assert (not (empty? (filter (fn [o] (= (get o :kind) :unused-binding)) tidy-obs)))
+        "tidy's portrait observes its own unused binding")
+
+(assert (contains? (portrait:render-module (portrait:module a7)) "never used")
+        "module render shows the unused-binding section")
+
+# ── Non-tail-recursion advisory ─────────────────────────────────────────
+
+(def a8
+  (compile/analyze "
+(defn depth [n] (if (= n 0) 0 (+ 1 (depth (- n 1)))))
+"))
+(def ntr (get (portrait:module a8) :non-tail-recursion))
+(assert (not (empty? ntr)) "depth's self-call is flagged")
+
+(def depth-obs (get (portrait:function a8 :depth) :observations))
+(assert (not (empty? (filter (fn [o] (= (get o :kind) :non-tail-recursion))
+                             depth-obs)))
+        "depth's portrait observes its own non-tail recursion")
+
+# Attribution is exact — the accumulator form inherits nothing.
+(def a9
+  (compile/analyze "
+(defn depth [n] (if (= n 0) 0 (+ 1 (depth (- n 1)))))
+(defn total [n acc] (if (= n 0) acc (total (- n 1) (+ acc 1))))
+"))
+(def total-obs (get (portrait:function a9 :total) :observations))
+(assert (empty? (filter (fn [o] (= (get o :kind) :non-tail-recursion)) total-obs))
+        "total does not inherit depth's advisory")
+
 (println "all portrait tests passed")

--- a/tests/fixtures/naming-bad.lisp
+++ b/tests/fixtures/naming-bad.lisp
@@ -1,9 +1,15 @@
 (elle/epoch 12)
 # Non-kebab naming conventions — a zero-diagnostic lint corpus since the
-# kebab-case naming lint was removed. Bindings are immutable so no
-# mutability lint fires; only the names are the subject.
+# kebab-case naming lint was removed. Bindings are immutable so no mutability
+# lint fires, and the trailing struct reads every one of them so no
+# unused-binding lint fires. Only the names are the subject.
 
 (def myVariable 10)
 (def camelCase 42)
 (def PascalCase 100)
 (def snake_case 5)
+
+{:my-variable myVariable
+ :camel-case camelCase
+ :pascal-case PascalCase
+ :snake-case snake_case}

--- a/tests/fixtures/naming-good.lisp
+++ b/tests/fixtures/naming-good.lisp
@@ -1,6 +1,7 @@
 (elle/epoch 12)
 # Good naming conventions — a zero-diagnostic lint corpus. Bindings are
-# immutable so no mutability lint fires; only the names are the subject.
+# immutable so no mutability lint fires, and the trailing struct reads every
+# one of them so no unused-binding lint fires. Only the names are the subject.
 
 (def square 42)
 (def my-variable 10)
@@ -8,3 +9,10 @@
 (def number? (fn (x) (int? x)))
 (def set-value! (fn (x v) v))
 (def foo-bar-baz 123)
+
+{:square square
+ :my-variable my-variable
+ :add-two add-two
+ :number? number?
+ :set-value! set-value!
+ :foo-bar-baz foo-bar-baz}


### PR DESCRIPTION
Three findings the analyzer already had the facts for, and none of them adds
state to `BindingInner`.

## W004 `unused-binding`

A `def`/`let`/`letrec` binding with zero uses is a misspelled reference
(`reuslt` defined, `result` read), a definition whose last reader a refactoring
removed, or an import nothing projects out of. The rule reads the def-use chains
`src/hir/defuse.rs` builds.

A capture is a use, so a self-recursive function and a mutual-recursion pair are
both referenced and neither warns. Synthetic, primitive, and `_`-prefixed
bindings are exempt — the same exemption set W003 applies, now read by both
rules from one `reportable_name`.

Scope is the three forms `check_binding_site` reaches. A lambda parameter never
reaches it, so an unused parameter is not flagged;
`unused_function_parameter_is_not_reached` pins that gap so extending the walker
is what changes the assertion.

## W005 `non-tail-self-recursion`

A function whose own binding stands in a non-tail call position grows the stack
with the recursion depth, and deep input then halts at runtime. The rule reads
the `is_tail` flag `src/hir/tailcall.rs` sets. Direct self-recursion only —
mutual recursion needs call-graph reasoning.

The rule keys on the *binding* of the enclosing function, not on a name, so an
anonymous `fn` under `letrec` is covered and a shadowed name cannot confuse it.

### Analysis now marks tail calls

W005 needs the tail classification on the analyzed tree, and analysis was not
setting it. `compile/callees` already read `is_tail` off that same tree, so every
callee it reported came back non-tail and portrait's `:tail-chain` observation
could never fire.

`pipeline::analyze` and `analyze_file` now run `mark_tail_calls` before
returning, which makes the flag a fact for both consumers rather than a default.
`regularize` still marks again, because map fusion mints call nodes after that
point. Without this change `tail_self_call_no_warning` reports the accumulator
form as non-tail.

## Dead binding elimination

`(let [x (%add 1 2) y 10] y)` compiles the operation and throws the result away.
When an unused binding's initializer is provably effect-free, the binding and
the initializer both go — at HIR level, from `regularize`, before
`functionalize`. That is the altitude `prune_typeof_match_arms` uses and for the
same reason: the region solver runs after the HIR transforms, so a call deleted
here mints no region and strands no release obligation.

**A silent function is not a pure function.** `Signal::silent()` says a callee
emits no signal bits, not that it has no effect. Every `%`-intrinsic is
registered silent, and `%push-array-mut` appends to its argument in place:

```lisp
(defn mutator [a] (%push-array-mut a 1))   # inferred signal: bits 0x0
```

A rule keyed on silence alone would delete that append. So the pass proves
effect-freedom from two facts that cannot lie:

- **The node's own signal is silent.** The analyzer combines the callee signal
  with every argument's, so a silent call node also proves the arguments silent,
  and proves a polymorphic callee got silent arguments. A yielding callback
  handed to an otherwise-silent higher-order function shows up here.
- **The callee stores nothing.** `RegionEffect::Immediate` and `Fresh` are the
  two declarations that state no argument is stored anywhere outliving the call;
  `moves_out` marks the natives that remove an element from a container
  argument. For an intrinsic op the gate is `routes_native_funnel`. In-place
  mutation is a store into an argument, so `Funnel`, `Stores`, `Sends`, `Mixed`,
  and `PassThrough` are all rejected. For a user-defined callee the same
  predicate runs over its lambda body, to a fixpoint.

The fixpoint starts with nothing proven and grows, so a self-recursive function
is never admitted. That keeps the pass out of the termination question: it
deletes only calls that provably return.

File-scope bindings, `Define` nodes, mutated bindings, and lambda initializers
are left alone. `docs/impl/hir.md` § "Dead binding elimination" says why for
each — briefly: a module's top-level names are what `(environment)` reflects, a
`Define` evaluates to its own value and can be the result of the enclosing body,
and `assign` records a definition rather than a use so a written-and-never-read
binding reads as unused while an `Assign` node still names it.

## Portrait

Both new rules reach a portrait at module and function granularity. The three
advisory readers were one shape repeated, so they now share `diagnostics-for`
and `advisories-for` over a `lint-kinds` table: a fourth rule reaches a portrait
by gaining a row.

## Measurement

`elle lint` over `src/stdlib.lisp` reports 3 unused definitions and 19 non-tail
self-calls, against 0 for `lib/http.lisp` and `src/prelude.lisp`. The heaviest
are `ev/join`, `ev/join-protected`, and `msort`; the rest are single sites in
`update-in`, `put-in`, `partition`, `part`, and `go`. All are true positives on
real code.

Rebasing over #962 dropped that count from 24 to 19 and removed `flat` from the
list: the cursor-stack rewrite is precisely the fix this rule asks for, made
independently on the function the rule flagged hardest.

`(let [unread (%add 1 2) kept 10] kept)` loses the binding and the operation in
`--dump=fhir`.

## Tests

Every "warns" and "eliminates" assertion was confirmed red before the rule
existed.

- `src/hir/lint/tests.rs` — W004 and W005, each with its negative cases: a read
  binding, a `_`-prefixed name, a captured binding, a self-reference, mutual
  recursion, a sibling call, a call from a nested named closure, and the
  parameter gap.
- `src/hir/dead/tests.rs` — what goes (a silent operation, a literal, an alias,
  a call to a proven-pure user function) and what stays (a silent call that
  mutates, a user function that mutates, `:io`, `:error`-capable, a used
  binding, a yielding callback, a self-recursive callee, a lambda, a mutated
  binding). Dropping the store gate turns the two mutation tests red.
- `tests/elle/lint-rules.lisp` — both rules end to end through
  `compile/diagnostics`, plus the `:tail` flag `compile/callees` reports.
- `tests/elle/dead-binding.lisp` — the transform's only real contract, run:
  program behavior is unchanged, and the append a silent initializer makes still
  happens.
- `tests/elle/portrait.lisp` — both advisories at both granularities, with
  attribution.

Two existing fixtures were wrong rather than the code. `naming-good.lisp` and
`naming-bad.lisp` are zero-diagnostic corpora whose bindings were every one of
them unused; they now read their own names, so naming stays the subject. The
region escape test's `%pair` was bound and never read, which is exactly what the
new pass deletes — its body reads the binding now, so the allocation the test is
about still reaches the solver.

Closes #953. Closes #954. Closes #955.
