### PR TITLE
regions: a denied call parks a payload no body releases

### DIFF
--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -198,10 +198,10 @@ parked fiber's accounting symmetric with its unpark:
 - **The parked signal's escape retain has a release on every path.** A suspending signal's
   payload is retained once as it escapes into `fiber.signal` (`EmitEscape` for
   `yield`/`emit`, `SuspendEscape` for a yielding io op or a capability denial). The resume
-  path consumes it (the resumed body's own pending release, or `release_parked_signal` for
-  an io request); a fiber that can never run again consumes it at its terminal teardown or
-  free-path discharge instead (`release_discarded_signal` via `Fiber::take_parked_state`) —
-  the `yield-discard`/`denied-discard` probes pin both faces.
+  path consumes it (the resumed body's own pending release, or `release_parked_signal` where
+  the park has no body reference — below); a fiber that can never run again consumes it at
+  its terminal teardown or free-path discharge instead (`release_discarded_signal` via
+  `Fiber::take_parked_state`) — the `yield-discard`/`denied-discard` probes pin both faces.
 - **A fiber body owns one reference of every value it yields.** Two references answer for a
   parked payload, and they answer to different consumers. The escape retain above is the
   **delivery** reference: the resumer's compiler-emitted release of the resume result consumes
@@ -232,6 +232,19 @@ parked fiber's accounting symmetric with its unpark:
   region where the record matches ([mechanism.md](mechanism.md) § "An abandoned frame runs
   the releases it still owes"). A halt takes neither the retain nor the record — a halted
   fiber is promoted to `:dead` and never resumed, so its delivery has no consumer.
+- **A park with no body reference owes one release at the resume.** The rule above names a
+  consumer for each of a park's two references, and the second consumer is the body's own
+  release past the suspend. Two parks have no body reference to release. A yielding io op
+  parks a request the native built, whose birth reference the scheduler's `fiber/value` read
+  consumes as it submits. A capability denial parks a payload the VM built in place of a
+  call that never ran (`VM::build_denial_payload`), and the replayed frame's result release
+  targets the mediating parent's resume value instead. Either way one reference is left over
+  at the resume, and one decref of the payload's region answers for it
+  (`release_parked_signal`) — the same single decref the discard face runs
+  (`release_discarded_signal`), so both faces of a park reclaim alike. Which shape a park has
+  is known only where it parks, so the denial sites record the payload on the fiber
+  (`Fiber::denial_payload`) and the resume matches the record against the parked signal
+  before releasing. Pinned by `tests/elle/region-capability-denial-resume-leak.lisp`.
 - **What yields is the emit OPERATION, not the `Emit` node.** A first argument the compiler
   cannot read as a keyword set falls through to the `emit` primitive
   ([../../signals/emit.md](../../signals/emit.md) § "Dynamic emit"), which parks the same way

--- a/src/jit/calls.rs
+++ b/src/jit/calls.rs
@@ -151,8 +151,10 @@ pub(crate) fn jit_capability_denial(
     crate::value::arena::incref_for_escape(heap, r, crate::value::arena::EscapeSite::SuspendEscape);
     // The denied primitive never runs, so the mediating parent's resume value
     // stands in for its result — the same park classification the interpreter's
-    // `handle_capability_denial` records.
+    // `handle_capability_denial` records, and the same left-over payload reference
+    // for the resume to release (`Fiber::denial_payload`).
     vm.fiber.resume_value_unfunded = true;
+    vm.fiber.denial_payload = Some(payload);
     vm.fiber.signal = Some((blocked, payload));
     YIELD_SENTINEL
 }

--- a/src/primitives/fiber_introspect.rs
+++ b/src/primitives/fiber_introspect.rs
@@ -200,6 +200,10 @@ fn inject_error_at_suspension(
     crate::vm::fiber::release_displaced_terminal_signal(ctx.heap_mut(), fiber_value, parked);
     handle.with_mut(|fiber| {
         fiber.signal = Some((SIG_ERROR, error_value));
+        // The park this record named is over, and the strand above is what the
+        // install leaves of it — so a later resume of the fiber must not read the
+        // record as a release it owes (`Fiber::denial_payload`).
+        fiber.denial_payload = None;
     });
     // The DELIVERY reference. Every other install of a terminal payload into a
     // signal slot funds itself — a raise mints, a re-park mints — but this one

--- a/src/primitives/fibers.rs
+++ b/src/primitives/fibers.rs
@@ -152,20 +152,32 @@ pub(crate) fn prim_fiber_resume(
     // request (or any value) holds it here, and its region carries the
     // suspend-time escape references that must be balanced before the resume
     // value replaces it.
-    let (status, parked) = handle.with(|fiber| (fiber.status, fiber.signal));
+    let (status, parked, denial_payload) =
+        handle.with(|fiber| (fiber.status, fiber.signal, fiber.denial_payload));
     match status {
         FiberStatus::New | FiberStatus::Paused | FiberStatus::Error => {
-            // Release the references the now-completing yielding call left on its
+            // Release the reference the now-completing yielding call left on its
             // parked value's region — otherwise every yielding io op leaks its
-            // IoRequest region (see `release_parked_signal`).
-            crate::vm::fiber::release_parked_signal(ctx.heap_mut(), parked, resume_value);
+            // IoRequest region, and every mediated capability denial its payload's
+            // (see `release_parked_signal`).
+            crate::vm::fiber::release_parked_signal(
+                ctx.heap_mut(),
+                parked,
+                denial_payload,
+                resume_value,
+            );
             // And a parked TERMINAL result this resume displaces (a restarted
             // `:error` fiber, a re-resumed drained stream source): its
             // park-retain + recorded content edge counted on the free-time
             // signal scan, which will never see it once the resume value
             // replaces it (see `release_displaced_terminal_signal`).
             crate::vm::fiber::release_displaced_terminal_signal(ctx.heap_mut(), args[0], parked);
-            handle.with_mut(|fiber| fiber.signal = Some((SIG_OK, resume_value)));
+            handle.with_mut(|fiber| {
+                fiber.signal = Some((SIG_OK, resume_value));
+                // The record's whole life is the park it names, whose payload has
+                // just left the slot (`Fiber::denial_payload`).
+                fiber.denial_payload = None;
+            });
         }
         FiberStatus::Alive => {
             return (

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -177,6 +177,26 @@ pub struct Fiber {
     /// with the parked signal, so every delivery route consumes it exactly once
     /// and a later park of a different shape starts from `false`.
     pub resume_value_unfunded: bool,
+    /// The capability-denial payload parked in [`Self::signal`], whose region the
+    /// resume owes one decref.
+    ///
+    /// A park's payload carries two references and the resume consumes both: the
+    /// delivery, which the resumer's release of the resume result takes, and the
+    /// suspending body's own, released by the continuation past the suspend. A
+    /// denial has no body reference to release — the denied primitive never ran, so
+    /// the replayed frame's result release targets the mediating parent's resume
+    /// value — and the payload's birth reference is left over
+    /// (docs/impl/region/owner.md § "A park with no body reference owes one release
+    /// at the resume"). Only the denial site knows a park has that shape, so it
+    /// records the payload here and `prim_fiber_resume` runs the decref.
+    ///
+    /// Carried as the payload rather than a flag so the release is gated on
+    /// representation identity with the live parked signal, exactly as
+    /// [`Self::emit_delivery`] is: an install that displaces the denial payload
+    /// without resuming — `fiber/abort`'s injection, a hard kill's terminal error —
+    /// leaves a record that names a value no longer in the slot, and the mismatch
+    /// withholds a decref that install did not owe.
+    pub denial_payload: Option<Value>,
     /// Suspended execution frames. Set when the fiber suspends; consumed
     /// when it resumes.
     ///
@@ -416,6 +436,13 @@ impl Fiber {
             }
             _ => None,
         };
+        // A discharged park is over, and the discharge below already runs its one
+        // decref — so the record must not survive to a later resume of this fiber
+        // (a hard kill leaves an `:error` fiber resumable). See
+        // [`Fiber::denial_payload`].
+        if signal.is_some() {
+            self.denial_payload = None;
+        }
         // The signal's payload leaves with the fiber's result — read through
         // `fiber/value`, or accounted by the signal discharge below — so a slot
         // naming its region is not this discharge's to release. Reported rather
@@ -456,6 +483,7 @@ impl Fiber {
             error_loc: None,
             emit_delivery: None,
             resume_value_unfunded: false,
+            denial_payload: None,
             suspended: None,
             activation_region_maps: vec![rustc_hash::FxHashMap::default()],
             activation_owner_nodes: vec![None],
@@ -493,6 +521,7 @@ impl Fiber {
             error_loc: None,
             emit_delivery: None,
             resume_value_unfunded: false,
+            denial_payload: None,
             suspended: None,
             activation_region_maps: vec![rustc_hash::FxHashMap::default()],
             activation_owner_nodes: vec![None],

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -233,6 +233,13 @@ primitive never returns, so nothing mints the reference that release consumes:
 `handle_primitive_signal` and the denial path record the shape on the fiber
 (`resume_value_unfunded`) and `do_fiber_resume_single` mints it as it delivers.
 
+A denial park owes a release in the other direction too. Its payload is the VM's,
+built in place of a call that never ran, so no body reference answers for it and
+the resume releases the one left over — `prim_fiber_resume` runs the decref, gated
+on the payload the denial recorded (`Fiber::denial_payload`). See
+docs/impl/region/owner.md § "A park with no body reference owes one release at the
+resume".
+
 Key methods:
 - `execute_bytecode_from_ip`: Executes from a given IP with Rc bytecode/constants
 - `execute_bytecode_saving_stack`: Saves/restores caller's stack, handles tail calls

--- a/src/vm/fiber/refcount.rs
+++ b/src/vm/fiber/refcount.rs
@@ -132,13 +132,20 @@ pub(crate) fn release_displaced_terminal_signal(
     crate::value::arena::decref_region(heap, Some(sig_r));
 }
 
-/// Release the `SuspendEscape` an io op left on its IoRequest's region when a
-/// parked fiber is resumed and that request — held in `fiber.signal` across the
-/// park — is replaced by `resume_value`. This reclaims the IoRequest region of a
-/// yielding io op; the gauge is `oracle.lisp`'s `io-yield ev/sleep` probe, which
-/// measures the whole suspend/pump/resume round bounded.
+/// Release the one reference a park with **no body reference** leaves over when
+/// the resume replaces its payload with `resume_value`.
 ///
-/// A yielding io op (`ev/sleep`, `port/read`, …) returns its `IoRequest` with
+/// A park's payload carries two references, and the resume consumes both: the
+/// delivery — the escape retain — which the resumer's release of the resume
+/// result takes, and the suspending body's own, released by the continuation past
+/// the suspend. Two parks have no body reference for that second consumer to
+/// take, so one is left over at every resume and one decref here answers for it
+/// (docs/impl/region/owner.md § "A park with no body reference owes one release at
+/// the resume"). A user `(yield v)` / `(emit …)` value is body-owned and must not
+/// reach the decref: releasing it double-frees the payload under every holder that
+/// outlives the fiber.
+///
+/// **A yielding io op** (`ev/sleep`, `port/read`, …) returns its `IoRequest` with
 /// `SIG_IO`, whereupon the suspend adds a
 /// [`SuspendEscape`](crate::value::arena::EscapeSite::SuspendEscape) retain so the
 /// scheduler can read the request out of `fiber.signal`. The request's own
@@ -147,43 +154,52 @@ pub(crate) fn release_displaced_terminal_signal(
 /// remaining reference. On resume the io call "returns" `resume_value` (the
 /// completion), so the caller's `DecrefValueRegion` targets THAT region, never
 /// the request's — orphaning the `SuspendEscape` and leaking the request region,
-/// unbounded in a long-running io loop. One decref here, the symmetric
-/// counterpart of the suspend-time incref, frees it: the request is dead (the
-/// scheduler already consumed it), so its region holds nothing live.
+/// unbounded in a long-running io loop. The gauge is `oracle.lisp`'s `io-yield
+/// ev/sleep` probe, which measures the whole suspend/pump/resume round bounded.
 ///
 /// **Skip when `resume_value` shares the region** — the `Fresh` io ops
 /// (`port/read`/`accept`) build their completion buffer *in* the IoRequest's
 /// region and hand it back as the resume value, so that region is still live;
 /// there the caller's `DecrefValueRegion` on the buffer balances the
 /// `SuspendEscape`, and a decref here would free the buffer out from under the
-/// caller (a use-after-free).
+/// caller (a use-after-free). The skip is the io arm's alone: a denial payload's
+/// region is the denied call's own, and the mediating parent's resume value comes
+/// from outside the denied fiber entirely.
 ///
-/// Gated on `SIG_IO`. A user `(yield v)` / `(emit …)` value is **body-owned** —
-/// the resumed body itself releases the reference it held across the suspend, and
-/// the resumer's release of the resume result consumes the delivery reference —
-/// so releasing it here would double-free; only an io op's request is the
-/// orphaned, transient native-call result this balances.
-/// A no-op for a non-io signal, an immediate / `None` value, or a region-0 value.
+/// **A capability denial** parks the payload the VM builds in place of a call it
+/// refuses to run. The denied primitive never returns, so the replayed frame's
+/// result release targets `resume_value` and the payload's birth reference is the
+/// one left over. Only the denial site knows a park has that shape, so it records
+/// the payload in `denial_payload` ([`crate::value::fiber::Fiber::denial_payload`])
+/// and the decref is gated on that record still naming the parked value.
+///
+/// A no-op for a park of neither shape, an immediate / `None` value, or a
+/// region-0 value.
 pub(crate) fn release_parked_signal(
     heap: &mut crate::value::fiberheap::FiberHeap,
     parked: Option<(SignalBits, Value)>,
+    denial_payload: Option<Value>,
     resume_value: Value,
 ) {
     let Some((bits, value)) = parked else {
         return;
     };
-    if !bits.intersects(crate::value::SIG_IO) {
-        return;
-    }
     let region = crate::value::arena::region_of(heap, value);
     if region.is_none() {
         return;
     }
-    // The resume value sharing the request's region is the `Fresh`-io-op signature
-    // (the completion buffer is built there): that region is still live, so leave
-    // it to the caller's `DecrefValueRegion`.
-    if crate::value::arena::region_of(heap, resume_value) == region {
+    if bits.intersects(crate::value::SIG_IO) {
+        // The resume value sharing the request's region is the `Fresh`-io-op
+        // signature (the completion buffer is built there): that region is still
+        // live, so leave it to the caller's `DecrefValueRegion`.
+        if crate::value::arena::region_of(heap, resume_value) == region {
+            return;
+        }
+    } else if !denial_payload.is_some_and(|p| p.bit_identical(value)) {
         return;
     }
     crate::value::arena::decref_region(heap, region);
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/vm/fiber/refcount/tests.rs
+++ b/src/vm/fiber/refcount/tests.rs
@@ -1,0 +1,127 @@
+//! The resume-path gate: which parks owe their payload a release, and which
+//! must be left to the resumed body.
+
+use super::*;
+use crate::value::arena::{alloc_in_fresh_region, region_rc};
+use crate::value::heap::{HeapObject, Pair};
+use crate::value::{SIG_IO, SIG_YIELD};
+
+fn cons() -> HeapObject {
+    HeapObject::Pair(Pair::new(Value::NIL, Value::NIL))
+}
+
+/// A pair on a region of its own, standing in for any parked payload.
+fn payload(
+    heap: &mut crate::value::fiberheap::FiberHeap,
+) -> (Value, crate::hir::region::RuntimeRegion) {
+    alloc_in_fresh_region(heap, cons())
+}
+
+/// A resume value on a region of its own — what a mediating parent hands back,
+/// which never shares the denial payload's region.
+fn foreign(heap: &mut crate::value::fiberheap::FiberHeap) -> Value {
+    alloc_in_fresh_region(heap, cons()).0
+}
+
+/// A capability denial's park has no body reference, so the resume releases the
+/// one the payload is left with (docs/impl/region/owner.md § "A park with no body
+/// reference owes one release at the resume"). The blocked bits are the park's,
+/// and they are NOT `SIG_IO` here — the io gate alone would let a denial of any
+/// other capability through, stranding the payload's region once per mediation.
+#[test]
+fn a_recorded_denial_park_is_released_at_the_resume() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (p, rid) = payload(&mut heap);
+    let resume_value = foreign(&mut heap);
+    let before = region_rc(&heap, rid);
+
+    release_parked_signal(&mut heap, Some((SIG_YIELD, p)), Some(p), resume_value);
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before - 1,
+        "a mediated denial's payload region owes exactly one decref at the resume",
+    );
+}
+
+/// The record is matched against the live parked signal, so an install that
+/// displaced the denial payload without resuming — `fiber/abort`'s injection, a
+/// hard kill's terminal error — leaves no release for the resume to run.
+#[test]
+fn a_record_that_no_longer_names_the_parked_signal_releases_nothing() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (parked, rid) = payload(&mut heap);
+    let (stale, _) = payload(&mut heap);
+    let resume_value = foreign(&mut heap);
+    let before = region_rc(&heap, rid);
+
+    release_parked_signal(
+        &mut heap,
+        Some((SIG_YIELD, parked)),
+        Some(stale),
+        resume_value,
+    );
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before,
+        "the decref is owed by the park the record names, not by whatever \
+         occupies the signal slot later",
+    );
+}
+
+/// The counter-factual for both: a `yield`/`emit` payload is body-owned. The
+/// resumed body releases the reference it held across the suspend, so a decref
+/// here would free the value under every holder that outlives the fiber.
+#[test]
+fn an_unrecorded_yield_park_releases_nothing() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (p, rid) = payload(&mut heap);
+    let resume_value = foreign(&mut heap);
+    let before = region_rc(&heap, rid);
+
+    release_parked_signal(&mut heap, Some((SIG_YIELD, p)), None, resume_value);
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before,
+        "a body-owned park owes the resume path nothing",
+    );
+}
+
+/// The io arm keeps its shared-region skip: a `Fresh` io op builds its completion
+/// buffer in the request's own region and hands it back as the resume value, so
+/// that region is still live and the caller's release answers for it.
+#[test]
+fn an_io_park_whose_resume_value_shares_its_region_releases_nothing() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (request, rid) = payload(&mut heap);
+    let completion = heap.alloc_in_region(cons(), rid);
+    let before = region_rc(&heap, rid);
+
+    release_parked_signal(&mut heap, Some((SIG_IO, request)), None, completion);
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before,
+        "the completion buffer built in the request's region keeps it live",
+    );
+}
+
+/// …and releases when the resume value comes from elsewhere, which is the io
+/// request's own orphaned escape retain.
+#[test]
+fn an_io_park_whose_resume_value_is_foreign_is_released() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (request, rid) = payload(&mut heap);
+    let completion = foreign(&mut heap);
+    let before = region_rc(&heap, rid);
+
+    release_parked_signal(&mut heap, Some((SIG_IO, request)), None, completion);
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before - 1,
+        "a submitted io request is dead at the resume — its region owes one decref",
+    );
+}

--- a/src/vm/fiber/resume.rs
+++ b/src/vm/fiber/resume.rs
@@ -149,6 +149,10 @@ impl VM {
                 inner_handle.with_mut(|f| {
                     f.signal = Some((SIG_OK, resume_value));
                     f.emit_delivery = None;
+                    // …nor a denial park's left-over payload reference, whose
+                    // record lives exactly as long as the park does
+                    // (`Fiber::denial_payload`).
+                    f.denial_payload = None;
                 });
 
                 // Set up the trampoline to descend into the inner fiber.

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -238,6 +238,11 @@ impl VM {
         // parent's resume value takes the place of its result — and the frame's
         // continuation releases that result (see the `SignalAction::Suspend` arm).
         self.fiber.resume_value_unfunded = true;
+        // Which is why the payload's own birth reference reaches no consumer past
+        // the park: the continuation's release names the resume value, not this
+        // struct. Record it so the resume runs the one decref the park is left
+        // owing (`Fiber::denial_payload`).
+        self.fiber.denial_payload = Some(payload);
 
         // Save the stack and build a suspended frame (same as suspending signals)
         let saved_stack: Vec<Value> = self.fiber.stack.drain(..).collect();
@@ -292,8 +297,10 @@ impl VM {
             crate::value::arena::EscapeSite::SuspendEscape,
         );
         // Tail-position mirror of the Call-position denial park (see
-        // `handle_capability_denial`).
+        // `handle_capability_denial`), delivery obligation and left-over payload
+        // reference alike.
         self.fiber.resume_value_unfunded = true;
+        self.fiber.denial_payload = Some(payload);
         self.fiber.signal = Some((blocked, payload));
         blocked
     }

--- a/src/vm/signal/tests.rs
+++ b/src/vm/signal/tests.rs
@@ -218,3 +218,81 @@ fn a_completing_primitive_owes_its_resume_value_nothing() {
         );
     })
 }
+
+// -- which parks owe their own payload a release --
+
+/// A capability denial parks a payload the VM built in place of a call that never
+/// ran, so no body reference answers for it and the resume owes its region one
+/// decref (docs/impl/region/owner.md § "A park with no body reference owes one
+/// release at the resume"). Only the denial site can tell a park has that shape,
+/// so it records the payload for `prim_fiber_resume` to match against the live
+/// parked signal.
+#[test]
+fn a_capability_denial_park_records_the_payload_it_leaves_over() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        let (code, env) = test_fixtures();
+        let mut ip = 0usize;
+        let blocked = SIG_IO;
+
+        let result = vm.handle_capability_denial(
+            &crate::primitives::def::NOOP_PRIM,
+            blocked,
+            &[],
+            &code,
+            &env,
+            &mut ip,
+        );
+
+        assert_eq!(result, Some(blocked));
+        let (_, payload) = vm.fiber.signal.expect("the denial parks its payload");
+        assert_eq!(
+            vm.fiber.denial_payload.map(|p| p.bit_identical(payload)),
+            Some(true),
+            "the denial records the very payload it parked, so the resume can \
+             match the record against the live signal",
+        );
+    })
+}
+
+/// The tail-position mirror. A tail denial builds no frame of its own, so the
+/// record — like the delivery obligation beside it — must ride the fiber.
+#[test]
+fn a_tail_capability_denial_park_records_the_payload_it_leaves_over() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        let blocked = SIG_IO;
+
+        let result =
+            vm.handle_capability_denial_tail(&crate::primitives::def::NOOP_PRIM, blocked, &[]);
+
+        assert_eq!(result, blocked);
+        let (_, payload) = vm.fiber.signal.expect("the tail denial parks its payload");
+        assert_eq!(
+            vm.fiber.denial_payload.map(|p| p.bit_identical(payload)),
+            Some(true),
+            "a tail denial records its payload too — the frame it resumes into is \
+             built by a driver that never saw the denied call",
+        );
+    })
+}
+
+/// The counter-factual for the two above: an ordinary suspend parks a payload the
+/// resumed body releases itself. Recording it would make the resume run a second
+/// release and free the value under every holder that outlives the fiber.
+#[test]
+fn an_ordinary_suspend_records_no_payload_to_release() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        let (code, env) = test_fixtures();
+        let mut ip = 0usize;
+
+        let result = vm.handle_primitive_signal(SIG_YIELD, Value::int(1), &code, &env, &mut ip);
+
+        assert_eq!(result, Some(SIG_YIELD));
+        assert!(
+            vm.fiber.denial_payload.is_none(),
+            "a yielded payload is body-owned — the resume owes it no release",
+        );
+    })
+}

--- a/tests/elle/region-capability-denial-resume-leak.lisp
+++ b/tests/elle/region-capability-denial-resume-leak.lisp
@@ -1,0 +1,124 @@
+(elle/epoch 12)
+# Counterfactual for the mediated-denial park's stranded payload region.
+#
+# A fiber that calls a withheld primitive parks the `{:error :capability-denied
+# …}` payload the VM builds in its place, and the parent mediates: it reads the
+# payload, decides, and resumes the fiber with a stand-in result. That park has
+# no body reference — the denied primitive never ran, so the replayed frame's
+# result release targets the parent's resume value — and the resume owes the
+# payload's region one decref (docs/impl/region/owner.md § "Park/unpark
+# symmetry", "A park with no body reference owes one release at the resume").
+#
+# Baseline stranded two regions per mediated call, growing without bound in any
+# loop that mediates. The counter-factual is the region count over a fixed loop:
+# a correct runtime keeps it flat, and the discard face — a denial the parent
+# never resumes past — was already flat, so the growth belongs to the resume.
+
+# A mediated denial in CALL position: `let` keeps the denied call
+# mid-activation, so the interpreter denies through `handle_capability_denial`.
+(defn mediate-call []
+  (let [f (fiber/new (fn []
+                       (let [r (file/read "/no/such/path")]
+                         5)) |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (fiber/resume f 7)))
+
+# The same denial in TAIL position, through `handle_capability_denial_tail` (and
+# its JIT twin `jit_capability_denial` once the loop makes the body hot).
+(defn read-blocked []
+  (file/read "/no/such/path"))
+
+(defn mediate-tail []
+  (let [f (fiber/new (fn [] (read-blocked)) |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (fiber/resume f 7)))
+
+# The control: the parent reads the payload and drops the fiber without
+# resuming past the denial. `release_discarded_signal` runs the same single
+# decref there, so this face was never the leak.
+(defn discard-denial []
+  (let [f (fiber/new (fn []
+                       (let [r (file/read "/no/such/path")]
+                         5)) |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (get (fiber/value f) :error)))
+
+# The second control: an ordinary park resumed the same way. Its payload IS
+# body-owned, so nothing here may release it — this is the shape the fix must
+# leave alone.
+(defn mediate-yield []
+  (let [f (fiber/new (fn []
+                       (let [r (emit :yield {:a 1})]
+                         5)) |:yield|)]
+    (fiber/resume f)
+    (fiber/resume f 7)))
+
+(defn region-growth [f n]
+  # Warm first: the first iterations mint the shape's constant regions (code,
+  # closure templates), which are not per-op growth.
+  (each i (range 0 50)
+    (f))
+  (let [before (arena/region-count)]
+    (each i (range 0 n)
+      (f))
+    (%sub (arena/region-count) before)))
+
+(let [d (region-growth mediate-call 400)]
+  (assert (%lt d 40)
+          (string "mediated capability denial (call position) strands regions: "
+                  "400 mediations grew the region count by " d
+                  " (must stay bounded — the resume owes the payload one decref)")))
+
+(let [d (region-growth mediate-tail 400)]
+  (assert (%lt d 40)
+          (string "mediated capability denial (tail position) strands regions: "
+                  "400 mediations grew the region count by " d
+                  " (must stay bounded — the resume owes the payload one decref)")))
+
+(let [d (region-growth discard-denial 400)]
+  (assert (%lt d 40)
+          (string "unmediated capability denial strands regions: 400 denials "
+                  "grew the region count by " d)))
+
+(let [d (region-growth mediate-yield 400)]
+  (assert (%lt d 40)
+          (string "resumed yield park strands regions: 400 parks grew the "
+                  "region count by " d)))
+
+# ── The over-free face ─────────────────────────────────────────────────
+# The resume's decref answers for the payload's own leftover reference, never
+# for a holder's. A parent that binds the payload before resuming still holds a
+# counted reference of it, so every field must read back intact after the
+# resume — a decref that took the holder's reference instead frees the struct
+# under this read.
+(each i (range 0 200)
+  (let [f (fiber/new (fn []
+                       (let [r (file/read "/no/such/path")]
+                         5)) |:fs :error| :deny |:fs|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/resume f 7)
+      # Churn between the resume and the read so a prematurely-freed payload
+      # region is recycled into a different heap object before it is derefed.
+      (def junk (@string))
+      (%string-push junk "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")
+      (assert (= :capability-denied (get p :error))
+              "a payload the parent still holds survives the resume")
+      (assert ((get p :denied) :fs)
+              "the held payload's :denied set survives the resume")
+      (assert (= "file/read" (get p :primitive))
+              "the held payload's :primitive string survives the resume"))))
+
+# ── Semantics ──────────────────────────────────────────────────────────
+# The release must not disturb what mediation returns: the fiber continues past
+# the denied call with the parent's stand-in value as that call's result.
+(let [f (fiber/new (fn []
+                     (let [r (file/read "/no/such/path")]
+                       (+ r 1))) |:fs :error| :deny |:fs|)]
+  (fiber/resume f)
+  (assert (= (fiber/status f) :paused) "a denied fiber parks")
+  (assert (= (fiber/resume f 41) 42)
+          "the mediating resume value stands in for the denied call's result")
+  (assert (= (fiber/status f) :dead) "the mediated fiber runs to completion"))
+
+(println "region-capability-denial-resume-leak: OK")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -553,6 +553,23 @@ fn region_primitive_resume_uaf() {
     );
 }
 
+// Guard — the resume of a mediated capability denial releases the one reference
+// the park has no body to release, and that decref answers for the payload's own
+// left-over reference, never for a holder's (docs/impl/region/owner.md § "A park
+// with no body reference owes one release at the resume"). The witness binds the
+// payload in the mediating parent, resumes the fiber past the denial, churns the
+// heap, then reads three payload fields; taking the holder's reference instead
+// frees the struct under those reads — SIGSEGV under guardfree. The leak face is
+// the region-count bound in the same file, which the object gauge in
+// `tests/elle/oracle.lisp` cannot see.
+#[test]
+fn region_capability_denial_resume_uaf() {
+    run_elle_script_with_args(
+        "region-capability-denial-resume-leak",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — `fiber/propagate` installs the child's parked payload as this fiber's
 // own `signal`, which is a fresh park and owes its own delivery reference
 // (docs/impl/region/owner.md § "Park/unpark symmetry"). The propagating fiber's


### PR DESCRIPTION
## What was wrong

A capability denial parks the `{:error :capability-denied …}` payload the VM
builds in place of the call it refuses to run. The mediating parent reads that
payload, decides, and resumes the fiber with a stand-in result. Every such
mediation stranded two regions, without bound in a loop that mediates.

A park's payload carries two references, and the resume consumes both: the
delivery, which the resumer's release of the resume result takes, and the
suspending body's own, released by the continuation past the suspend. A denial
has no body reference. The denied primitive never ran, so the replayed frame's
result release names the parent's resume value instead, and one reference of the
payload is left with no consumer at all.

`release_parked_signal` is where a park with no body reference is released, and
its gate read `SIG_IO` alone — the io request's shape. A denial of `:io` passed
that gate by coincidence; a denial of any other capability did not.

The unmediated face was already correct. A fiber dropped at its denial runs
`release_discarded_signal`, which is the same single decref.

## What the change does

The gate now states the shape it always meant: a park no resumed body releases
for. An io park keeps its arm and its shared-region skip — a `Fresh` io op
builds its completion buffer in the request's own region — and a denial park is
released on the other, where no such skip applies.

Only the site that parks knows a park has that shape, so the three denial sites
— call position, tail position, and the JIT twin — record the payload they park
in `Fiber::denial_payload`, beside the delivery obligation they already record.
`prim_fiber_resume` matches the record against the live parked signal before
releasing. An install that displaces the payload without resuming —
`fiber/abort`'s injection, a hard kill's terminal error — therefore releases
nothing.

## Measurement

`arena/region-count` over 400 mediated denials, release binary:

| shape | before | after |
| --- | --- | --- |
| mediated `:fs` denial, call position | 800 | 0 |
| mediated `:fs` denial, tail position | 800 | 0 |
| mediated `:io` denial (the gate's coincidence) | 0 | 0 |
| unmediated `:fs` denial (control) | 0 | 0 |
| resumed yield park (control) | 0 | 0 |

`make smoke ELLE=./target/release/elle CARGO_PROFILE=--release` is green and the
oracle reads `open defects: 1 across 1 roots; by-design: 3`, unchanged.
`denied-discard` still reads 2.0: it gauges the denied call's own argument
scratch under F2, which this change does not touch. The 91 `region_*` guardfree
pins pass, `cargo test -p elle --lib` is 2236 pass, `cargo test --test '*'` is
green, and `make crosscheck`, clippy, rustdoc and both formatters are clean.

## Tests

- `tests/elle/region-capability-denial-resume-leak.lisp` — the region-count
  bound in call and tail position, with the unmediated denial and the resumed
  yield park as controls, plus an over-free face that binds the payload in the
  mediating parent, resumes past the denial, churns the heap and reads three of
  its fields. Registered guardfree as `region_capability_denial_resume_uaf`.
  Counterfactual: with the denial arm of the gate disabled it reports `grew the
  region count by 800`.
- `vm::fiber::refcount::tests` — the gate itself. A recorded denial park is
  released; a record that no longer names the parked signal is not; a
  body-owned yield park is not; and the io arm keeps both faces of its
  shared-region skip.
- `vm::signal::tests` — each denial position records the payload it parked, and
  an ordinary suspend records none.
- `docs/impl/region/owner.md` — new rule "A park with no body reference owes one
  release at the resume", beside the two-reference rule it follows from.

Closes #934.
