### PR TITLE
regions: a park payload the runtime built is released by the install that displaces it

### DIFF
--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -171,7 +171,7 @@ the same clean-break discipline as the trampoline's tail-call-adopted closure re
 frame-replacing tail call likewise keeps the activation — and its node — alive to the
 recursion's completion.
 
-**Park/unpark symmetry — what a park retains, and who releases it.** Three rules keep a
+**Park/unpark symmetry — what a park retains, and who releases it.** These rules keep a
 parked fiber's accounting symmetric with its unpark:
 
 - **The resume carrier is never retained.** `prim_fiber_resume` (and `fiber/abort` /
@@ -198,9 +198,9 @@ parked fiber's accounting symmetric with its unpark:
 - **The parked signal's escape retain has a release on every path.** A suspending signal's
   payload is retained once as it escapes into `fiber.signal` (`EmitEscape` for
   `yield`/`emit`, `SuspendEscape` for a yielding io op or a capability denial). The resume
-  path consumes it (the resumed body's own pending release, or `release_parked_signal` where
-  the park has no body reference — below); a fiber that can never run again consumes it at
-  its terminal teardown or free-path discharge instead (`release_discarded_signal` via
+  path consumes it (the resumed body's own pending release, or — where the body has none —
+  the displacing install's, below); a fiber that can never run again consumes it at its
+  terminal teardown or free-path discharge instead (`release_discarded_signal` via
   `Fiber::take_parked_state`) — the `yield-discard`/`denied-discard` probes pin both faces.
 - **A fiber body owns one reference of every value it yields.** Two references answer for a
   parked payload, and they answer to different consumers. The escape retain above is the
@@ -232,19 +232,40 @@ parked fiber's accounting symmetric with its unpark:
   region where the record matches ([mechanism.md](mechanism.md) § "An abandoned frame runs
   the releases it still owes"). A halt takes neither the retain nor the record — a halted
   fiber is promoted to `:dead` and never resumed, so its delivery has no consumer.
-- **A park with no body reference owes one release at the resume.** The rule above names a
-  consumer for each of a park's two references, and the second consumer is the body's own
-  release past the suspend. Two parks have no body reference to release. A yielding io op
-  parks a request the native built, whose birth reference the scheduler's `fiber/value` read
-  consumes as it submits. A capability denial parks a payload the VM built in place of a
-  call that never ran (`VM::build_denial_payload`), and the replayed frame's result release
-  targets the mediating parent's resume value instead. Either way one reference is left over
-  at the resume, and one decref of the payload's region answers for it
-  (`release_parked_signal`) — the same single decref the discard face runs
-  (`release_discarded_signal`), so both faces of a park reclaim alike. Which shape a park has
-  is known only where it parks, so the denial sites record the payload on the fiber
-  (`Fiber::denial_payload`) and the resume matches the record against the parked signal
-  before releasing. Pinned by `tests/elle/region-capability-denial-resume-leak.lisp`.
+- **A payload the RUNTIME built is released by the install that displaces it.** The second
+  of the two references above — the body's own, released by the continuation past the
+  suspend — exists only where the BODY allocated the value. Two parks build their payload
+  in the runtime instead: a yielding io op, whose `IoRequest` the native returned, and a
+  capability denial, whose `{:error :capability-denied …}` struct the denial path builds
+  for the parent to mediate. Neither body ever named the value, so no `decref_point` names
+  its region and the continuation releases nothing. The reference the allocation left is
+  therefore the discharge's on a fiber that never runs again, and the DISPLACING install's
+  on one that does: `fiber/resume`'s delivery and `fiber/abort` / `fiber/refuse`'s injected
+  error each replace the payload in the slot, and each owes it a release as it does.
+  Which parks are that shape is read two ways, because the bits answer for only one of
+  them. An io park is its `SIG_IO` bit, and its release is
+  `release_parked_signal` — resume-only, because a `Fresh` io op builds its completion
+  buffer IN the request's region and hands that back as the resume value, where the
+  resumer's release of the resume result is the second consumer and a release here would
+  free the buffer under the caller. A denial parks under the WITHHELD capability's bits,
+  which say nothing about who built the payload and are indistinguishable from an
+  `(emit :fs v)` of a body-allocated value — so the classifier records the payload
+  (`Fiber::denial_payload`, an uncounted marker compared bit-wise like
+  `Fiber::emit_delivery`) and `release_displaced_denial_payload` releases exactly what the
+  record names, on both installs. The injected error takes no skip: it is not a delivery,
+  and the abort's own `AbortDelivery` mint funds the consumer it does have.
+
+  **The two readings overlap on one denial, and the record wins it.** `:io` is a
+  withheld capability like any other, so a fiber denied `:io` parks under `SIG_IO` —
+  the very bit the io arm reads — and there the denial payload and an `IoRequest`
+  cannot be told apart by bits at all. One reference is owed, so `fiber/resume` asks
+  the record first and skips the io arm when it claims the park; running both frees
+  the payload under the mediator that is still reading it. Every other install
+  displaces on the record alone, the io arm never having reached them. Gauged by
+  `tests/elle/region-denial-park.lisp` per install and by
+  `tests/elle/region-capability-denial-resume-leak.lisp` per denial position, and pinned
+  guardfree by `tests/elle/region-denial-park-uaf.lisp`, whose `:io` witnesses are the
+  collision.
 - **What yields is the emit OPERATION, not the `Emit` node.** A first argument the compiler
   cannot read as a keyword set falls through to the `emit` primitive
   ([../../signals/emit.md](../../signals/emit.md) § "Dynamic emit"), which parks the same way

--- a/src/jit/calls.rs
+++ b/src/jit/calls.rs
@@ -149,10 +149,12 @@ pub(crate) fn jit_capability_denial(
     let heap = unsafe { &mut *vm.heap_ptr };
     let r = crate::value::arena::region_of(heap, payload);
     crate::value::arena::incref_for_escape(heap, r, crate::value::arena::EscapeSite::SuspendEscape);
-    // The denied primitive never runs, so the mediating parent's resume value
-    // stands in for its result — the same park classification the interpreter's
-    // `handle_capability_denial` records, and the same left-over payload reference
-    // for the resume to release (`Fiber::denial_payload`).
+    // The same two records the interpreter's `handle_capability_denial` writes:
+    // the park classification, because the denied primitive never runs so the
+    // mediating parent's resume value stands in for its result, and the payload,
+    // because the RUNTIME built it and the install that displaces the park owes
+    // the reference the allocation left (docs/impl/region/owner.md § "Park/unpark
+    // symmetry").
     vm.fiber.resume_value_unfunded = true;
     vm.fiber.denial_payload = Some(payload);
     vm.fiber.signal = Some((blocked, payload));

--- a/src/primitives/fiber_introspect.rs
+++ b/src/primitives/fiber_introspect.rs
@@ -193,11 +193,19 @@ fn inject_error_at_suspension(
 ) -> (SignalBits, Value) {
     // A parked TERMINAL result this install displaces carries a park-retain +
     // recorded content edge the free-time signal scan will never see
-    // (`release_displaced_terminal_signal`); a parked non-terminal signal's
-    // strand here is the dead-continuation residual (docs/impl/region/owner.md
-    // § "Park/unpark symmetry"), not released blind.
+    // (`release_displaced_terminal_signal`). A parked non-terminal signal is
+    // released only where the RUNTIME built its payload (below); a body-allocated
+    // one keeps its body reference, which the unwinding frames' own owed-release
+    // tables claim (docs/impl/region/owner.md § "Park/unpark symmetry").
     let parked = handle.with(|fiber| fiber.signal);
     crate::vm::fiber::release_displaced_terminal_signal(ctx.heap_mut(), fiber_value, parked);
+    // A parked CAPABILITY-DENIAL payload is the one non-terminal park this
+    // install does answer for: the runtime built it, so the child's continuation
+    // releases nothing for it, and refusing the denied call displaces it exactly
+    // as a resume would (docs/impl/region/owner.md § "Park/unpark symmetry" —
+    // "A payload the RUNTIME built is released by the install that displaces
+    // it").
+    crate::vm::fiber::release_displaced_denial_payload(ctx.heap_mut(), handle);
     handle.with_mut(|fiber| {
         fiber.signal = Some((SIG_ERROR, error_value));
         // The park this record named is over, and the strand above is what the

--- a/src/primitives/fibers.rs
+++ b/src/primitives/fibers.rs
@@ -152,32 +152,27 @@ pub(crate) fn prim_fiber_resume(
     // request (or any value) holds it here, and its region carries the
     // suspend-time escape references that must be balanced before the resume
     // value replaces it.
-    let (status, parked, denial_payload) =
-        handle.with(|fiber| (fiber.status, fiber.signal, fiber.denial_payload));
+    let (status, parked) = handle.with(|fiber| (fiber.status, fiber.signal));
     match status {
         FiberStatus::New | FiberStatus::Paused | FiberStatus::Error => {
-            // Release the reference the now-completing yielding call left on its
-            // parked value's region — otherwise every yielding io op leaks its
-            // IoRequest region, and every mediated capability denial its payload's
-            // (see `release_parked_signal`).
-            crate::vm::fiber::release_parked_signal(
-                ctx.heap_mut(),
-                parked,
-                denial_payload,
-                resume_value,
-            );
+            // The park's payload is the RUNTIME's, not the body's, in two shapes,
+            // and each owes one release as this resume displaces it: a
+            // capability-denial struct, named by the classifier's record, and a
+            // yielding io op's `IoRequest`, named by its `SIG_IO` bit. They are
+            // asked in that order because a fiber denied `:io` parks under
+            // `SIG_IO` too, so the bit alone cannot tell that one denial from a
+            // real io park — the record can, and one reference is owed, not two
+            // (docs/impl/region/owner.md § "Park/unpark symmetry").
+            if !crate::vm::fiber::release_displaced_denial_payload(ctx.heap_mut(), handle) {
+                crate::vm::fiber::release_parked_signal(ctx.heap_mut(), parked, resume_value);
+            }
             // And a parked TERMINAL result this resume displaces (a restarted
             // `:error` fiber, a re-resumed drained stream source): its
             // park-retain + recorded content edge counted on the free-time
             // signal scan, which will never see it once the resume value
             // replaces it (see `release_displaced_terminal_signal`).
             crate::vm::fiber::release_displaced_terminal_signal(ctx.heap_mut(), args[0], parked);
-            handle.with_mut(|fiber| {
-                fiber.signal = Some((SIG_OK, resume_value));
-                // The record's whole life is the park it names, whose payload has
-                // just left the slot (`Fiber::denial_payload`).
-                fiber.denial_payload = None;
-            });
+            handle.with_mut(|fiber| fiber.signal = Some((SIG_OK, resume_value)));
         }
         FiberStatus::Alive => {
             return (

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -180,25 +180,31 @@ pub struct Fiber {
     /// with the parked signal, so every delivery route consumes it exactly once
     /// and a later park of a different shape starts from `false`.
     pub resume_value_unfunded: bool,
-    /// The capability-denial payload parked in [`Self::signal`], whose region the
-    /// resume owes one decref.
+    /// The CAPABILITY-DENIAL payload this fiber has parked, if its innermost
+    /// suspension is a denial.
     ///
-    /// A park's payload carries two references and the resume consumes both: the
-    /// delivery, which the resumer's release of the resume result takes, and the
-    /// suspending body's own, released by the continuation past the suspend. A
-    /// denial has no body reference to release — the denied primitive never ran, so
-    /// the replayed frame's result release targets the mediating parent's resume
-    /// value — and the payload's birth reference is left over
-    /// (docs/impl/region/owner.md § "A park with no body reference owes one release
-    /// at the resume"). Only the denial site knows a park has that shape, so it
-    /// records the payload here and `prim_fiber_resume` runs the decref.
+    /// A park leaves two references on its payload's region — the delivery, and
+    /// the body's own, released by the continuation past the suspend — but a
+    /// denial's `{:error :capability-denied …}` struct is built by the denial
+    /// path, so the body never names it and no `decref_point` names its region.
+    /// The reference the allocation left is owed by whatever displaces the
+    /// payload: a resume's delivery, or an abort's / refusal's injected error
+    /// (docs/impl/region/owner.md § "Park/unpark symmetry" — "A payload the
+    /// RUNTIME built is released by the install that displaces it").
     ///
-    /// Carried as the payload rather than a flag so the release is gated on
-    /// representation identity with the live parked signal, exactly as
-    /// [`Self::emit_delivery`] is: an install that displaces the denial payload
-    /// without resuming — `fiber/abort`'s injection, a hard kill's terminal error —
-    /// leaves a record that names a value no longer in the slot, and the mismatch
-    /// withholds a decref that install did not owe.
+    /// A record is needed because the bits cannot say so. An io park is its
+    /// `SIG_IO` bit, but a denial parks under the WITHHELD capability's bits,
+    /// which an `(emit :fs v)` of a body-allocated value carries too — and only
+    /// the classifier (`handle_capability_denial`, its tail twin, and the JIT's
+    /// `jit_capability_denial`) knows which of the two it built.
+    ///
+    /// Like `emit_delivery`, this is an UNCOUNTED marker: only ever compared
+    /// bit-wise against the parked signal, never dereferenced, so it takes no
+    /// retain and the Fiber content scan records no edge for it. The counted
+    /// edge for the same value is `signal`'s. The comparison is what bounds a
+    /// stale record — a record that no longer names the parked payload releases
+    /// nothing — and the displacing install TAKES it, so no second install can
+    /// release the same reference.
     pub denial_payload: Option<Value>,
     /// Suspended execution frames. Set when the fiber suspends; consumed
     /// when it resumes.

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -176,6 +176,7 @@ On resume, the VM wires up the parent/child chain (Janet semantics):
 | `error_loc` | `Option<(Value, SourceLoc)>` | The parked `SIG_ERROR` payload and where it was raised. Parked by `absorbs`, read back by `fiber/propagate` so a re-raised error keeps its raising form |
 | `suspended` | `Option<Vec<SuspendedFrame>>` | Suspended execution frames (for yield/signal resumption) |
 | `resume_value_unfunded` | `bool` | Whether the innermost suspension is a PRIMITIVE call, so the next delivery owes its resume value one reference (docs/impl/region/owner.md § "A delivery into a replayed frame carries one owning reference") |
+| `denial_payload` | `Option<Value>` | The capability-denial payload this fiber has parked. The runtime built it, so no continuation of the body releases it and the install that displaces the park owes that release; the bits cannot say so, a denial parking under the withheld capability's own bits (docs/impl/region/owner.md § "A payload the RUNTIME built is released by the install that displaces it") |
 | `signal_mask` | `SignalBits` | Which signals this fiber catches |
 | `param_frames` | `Vec<Vec<(Value, Value)>>` | Parameter binding frames (stack of frames, each frame is vec of (param, value) pairs) |
 | `parent` | `Option<WeakFiberHandle>` | Weak back-pointer to parent fiber |
@@ -233,12 +234,15 @@ primitive never returns, so nothing mints the reference that release consumes:
 `handle_primitive_signal` and the denial path record the shape on the fiber
 (`resume_value_unfunded`) and `do_fiber_resume_single` mints it as it delivers.
 
-A denial park owes a release in the other direction too. Its payload is the VM's,
-built in place of a call that never ran, so no body reference answers for it and
-the resume releases the one left over — `prim_fiber_resume` runs the decref, gated
-on the payload the denial recorded (`Fiber::denial_payload`). See
-docs/impl/region/owner.md § "A park with no body reference owes one release at the
-resume".
+The denial owes one more, in the other direction. Its payload is the RUNTIME's,
+so the body names it nowhere and no continuation releases it — the install that
+displaces the park does, through `release_displaced_denial_payload` off the
+`denial_payload` record: `fiber/resume`, the `fiber/abort` / `fiber/refuse`
+injection, and the three `FiberResume` deliveries that reach an inner fiber
+directly. `fiber/resume` asks the record before `release_parked_signal`'s io arm
+and skips that arm when the record claims the park, a fiber denied `:io` parking
+under the same `SIG_IO` bit an io request does. See docs/impl/region/owner.md
+§ "A payload the RUNTIME built is released by the install that displaces it".
 
 Key methods:
 - `execute_bytecode_from_ip`: Executes from a given IP with Rc bytecode/constants

--- a/src/vm/core/resume.rs
+++ b/src/vm/core/resume.rs
@@ -44,6 +44,12 @@ impl VM {
                     // would recurse on the Rust stack), set pending_fiber_resume
                     // and return SIG_SWITCH. The trampoline in do_fiber_resume
                     // will handle the fiber transition iteratively.
+                    //
+                    // The install displaces this inner fiber's park, so a payload
+                    // the RUNTIME built there is owed the release its body has
+                    // none for, exactly as at `fiber/resume` itself
+                    // (docs/impl/region/owner.md § "Park/unpark symmetry").
+                    crate::vm::fiber::release_displaced_denial_payload(self.heap(), handle);
                     handle.with_mut(|f| {
                         f.signal = Some((SIG_OK, current_value));
                     });

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -51,7 +51,8 @@ mod borrow_tests;
 pub(crate) use owned::{kill_fiber, parked_owner_nodes, release_fiber_owned, take_fiber_owned};
 use refcount::{incref_signal_region, release_discarded_signal};
 pub(crate) use refcount::{
-    is_terminal_signal, release_displaced_terminal_signal, release_parked_signal,
+    is_terminal_signal, release_displaced_denial_payload, release_displaced_terminal_signal,
+    release_parked_signal,
 };
 // Re-exported for the WASM resume path (`crate::vm::fiber::record_terminal_signal_park`),
 // the only external caller; `owned::kill_fiber` reaches it by module path. Unused

--- a/src/vm/fiber/refcount.rs
+++ b/src/vm/fiber/refcount.rs
@@ -132,20 +132,71 @@ pub(crate) fn release_displaced_terminal_signal(
     crate::value::arena::decref_region(heap, Some(sig_r));
 }
 
-/// Release the one reference a park with **no body reference** leaves over when
-/// the resume replaces its payload with `resume_value`.
+/// Release the reference a parked CAPABILITY-DENIAL payload leaves stranded when
+/// an install displaces it from `fiber.signal`.
 ///
-/// A park's payload carries two references, and the resume consumes both: the
-/// delivery — the escape retain — which the resumer's release of the resume
-/// result takes, and the suspending body's own, released by the continuation past
-/// the suspend. Two parks have no body reference for that second consumer to
-/// take, so one is left over at every resume and one decref here answers for it
-/// (docs/impl/region/owner.md § "A park with no body reference owes one release at
-/// the resume"). A user `(yield v)` / `(emit …)` value is body-owned and must not
-/// reach the decref: releasing it double-frees the payload under every holder that
-/// outlives the fiber.
+/// A park leaves two references on its payload's region: the **delivery**, which
+/// the resumer's release of the resume result consumes, and the **body's own**,
+/// released by the continuation past the suspend. A denial has no second one —
+/// the denial path builds the `{:error :capability-denied …}` struct itself, so
+/// the body never names it and no `decref_point` names its region. What the
+/// discard discharge ([`release_discarded_signal`]) stands in for on a fiber that
+/// never runs again, this stands in for on one that does: `fiber/resume`'s
+/// delivery and `fiber/abort` / `fiber/refuse`'s injected error each replace the
+/// payload in the slot, and each owes it one release
+/// (docs/impl/region/owner.md § "Park/unpark symmetry" — "A payload the RUNTIME
+/// built is released by the install that displaces it").
 ///
-/// **A yielding io op** (`ev/sleep`, `port/read`, …) returns its `IoRequest` with
+/// Call this BEFORE the install, from every site that replaces another fiber's
+/// parked signal — `fiber/resume`, the abort/refuse injection, and the three
+/// `FiberResume` deliveries that reach an inner fiber directly, which is the
+/// route a `protect`ed body's denial takes. The record is read and TAKEN under
+/// one fiber borrow and the release runs against the heap afterwards, so heap
+/// mutation never overlaps fiber access; taking is the receipt, so a later
+/// install cannot release the same reference. Releasing only what the record
+/// bit-identically names is the other half — a record left over from an earlier
+/// park no longer names what is in the slot, and an `(emit :fs v)` under the same
+/// withheld bits is a body-allocated payload this must never touch.
+///
+/// No resume-value skip, unlike [`release_parked_signal`]: that skip answers for
+/// a `Fresh` io op building its completion buffer IN the request's region, and a
+/// denial payload is complete before the park. A resume value read back OUT of
+/// the payload shares its region and still owes this release — the child's
+/// continuation releases the denied call's RESULT, which the delivery's own
+/// `ResumeDelivery` mint funds. A no-op for a fiber with no record, a record that
+/// no longer names the parked signal, or an immediate payload.
+///
+/// Returns whether the park WAS a denial, so a caller that also runs
+/// [`release_parked_signal`] can keep the two exclusive. They overlap on exactly
+/// one denial and no other: a fiber denied `:io` parks under `SIG_IO`, the very
+/// bit that arm reads, so there the io request and the denial payload cannot be
+/// told apart by bits — and one reference is owed, not two.
+///
+/// [`Fiber::denial_payload`]: crate::value::fiber::Fiber::denial_payload
+pub(crate) fn release_displaced_denial_payload(
+    heap: &mut crate::value::fiberheap::FiberHeap,
+    handle: &crate::value::fiber::FiberHandle,
+) -> bool {
+    let displaced = handle.with_mut(|fiber| {
+        let record = fiber.denial_payload.take()?;
+        let (_, payload) = fiber.signal?;
+        record.bit_identical(payload).then_some(payload)
+    });
+    let Some(payload) = displaced else {
+        return false;
+    };
+    let region = crate::value::arena::region_of(heap, payload);
+    crate::value::arena::decref_region(heap, region);
+    true
+}
+
+/// Release the `SuspendEscape` an io op left on its IoRequest's region when a
+/// parked fiber is resumed and that request — held in `fiber.signal` across the
+/// park — is replaced by `resume_value`. This reclaims the IoRequest region of a
+/// yielding io op; the gauge is `oracle.lisp`'s `io-yield ev/sleep` probe, which
+/// measures the whole suspend/pump/resume round bounded.
+///
+/// A yielding io op (`ev/sleep`, `port/read`, …) returns its `IoRequest` with
 /// `SIG_IO`, whereupon the suspend adds a
 /// [`SuspendEscape`](crate::value::arena::EscapeSite::SuspendEscape) retain so the
 /// scheduler can read the request out of `fiber.signal`. The request's own
@@ -154,48 +205,45 @@ pub(crate) fn release_displaced_terminal_signal(
 /// remaining reference. On resume the io call "returns" `resume_value` (the
 /// completion), so the caller's `DecrefValueRegion` targets THAT region, never
 /// the request's — orphaning the `SuspendEscape` and leaking the request region,
-/// unbounded in a long-running io loop. The gauge is `oracle.lisp`'s `io-yield
-/// ev/sleep` probe, which measures the whole suspend/pump/resume round bounded.
+/// unbounded in a long-running io loop. One decref here, the symmetric
+/// counterpart of the suspend-time incref, frees it: the request is dead (the
+/// scheduler already consumed it), so its region holds nothing live.
 ///
 /// **Skip when `resume_value` shares the region** — the `Fresh` io ops
 /// (`port/read`/`accept`) build their completion buffer *in* the IoRequest's
 /// region and hand it back as the resume value, so that region is still live;
 /// there the caller's `DecrefValueRegion` on the buffer balances the
 /// `SuspendEscape`, and a decref here would free the buffer out from under the
-/// caller (a use-after-free). The skip is the io arm's alone: a denial payload's
-/// region is the denied call's own, and the mediating parent's resume value comes
-/// from outside the denied fiber entirely.
+/// caller (a use-after-free).
 ///
-/// **A capability denial** parks the payload the VM builds in place of a call it
-/// refuses to run. The denied primitive never returns, so the replayed frame's
-/// result release targets `resume_value` and the payload's birth reference is the
-/// one left over. Only the denial site knows a park has that shape, so it records
-/// the payload in `denial_payload` ([`crate::value::fiber::Fiber::denial_payload`])
-/// and the decref is gated on that record still naming the parked value.
-///
-/// A no-op for a park of neither shape, an immediate / `None` value, or a
-/// region-0 value.
+/// Gated on `SIG_IO`. A user `(yield v)` / `(emit …)` value is **body-owned** —
+/// the resumed body itself releases the reference it held across the suspend, and
+/// the resumer's release of the resume result consumes the delivery reference —
+/// so releasing it here would double-free. The other runtime-built park payload,
+/// a capability denial's struct, parks under the withheld capability's bits and
+/// so cannot be told from that `(emit …)` by its bits at all; it is released by
+/// [`release_displaced_denial_payload`], off the classifier's record, on every
+/// install that displaces it rather than on the resume alone.
+/// A no-op for a non-io signal, an immediate / `None` value, or a region-0 value.
 pub(crate) fn release_parked_signal(
     heap: &mut crate::value::fiberheap::FiberHeap,
     parked: Option<(SignalBits, Value)>,
-    denial_payload: Option<Value>,
     resume_value: Value,
 ) {
     let Some((bits, value)) = parked else {
         return;
     };
+    if !bits.intersects(crate::value::SIG_IO) {
+        return;
+    }
     let region = crate::value::arena::region_of(heap, value);
     if region.is_none() {
         return;
     }
-    if bits.intersects(crate::value::SIG_IO) {
-        // The resume value sharing the request's region is the `Fresh`-io-op
-        // signature (the completion buffer is built there): that region is still
-        // live, so leave it to the caller's `DecrefValueRegion`.
-        if crate::value::arena::region_of(heap, resume_value) == region {
-            return;
-        }
-    } else if !denial_payload.is_some_and(|p| p.bit_identical(value)) {
+    // The resume value sharing the request's region is the `Fresh`-io-op signature
+    // (the completion buffer is built there): that region is still live, so leave
+    // it to the caller's `DecrefValueRegion`.
+    if crate::value::arena::region_of(heap, resume_value) == region {
         return;
     }
     crate::value::arena::decref_region(heap, region);

--- a/src/vm/fiber/refcount/tests.rs
+++ b/src/vm/fiber/refcount/tests.rs
@@ -1,10 +1,11 @@
-//! The resume-path gate: which parks owe their payload a release, and which
-//! must be left to the resumed body.
+//! Which parks owe their payload a release at an install, and which must be
+//! left to the resumed body.
 
 use super::*;
 use crate::value::arena::{alloc_in_fresh_region, region_rc};
 use crate::value::heap::{HeapObject, Pair};
-use crate::value::{SIG_IO, SIG_YIELD};
+use crate::value::{Closure, Fiber, FiberHandle, SIG_IO, SIG_YIELD};
+use std::rc::Rc;
 
 fn cons() -> HeapObject {
     HeapObject::Pair(Pair::new(Value::NIL, Value::NIL))
@@ -23,45 +24,70 @@ fn foreign(heap: &mut crate::value::fiberheap::FiberHeap) -> Value {
     alloc_in_fresh_region(heap, cons()).0
 }
 
-/// A capability denial's park has no body reference, so the resume releases the
-/// one the payload is left with (docs/impl/region/owner.md § "A park with no body
-/// reference owes one release at the resume"). The blocked bits are the park's,
-/// and they are NOT `SIG_IO` here — the io gate alone would let a denial of any
-/// other capability through, stranding the payload's region once per mediation.
+fn test_closure() -> Rc<Closure> {
+    use crate::value::types::Arity;
+    use crate::value::ClosureTemplate;
+    Rc::new(Closure {
+        template: crate::value::TemplateRef::new(Rc::new(ClosureTemplate::new(
+            Rc::new(vec![]),
+            Arity::Exact(0),
+            Rc::new(vec![]),
+        ))),
+        env: crate::value::region_slice::RegionSlice::empty(),
+        squelch_mask: SignalBits::EMPTY,
+    })
+}
+
+/// A fiber parked on `parked` under `bits`, with `record` as its denial record.
+/// The blocked bits of a real denial are the WITHHELD capability's, which is why
+/// they are not `SIG_IO` in most faces below.
+fn parked_fiber(bits: SignalBits, parked: Value, record: Option<Value>) -> FiberHandle {
+    let handle = FiberHandle::new(Fiber::new(test_closure(), SignalBits::ALL));
+    handle.with_mut(|f| {
+        f.signal = Some((bits, parked));
+        f.denial_payload = record;
+    });
+    handle
+}
+
+// -- release_displaced_denial_payload: the record names what the install owes --
+
+/// A capability denial's park has no body reference, so the install that
+/// displaces it releases the one the payload is left with. The blocked bits are
+/// NOT `SIG_IO` here: a bits-only gate would let a denial of any other capability
+/// through, stranding the payload's region once per mediation.
 #[test]
-fn a_recorded_denial_park_is_released_at_the_resume() {
+fn a_recorded_denial_park_is_released_by_the_install() {
     let mut heap = crate::value::fiberheap::FiberHeap::new();
     let (p, rid) = payload(&mut heap);
-    let resume_value = foreign(&mut heap);
+    let handle = parked_fiber(SIG_YIELD, p, Some(p));
     let before = region_rc(&heap, rid);
 
-    release_parked_signal(&mut heap, Some((SIG_YIELD, p)), Some(p), resume_value);
+    let claimed = release_displaced_denial_payload(&mut heap, &handle);
 
+    assert!(claimed, "the record claims the park it names");
     assert_eq!(
         region_rc(&heap, rid),
         before - 1,
-        "a mediated denial's payload region owes exactly one decref at the resume",
+        "a mediated denial's payload region owes exactly one decref at the install",
     );
 }
 
-/// The record is matched against the live parked signal, so an install that
-/// displaced the denial payload without resuming — `fiber/abort`'s injection, a
-/// hard kill's terminal error — leaves no release for the resume to run.
+/// The record is matched against the LIVE parked signal, so an install reaching a
+/// fiber whose denial park is already over releases nothing. Counter-factual:
+/// releasing on the record alone would decref a region this install never owed,
+/// once per stale record left on a fiber that parked again.
 #[test]
 fn a_record_that_no_longer_names_the_parked_signal_releases_nothing() {
     let mut heap = crate::value::fiberheap::FiberHeap::new();
     let (parked, rid) = payload(&mut heap);
     let (stale, _) = payload(&mut heap);
-    let resume_value = foreign(&mut heap);
+    let handle = parked_fiber(SIG_YIELD, parked, Some(stale));
     let before = region_rc(&heap, rid);
 
-    release_parked_signal(
-        &mut heap,
-        Some((SIG_YIELD, parked)),
-        Some(stale),
-        resume_value,
-    );
+    let claimed = release_displaced_denial_payload(&mut heap, &handle);
 
+    assert!(!claimed, "a stale record claims nothing");
     assert_eq!(
         region_rc(&heap, rid),
         before,
@@ -70,24 +96,78 @@ fn a_record_that_no_longer_names_the_parked_signal_releases_nothing() {
     );
 }
 
-/// The counter-factual for both: a `yield`/`emit` payload is body-owned. The
-/// resumed body releases the reference it held across the suspend, so a decref
-/// here would free the value under every holder that outlives the fiber.
+/// The counter-factual for the gate itself: an `(emit :fs v)` parks a
+/// body-allocated payload under the very bits a `:fs` denial parks under. Nothing
+/// records it, so nothing releases it — the resumed body's own continuation does,
+/// and a decref here would free the value under every holder that outlives the
+/// fiber.
 #[test]
-fn an_unrecorded_yield_park_releases_nothing() {
+fn an_unrecorded_park_under_the_same_bits_releases_nothing() {
     let mut heap = crate::value::fiberheap::FiberHeap::new();
     let (p, rid) = payload(&mut heap);
-    let resume_value = foreign(&mut heap);
+    let handle = parked_fiber(SIG_YIELD, p, None);
     let before = region_rc(&heap, rid);
 
-    release_parked_signal(&mut heap, Some((SIG_YIELD, p)), None, resume_value);
+    let claimed = release_displaced_denial_payload(&mut heap, &handle);
 
+    assert!(!claimed, "an unrecorded park is not a denial");
     assert_eq!(
         region_rc(&heap, rid),
         before,
-        "a body-owned park owes the resume path nothing",
+        "a body-owned park owes the install nothing",
     );
 }
+
+/// Taking the record IS the receipt. Five installs run this and a denied fiber
+/// can reach more than one of them — `fiber/refuse` after a `fiber/resume` that
+/// re-parked, the `protect` route's inner delivery ahead of the outer resume.
+/// Counter-factual: a gate that only compared, leaving the record in place, would
+/// release the same reference once per install and free the payload under the
+/// mediator still reading it.
+#[test]
+fn the_record_is_taken_so_a_second_install_releases_nothing() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (p, rid) = payload(&mut heap);
+    let handle = parked_fiber(SIG_YIELD, p, Some(p));
+
+    assert!(release_displaced_denial_payload(&mut heap, &handle));
+    let after_first = region_rc(&heap, rid);
+
+    let claimed = release_displaced_denial_payload(&mut heap, &handle);
+
+    assert!(
+        !claimed,
+        "the record is gone — the second install claims nothing"
+    );
+    assert_eq!(
+        region_rc(&heap, rid),
+        after_first,
+        "one reference is owed per park, however many installs displace it",
+    );
+}
+
+/// A fiber denied `:io` parks under `SIG_IO`, the very bit an io request's park
+/// carries, so there the two readings name the same park. The record answers, and
+/// `prim_fiber_resume` skips the io arm on this `true` — running both frees the
+/// payload under the mediator that is still reading it.
+#[test]
+fn an_io_denial_is_claimed_by_the_record_that_names_it() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (p, rid) = payload(&mut heap);
+    let handle = parked_fiber(SIG_IO, p, Some(p));
+    let before = region_rc(&heap, rid);
+
+    let claimed = release_displaced_denial_payload(&mut heap, &handle);
+
+    assert!(claimed, "the record tells the denial from the io request");
+    assert_eq!(
+        region_rc(&heap, rid),
+        before - 1,
+        "the collision owes ONE reference, not one per reading",
+    );
+}
+
+// -- release_parked_signal: the io arm, gated on SIG_IO alone --
 
 /// The io arm keeps its shared-region skip: a `Fresh` io op builds its completion
 /// buffer in the request's own region and hands it back as the resume value, so
@@ -99,7 +179,7 @@ fn an_io_park_whose_resume_value_shares_its_region_releases_nothing() {
     let completion = heap.alloc_in_region(cons(), rid);
     let before = region_rc(&heap, rid);
 
-    release_parked_signal(&mut heap, Some((SIG_IO, request)), None, completion);
+    release_parked_signal(&mut heap, Some((SIG_IO, request)), completion);
 
     assert_eq!(
         region_rc(&heap, rid),
@@ -117,11 +197,30 @@ fn an_io_park_whose_resume_value_is_foreign_is_released() {
     let completion = foreign(&mut heap);
     let before = region_rc(&heap, rid);
 
-    release_parked_signal(&mut heap, Some((SIG_IO, request)), None, completion);
+    release_parked_signal(&mut heap, Some((SIG_IO, request)), completion);
 
     assert_eq!(
         region_rc(&heap, rid),
         before - 1,
         "a submitted io request is dead at the resume — its region owes one decref",
+    );
+}
+
+/// The counter-factual for the io gate: a `yield`/`emit` payload is body-owned.
+/// The resumed body releases the reference it held across the suspend, so a
+/// decref here would free the value under every holder that outlives the fiber.
+#[test]
+fn a_non_io_park_releases_nothing() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (p, rid) = payload(&mut heap);
+    let resume_value = foreign(&mut heap);
+    let before = region_rc(&heap, rid);
+
+    release_parked_signal(&mut heap, Some((SIG_YIELD, p)), resume_value);
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before,
+        "the io arm answers for io requests alone",
     );
 }

--- a/src/vm/fiber/resume.rs
+++ b/src/vm/fiber/resume.rs
@@ -145,7 +145,14 @@ impl VM {
                 // Deliver the resume value to the inner fiber (matches what
                 // resume_suspended does at the FiberResume arm). The install
                 // displaces any parked signal, so a recorded emit-minted
-                // delivery no longer names the slot's payload.
+                // delivery no longer names the slot's payload — and a park whose
+                // payload the RUNTIME built is owed the release its body has
+                // none for, exactly as at `fiber/resume` itself. This is the
+                // route a `protect`ed body's denial takes: the denial parks in
+                // the inner fiber, which the outer one awaits through a
+                // `FiberResume` frame (docs/impl/region/owner.md § "Park/unpark
+                // symmetry").
+                crate::vm::fiber::release_displaced_denial_payload(self.heap(), &inner_handle);
                 inner_handle.with_mut(|f| {
                     f.signal = Some((SIG_OK, resume_value));
                     f.emit_delivery = None;
@@ -366,6 +373,11 @@ impl VM {
 
                     // Abort the inner fiber (e.g. protect child blocked on I/O).
                     // Store the error on the inner fiber so do_fiber_abort picks it up.
+                    // The install displaces the inner fiber's park, so a payload
+                    // the RUNTIME built there is owed its release first — the
+                    // `protect`ed face of the injection's own (see
+                    // `inject_error_at_suspension`).
+                    crate::vm::fiber::release_displaced_denial_payload(vm.heap(), &inner_handle);
                     inner_handle.with_mut(|f| {
                         f.signal = Some((SIG_ERROR, error_value));
                     });

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -223,9 +223,7 @@ impl VM {
         // its region: the resumer's `DecrefValueRegion` at the denied call's
         // decref_point would otherwise drop this freshly-built struct's only
         // reference (rc=1, the owning activation scope) and free it out from
-        // under `fiber/value`. The release is symmetric with `Suspend`: the
-        // value's region is this (child) activation's, freed when the fiber is
-        // torn down, or consumed by normal value flow if the fiber is resumed.
+        // under `fiber/value`.
         let heap = unsafe { &mut *self.heap_ptr };
         let r = crate::value::arena::region_of(heap, payload);
         crate::value::arena::incref_for_escape(
@@ -233,15 +231,16 @@ impl VM {
             r,
             crate::value::arena::EscapeSite::SuspendEscape,
         );
-
         // The denied primitive never runs, let alone returns, so the mediating
         // parent's resume value takes the place of its result — and the frame's
         // continuation releases that result (see the `SignalAction::Suspend` arm).
         self.fiber.resume_value_unfunded = true;
         // Which is why the payload's own birth reference reaches no consumer past
         // the park: the continuation's release names the resume value, not this
-        // struct. Record it so the resume runs the one decref the park is left
-        // owing (`Fiber::denial_payload`).
+        // struct. Record it, because the install that displaces the park owes that
+        // reference and only this classifier can tell a denial from an `(emit …)`
+        // under the same withheld bits (docs/impl/region/owner.md § "Park/unpark
+        // symmetry").
         self.fiber.denial_payload = Some(payload);
 
         // Save the stack and build a suspended frame (same as suspending signals)

--- a/src/vm/signal/tests.rs
+++ b/src/vm/signal/tests.rs
@@ -222,11 +222,11 @@ fn a_completing_primitive_owes_its_resume_value_nothing() {
 // -- which parks owe their own payload a release --
 
 /// A capability denial parks a payload the VM built in place of a call that never
-/// ran, so no body reference answers for it and the resume owes its region one
-/// decref (docs/impl/region/owner.md § "A park with no body reference owes one
-/// release at the resume"). Only the denial site can tell a park has that shape,
-/// so it records the payload for `prim_fiber_resume` to match against the live
-/// parked signal.
+/// ran, so no body reference answers for it and the install that displaces it owes
+/// its region one decref (docs/impl/region/owner.md § "A payload the RUNTIME built
+/// is released by the install that displaces it"). Only the denial site can tell a
+/// park has that shape, so it records the payload for
+/// `release_displaced_denial_payload` to match against the live parked signal.
 #[test]
 fn a_capability_denial_park_records_the_payload_it_leaves_over() {
     with_test_region(|| {
@@ -278,8 +278,9 @@ fn a_tail_capability_denial_park_records_the_payload_it_leaves_over() {
 }
 
 /// The counter-factual for the two above: an ordinary suspend parks a payload the
-/// resumed body releases itself. Recording it would make the resume run a second
-/// release and free the value under every holder that outlives the fiber.
+/// resumed body releases itself. Recording it would make the displacing install
+/// run a second release and free the value under every holder that outlives the
+/// fiber.
 #[test]
 fn an_ordinary_suspend_records_no_payload_to_release() {
     with_test_region(|| {

--- a/tests/elle/region-denial-park-uaf.lisp
+++ b/tests/elle/region-denial-park-uaf.lisp
@@ -1,0 +1,211 @@
+(elle/epoch 12)
+# A payload the RUNTIME built is released by the install that displaces it —
+# the soundness face (docs/impl/region/owner.md § "Park/unpark symmetry").
+#
+# The leak face is region-denial-park.lisp: a mediated denial stranded its
+# payload because no continuation of the body releases a value the body never
+# named. Closing it makes `fiber/resume`, `fiber/refuse` and `fiber/abort` each
+# run a release that fired on no path before, so each is a fresh chance to free
+# the payload under a reader that still holds it.
+#
+# The trap: the parent reads the payload BEFORE it displaces it — that is what
+# mediation is — and may still hold it afterwards. `fiber/value` is
+# pass-through, so a binding of the payload carries a counted reference of its
+# own; the release must consume the allocation's reference and no other. Every
+# witness below therefore reads a HEAP field (`:primitive`, `:args`) AFTER the
+# displacing install. A bare status or arity check passes over a freed payload
+# and would have missed this.
+#
+# The counter-factual is the release running twice, or running on a value the
+# body allocated: the payload's region frees while the mediator still holds it,
+# and the field read faults at the deref under `--trace=guardfree`.
+
+# ── the mediated subject ─────────────────────────────────────────────────────
+(defn denied-body ()
+  (let [r (file/read "/no/such/path")]
+    (length r)))
+(defn mk ()
+  (fiber/new denied-body |:fs :error| :deny |:fs|))
+
+# ── (a) the payload held across a resume, read after ─────────────────────────
+(defn w-hold-resume (n)
+  (let [f (mk)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/resume f (string "answer" n))
+      (assert (= (get p :error) :capability-denied)
+              "held payload lost its tag across the resume")
+      (length (get p :primitive)))))
+
+# ── (b) the resume value read OUT of the payload ─────────────────────────────
+# The delivered value lives in the payload's own region, so the release must not
+# treat the two as one — the body binds it and reads it past the suspend.
+(defn args-body ()
+  (let [r (file/read "/no/such/path")]
+    (length (get r 0))))
+(defn w-alias-resume (n)
+  (let [f (fiber/new args-body |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/resume f (get p :args))
+      (assert (%gt (length (get p :args)) 0)
+              "aliased payload lost its :args across the resume")
+      (fiber/value f))))
+
+# ── (c) the payload outlives the fiber, in a container ───────────────────────
+# Nothing on the stack holds it once the driver moves on; the holder that must
+# still find it alive is the array read back out.
+(def @denials @[])
+(defn w-stored (n)
+  (let [f (mk)]
+    (fiber/resume f)
+    (push denials (fiber/value f))
+    (fiber/resume f n)
+    (length (get (get denials (%sub (length denials) 1)) :primitive))))
+
+# ── (d) the refusal face — the child catches and traps again ─────────────────
+# `caps-refuse.lisp` in region form: each refusal displaces the park it answers,
+# and the parent reads the NEXT denial's payload after the previous release ran.
+(defn twice-body ()
+  (let [[ok1? e1] (protect (file/read "/no/such/one"))
+        [ok2? e2] (protect (file/read "/no/such/two"))]
+    (list ok1? ok2?)))
+(defn w-refuse-twice (n)
+  (let [f (fiber/new twice-body |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (let [first-p (fiber/value f)]
+      (fiber/refuse f :first)
+      (assert (= (get (get first-p :args) 0) "/no/such/one")
+              "first denial's payload freed by the refusal that displaced it")
+      (let [second-p (fiber/value f)]
+        (assert (= (get (get second-p :args) 0) "/no/such/two")
+                "second denial named the wrong path")
+        (fiber/refuse f :second)
+        (assert (= (get first-p :primitive) "file/read")
+                "first payload freed by the second refusal")
+        (length (get second-p :primitive))))))
+
+# ── (e) the denial inside a `protect` ────────────────────────────────────────
+# `protect` runs the body in an inner fiber, so the denial parks THERE and the
+# mediator's install reaches that fiber directly through a `FiberResume` frame,
+# never through `fiber/resume`. The payload the parent reads is the inner park's,
+# and it must survive the install that displaces it on this route too.
+(defn protect-body ()
+  (let [[ok? e] (protect (file/read "/no/such/path"))]
+    (if ok? 1 0)))
+(defn w-protect-resume (n)
+  (let [f (fiber/new protect-body |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/resume f (string "c" n))
+      (assert (= (get (get p :args) 0) "/no/such/path")
+              "payload freed by the resume that displaced the inner park")
+      (length (get p :primitive)))))
+(defn w-protect-refuse (n)
+  (let [f (fiber/new protect-body |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/refuse f :denied)
+      (assert (= (get p :error) :capability-denied)
+              "payload freed by the refusal that displaced the inner park")
+      (length (get p :primitive)))))
+
+# ── (f) the bits collision — the shape a second release detonates on ─────────
+# A fiber denied `:io` parks under `SIG_IO`, the very bit `release_parked_signal`
+# reads to recognize a yielding io op's request. So this park answers to BOTH
+# routes at a resume, and exactly one reference is owed: run them both and the
+# payload's region is freed while the mediator still holds it. That is the whole
+# reason the record is asked FIRST and the io arm skipped when it claims the park.
+(defn io-denied-body ()
+  (println "never runs — the fiber is denied :io"))
+(defn w-io-resume (n)
+  (let [f (fiber/new io-denied-body |:error :io| :deny |:io|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/resume f n)
+      (assert (= (get p :error) :capability-denied)
+              "an :io denial's payload was released twice at the resume")
+      (length (get p :primitive)))))
+(defn w-io-refuse (n)
+  (let [f (fiber/new io-denied-body |:error :io| :deny |:io|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/refuse f :denied)
+      (assert (= (get p :error) :capability-denied)
+              "an :io denial's payload was released twice at the refusal")
+      (length (get p :primitive)))))
+
+# ── (g) the abort face ───────────────────────────────────────────────────────
+(defn w-abort (n)
+  (let [f (mk)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/abort f :done)
+      (assert (= (get p :error) :capability-denied)
+              "payload freed by the abort that displaced it")
+      (length (get p :primitive)))))
+
+# ── controls — a body-allocated park payload, displaced the same three ways ──
+# Its body owns a reference of its own, so the install owes nothing. A release
+# added here would free the payload under these very reads.
+(defn emit-body (n)
+  (let [r (emit :yield {:tag (string "e" n)})]
+    5))
+(defn c-emit-resume (n)
+  (let [f (fiber/new (fn () (emit-body n)) |:yield :error|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/resume f 7)
+      (length (get p :tag)))))
+(defn c-emit-refuse (n)
+  (let [f (fiber/new (fn () (emit-body n)) |:yield :error|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/refuse f :no)
+      (length (get p :tag)))))
+
+# ── drive: a fresh payload per iteration keeps region ids churning, so a ─────
+# recycled id detonates on its generation stamp rather than reading stale bytes.
+(defn drive (reps)
+  (var i 0)
+  (var a 0)
+  (var b 0)
+  (var c 0)
+  (var d 0)
+  (var e 0)
+  (var f 0)
+  (var g 0)
+  (var h 0)
+  (var k 0)
+  (var m 0)
+  (var n 0)
+  (while (%lt i reps)
+    (assign a (w-hold-resume i))
+    (assign b (w-alias-resume i))
+    (assign c (w-stored i))
+    (assign d (w-refuse-twice i))
+    (assign e (w-protect-resume i))
+    (assign f (w-protect-refuse i))
+    (assign g (w-io-resume i))
+    (assign h (w-io-refuse i))
+    (assign k (w-abort i))
+    (assign m (c-emit-resume i))
+    (assign n (c-emit-refuse i))
+    (assign denials @[])
+    (assign i (%add i 1)))
+  (list a b c d e f g h k m n))
+
+(let [r (drive 300)]
+  (assert (> (get r 0) 0) "payload freed under a held read past the resume")
+  (assert (> (get r 1) 0) "aliased resume value freed under the body's read")
+  (assert (> (get r 2) 0) "stored payload freed under the container read")
+  (assert (> (get r 3) 0) "payload freed across a refusal chain")
+  (assert (> (get r 4) 0) "inner park's payload freed by the resume install")
+  (assert (> (get r 5) 0) "inner park's payload freed by the refusal install")
+  (assert (> (get r 6) 0) ":io denial's payload released twice at the resume")
+  (assert (> (get r 7) 0) ":io denial's payload released twice at the refusal")
+  (assert (> (get r 8) 0) "payload freed under the read past the abort")
+  (assert (> (get r 9) 0) "control: emit payload freed by the resume install")
+  (assert (> (get r 10) 0) "control: emit payload freed by the refusal install"))
+
+(println "region-denial-park-uaf: ok")

--- a/tests/elle/region-denial-park.lisp
+++ b/tests/elle/region-denial-park.lisp
@@ -1,0 +1,232 @@
+(elle/epoch 12)
+# A payload the RUNTIME built is released by the install that displaces it
+# (docs/impl/region/owner.md § "Park/unpark symmetry").
+#
+# A park leaves two references on its payload's region: the DELIVERY, which the
+# resumer's release of the resume result consumes, and the BODY's own, released
+# by the continuation past the suspend. A capability denial has no second one to
+# release — the denial path builds `{:error :capability-denied …}` itself, so the
+# body never names the value and no `decref_point` names its region. The
+# reference the allocation left is owed by whatever displaces the payload.
+#
+# Three installs displace it, and every one is the mediator's ordinary move:
+# `fiber/resume` answers the denied call with a value, `fiber/refuse` raises the
+# refusal at the child's own call site, and `fiber/abort` ends the child. Each is
+# gauged directly and again through `protect`, which parks the denial in an inner
+# fiber and so reaches it by a different route. A fiber that is never resumed
+# again takes the discard discharge instead, which is what the `cold` and `cancel`
+# controls hold to.
+#
+# The trap: the payload holds the denied call's ARGUMENTS, so one stranded
+# payload pins every heap argument's region behind it. A mediated `file/read`
+# strands the struct AND the path string, which is why the object counts here run
+# ahead of one per call.
+#
+# This file is the LEAK gauge — an `arena/count` delta over a fixed window, which
+# must be BOUNDED for every displacing install. The soundness complement is
+# region-denial-park-uaf.lisp; the discard face is the `denied-discard` probe in
+# tests/elle/oracle.lisp.
+
+(def window 400)
+
+(defn measure (thunk warm window)
+  (var i 0)
+  (while (%lt i warm)
+    (thunk)
+    (assign i (%add i 1)))
+  (def before (arena/count))
+  (var j 0)
+  (while (%lt j window)
+    (thunk)
+    (assign j (%add j 1)))
+  (%sub (arena/count) before))
+
+# A body that traps on its first `:fs` call. The mask catches the denial so the
+# parent mediates it; `:error` is masked too, so a refusal the body does not
+# catch still comes back as data rather than tearing the driver down.
+(defn denied-body ()
+  (let [r (file/read "/no/such/path")]
+    5))
+
+(defn mk ()
+  (fiber/new denied-body |:fs :error| :deny |:fs|))
+
+# subjects — the three displacing installs ─────────────────────────────────────
+
+# (a) resume: the mediator answers the denied call with a value.
+(defn w-resume ()
+  (let [f (mk)]
+    (fiber/resume f)
+    (fiber/resume f 7)))
+
+# (b) resume, with the payload read first — the documented mediation idiom
+# (tests/elle/caps-fs.lisp). The read is pass-through, so it changes the count by
+# nothing and must change the verdict by nothing either.
+(defn w-read-resume ()
+  (let [f (mk)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/resume f (length (get p :primitive))))))
+
+# (c) refuse: the refusal is raised at the child's own call site.
+(defn w-refuse ()
+  (let [f (mk)]
+    (fiber/resume f)
+    (fiber/refuse f :denied)
+    (fiber/status f)))
+
+# (d) abort: the child is ended where it stopped.
+(defn w-abort ()
+  (let [f (mk)]
+    (fiber/resume f)
+    (fiber/abort f :done)
+    (fiber/status f)))
+
+# (e) the body catches its own refusal, so the denial parks in the INNER fiber
+# `protect` runs it in and the outer one awaits it through a `FiberResume` frame.
+# The mediator's install then reaches the inner fiber directly, never through
+# `fiber/resume` — a route of its own for both the answer and the refusal.
+(defn protect-body ()
+  (let [[ok? e] (protect (file/read "/no/such/path"))]
+    (if ok? 1 0)))
+(defn mk-protect ()
+  (fiber/new protect-body |:fs :error| :deny |:fs|))
+(defn w-protect-resume ()
+  (let [f (mk-protect)]
+    (fiber/resume f)
+    (fiber/resume f "content")))
+(defn w-protect-refuse ()
+  (let [f (mk-protect)]
+    (fiber/resume f)
+    (fiber/refuse f :denied)
+    (fiber/value f)))
+
+# (f) two denials in one session — a refused child that catches survives and
+# traps again, so the second park must account exactly like the first.
+(defn twice-body ()
+  (let [[ok1? e1] (protect (file/read "/no/such/one"))
+        [ok2? e2] (protect (file/read "/no/such/two"))]
+    (if ok1? 1 (if ok2? 2 0))))
+(defn w-twice ()
+  (let [f (fiber/new twice-body |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (fiber/refuse f :first)
+    (fiber/refuse f :second)
+    (fiber/value f)))
+
+# (g) the bits collision. A fiber denied `:io` parks under `SIG_IO` — the very
+# bit a yielding io op's `IoRequest` park carries — so at the resume the denial
+# payload cannot be told from an io request by its bits, and the two releases
+# that could answer for it must be exactly one. This shape carries a per-call
+# residual of its own, the rest list the calling convention builds for a variadic
+# callee (F2's `denied-discard` rate in tests/elle/oracle.lisp), and its DISCARD
+# face carries the identical one — so the pin here is that mediating the denial
+# costs no more than dropping the fiber does. Two releases is a use-after-free
+# rather than a number, which region-denial-park-uaf.lisp is what catches.
+(defn io-denied-body ()
+  (println "never runs — the fiber is denied :io"))
+(defn mk-io ()
+  (fiber/new io-denied-body |:error :io| :deny |:io|))
+(defn w-io-resume ()
+  (let [f (mk-io)]
+    (fiber/resume f)
+    (fiber/resume f 7)))
+(defn c-io-cold ()
+  (let [f (mk-io)]
+    (fiber/resume f)
+    3))
+
+# controls ─────────────────────────────────────────────────────────────────────
+
+# (h) the denial park nobody displaces: the discard discharge releases it, so
+# this face was already bounded and proves the strand is the install's.
+(defn c-cold ()
+  (let [f (mk)]
+    (fiber/resume f)
+    3))
+
+# (i) hard kill — the teardown route, likewise already bounded.
+(defn c-cancel ()
+  (let [f (mk)]
+    (fiber/resume f)
+    (fiber/cancel f :gone)
+    3))
+
+# (j) an ordinary `emit` park displaced the same three ways. Its payload IS
+# body-allocated, so the body's own continuation release answers for it and the
+# install owes nothing — a release added here would free it under the reader.
+(defn emit-body ()
+  (let [r (emit :yield {:a 1})]
+    5))
+(defn mk-emit ()
+  (fiber/new emit-body |:yield :error|))
+(defn c-emit-resume ()
+  (let [f (mk-emit)]
+    (fiber/resume f)
+    (fiber/resume f 7)))
+(defn c-emit-refuse ()
+  (let [f (mk-emit)]
+    (fiber/resume f)
+    (fiber/refuse f :denied)
+    (fiber/status f)))
+
+(def resume-d (measure w-resume 100 window))
+(def read-resume-d (measure w-read-resume 100 window))
+(def refuse-d (measure w-refuse 100 window))
+(def abort-d (measure w-abort 100 window))
+(def protect-resume-d (measure w-protect-resume 100 window))
+(def protect-refuse-d (measure w-protect-refuse 100 window))
+(def twice-d (measure w-twice 100 window))
+(def io-resume-d (measure w-io-resume 100 window))
+(def io-cold-d (measure c-io-cold 100 window))
+(def cold-d (measure c-cold 100 window))
+(def cancel-d (measure c-cancel 100 window))
+(def emit-resume-d (measure c-emit-resume 100 window))
+(def emit-refuse-d (measure c-emit-refuse 100 window))
+
+(println "region-denial-park deltas over " window " iters:")
+(println "  resume " resume-d "  read+resume " read-resume-d "  refuse "
+         refuse-d "  abort " abort-d "  twice " twice-d)
+(println "  through protect: resume " protect-resume-d "  refuse "
+         protect-refuse-d)
+(println "  :io denial (bits collide): resume " io-resume-d "  discard "
+         io-cold-d)
+(println "  controls: cold " cold-d "  cancel " cancel-d "  emit+resume "
+         emit-resume-d "  emit+refuse " emit-refuse-d)
+
+# Every strand in this class is at least one whole payload struct per mediated
+# call, so a survivor reads ≥400 over the window. 100 is slack for the one-time
+# intercept.
+(defn bounded? (d label)
+  (assert (%lt d 100) (concat label " leaks, delta=" (number->string d))))
+
+(bounded? cold-d "control: a denial park nobody displaces")
+(bounded? cancel-d "control: a denial park hard-killed")
+(bounded? emit-resume-d "control: an emit park answered by a resume")
+(bounded? emit-refuse-d "control: an emit park answered by a refusal")
+(bounded? resume-d "denial payload displaced by a resume")
+(bounded? read-resume-d "denial payload read, then displaced by a resume")
+(bounded? refuse-d "denial payload displaced by a refusal")
+(bounded? abort-d "denial payload displaced by an abort")
+(bounded? protect-resume-d "denial inside a `protect`, answered by a resume")
+(bounded? protect-refuse-d "denial inside a `protect`, answered by a refusal")
+(bounded? twice-d "two denials mediated in one session")
+
+# The `:io` denial carries the variadic callee's own per-call residual on BOTH
+# faces, so the pin is relative: mediating must cost no more than dropping.
+(assert (%lt io-resume-d (%add io-cold-d 100))
+        (concat "a mediated :io denial costs more than a dropped one, "
+                (number->string io-resume-d) " vs " (number->string io-cold-d)))
+
+# Value preservation: the release must not change what the mediation reads.
+(assert (= (w-resume) 5) "a mediated resume lost the body's result")
+(assert (= (w-read-resume) 5) "reading the payload changed the body's result")
+(assert (= (w-refuse) :error) "a refusal the body does not catch is an error")
+(assert (= (w-abort) :error) "an aborted child did not end :error")
+(assert (= (w-protect-resume) 1)
+        "a resume through `protect` did not answer the call")
+(assert (= (w-protect-refuse) 0)
+        "a refusal through `protect` did not fail the call")
+(assert (= (w-twice) 0) "both refusals should have failed their calls")
+
+(println "region-denial-park: ok")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -576,17 +576,41 @@ fn region_primitive_resume_uaf() {
 
 // Guard — the resume of a mediated capability denial releases the one reference
 // the park has no body to release, and that decref answers for the payload's own
-// left-over reference, never for a holder's (docs/impl/region/owner.md § "A park
-// with no body reference owes one release at the resume"). The witness binds the
-// payload in the mediating parent, resumes the fiber past the denial, churns the
-// heap, then reads three payload fields; taking the holder's reference instead
-// frees the struct under those reads — SIGSEGV under guardfree. The leak face is
-// the region-count bound in the same file, which the object gauge in
-// `tests/elle/oracle.lisp` cannot see.
+// left-over reference, never for a holder's (docs/impl/region/owner.md § "A
+// payload the RUNTIME built is released by the install that displaces it"). The
+// witness binds the payload in the mediating parent, resumes the fiber past the
+// denial, churns the heap, then reads three payload fields; taking the holder's
+// reference instead frees the struct under those reads — SIGSEGV under guardfree.
+// This file's faces are the denial POSITIONS (call and tail); the per-install
+// faces are `region_denial_park_uaf` below. The leak face is the region-count
+// bound in the same file, which the object gauge in `tests/elle/oracle.lisp`
+// cannot see.
 #[test]
 fn region_capability_denial_resume_uaf() {
     run_elle_script_with_args(
         "region-capability-denial-resume-leak",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
+// Guard — a park payload the RUNTIME built is released by the install that
+// displaces it (docs/impl/region/owner.md § "Park/unpark symmetry"). A capability
+// denial's payload is built by the denial path, so the body never names it and no
+// continuation releases it; `fiber/resume`, `fiber/refuse` and `fiber/abort` each
+// replace it in the slot and each owe that release. Every one of those releases
+// fires on a path where none fired before, and the mediator is precisely the
+// reader that may still hold the payload — `fiber/value` is pass-through, so a
+// binding of it carries a counted reference the release must not consume. Each
+// witness therefore reads a HEAP field (`:primitive`, `:args`) AFTER the install,
+// including the shape whose resume value is read OUT of the payload's own region;
+// a bare status check passes over a freed payload. Two controls drive a
+// body-allocated `emit` payload through the same installs, where a release added
+// would free it under these reads. The leak face is
+// `tests/elle/region-denial-park.lisp`.
+#[test]
+fn region_denial_park_uaf() {
+    run_elle_script_with_args(
+        "region-denial-park-uaf",
         &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
     );
 }


### PR DESCRIPTION
## What was wrong

A park leaves two references on its payload's region: the **delivery**, which the
resumer's release of the resume result consumes, and the **body's own**, released
by the continuation past the suspend.

A capability denial has no second one. `handle_capability_denial` builds the
`{:error :capability-denied …}` struct itself, so the body never names the value,
no `decref_point` names its region, and the continuation releases nothing for it.
A fiber that is dropped or cancelled reclaims the payload through
`release_discarded_signal` — which is why `denied-discard` reads clean and this
stayed invisible. A fiber the parent **mediates** did not: `fiber/resume`,
`fiber/refuse` and `fiber/abort` each replace the payload in the slot and none of
them released it. Two regions per mediated denial — the payload struct, and the
heap arguments its `:args` array pins behind it — growing without bound.

Measured on the issue's reproduction: `growth=801` over 400 mediated denials,
against `growth=1` for the same fiber dropped and `growth=1` for an ordinary
`emit` park.

## What the change does

The install that displaces the park owes that release.

Which parks are that shape cannot be read off the bits. An io park is its
`SIG_IO` bit, and `release_parked_signal` already answers for it; a denial parks
under the **withheld capability's** bits, which an `(emit :fs v)` of a
body-allocated payload carries too. So the classifier records the payload on the
fiber — `Fiber::denial_payload`, an uncounted marker compared bit-wise like
`Fiber::emit_delivery` — and `release_displaced_denial_payload` releases exactly
what the record names, taking the record as the receipt so no second install can
release the same reference. Five installs run it: `fiber/resume`, the
`fiber/abort` / `fiber/refuse` injection, and the three `FiberResume` deliveries
that reach an inner fiber directly, which is the route a `protect`ed body's
denial takes.

The two readings overlap on exactly one denial, and the record wins it. `:io` is
a withheld capability like any other, so a fiber denied `:io` parks under
`SIG_IO` — the very bit the io arm reads — and there the denial payload and an
`IoRequest` cannot be told apart by bits at all. One reference is owed, so
`fiber/resume` asks the record first and skips the io arm when it claims the
park; running both frees the payload under the mediator that is still reading it.

`docs/impl/region/owner.md` § "Park/unpark symmetry" carries the argument.

## How it was measured

`arena/count` deltas over a 400-iteration window, before → after:

| shape | before | after |
|---|--:|--:|
| resume | 2000 | 0 |
| resume, payload read first | 2000 | 0 |
| refuse | 2000 | 0 |
| abort | 2000 | 0 |
| resume through `protect` | 2000 | 0 |
| refuse through `protect` | 2000 | 0 |
| two denials in one session | 4000 | 0 |
| control: denial dropped | 0 | 0 |
| control: denial hard-killed | 0 | 0 |
| control: `emit` park resumed / refused | 0 | 0 |

The `:io` denial's own per-call residual (the rest list the calling convention
builds for a variadic callee, F2's `denied-discard` rate) is unchanged on both
its mediated and its discard face, so that subject is pinned relative: mediating
costs no more than dropping.

## Tests

- `tests/elle/region-denial-park.lisp` — the leak gauge. Every subject reads
  2000–4000 with the release removed and 0 with it; every control reads 0 both
  ways.
- `tests/elle/region-denial-park-uaf.lisp` + `region_denial_park_uaf` — the
  guardfree pin. Each witness reads a heap field of the payload **after** the
  install that displaces it, including the shape whose resume value is read out
  of the payload's own region. Its `:io` witnesses SIGSEGV when the io arm and
  the record both fire, which is what pins the exclusivity.
- Gates: `cargo test -p elle --lib` (2228), `cargo test --test lib region_` (91),
  `make smoke-elle` (0 fail / 0 diverge / 0 timeout, `oracle: ok`), clippy,
  `cargo fmt`, `make fmt-check`, `make crosscheck`.

Closes #934.
