### PR TITLE
regions: a statement-position dynamic emit mints its payload's delivery

### DIFF
--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1412,32 +1412,23 @@ That exemption is what carries a **dynamic** `emit` in tail position, whose non-
 first argument makes it an ordinary native call rather than the `Emit` terminator: the
 borrowed-argument retain is the body reference the park owes, and there is no second mint.
 
-**A terminal `:error` mints instead of exempting.** The same operation raising a terminal
-signal hands its payload to a **catcher**, whose read of the signal consumes one reference —
-the payload's **delivery** (§ "An abandoned frame runs the releases it still owes"). The
-suspend exemption cannot supply that one. An `:error` fiber is resumable, so a restart replays
-this block too, and the stash release then reaches a retain the catcher has already consumed.
-So the exit consumes its retains like any other — the nil stamp makes the replay a no-op — and
-mints the delivery itself, exactly as `handle_emit` mints it on the literal path, recording it
-in the same `Fiber::emit_delivery`.
+**A terminal `:error` consumes its retains like any other exit.** The exemption above cannot
+carry one. An `:error` fiber is resumable, so a restart replays this block, and the stash
+release then reaches a retain the **catcher** has already consumed as the payload's delivery
+(§ "An abandoned frame runs the releases it still owes"). What funds the catcher is a delivery
+the raise mints for itself at the signal exit — in either position, under the identity gate and
+the record that travel with it ([owner.md](owner.md) § "What yields is the emit OPERATION, not
+the `Emit` node"). So this exit consumes its retains as on any other path, and the nil stamp
+makes the replay a no-op.
 
-The mint is taken only where the payload is one of the call's **own arguments**. A payload the
-native BUILT funds the delivery with its birth reference, so an ordinary native raise — a fresh
-error struct — must not receive one. The identity test is what tells the two apart, and the
-`emit` primitive handing back its second argument is the shape that needs it.
-
-**The record travels with the mint**, as it does on the literal path. Once the mint funds the
-delivery, every reference the frame holds is owed to the frame's own routes, so the walk and
-the discharge must stop exempting the payload's region. Two references are reclaimed that way:
-a payload the body ALLOCATED, whose owned-argument release sits in the abandoned block, and the
-second name of a payload that reaches the call twice — the first occurrence moves the frame's
-reference and the second takes a retain of its own (rules.md Rule 5), as `(emit s s)` does.
-Where the fiber is restarted rather than discharged, the replayed block runs that same release,
-so the accounting is the same either way.
-
-A **halt** takes neither mint nor record, for the reason `handle_emit` withholds its own retain
-there: the fiber is promoted to `:dead` and never resumed, so that delivery has no consumer and
-a reference taken for it is stranded (owner.md § "Park/unpark symmetry").
+**What the record frees is this block's own releases.** With the delivery funded, every
+reference the frame holds answers to the frame's own routes, so the walk and the discharge stop
+exempting the payload's region and the releases in the abandoned block run. Two references are
+reclaimed that way, both of them this position's: a payload the body ALLOCATED, whose
+owned-argument release sits in the block, and the second name of a payload that reaches the
+call twice — the first occurrence moves the frame's reference and the second takes a retain of
+its own (rules.md Rule 5), as `(emit s s)` does. A restart runs those same releases at the
+replay, so the accounting is the same either way.
 
 **Every OTHER release in that block stays.** They divide in two and neither half has that
 argument. An **argument's** own release is the ownership move, and a signal exit is exactly
@@ -1587,6 +1578,17 @@ rather than a new one:
   cell release naming the box, and a transfer adopt each record nothing. The walk can
   only run a release the frame genuinely had.
 
+**One other site records, on the same three facts.** A dynamic `emit` off tail position
+takes a retain at its payload argument and releases it in the continuation past the call
+([owner.md](owner.md) § "What yields is the emit OPERATION, not the `Emit` node"). That
+release is a value route in every respect the walk reads: a slot the site allocates for
+itself, writes once before the call and reads once after it, and clears as it releases. What
+records it is the **terminal** raise. There the catcher consumes the delivery and this retain
+answers to the continuation alone — which a fiber nobody restarts never runs, so the table is
+the only route to it. A suspending raise records the slot too and is unaffected: its parked
+payload is what the walk protects, so the walk passes the slot over and the discharge answers
+for the retain instead.
+
 **Two routes, two receipts.** The slot-resolved release (`DecrefRegion`) is named the
 same way, by the static region slot it carries, and its receipt is the activation map
 itself: the alloc mints the mapping and the release TAKES it
@@ -1612,11 +1614,13 @@ walk may release, and the two raise paths differ:
   would strand one region per raised-and-caught error whose payload the raise chain
   owns. The raise records the mint (`Fiber::emit_delivery`), and a walk whose live
   signal payload matches it skips nothing.
-- A **dynamic `emit` in tail position** reads like the `Emit` case with the mint moved to
-  the exit: the raise is an ordinary native call, so the signal exit mints the delivery of
-  a payload the call received as an argument and records it there (§ "What the fall-through
-  owes, a signal exit owes too"). What the walk then reclaims is the frame's own reference,
-  wherever the payload is one the body allocated.
+- A **dynamic `emit`** reads like the `Emit` case with the mint moved to the exit: the
+  raise is an ordinary native call, so the signal exit mints the delivery of a payload
+  the call received as an argument and records it there ([owner.md](owner.md) § "What
+  yields is the emit OPERATION, not the `Emit` node"). What the walk then reclaims is the
+  frame's own reference to the payload — in TAIL position wherever the body allocated it,
+  and off tail position the site's own payload retain, which the table names for exactly
+  this reason.
 - An **injected** `fiber/abort` / `fiber/refuse` payload reads like the `Emit` case,
   for the same reason: the injection mints the delivery
   ([effects.md](effects.md) § `Delivers`) and records it on every fiber whose frames
@@ -1697,8 +1701,12 @@ frame stack, and the payload exemption reads the same) and
 `jit::dispatch::tests::release_abandoned_frame_runs_both_routes_off_the_compiled_exits_buffers`
 (the two tables reach the runtime as separate buffers of different widths),
 `lir::lower::tests::release::emission::{frame_release_tables_name_exactly_the_routes_emitted,
-a_reassigned_binding_records_no_value_route}` (the tables are the emit sites, so a route
-the emitter declined has no entry), and `tests/elle/region-error-unwind-uaf.lisp` (the
+a_reassigned_binding_records_no_value_route,
+a_non_tail_dynamic_emit_payload_release_carries_its_receipt}` (the tables are the emit
+sites, so a route the emitter declined has no entry and the one other site that records
+carries both halves of a value route's receipt), with
+`tests/elle/region-dynamic-emit-statement-uaf.lisp` as that site's guardfree complement,
+and `tests/elle/region-error-unwind-uaf.lisp` (the
 soundness complement — the payload the raising native builds while the frame holds its
 argument, a value the frame stored into a container that outlives it, a parked frame the
 restarts system replays, and a catching frame's own values, all under

--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -283,17 +283,34 @@ parked fiber's accounting symmetric with its unpark:
   stash slot, and `DecrefValueRegion` shape `lower_emit` uses, the resume landing at the
   instruction after the call.
   The signal is a runtime value here, so the mint cannot be gated on `suspends` the way the
-  literal path gates it. It is taken whatever the signal turns out to be, and a TERMINAL one
-  reaches the same consumer by another route: the raise leaves through the mask that catches
-  it, which delivers the payload as the resumer's result, and the resumer's release of that
-  result consumes one reference exactly as it consumes the delivery of a park. What supplies
-  that reference in TAIL position is not the borrowed-argument retain, which a restart's
-  replay of the post-`TailCall` block still claims: the exit consumes the retain and mints the
-  delivery itself, recording it so the frames' owed releases stop standing in for a delivery
-  this call now funds ([mechanism.md](mechanism.md) § "What the fall-through owes, a signal
-  exit owes too"). Pinned by
-  `tests/elle/region-dynamic-emit-borrow-uaf.lisp` and
-  `tests/elle/region-dynamic-emit-terminal-uaf.lisp`, and gauged per op by the `emit-dyn-*`
+  literal path gates it: the site takes its retain whatever the signal turns out to be. A
+  SUSPEND hands that retain to the consumer it was made for, the continuation past the park,
+  which the resume replays. A TERMINAL `:error` adds a second consumer beside it. The raise
+  leaves through the mask that catches it, which delivers the payload as the resumer's
+  result, and the resumer's release of that result consumes a reference of its own; and an
+  `:error` fiber is resumable, so the continuation runs as well — at a restart's replay, or
+  at the walk that stands in for a replay no resume will bring
+  ([mechanism.md](mechanism.md) § "An abandoned frame runs the releases it still owes"). One
+  retain, two consumers. So the raise mints the DELIVERY at its signal exit, in either
+  position and for the reason `handle_emit` mints it on the literal path, and records it
+  (`Fiber::emit_delivery`) so the frames' owed releases stop standing in for a delivery this
+  call now funds. The site's retain then answers to the continuation alone.
+  The mint is taken only where the payload is one of the call's own ARGUMENTS. A payload the
+  native BUILT funds the delivery with its birth reference, so an ordinary native raise — a
+  fresh error struct — must not receive one, and the identity test is what tells the two
+  apart. A HALT takes neither mint nor record, for the reason `handle_emit` withholds its own
+  retain there: the fiber is promoted to `:dead` and never resumed, so that delivery has no
+  consumer and a reference taken for it is stranded.
+  Which route carries the continuation's release on a TERMINAL raise is what differs by
+  position, and the difference is what the signal exit can NAME. A tail call carries its
+  stash slots on the `TailCall` itself, so the exit consumes the retain there and nil-stamps
+  the slot, and the replay reloads an immediate and no-ops ([mechanism.md](mechanism.md)
+  § "What the fall-through owes, a signal exit owes too"). A non-tail site's stash is the
+  lowerer's own slot and no instruction names it — but the frame's release table is a table
+  of exactly such slots, so the site records there instead, and the replay or the walk runs
+  the release whole. Pinned by `tests/elle/region-dynamic-emit-borrow-uaf.lisp`,
+  `tests/elle/region-dynamic-emit-terminal-uaf.lisp` and
+  `tests/elle/region-dynamic-emit-statement-uaf.lisp`, and gauged per op by the `emit-dyn-*`
   probes in `tests/elle/oracle.lisp`.
 - **A delivery into a replayed frame carries one owning reference.** A parked
   `BytecodeFrame` re-enters at its suspending call's continuation, whose

--- a/src/lir/lower/control/call.rs
+++ b/src/lir/lower/control/call.rs
@@ -673,10 +673,27 @@ impl<'a> Lowerer<'a> {
                 // `LoadLocal`/`DecrefValueRegion` pair is push-pop-neutral around
                 // the result the call left on top. Empty for every other non-tail
                 // call: only the emit payload sets `borrowed` off tail position.
+                //
+                // The nil stamp and the table entry are what make this release run
+                // ONCE when the signal turns out to be terminal. There the catcher
+                // consumes the delivery the raise minted and this retain answers to
+                // the continuation alone — reached by a restart's replay, or, for a
+                // fiber nobody restarts, by the abandoned-frame walk off exactly
+                // this table (docs/impl/region/mechanism.md § "An abandoned frame
+                // runs the releases it still owes"). A frame that takes both routes
+                // reloads the stamp on the second and no-ops. A SUSPENDING raise
+                // records the slot too and is unaffected: its parked payload is what
+                // the walk protects, so the walk passes the slot over.
                 for &slot in &borrowed_arg_slots {
                     let v = self.fresh_reg();
                     self.emit(LirInstr::LoadLocal { dst: v, slot });
                     self.emit(LirInstr::DecrefValueRegion { src: v });
+                    if let Ok(nil_reg) = self.emit_const(crate::lir::LirConst::Nil) {
+                        self.emit(LirInstr::StoreLocal { slot, src: nil_reg });
+                    }
+                    if !self.current_func.frame_release_slots.contains(&slot) {
+                        self.current_func.frame_release_slots.push(slot);
+                    }
                 }
                 // After ANF (`src/hir/anf.rs`), every consumer position
                 // for a Call has a synthetic `Let` binding owning the

--- a/src/lir/lower/tests/release/emission.rs
+++ b/src/lir/lower/tests/release/emission.rs
@@ -157,6 +157,83 @@ fn dynamic_park_mints_nothing_for_a_body_allocated_payload() {
 }
 
 #[test]
+fn a_non_tail_dynamic_emit_payload_release_carries_its_receipt() {
+    // The site's payload release is a recorded value route, not a bare pair
+    // (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    // still owes"). Two things make it one, and both are load-bearing where the
+    // signal turns out to be TERMINAL: the nil stamp, so a restart's replay of the
+    // continuation cannot run the release the walk already ran, and the table
+    // entry, so a fiber nobody restarts reaches the release at all.
+    //
+    // Counterfactual — with the pair alone the same programs read correct on a
+    // restart and strand one region per raise without one, which is what the
+    // `emit-dyn-error-discard` probe measures.
+    let module = compile_to_lir(
+        "(let [s :yield] (fn () (let [x (string \"a\")] (fn () (begin (emit s x) 0)))))",
+    );
+    // Scoped to what follows the park in its own block — the site's own releases,
+    // not some other route's elsewhere in the body, which stamps and records for
+    // reasons of its own and would let this pass vacuously.
+    let (func, released): (&LirFunction, Vec<(u16, bool)>) =
+        std::iter::once(&module.entry)
+            .chain(module.closures.iter())
+            .find_map(|f| {
+                let b = f.blocks.iter().find(|b| {
+                    b.instructions
+                        .iter()
+                        .any(|i| matches!(i.instr, LirInstr::SuspendingCall { .. }))
+                })?;
+                let at = b
+                    .instructions
+                    .iter()
+                    .position(|i| matches!(i.instr, LirInstr::SuspendingCall { .. }))?;
+                let instrs: Vec<&LirInstr> =
+                    b.instructions[at + 1..].iter().map(|i| &i.instr).collect();
+                Some((
+                    f,
+                    (0..instrs.len())
+                        .filter_map(|i| {
+                            let (
+                                LirInstr::LoadLocal { dst, slot },
+                                LirInstr::DecrefValueRegion { src },
+                            ) = (instrs.get(i)?, instrs.get(i + 1)?)
+                            else {
+                                return None;
+                            };
+                            if dst != src {
+                                return None;
+                            }
+                            // The stamp is `StoreLocal slot <nil>`, and
+                            // materializing the nil takes an instruction of its
+                            // own, so look past it.
+                            let stamped = instrs[i + 2..].iter().take(2).any(
+                                |n| matches!(n, LirInstr::StoreLocal { slot: back, .. } if back == slot),
+                            );
+                            Some((*slot, stamped))
+                        })
+                        .collect(),
+                ))
+            })
+            .expect("a function containing a SuspendingCall");
+    assert!(
+        !released.is_empty(),
+        "the park's own block must carry the payload release for this to be about",
+    );
+    for (slot, stamped) in released {
+        assert!(
+            stamped,
+            "the payload release at slot {slot} must stamp the slot it read, or a \
+             restart's replay runs it a second time",
+        );
+        assert!(
+            func.frame_release_slots.contains(&slot),
+            "slot {slot} carries a stamped value route but is absent from \
+             frame_release_slots, so an abandoned frame never runs it",
+        );
+    }
+}
+
+#[test]
 fn release_emitted_for_unbound_call_result() {
     // An unbound Call result — `(f "a")` whose result flows
     // directly into Begin's discard position — must have a

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -145,7 +145,7 @@ pub struct Fiber {
     ///
     /// - an `emit` raise — the `EmitEscape` retain `handle_emit` (and its JIT
     ///   mirror) takes, which the resumer's release of the resume result consumes;
-    /// - the same raise leaving the emit PRIMITIVE in tail position, where the
+    /// - the same raise leaving the emit PRIMITIVE, in either position, where the
     ///   signal exit takes that retain in `handle_emit`'s place
     ///   (`VM::mint_raised_argument_delivery`);
     /// - an injected `fiber/abort` / `fiber/refuse` payload — the `AbortDelivery`

--- a/src/vm/call/inner.rs
+++ b/src/vm/call/inner.rs
@@ -98,6 +98,24 @@ impl VM {
             // pass-through retain. Shared with the JIT (`elle_jit_call`) so both
             // tiers account identically; see `VM::dispatch_native_call`.
             let (bits, value) = self.dispatch_native_call(def, args.as_slice(), region_id);
+            // A terminal :error hands the payload to a catcher, whose read
+            // consumes one reference this frame's own routes do not fund — so the
+            // raise mints it here where the payload is an argument of this call,
+            // the Call-position twin of the tail exit's mint (`tail_call_inner`).
+            // The site's own payload retain, where the compiler took one, is left
+            // standing for the continuation past this call: a restart replays it,
+            // and a fiber nobody restarts reaches it through the frame's release
+            // table. A HALT takes no mint, for the reason `handle_emit` takes none.
+            // Minted before the handler, which is where this fiber stops being the
+            // one whose frames hold the payload. The `is_empty` test keeps the
+            // classification off the ordinary-completion path, which every native
+            // call takes.
+            if !bits.is_empty()
+                && crate::signals::dispatch::classify(bits, &value)
+                    == crate::signals::dispatch::SignalAction::Error
+            {
+                self.mint_raised_argument_delivery(args.as_slice(), value);
+            }
             return self.handle_primitive_signal(bits, value, code, closure_env, ip);
         }
 

--- a/src/vm/call/inner/tail.rs
+++ b/src/vm/call/inner/tail.rs
@@ -56,43 +56,6 @@ impl VM {
         regions
     }
 
-    /// Mint the DELIVERY reference of a payload this tail call is RAISING, where
-    /// the payload is one of the call's own arguments — the shape a dynamic
-    /// `emit` takes, its non-literal first argument making the raise an ordinary
-    /// native call (docs/impl/region/mechanism.md § "What the fall-through owes,
-    /// a signal exit owes too").
-    ///
-    /// The catcher's read of the signal consumes exactly one reference, and every
-    /// reference this frame holds answers to the frame's own release routes: the
-    /// borrowed-argument retain is consumed by the exit (and no-oped at a
-    /// restart's replay by its nil stamp), an owned argument's release sits in the
-    /// abandoned block for the walk or that same replay to run. So the delivery is
-    /// minted here, exactly as `handle_emit` mints it on the literal path — and
-    /// recorded with it (`Fiber::emit_delivery`), so the abandoned-frame walk and
-    /// the parked frame's discharge stop exempting the payload's region and
-    /// reclaim the frame's own reference to a payload it allocated.
-    ///
-    /// A payload the native BUILT — a fresh error struct — is nobody's argument
-    /// and funds the delivery with its birth reference, so the identity test is
-    /// what keeps this off every ordinary native raise.
-    fn mint_raised_argument_delivery(&mut self, args: &[Value], payload: Value) {
-        if !args.iter().any(|a| a.bit_identical(payload)) {
-            return;
-        }
-        let heap = unsafe { &mut *self.heap_ptr };
-        // An immediate payload crosses no region, so there is nothing to fund and
-        // nothing for the record to say stands.
-        let Some(region) = crate::value::arena::region_of(heap, payload) else {
-            return;
-        };
-        crate::value::arena::incref_for_escape(
-            heap,
-            Some(region),
-            crate::value::arena::EscapeSite::EmitEscape,
-        );
-        self.fiber.emit_delivery = Some(payload);
-    }
-
     /// Release the regions [`Self::take_borrowed_arg_retains`] resolved. Split
     /// from the resolution so the signal handler runs between the two — see that
     /// method for why.

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -18,6 +18,47 @@ mod modules;
 mod config;
 
 impl VM {
+    /// Mint the DELIVERY reference of a payload a native call is RAISING, where
+    /// the payload is one of the call's own arguments — the shape a dynamic
+    /// `emit` takes, its non-literal first argument making the raise an ordinary
+    /// native call (docs/impl/region/owner.md § "What yields is the emit
+    /// OPERATION, not the `Emit` node").
+    ///
+    /// The catcher's read of the signal consumes exactly one reference, and every
+    /// other reference the raising frame holds answers to that frame's own release
+    /// routes. So the delivery is minted here, exactly as `handle_emit` mints it on
+    /// the literal path — and recorded with it (`Fiber::emit_delivery`), so the
+    /// abandoned-frame walk and the parked frame's discharge stop exempting the
+    /// payload's region and run those routes in full.
+    ///
+    /// Both positions raise through this. Which route the frame's own reference
+    /// then takes is theirs to arrange: a tail exit consumes its borrowed-argument
+    /// retains and nil-stamps their stashes, while a Call-position site's payload
+    /// stash is a recorded value route the replay or the walk runs
+    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    /// still owes").
+    ///
+    /// A payload the native BUILT — a fresh error struct — is nobody's argument
+    /// and funds the delivery with its birth reference, so the identity test is
+    /// what keeps this off every ordinary native raise.
+    pub(crate) fn mint_raised_argument_delivery(&mut self, args: &[Value], payload: Value) {
+        if !args.iter().any(|a| a.bit_identical(payload)) {
+            return;
+        }
+        let heap = unsafe { &mut *self.heap_ptr };
+        // An immediate payload crosses no region, so there is nothing to fund and
+        // nothing for the record to say stands.
+        let Some(region) = crate::value::arena::region_of(heap, payload) else {
+            return;
+        };
+        crate::value::arena::incref_for_escape(
+            heap,
+            Some(region),
+            crate::value::arena::EscapeSite::EmitEscape,
+        );
+        self.fiber.emit_delivery = Some(payload);
+    }
+
     /// Handle signal bits returned by a primitive in a Call position.
     ///
     /// Returns `None` to continue the dispatch loop, or `Some(bits)` to

--- a/src/vm/signal/tests.rs
+++ b/src/vm/signal/tests.rs
@@ -297,3 +297,66 @@ fn an_ordinary_suspend_records_no_payload_to_release() {
         );
     })
 }
+
+// -- the raised delivery's identity gate --
+
+/// A raised payload that IS one of the call's arguments gets the delivery minted
+/// and recorded; a payload the native BUILT does not. Both positions raise through
+/// this, so the gate is what keeps the mint off every ordinary native raise — a
+/// fresh error struct funds its delivery with its birth reference, and a second
+/// one is stranded per raised-and-caught error.
+#[test]
+fn a_raised_argument_takes_the_delivery_and_a_built_payload_does_not() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        let (payload, region) = crate::value::arena::alloc_in_fresh_region(
+            unsafe { &mut *vm.heap_ptr },
+            crate::value::heap::HeapObject::Pair(crate::value::heap::Pair::new(
+                Value::int(1),
+                Value::NIL,
+            )),
+        );
+        let before = vm.heap().region_rc(region);
+
+        // Nobody's argument: the native built it, so its birth reference is the
+        // delivery and a mint here would out-count the catcher's single release.
+        vm.mint_raised_argument_delivery(&[Value::int(9)], payload);
+        assert_eq!(
+            vm.heap().region_rc(region),
+            before,
+            "a payload the native built funds its own delivery",
+        );
+        assert!(
+            vm.fiber.emit_delivery.is_none(),
+            "an unminted delivery must leave the frames' payload exemption standing",
+        );
+
+        // The call's own argument handed back: the frame's references all answer
+        // to the frame's own routes, so the catcher's read needs one of its own.
+        vm.mint_raised_argument_delivery(&[Value::int(9), payload], payload);
+        assert_eq!(
+            vm.heap().region_rc(region),
+            before + 1,
+            "a raised argument's delivery is minted at the signal exit",
+        );
+        assert_eq!(
+            vm.fiber.emit_delivery,
+            Some(payload),
+            "the record is what withdraws the walk's payload exemption",
+        );
+    })
+}
+
+/// An IMMEDIATE payload crosses no region, so there is nothing to fund — and
+/// recording it would withdraw the exemption for a value no walk can release.
+#[test]
+fn an_immediate_raised_argument_takes_no_delivery() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        vm.mint_raised_argument_delivery(&[Value::int(9)], Value::int(9));
+        assert!(
+            vm.fiber.emit_delivery.is_none(),
+            "an immediate payload has no region for the record to speak for",
+        );
+    })
+}

--- a/tests/elle/oracle.lisp
+++ b/tests/elle/oracle.lisp
@@ -1570,6 +1570,33 @@
     (fn [j]
       (let [f (fiber/new (fn [] (emit emit-error-sig (string "v" j))) |:error|)]
         (fiber/resume f)
+        (fiber/resume f))) 0]  # The same raise OFF TAIL POSITION, where the site
+   # takes the retain instead of the call's argument convention and the exit leaves
+   # it standing for the continuation past the call (docs/impl/region/owner.md
+   # § "What yields is the emit OPERATION, not the `Emit` node"). CLOSED controls
+   # (undeclared, like `rest-array-copy`). What each reads is where that retain's one
+   # consumer is: `emit-dyn-error-discard` above resumes once, so no replay arrives
+   # and the frames' own release table is the only route to it — the face that goes
+   # open by one region per op if the site's stash stops recording there, or if the
+   # raise stops recording its mint. `emit-dyn-stmt-error-restart` resumes twice, so
+   # the replay runs that release instead, and `emit-dyn-stmt-error-fresh` allocates
+   # its payload in the body, where the site mints nothing and the body's own release
+   # is what the two routes carry. All three read the mint's ARITY: withholding it
+   # over-frees, which no leak gauge sees and
+   # tests/elle/region-dynamic-emit-statement-uaf.lisp reports.
+   ["emit-dyn-stmt-error-restart"
+    (fn [j]
+      (let [f (fiber/new (fn []
+                           (emit emit-error-sig emit-subject)
+                           9) |:error|)]
+        (fiber/resume f)
+        (fiber/resume f))) 0]
+   ["emit-dyn-stmt-error-fresh"
+    (fn [j]
+      (let [f (fiber/new (fn []
+                           (emit emit-error-sig (string "v" j))
+                           9) |:error|)]
+        (fiber/resume f)
         (fiber/resume f))) 0]  # An emit-raised error's payload keeps
    # every frame-owed release: `(error v)` mints the payload's delivery itself (the
    # `EmitEscape` retain the resumer's release of the resume result consumes), so the

--- a/tests/elle/region-dynamic-emit-statement-uaf.lisp
+++ b/tests/elle/region-dynamic-emit-statement-uaf.lisp
@@ -1,0 +1,324 @@
+(elle/epoch 12)
+# A raised payload's DELIVERY reference is the one the catcher's read consumes, and
+# the site's own retain answers to the continuation past the call — two references,
+# two consumers, wherever the raise leaves the emit PRIMITIVE (docs/impl/region/owner.md
+# § "What yields is the emit OPERATION, not the `Emit` node").
+#
+# A first argument the compiler cannot read as a keyword set falls through to that
+# primitive (docs/signals/emit.md § "Dynamic emit"), so a raise OFF TAIL POSITION is an
+# ordinary native call whose site mints one retain at the payload argument and releases
+# it in the continuation. The signal is a runtime value, so that retain is taken
+# whatever the signal turns out to be — and a terminal `:error` adds the catcher beside
+# the continuation. An `:error` fiber is resumable, so both consumers run: the catcher
+# at the raise, the continuation at a restart's replay. The raise therefore mints the
+# delivery itself at the signal exit and records it, and the site's retain is left to
+# the continuation.
+#
+# The trap: with a single `fiber/resume` the shape reads correct either way. The parked
+# frame never replays, so the site's retain reaches no consumer but the catcher and
+# stands in for the delivery. Only a RESTART brings the second consumer, which is why
+# every witness here resumes twice and control (o) — the same body resumed once —
+# stays clean.
+#
+# The counter-factual the record answers for: a fiber nobody restarts reaches the
+# continuation only through the frames' own release table, so the site's stash must be
+# a recorded value route (docs/impl/region/mechanism.md § "An abandoned frame runs the
+# releases it still owes"). Mint the delivery without recording the route and the same
+# programs strand one region per raise instead — the growth gate at the bottom refuses
+# that trade.
+#
+# Every witness reads its payload after the raise has left the fiber — through the
+# resume result, through `fiber/value`, through the borrow's own holder, and through a
+# container — so an over-free faults at the deref rather than reading stale but mapped
+# bytes. A fresh subject per iteration keeps region ids churning, so a recycled id
+# detonates on its generation stamp.
+#
+# Run under `--trace=guardfree` by the subprocess pin
+# `region_dynamic_emit_statement_uaf` in tests/integration/elle_scripts.rs.
+
+(def sig :error)
+
+# ── (a) a module-level borrow, raised in statement position, then RESTARTED ──
+# Nothing in the body releases `shared`, so the frame's only reference to it is the
+# retain the site minted — and the replayed continuation is what releases that.
+(def shared (string "shared-subject"))
+(defn w-module [i]
+  (let [f (fiber/new (fn ()
+                       (emit sig shared)
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length shared))))))
+
+# ── (b) a captured `let`-local ───────────────────────────────────────────────
+(defn w-local [i]
+  (let [s (string "local" i)]
+    (let [f (fiber/new (fn ()
+                         (emit sig s)
+                         9) |:error|)]
+      (let [v (fiber/resume f)]
+        (let [n (length v)]
+          (try
+            (fiber/resume f)
+            (catch e nil))
+          (%add n (length s)))))))
+
+# ── (c) a captured PARAMETER of the enclosing frame ──────────────────────────
+(defn w-param [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length s))))))
+
+# ── (d) a body-ALLOCATED payload ─────────────────────────────────────────────
+# The body owns a reference of its own here, so the site mints none — what the
+# restart's replay releases is the body's, and the catcher's is the delivery.
+(defn w-owned [i]
+  (let [f (fiber/new (fn ()
+                       (emit sig (string "owned" i))
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length v))))))
+
+# ── (e) the payload read through `fiber/value` after the restart ─────────────
+(defn w-fiber-value [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (fiber/resume f)
+    (let [n (length (fiber/value f))]
+      (try
+        (fiber/resume f)
+        (catch e nil))
+      (%add n (length s)))))
+
+# ── (f) the borrow outlives the fiber in a container ─────────────────────────
+(def @sink @[])
+(defn w-stored [s]
+  (push sink s)
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        n))))
+
+# ── (g) the raise the fiber's mask does NOT catch, then a restart ────────────
+# The signal propagates out of the fiber and the caller's `catch` binds the
+# payload, so the delivery is consumed one frontier further out.
+(defn w-propagated [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) 0)]
+    (let [n (try
+              (fiber/resume f)
+              (catch e (length e)))]
+      (try
+        (fiber/resume f)
+        (catch e nil))
+      (+ n (length s)))))
+
+# ── (h) TWO restarts of one raise ────────────────────────────────────────────
+# The replay runs the continuation's release once; the third resume finds the
+# fiber dead and must not reach it a second time.
+(defn w-twice [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length s))))))
+
+# ── (i) one region named through BOTH arguments ──────────────────────────────
+# The signal and the payload are one value, so the identity gate matches on the
+# payload and the delivery is minted once out of two names for it.
+(defn w-repeat []
+  (let [f (fiber/new (fn ()
+                       (let [t (set :error)]
+                         (emit t t)
+                         9)) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        n))))
+
+# ── controls — remove one ingredient each; correct with no delivery mint ─────
+
+# (j) the LITERAL path, whose `Emit` terminator mints no body reference for a
+# terminal signal at all, so its replayed continuation releases nothing.
+(defn c-literal [s]
+  (let [f (fiber/new (fn ()
+                       (emit :error s)
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length s))))))
+
+# (k) TAIL position: the exit consumes the borrowed-argument retain itself and
+# nil-stamps its stash, so the replay finds an immediate there.
+(defn c-tail [s]
+  (let [f (fiber/new (fn () (emit sig s)) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length s))))))
+
+# (l) an immediate payload crosses no region at all.
+(defn c-immediate [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig (length s))
+                       9) |:error|)]
+    (fiber/resume f)
+    (try
+      (fiber/resume f)
+      (catch e nil))
+    (length s)))
+
+# (m) the SUSPENDING twin: the site's retain is the body reference the park owes,
+# and the resume replays the very continuation that releases it — one consumer.
+(defn c-yield [s]
+  (let [f (fiber/new (fn ()
+                       (emit :yield s)
+                       9) |:yield|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (fiber/resume f)
+        (%add n (length s))))))
+
+# (n) the DYNAMIC suspending twin, where the site mints the same retain but the
+# signal resolves to a park rather than a raise.
+(defn c-yield-dyn [s]
+  (let [ysig :yield]
+    (let [f (fiber/new (fn ()
+                         (emit ysig s)
+                         9) |:yield|)]
+      (let [v (fiber/resume f)]
+        (let [n (length v)]
+          (fiber/resume f)
+          (%add n (length s)))))))
+
+# (o) NO restart: the parked frame never replays, so the site's retain reaches
+# only the catcher. This is the shape that reads correct either way.
+(defn c-once [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (let [n (length (fiber/resume f))]
+      (%add n (length s)))))
+
+# ── drive: a fresh subject per iteration; an over-free faults on the read ─────
+
+(defn drive [reps]
+  (var i 0)
+  (var a 0)
+  (var b 0)
+  (var c 0)
+  (var d 0)
+  (var e 0)
+  (var f 0)
+  (var g 0)
+  (var h 0)
+  (var k 0)
+  (var l 0)
+  (var m 0)
+  (var n 0)
+  (var o 0)
+  (var p 0)
+  (var q 0)
+  (while (%lt i reps)
+    (assign a (w-module i))
+    (assign b (w-local i))
+    (assign c (w-param (string "param" i)))
+    (assign d (w-owned i))
+    (assign e (w-fiber-value (string "value" i)))
+    (assign f (w-stored (string "stored" i)))
+    (assign g (w-propagated (string "prop" i)))
+    (assign h (w-twice (string "twice" i)))
+    (assign k (w-repeat))
+    (assign l (c-literal (string "lit" i)))
+    (assign m (c-tail (string "tail" i)))
+    (assign n (c-immediate (string "imm" i)))
+    (assign o (c-yield (string "yield" i)))
+    (assign p (c-yield-dyn (string "ydyn" i)))
+    (assign q (c-once (string "once" i)))
+    # The (f) sink is a module-level container by design: read the stored borrow
+    # back out — it must still be alive — then drain, so the driver's own
+    # retention stays flat.
+    (assert (%gt (length (get sink (%sub (length sink) 1))) 0)
+            "stored borrow freed by the restarted fiber's replay")
+    (assign sink @[])
+    (assign i (%add i 1)))
+  (list a b c d e f g h k l m n o p q))
+
+(let [r (drive 400)]
+  (assert (> (get r 9) 0)
+          "control: literal statement raise mis-read (harness broken)")
+  (assert (> (get r 10) 0) "control: tail raise mis-read")
+  (assert (> (get r 11) 0) "control: immediate payload mis-read")
+  (assert (> (get r 12) 0) "control: literal suspending emit mis-read")
+  (assert (> (get r 13) 0) "control: dynamic suspending emit mis-read")
+  (assert (> (get r 14) 0) "control: unrestarted raise mis-read")
+  (assert (> (get r 0) 0)
+          "statement raise: module-level borrow freed by the restart's replay")
+  (assert (> (get r 1) 0)
+          "statement raise: captured local freed by the restart's replay")
+  (assert (> (get r 2) 0)
+          "statement raise: captured parameter freed by the restart's replay")
+  (assert (> (get r 3) 0)
+          "statement raise: body-allocated payload freed by the restart's replay")
+  (assert (> (get r 4) 0)
+          "statement raise: payload freed under a `fiber/value` read")
+  (assert (> (get r 5) 0)
+          "statement raise: stored borrow freed under the container read")
+  (assert (> (get r 6) 0)
+          "statement raise: propagated payload freed under the catcher")
+  (assert (> (get r 7) 0) "statement raise: payload freed by the second restart")
+  (assert (> (get r 8) 0)
+          "statement raise: two-name payload freed by the restart's replay"))
+
+# The module-level subject must survive every fiber that raised it.
+(assert (%gt (length shared) 0)
+        "module-level borrow freed by a restarted statement-position raise")
+
+# ── the leak face: one delivery per raise, and one consumer per retain ───────
+# The mint answers to the catcher's single release and the site's retain to the
+# continuation — which a fiber nobody restarts reaches only through the frames'
+# own release table. A mint with no such route strands one region per raise.
+(drive 100)
+(let [before (arena/region-count)]
+  (drive 400)
+  (let [growth (%sub (arena/region-count) before)]
+    (assert (%lt growth 40)
+            (string "statement dynamic-emit delivery strands regions: live count "
+                    "grew by " growth " over 400 iterations of fifteen raises "
+                    "each (expected flat)"))))
+
+(println "region-dynamic-emit-statement-uaf: ok")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -553,6 +553,30 @@ fn region_dynamic_emit_terminal_uaf() {
     );
 }
 
+// Guard — the same raised delivery where the raise leaves the emit PRIMITIVE OFF
+// TAIL POSITION (docs/impl/region/owner.md § "What yields is the emit OPERATION, not
+// the `Emit` node"). There the site takes the retain, so the exit mints the delivery
+// and leaves that retain to the continuation past the call. An `:error` fiber is
+// resumable, so a RESTART replays that continuation: without the mint the replay
+// releases the very reference the catcher already consumed, and every holder that
+// outlives the fiber reads freed memory. Nine witnesses drive one raise each past a
+// restart — a module-level binding, a captured local, a captured parameter, a
+// body-allocated payload, a `fiber/value` read, a container, an uncaught propagation,
+// a second restart, and one region named through both arguments — and read the
+// payload afterwards, so an over-free faults under guardfree. Six controls remove one
+// ingredient each and must stay clean, the sharpest being the same body resumed ONCE:
+// with no replay the site's retain reaches only the catcher, which is why the shape
+// reads correct until a restart claims it twice. A growth gauge refuses the trade in
+// the other direction — a mint whose retain no route reaches strands one region per
+// raise.
+#[test]
+fn region_dynamic_emit_statement_uaf() {
+    run_elle_script_with_args(
+        "region-dynamic-emit-statement-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — a resume value delivered into a frame parked at a suspending PRIMITIVE
 // call carries one owning reference (docs/impl/region/owner.md § "A delivery into
 // a replayed frame carries one owning reference"). The replayed frame re-enters at


### PR DESCRIPTION
## What was wrong

A first argument the compiler cannot read as a keyword set falls through to the
`emit` primitive (docs/signals/emit.md § "Dynamic emit"), so a raise off tail
position is an ordinary native call. `lower_call` mints one retain at the payload
argument and releases it in the continuation past the call — the body reference a
park owes.

The signal is a runtime value, so that retain is taken whatever the signal turns
out to be, and a terminal `:error` gives it a second consumer. The catcher's read
of the delivered payload consumes one reference, and an `:error` fiber is
resumable, so a restart replays the continuation and releases again. Three
iterations of the issue's shape detonate the generation check.

With a single `fiber/resume` the shape reads correct: nothing replays, so the
site's retain reaches only the catcher and stands in for the delivery. Only a
restart brings the second consumer.

## What the change does

The Call-position signal exit mints the payload's delivery where the payload is
one of the call's own arguments, and records it — the same pair
`handle_emit` performs on the literal path, and the same seam
`tail_call_inner` reaches in tail position. `VM::mint_raised_argument_delivery`
moves to `src/vm/signal.rs` accordingly: it is a fact about a raise, not about
tail calls, and both positions now raise through it.

The site's retain is then left to the continuation alone, which needs one
consumer on every path. A restart's replay is one. For a fiber nobody restarts,
the only route is the frame's own release table — so the site's payload stash
becomes a recorded value route: it stamps its slot nil as it releases and
registers the slot in `frame_release_slots`. That is what the abandoned-frame
walk and the parked frame's discharge run, and the stamp is what makes a frame
that takes both routes count once.

A suspending raise records its slot too and is unaffected: its parked payload is
what the walk protects, so the walk passes the slot over and the discharge
answers for the retain as before.

The JIT keeps today's reading, which is self-consistent there: a compiled frame
is never one a restart replays (a fiber body's first run enters through
`execute_bytecode_saving_stack`), so the second consumer never arrives, the
walk's payload exemption stands, and the site's retain is the delivery.

## How it was measured

The issue's reproduction faulted at iteration 3 under `--trace=guardfree` and now
prints `done, shared=14`. Each of the nine witnesses in the new fixture faults
independently before the change; the six controls are clean before and after.

Counterfactuals, each against a build with one part disabled:

| disabled | result |
|---|---|
| the mint | `region-dynamic-emit-statement-uaf.lisp` faults on a use-after-free |
| the stash's nil stamp and table entry | 399 stranded regions over 400 iterations |
| the record | 399 stranded regions over 400 iterations |
| the argument gate | an ordinary native raise strands one region per op (800/800) |

`oracle: ok` on all three passes (default, `--jit=off`, `--jit=eager`) with the
split unchanged (`open defects: 1 across 1 roots; by-design: 3`) and every
`emit-dyn*` probe at 0, the two added here included. The new fixture is clean
under `--jit=off`, `--jit=eager` and `--jit=adaptive`. `cargo test -p elle --lib`
is 2231 pass; `cargo clippy -p elle --all-targets` is clean.

## Tests

- `tests/elle/region-dynamic-emit-statement-uaf.lisp` — nine witnesses, each a
  statement-position raise driven past a restart and read afterwards (a
  module-level binding, a captured local, a captured parameter, a body-allocated
  payload, a `fiber/value` read, a container that outlives the fiber, an uncaught
  propagation, a second restart, and one region named through both arguments),
  six controls that must stay clean with no mint (the literal path, tail
  position, an immediate payload, both suspending twins, and the same body
  resumed once), and a growth gate that refuses a mint no route reaches.
  Registered guardfree as `region_dynamic_emit_statement_uaf`.
- `tests/elle/oracle.lisp` — `emit-dyn-stmt-error-restart` and
  `emit-dyn-stmt-error-fresh`, each a closed control at 0 beside the existing
  `emit-dyn-error-discard`, which is the face that reads the stash's receipt.
- `lir::lower::tests::release::emission::a_non_tail_dynamic_emit_payload_release_carries_its_receipt`
  — the payload release stamps the slot it read and records it.
- `vm::signal::tests::{a_raised_argument_takes_the_delivery_and_a_built_payload_does_not,
  an_immediate_raised_argument_takes_no_delivery}` — the identity gate, both faces.
- `docs/impl/region/owner.md` § "What yields is the emit OPERATION, not the
  `Emit` node" states the rule once for both positions;
  `docs/impl/region/mechanism.md` names the second site that records a value
  route and drops the duplicate statement of the shared rule.

Closes #970.

