### PR TITLE
regions: a park names its funding in one delivery ledger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,8 @@ It takes ~30 minutes.
 |---------|---------|-------------|
 | `cargo test -p elle --lib` | ~1.5min | Rust unit tests — the fast inner loop |
 | `make smoke` | ~30min release | corpus + doctests + embedding |
-| `make test` | smoke + ~5min | smoke, then fmt, clippy, macOS cross-check, rustdoc, unit and integration tests |
+| `make qa` | ~2min | The PR gate's QA job, locally: rustfmt, workspace clippy, macOS cross-check, rustdoc. Run before every push |
+| `make test` | smoke + ~5min | smoke, then qa, then unit and integration tests |
 | `make crosscheck` | ~1min | Clippy over the macOS `cfg(target_os)` arms — needs `rustup target add x86_64-apple-darwin` |
 | `cargo test --workspace` | ~30min | full suite — **ask first** |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,8 +90,9 @@ tests and zero assertions, the session was wasted.
 | Command | Runtime | What it does |
 |---------|---------|-------------|
 | `cargo test -p elle --lib` | ~1.5min | Rust unit tests — the fast inner loop |
+| `make qa` | ~2min | The PR gate's QA job, locally: rustfmt, workspace clippy, macOS cross-check, rustdoc. Run before every push |
 | `make smoke` | ~30min release | Elle corpus (VM, JIT) + doctests + embedding |
-| `make test` | smoke + ~5min | smoke + fmt + clippy + macOS cross-check + rustdoc + unit + integration tests |
+| `make test` | smoke + ~5min | smoke + qa + unit + integration tests |
 | `make crosscheck` | ~1min | Clippy over the macOS `cfg(target_os)` arms a Linux build never compiles |
 
 Pass the release binary to anything that runs the corpus — the debug default

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all elle docs docgen smoke test crosscheck clean space help \
+.PHONY: all elle docs docgen smoke test qa crosscheck clean space help \
        smoke-elle smoke-vm smoke-noffi smoke-jit smoke-wasm smoke-mlir \
        doctest elle-wasm check-wasm elle-mlir elle-noffi plugins plugins-all mcp embedding \
        fmt fmt-check
@@ -115,7 +115,8 @@ fmt-check: elle  ## Check Elle formatting (exit 1 on diff)
 
 # Approximate runtimes (for guidance — vary by machine):
 #   make smoke    docs + the elle test corpus (runner + per-file passes) + embedding
-#   make test     smoke + rust fmt/clippy/rustdoc/unit/integration
+#   make qa       ~2min: the PR gate's QA job (rustfmt, workspace clippy, crosscheck, rustdoc)
+#   make test     smoke + qa + rust unit/integration
 #   cargo test    ~60min full suite (unit + integration + property)
 #
 # `make test` exists to predict the PR gate, so it runs what the gate runs. A
@@ -350,10 +351,12 @@ MLIR_ENV    := LLVM_SYS_220_PREFIX=$(MLIR_PREFIX) \
 # CI documents private items too, and most of this crate is private — without
 # the flag rustdoc never resolves a link into a `pub(crate)` item, so a broken
 # one reaches CI unseen. Keep the flag here and in .github/workflows in step.
-test: smoke crosscheck  ## Rust unit + integration tests + clippy + fmt + crosscheck + rustdoc after smoke
+qa: crosscheck  ## The PR gate's QA job, locally (~2min, no smoke): rustfmt, workspace clippy, rustdoc
 	cargo fmt --check
 	$(MLIR_ENV) cargo clippy --workspace --all-targets --all-features -- -D warnings
 	$(MLIR_ENV) RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items
+
+test: smoke qa  ## Rust unit + integration tests + QA (fmt/clippy/crosscheck/rustdoc) after smoke
 	$(MLIR_ENV) cargo test --workspace --lib --all-features
 	cargo test --test '*' -- --skip property
 

--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1417,9 +1417,9 @@ carry one. An `:error` fiber is resumable, so a restart replays this block, and 
 release then reaches a retain the **catcher** has already consumed as the payload's delivery
 (§ "An abandoned frame runs the releases it still owes"). What funds the catcher is a delivery
 the raise mints for itself at the signal exit — in either position, under the identity gate and
-the record that travel with it ([owner.md](owner.md) § "What yields is the emit OPERATION, not
-the `Emit` node"). So this exit consumes its retains as on any other path, and the nil stamp
-makes the replay a no-op.
+the ledger record that travel with it (`Fiber::delivery`, `record_mint`;
+[owner.md](owner.md) § "What yields is the emit OPERATION, not the `Emit` node"). So this exit
+consumes its retains as on any other path, and the nil stamp makes the replay a no-op.
 
 **What the record frees is this block's own releases.** With the delivery funded, every
 reference the frame holds answers to the frame's own routes, so the walk and the discharge stop
@@ -1612,8 +1612,8 @@ walk may release, and the two raise paths differ:
   retain `handle_emit` takes, consumed by the resumer's release of the resume result.
   The frame's own reference funds nothing, so the skip has nothing to stand in for and
   would strand one region per raised-and-caught error whose payload the raise chain
-  owns. The raise records the mint (`Fiber::emit_delivery`), and a walk whose live
-  signal payload matches it skips nothing.
+  owns. The raise records the mint in the ledger (`Fiber::delivery`, `record_mint`),
+  and a walk whose live signal payload matches it (`mint_names`) skips nothing.
 - A **dynamic `emit`** reads like the `Emit` case with the mint moved to the exit: the
   raise is an ordinary native call, so the signal exit mints the delivery of a payload
   the call received as an argument and records it there ([owner.md](owner.md) § "What

--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1412,32 +1412,23 @@ That exemption is what carries a **dynamic** `emit` in tail position, whose non-
 first argument makes it an ordinary native call rather than the `Emit` terminator: the
 borrowed-argument retain is the body reference the park owes, and there is no second mint.
 
-**A terminal `:error` mints instead of exempting.** The same operation raising a terminal
-signal hands its payload to a **catcher**, whose read of the signal consumes one reference —
-the payload's **delivery** (§ "An abandoned frame runs the releases it still owes"). The
-suspend exemption cannot supply that one. An `:error` fiber is resumable, so a restart replays
-this block too, and the stash release then reaches a retain the catcher has already consumed.
-So the exit consumes its retains like any other — the nil stamp makes the replay a no-op — and
-mints the delivery itself, exactly as `handle_emit` mints it on the literal path, recording it
-in the same `Fiber::emit_delivery`.
+**A terminal `:error` consumes its retains like any other exit.** The exemption above cannot
+carry one. An `:error` fiber is resumable, so a restart replays this block, and the stash
+release then reaches a retain the **catcher** has already consumed as the payload's delivery
+(§ "An abandoned frame runs the releases it still owes"). What funds the catcher is a delivery
+the raise mints for itself at the signal exit — in either position, under the identity gate and
+the record that travel with it ([owner.md](owner.md) § "What yields is the emit OPERATION, not
+the `Emit` node"). So this exit consumes its retains as on any other path, and the nil stamp
+makes the replay a no-op.
 
-The mint is taken only where the payload is one of the call's **own arguments**. A payload the
-native BUILT funds the delivery with its birth reference, so an ordinary native raise — a fresh
-error struct — must not receive one. The identity test is what tells the two apart, and the
-`emit` primitive handing back its second argument is the shape that needs it.
-
-**The record travels with the mint**, as it does on the literal path. Once the mint funds the
-delivery, every reference the frame holds is owed to the frame's own routes, so the walk and
-the discharge must stop exempting the payload's region. Two references are reclaimed that way:
-a payload the body ALLOCATED, whose owned-argument release sits in the abandoned block, and the
-second name of a payload that reaches the call twice — the first occurrence moves the frame's
-reference and the second takes a retain of its own (rules.md Rule 5), as `(emit s s)` does.
-Where the fiber is restarted rather than discharged, the replayed block runs that same release,
-so the accounting is the same either way.
-
-A **halt** takes neither mint nor record, for the reason `handle_emit` withholds its own retain
-there: the fiber is promoted to `:dead` and never resumed, so that delivery has no consumer and
-a reference taken for it is stranded (owner.md § "Park/unpark symmetry").
+**What the record frees is this block's own releases.** With the delivery funded, every
+reference the frame holds answers to the frame's own routes, so the walk and the discharge stop
+exempting the payload's region and the releases in the abandoned block run. Two references are
+reclaimed that way, both of them this position's: a payload the body ALLOCATED, whose
+owned-argument release sits in the block, and the second name of a payload that reaches the
+call twice — the first occurrence moves the frame's reference and the second takes a retain of
+its own (rules.md Rule 5), as `(emit s s)` does. A restart runs those same releases at the
+replay, so the accounting is the same either way.
 
 **Every OTHER release in that block stays.** They divide in two and neither half has that
 argument. An **argument's** own release is the ownership move, and a signal exit is exactly
@@ -1587,6 +1578,17 @@ rather than a new one:
   cell release naming the box, and a transfer adopt each record nothing. The walk can
   only run a release the frame genuinely had.
 
+**One other site records, on the same three facts.** A dynamic `emit` off tail position
+takes a retain at its payload argument and releases it in the continuation past the call
+([owner.md](owner.md) § "What yields is the emit OPERATION, not the `Emit` node"). That
+release is a value route in every respect the walk reads: a slot the site allocates for
+itself, writes once before the call and reads once after it, and clears as it releases. What
+records it is the **terminal** raise. There the catcher consumes the delivery and this retain
+answers to the continuation alone — which a fiber nobody restarts never runs, so the table is
+the only route to it. A suspending raise records the slot too and is unaffected: its parked
+payload is what the walk protects, so the walk passes the slot over and the discharge answers
+for the retain instead.
+
 **Two routes, two receipts.** The slot-resolved release (`DecrefRegion`) is named the
 same way, by the static region slot it carries, and its receipt is the activation map
 itself: the alloc mints the mapping and the release TAKES it
@@ -1612,11 +1614,13 @@ walk may release, and the two raise paths differ:
   would strand one region per raised-and-caught error whose payload the raise chain
   owns. The raise records the mint (`Fiber::emit_delivery`), and a walk whose live
   signal payload matches it skips nothing.
-- A **dynamic `emit` in tail position** reads like the `Emit` case with the mint moved to
-  the exit: the raise is an ordinary native call, so the signal exit mints the delivery of
-  a payload the call received as an argument and records it there (§ "What the fall-through
-  owes, a signal exit owes too"). What the walk then reclaims is the frame's own reference,
-  wherever the payload is one the body allocated.
+- A **dynamic `emit`** reads like the `Emit` case with the mint moved to the exit: the
+  raise is an ordinary native call, so the signal exit mints the delivery of a payload
+  the call received as an argument and records it there ([owner.md](owner.md) § "What
+  yields is the emit OPERATION, not the `Emit` node"). What the walk then reclaims is the
+  frame's own reference to the payload — in TAIL position wherever the body allocated it,
+  and off tail position the site's own payload retain, which the table names for exactly
+  this reason.
 - An **injected** `fiber/abort` / `fiber/refuse` payload reads like the `Emit` case,
   for the same reason: the injection mints the delivery
   ([effects.md](effects.md) § `Delivers`) and records it on every fiber whose frames
@@ -1697,8 +1701,12 @@ frame stack, and the payload exemption reads the same) and
 `jit::dispatch::tests::release_abandoned_frame_runs_both_routes_off_the_compiled_exits_buffers`
 (the two tables reach the runtime as separate buffers of different widths),
 `lir::lower::tests::release::emission::{frame_release_tables_name_exactly_the_routes_emitted,
-a_reassigned_binding_records_no_value_route}` (the tables are the emit sites, so a route
-the emitter declined has no entry), and `tests/elle/region-error-unwind-uaf.lisp` (the
+a_reassigned_binding_records_no_value_route,
+a_non_tail_dynamic_emit_payload_release_carries_its_receipt}` (the tables are the emit
+sites, so a route the emitter declined has no entry and the one other site that records
+carries both halves of a value route's receipt), with
+`tests/elle/region-dynamic-emit-statement-uaf.lisp` as that site's guardfree complement,
+and `tests/elle/region-error-unwind-uaf.lisp` (the
 soundness complement — the payload the raising native builds while the frame holds its
 argument, a value the frame stored into a container that outlives it, a parked frame the
 restarts system replays, and a catching frame's own values, all under

--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -227,9 +227,9 @@ parked fiber's accounting symmetric with its unpark:
   `:error` emit needs no compiler mint for the same invariant: its `EmitEscape` retain is
   the delivery reference exactly as above, and the body's own reference — where the raise
   chain holds one — is claimed through the frames' release tables instead of a blanket
-  discharge, because the raise records its minted delivery (`Fiber::emit_delivery`) and
-  the abandoned-frame walk and the parked frame's discharge stop exempting the payload's
-  region where the record matches ([mechanism.md](mechanism.md) § "An abandoned frame runs
+  discharge, because the raise records its minted delivery in the ledger
+  (`Fiber::delivery`, `record_mint`) and the abandoned-frame walk and the parked frame's
+  discharge stop exempting the payload's region where the record matches ([mechanism.md](mechanism.md) § "An abandoned frame runs
   the releases it still owes"). A halt takes neither the retain nor the record — a halted
   fiber is promoted to `:dead` and never resumed, so its delivery has no consumer.
 - **A payload the RUNTIME built is released by the install that displaces it.** The second
@@ -249,11 +249,12 @@ parked fiber's accounting symmetric with its unpark:
   resumer's release of the resume result is the second consumer and a release here would
   free the buffer under the caller. A denial parks under the WITHHELD capability's bits,
   which say nothing about who built the payload and are indistinguishable from an
-  `(emit :fs v)` of a body-allocated value — so the classifier records the payload
-  (`Fiber::denial_payload`, an uncounted marker compared bit-wise like
-  `Fiber::emit_delivery`) and `release_displaced_denial_payload` releases exactly what the
-  record names, on both installs. The injected error takes no skip: it is not a delivery,
-  and the abort's own `AbortDelivery` mint funds the consumer it does have.
+  `(emit :fs v)` of a body-allocated value — so the classifier records the payload in the
+  ledger (`park_denial`, an uncounted marker compared bit-wise like the mint record) and
+  `release_displaced_denial_payload` releases exactly what the record names, taking it
+  (`take_bodyless`) as the receipt, on both installs. The injected error takes no skip: it
+  is not a delivery, and the abort's own `AbortDelivery` mint funds the consumer it does
+  have.
 
   **The two readings overlap on one denial, and the record wins it.** `:io` is a
   withheld capability like any other, so a fiber denied `:io` parks under `SIG_IO` —
@@ -335,10 +336,10 @@ parked fiber's accounting symmetric with its unpark:
   `Emit` terminator, and a capability denial, which parks a denied primitive call
   for the parent to mediate — and neither can be told from an `Emit` park at the
   delivery, where the frame is already built and, for a tail suspend, was built by a
-  driver that never saw the primitive. So the classifier records the shape on the
-  fiber (`Fiber::resume_value_unfunded`) and `do_fiber_resume_single` takes it with
-  the parked signal, minting one `ResumeDelivery` retain on every route into the
-  fiber. What needs no mint is an `Emit` park, whose resume block mints in bytecode
+  driver that never saw the primitive. So the classifier records the shape in the
+  ledger (`Fiber::delivery`, `park_primitive`) and `do_fiber_resume_single` takes it
+  with the parked signal (`take_resume_funding`), minting one `ResumeDelivery` retain
+  on every route into the fiber. What needs no mint is an `Emit` park, whose resume block mints in bytecode
   (above), and an io completion, which the scheduler allocates fresh and hands over
   carrying its own birth reference. Pinned by
   `tests/elle/region-primitive-resume-uaf.lisp`.
@@ -404,6 +405,43 @@ parked fiber's accounting symmetric with its unpark:
   the count holds. Pinned by `tests/elle/param-fiber-inherit.lisp` and the
   `region_param_fiber_inherit_uaf` integration pin (debug builds panic at the resume
   boundary when the count is missing).
+- **A park names its funding in the delivery ledger, and a consume seam takes it.** The
+  three rules above each leave one funding fact on the fiber, written where the park is
+  built and read where the park ends: the parked payload whose delivery the raise or
+  injection minted, the parked payload with no body reference, and whether the resume
+  value owes a mint at the delivery. One record carries all three — `Fiber::delivery`
+  (`src/value/fiber/delivery.rs`), whose fields are private to its module — so a park
+  names its funding through a method or not at all. The park writes are
+  `park_primitive()` (a suspending primitive or io park), `park_denial(payload)` (a
+  capability denial: a primitive park whose payload also has no body reference),
+  `record_mint(payload)` (a raise minted the payload's delivery), and
+  `install_abort(payload)` (an abort injection: the mint is recorded, no resume value is
+  owed, and the displaced park's records leave with its payload). The consume seams are
+  `take_resume_funding()` at each tier's one delivery funnel (`do_fiber_resume_single`,
+  the WASM `handle_fiber_resume`), which clears the mint record with the parked signal
+  and answers whether to mint the `ResumeDelivery` retain; `take_bodyless()`, run by
+  `release_displaced_denial_payload` at every install that replaces the parked signal —
+  taking is the receipt, so a second install releases nothing; `displace()`, where the
+  trampoline's `FiberResume` short-circuit replaces the parked payload without
+  delivering it (the unfunded flag survives a displace, because the funnel that consumes
+  it has not run yet); and `discharge()`, where the park is over with no delivery to
+  fund: `take_parked_state` consuming the park of a fiber that can never run again, the
+  squelch/abort discard chokepoint (`discard_suspended_frames`), and
+  `VM::abandon_hosted_park` — the seam every host that drives a thunk on the current
+  fiber (`eval`, `import`, `arena/allocs`, `compile/run-on`, the root driver) crosses
+  when it refuses a suspend-class signal it cannot host and the fiber runs on. After a
+  discharge no funding survives, so a later park starts from nothing and a later
+  (invalid) resume of a killed fiber mints nothing. The gated read is
+  `mint_names(payload)` for the abandoned-frame walk and the parked frame's discharge —
+  compared by representation identity against the live parked signal, so a stale record
+  withholds nothing; the bodyless take's consumers gate the same way before releasing. The record is uncounted
+  throughout: the payloads it names are only ever compared bit-wise, never dereferenced,
+  so it takes no retain and the Fiber content scan records no edge for them (the counted
+  edge for the same value is `signal`'s). The method surface is the enforcement: a park
+  write asserts (debug builds) that the previous park's funding was consumed, so a new
+  park shape wired without a consume seam panics at its first park instead of leaking one
+  region per cycle. Pinned by `value::fiber::delivery::tests` (each transition, the
+  displace/discharge split, and the double-park panic).
 - **A parked TERMINAL result displaced by a resume or abort install is released as it is
   displaced.** A terminal result parked in `fiber.signal` carries the park-retain and a
   recorded `fiber-region → result-region` content edge, both counting on the fiber's

--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -283,17 +283,34 @@ parked fiber's accounting symmetric with its unpark:
   stash slot, and `DecrefValueRegion` shape `lower_emit` uses, the resume landing at the
   instruction after the call.
   The signal is a runtime value here, so the mint cannot be gated on `suspends` the way the
-  literal path gates it. It is taken whatever the signal turns out to be, and a TERMINAL one
-  reaches the same consumer by another route: the raise leaves through the mask that catches
-  it, which delivers the payload as the resumer's result, and the resumer's release of that
-  result consumes one reference exactly as it consumes the delivery of a park. What supplies
-  that reference in TAIL position is not the borrowed-argument retain, which a restart's
-  replay of the post-`TailCall` block still claims: the exit consumes the retain and mints the
-  delivery itself, recording it so the frames' owed releases stop standing in for a delivery
-  this call now funds ([mechanism.md](mechanism.md) § "What the fall-through owes, a signal
-  exit owes too"). Pinned by
-  `tests/elle/region-dynamic-emit-borrow-uaf.lisp` and
-  `tests/elle/region-dynamic-emit-terminal-uaf.lisp`, and gauged per op by the `emit-dyn-*`
+  literal path gates it: the site takes its retain whatever the signal turns out to be. A
+  SUSPEND hands that retain to the consumer it was made for, the continuation past the park,
+  which the resume replays. A TERMINAL `:error` adds a second consumer beside it. The raise
+  leaves through the mask that catches it, which delivers the payload as the resumer's
+  result, and the resumer's release of that result consumes a reference of its own; and an
+  `:error` fiber is resumable, so the continuation runs as well — at a restart's replay, or
+  at the walk that stands in for a replay no resume will bring
+  ([mechanism.md](mechanism.md) § "An abandoned frame runs the releases it still owes"). One
+  retain, two consumers. So the raise mints the DELIVERY at its signal exit, in either
+  position and for the reason `handle_emit` mints it on the literal path, and records it
+  (`Fiber::emit_delivery`) so the frames' owed releases stop standing in for a delivery this
+  call now funds. The site's retain then answers to the continuation alone.
+  The mint is taken only where the payload is one of the call's own ARGUMENTS. A payload the
+  native BUILT funds the delivery with its birth reference, so an ordinary native raise — a
+  fresh error struct — must not receive one, and the identity test is what tells the two
+  apart. A HALT takes neither mint nor record, for the reason `handle_emit` withholds its own
+  retain there: the fiber is promoted to `:dead` and never resumed, so that delivery has no
+  consumer and a reference taken for it is stranded.
+  Which route carries the continuation's release on a TERMINAL raise is what differs by
+  position, and the difference is what the signal exit can NAME. A tail call carries its
+  stash slots on the `TailCall` itself, so the exit consumes the retain there and nil-stamps
+  the slot, and the replay reloads an immediate and no-ops ([mechanism.md](mechanism.md)
+  § "What the fall-through owes, a signal exit owes too"). A non-tail site's stash is the
+  lowerer's own slot and no instruction names it — but the frame's release table is a table
+  of exactly such slots, so the site records there instead, and the replay or the walk runs
+  the release whole. Pinned by `tests/elle/region-dynamic-emit-borrow-uaf.lisp`,
+  `tests/elle/region-dynamic-emit-terminal-uaf.lisp` and
+  `tests/elle/region-dynamic-emit-statement-uaf.lisp`, and gauged per op by the `emit-dyn-*`
   probes in `tests/elle/oracle.lisp`.
 - **A delivery into a replayed frame carries one owning reference.** A parked
   `BytecodeFrame` re-enters at its suspending call's continuation, whose

--- a/src/hir/region/infer/yieldborrow.rs
+++ b/src/hir/region/infer/yieldborrow.rs
@@ -20,7 +20,7 @@
 //! a halt promotes the fiber to `:dead` and its delivery has no consumer at
 //! all, and an error's body-owned reference is reclaimed through the frames'
 //! own release tables instead — the raise records its minted delivery
-//! (`Fiber::emit_delivery`), so the abandoned-frame walk and the parked frame's
+//! (the delivery ledger's `record_mint`), so the abandoned-frame walk and the parked frame's
 //! discharge run the payload's owed releases with their receipts, where a
 //! blanket discharge could not tell a borrowed payload from an owned one.
 //!

--- a/src/jit/calls.rs
+++ b/src/jit/calls.rs
@@ -112,7 +112,7 @@ fn jit_handle_primitive_signal(vm: &mut crate::vm::VM, bits: SignalBits, value: 
             // delivery owes the reference the missing `Return` mint would have
             // carried (docs/impl/region/owner.md § "A delivery into a replayed
             // frame carries one owning reference").
-            vm.fiber.resume_value_unfunded = true;
+            vm.fiber.delivery.park_primitive();
             vm.fiber.signal = Some((bits, value));
             YIELD_SENTINEL
         }
@@ -155,8 +155,7 @@ pub(crate) fn jit_capability_denial(
     // because the RUNTIME built it and the install that displaces the park owes
     // the reference the allocation left (docs/impl/region/owner.md § "Park/unpark
     // symmetry").
-    vm.fiber.resume_value_unfunded = true;
-    vm.fiber.denial_payload = Some(payload);
+    vm.fiber.delivery.park_denial(payload);
     vm.fiber.signal = Some((blocked, payload));
     YIELD_SENTINEL
 }

--- a/src/jit/suspend.rs
+++ b/src/jit/suspend.rs
@@ -175,7 +175,7 @@ pub extern "C" fn elle_jit_yield(
     // exactly as `handle_emit` does, so the walk and the parked frame's
     // discharge reclaim the raise chain's own reference.
     if sig.intersects(crate::value::fiber::SIG_ERROR) {
-        vm.fiber.emit_delivery = Some(yielded);
+        vm.fiber.delivery.record_mint(yielded);
     }
     vm.fiber.signal = Some((sig, yielded));
 

--- a/src/lir/lower/control/call.rs
+++ b/src/lir/lower/control/call.rs
@@ -673,10 +673,27 @@ impl<'a> Lowerer<'a> {
                 // `LoadLocal`/`DecrefValueRegion` pair is push-pop-neutral around
                 // the result the call left on top. Empty for every other non-tail
                 // call: only the emit payload sets `borrowed` off tail position.
+                //
+                // The nil stamp and the table entry are what make this release run
+                // ONCE when the signal turns out to be terminal. There the catcher
+                // consumes the delivery the raise minted and this retain answers to
+                // the continuation alone — reached by a restart's replay, or, for a
+                // fiber nobody restarts, by the abandoned-frame walk off exactly
+                // this table (docs/impl/region/mechanism.md § "An abandoned frame
+                // runs the releases it still owes"). A frame that takes both routes
+                // reloads the stamp on the second and no-ops. A SUSPENDING raise
+                // records the slot too and is unaffected: its parked payload is what
+                // the walk protects, so the walk passes the slot over.
                 for &slot in &borrowed_arg_slots {
                     let v = self.fresh_reg();
                     self.emit(LirInstr::LoadLocal { dst: v, slot });
                     self.emit(LirInstr::DecrefValueRegion { src: v });
+                    if let Ok(nil_reg) = self.emit_const(crate::lir::LirConst::Nil) {
+                        self.emit(LirInstr::StoreLocal { slot, src: nil_reg });
+                    }
+                    if !self.current_func.frame_release_slots.contains(&slot) {
+                        self.current_func.frame_release_slots.push(slot);
+                    }
                 }
                 // After ANF (`src/hir/anf.rs`), every consumer position
                 // for a Call has a synthetic `Let` binding owning the

--- a/src/lir/lower/tests/release/emission.rs
+++ b/src/lir/lower/tests/release/emission.rs
@@ -157,6 +157,83 @@ fn dynamic_park_mints_nothing_for_a_body_allocated_payload() {
 }
 
 #[test]
+fn a_non_tail_dynamic_emit_payload_release_carries_its_receipt() {
+    // The site's payload release is a recorded value route, not a bare pair
+    // (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    // still owes"). Two things make it one, and both are load-bearing where the
+    // signal turns out to be TERMINAL: the nil stamp, so a restart's replay of the
+    // continuation cannot run the release the walk already ran, and the table
+    // entry, so a fiber nobody restarts reaches the release at all.
+    //
+    // Counterfactual — with the pair alone the same programs read correct on a
+    // restart and strand one region per raise without one, which is what the
+    // `emit-dyn-error-discard` probe measures.
+    let module = compile_to_lir(
+        "(let [s :yield] (fn () (let [x (string \"a\")] (fn () (begin (emit s x) 0)))))",
+    );
+    // Scoped to what follows the park in its own block — the site's own releases,
+    // not some other route's elsewhere in the body, which stamps and records for
+    // reasons of its own and would let this pass vacuously.
+    let (func, released): (&LirFunction, Vec<(u16, bool)>) =
+        std::iter::once(&module.entry)
+            .chain(module.closures.iter())
+            .find_map(|f| {
+                let b = f.blocks.iter().find(|b| {
+                    b.instructions
+                        .iter()
+                        .any(|i| matches!(i.instr, LirInstr::SuspendingCall { .. }))
+                })?;
+                let at = b
+                    .instructions
+                    .iter()
+                    .position(|i| matches!(i.instr, LirInstr::SuspendingCall { .. }))?;
+                let instrs: Vec<&LirInstr> =
+                    b.instructions[at + 1..].iter().map(|i| &i.instr).collect();
+                Some((
+                    f,
+                    (0..instrs.len())
+                        .filter_map(|i| {
+                            let (
+                                LirInstr::LoadLocal { dst, slot },
+                                LirInstr::DecrefValueRegion { src },
+                            ) = (instrs.get(i)?, instrs.get(i + 1)?)
+                            else {
+                                return None;
+                            };
+                            if dst != src {
+                                return None;
+                            }
+                            // The stamp is `StoreLocal slot <nil>`, and
+                            // materializing the nil takes an instruction of its
+                            // own, so look past it.
+                            let stamped = instrs[i + 2..].iter().take(2).any(
+                                |n| matches!(n, LirInstr::StoreLocal { slot: back, .. } if back == slot),
+                            );
+                            Some((*slot, stamped))
+                        })
+                        .collect(),
+                ))
+            })
+            .expect("a function containing a SuspendingCall");
+    assert!(
+        !released.is_empty(),
+        "the park's own block must carry the payload release for this to be about",
+    );
+    for (slot, stamped) in released {
+        assert!(
+            stamped,
+            "the payload release at slot {slot} must stamp the slot it read, or a \
+             restart's replay runs it a second time",
+        );
+        assert!(
+            func.frame_release_slots.contains(&slot),
+            "slot {slot} carries a stamped value route but is absent from \
+             frame_release_slots, so an abandoned frame never runs it",
+        );
+    }
+}
+
+#[test]
 fn release_emitted_for_unbound_call_result() {
     // An unbound Call result — `(f "a")` whose result flows
     // directly into Begin's discard position — must have a

--- a/src/primitives/fiber_introspect.rs
+++ b/src/primitives/fiber_introspect.rs
@@ -208,10 +208,10 @@ fn inject_error_at_suspension(
     crate::vm::fiber::release_displaced_denial_payload(ctx.heap_mut(), handle);
     handle.with_mut(|fiber| {
         fiber.signal = Some((SIG_ERROR, error_value));
-        // The park this record named is over, and the strand above is what the
-        // install leaves of it — so a later resume of the fiber must not read the
-        // record as a release it owes (`Fiber::denial_payload`).
-        fiber.denial_payload = None;
+        // The park the payload-named records described is over, and the strand
+        // above is what the install leaves of it — so a later resume of the
+        // fiber must not read a record as a release it owes.
+        fiber.delivery.displace();
     });
     // The DELIVERY reference. Every other install of a terminal payload into a
     // signal slot funds itself — a raise mints, a re-park mints — but this one

--- a/src/primitives/modules.rs
+++ b/src/primitives/modules.rs
@@ -352,12 +352,16 @@ pub(crate) fn prim_import_file(
                     path = ctx.string(path.as_str()),
                 )
             }
-            bits => crate::rich_error!(
-                ctx,
-                "eval-error",
-                format!("import: unexpected signal {} in {}", bits, path),
-                path = ctx.string(path.as_str()),
-            ),
+            bits => {
+                // The refused suspend-class park is abandoned with its host.
+                vm.abandon_hosted_park(bits);
+                crate::rich_error!(
+                    ctx,
+                    "eval-error",
+                    format!("import: unexpected signal {} in {}", bits, path),
+                    path = ctx.string(path.as_str()),
+                )
+            }
         }
     }
 }

--- a/src/runtime/tests/ownership/fnode.rs
+++ b/src/runtime/tests/ownership/fnode.rs
@@ -811,9 +811,10 @@ fn a_parked_terminal_payload_is_worth_one_retain_at_every_stage() {
 /// that call's compiler-emitted result release. A bytecode callee funds the
 /// reference that release consumes with its `Return` mint; a primitive that
 /// suspends never returns, so the delivery mints it instead. Which shape a park
-/// has is the classifier's answer, recorded on the fiber, so the two arms below
-/// park IDENTICAL frames and differ only in `Fiber::resume_value_unfunded` — the
-/// flag is the counter-factual. Both arms then complete and park the same value
+/// has is the classifier's answer, recorded in the delivery ledger, so the two
+/// arms below park IDENTICAL frames and differ only in the ledger's
+/// resume-funding fact — the record is the counter-factual. Both arms then
+/// complete and park the same value
 /// as their terminal result, which is worth its own single retain
 /// (`a_parked_terminal_payload_is_worth_one_retain_at_every_stage`), so the whole
 /// difference between the arms is the delivery's one reference.
@@ -872,7 +873,9 @@ fn a_primitive_park_delivery_is_worth_one_retain() {
             // What `prim_fiber_resume` installs: the value to deliver, plus the
             // park shape the classifier recorded when the fiber suspended.
             f.signal = Some((crate::value::fiber::SIG_OK, payload));
-            f.resume_value_unfunded = unfunded;
+            if unfunded {
+                f.delivery.park_primitive();
+            }
         });
         rc!("after the park is installed — the delivery has not run", 1);
 

--- a/src/value/AGENTS.md
+++ b/src/value/AGENTS.md
@@ -19,6 +19,7 @@ Runtime value representation using a tagged union.
 | `types.rs` | `Arity`, `SymbolId`, `NativeFn`, `TableKey`, sorted-struct helpers |
 | `closure.rs` | `Closure` (template + env + squelch mask), `ClosureTemplate`, `TemplateRef` |
 | `fiber.rs` | `Fiber`, `FiberHandle`, `WeakFiberHandle`, `SuspendedFrame`, `Frame`, `FiberStatus`; re-exports `SignalBits` (from `fiber/signalbits.rs`) and the `SIG_*` constants (from `crate::signals`) |
+| `fiber/delivery.rs` | `Delivery` — the delivery ledger: how the current park's delivery references are funded, with a method-only surface (docs/impl/region/owner.md § "A park names its funding in the delivery ledger") |
 | `error.rs` | `rich_error!` macro plus `error_val_in()`, `error_val_extra_in()`, `match_fail_error_in()`, and `format_error()` for region-coherent error structs (docs/impl/region/errors.md) |
 | `ffi.rs` | `LibHandle` for C interop |
 | `fiberheap/` | `FiberHeap` over a `RegionStore` (physical region allocator; each region owns its pages via a `PagePool`) plus a custom-allocator stack and object-limit tracking. Submodules: `regionstore`, `regionpool`, `pagepool`, `freelog`. One heap per VM, shared by all of that VM's fibers. |

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -18,6 +18,9 @@ pub use frame::*;
 pub use handle::*;
 pub use status::*;
 
+mod delivery;
+pub use delivery::Delivery;
+
 mod signalbits;
 pub use signalbits::SignalBits;
 
@@ -130,82 +133,25 @@ pub struct Fiber {
     /// location comes from").
     ///
     /// The payload is carried so the reader can tell that the location still
-    /// describes the error being re-raised — representation identity, as for
-    /// `emit_delivery`, never structural equality. A fiber that goes on to
+    /// describes the error being re-raised — representation identity, as in
+    /// the delivery ledger, never structural equality. A fiber that goes on to
     /// park a different error (an injected abort, a second raise that recorded
     /// no location) therefore lends its old location to nothing.
     ///
-    /// Like `emit_delivery`, the payload is an UNCOUNTED marker: it is only
-    /// ever compared bit-wise, never dereferenced, so it takes no retain and
-    /// the Fiber content scan records no edge for it. The counted edge for the
-    /// same value is `signal`'s.
+    /// Like the ledger's records, the payload is an UNCOUNTED marker: it is
+    /// only ever compared bit-wise, never dereferenced, so it takes no retain
+    /// and the Fiber content scan records no edge for it. The counted edge for
+    /// the same value is `signal`'s. Kept beside the ledger rather than in it:
+    /// this is a diagnostics record with a life of its own (it survives the
+    /// resume take, waiting for a matching re-raise), not a funding fact.
     pub error_loc: Option<(Value, crate::error::SourceLoc)>,
-    /// The `SIG_ERROR` payload whose DELIVERY reference something OTHER than this
-    /// fiber's frames minted. Three raises record here, for one reason:
-    ///
-    /// - an `emit` raise — the `EmitEscape` retain `handle_emit` (and its JIT
-    ///   mirror) takes, which the resumer's release of the resume result consumes;
-    /// - the same raise leaving the emit PRIMITIVE, in either position, where the
-    ///   signal exit takes that retain in `handle_emit`'s place
-    ///   (`VM::mint_raised_argument_delivery`);
-    /// - an injected `fiber/abort` / `fiber/refuse` payload — the `AbortDelivery`
-    ///   retain the injection takes, recorded on the aborted fiber
-    ///   (`do_fiber_abort`) and on the aborting one where the error escapes it
-    ///   (`VM::park_propagating_abort`).
-    ///
-    /// While this matches the live signal's payload (representation identity,
-    /// never structural equality), the payload exemption on the abandoned-frame
-    /// walk and the parked frame's discharge is withdrawn: a frame's own
-    /// reference funds no delivery, so every release the tables name is genuinely
-    /// owed (docs/impl/region/mechanism.md § "An abandoned frame runs the releases
-    /// it still owes"). A native install leaves this untouched — its delivery is
-    /// the payload's birth reference or the frame's left-standing one, which the
-    /// exemption preserves. Cleared at the resume's signal take, where the parked
-    /// payload this record named leaves the slot.
-    pub emit_delivery: Option<Value>,
-    /// Whether this fiber's innermost suspension is a PRIMITIVE call, whose
-    /// resume value therefore arrives owing one reference.
-    ///
-    /// A parked frame re-enters at its suspending call's continuation, which
-    /// runs that call's compiler-emitted result release. A bytecode callee funds
-    /// the reference that release consumes with its `Return` mint; a primitive
-    /// that suspends never returns, so the delivery mints it instead
-    /// (docs/impl/region/owner.md § "A delivery into a replayed frame carries one
-    /// owning reference"). The classifier — `handle_primitive_signal` and the
-    /// capability-denial path, in call and tail position and in their JIT twins
-    /// (`src/jit/calls.rs`) — is the only place that knows which shape a park has,
-    /// and the park itself may be built later
-    /// and elsewhere (a tail suspend leaves no frame of its own), so the answer
-    /// rides the fiber rather than the frame. `do_fiber_resume_single` takes it
-    /// with the parked signal, so every delivery route consumes it exactly once
-    /// and a later park of a different shape starts from `false`.
-    pub resume_value_unfunded: bool,
-    /// The CAPABILITY-DENIAL payload this fiber has parked, if its innermost
-    /// suspension is a denial.
-    ///
-    /// A park leaves two references on its payload's region — the delivery, and
-    /// the body's own, released by the continuation past the suspend — but a
-    /// denial's `{:error :capability-denied …}` struct is built by the denial
-    /// path, so the body never names it and no `decref_point` names its region.
-    /// The reference the allocation left is owed by whatever displaces the
-    /// payload: a resume's delivery, or an abort's / refusal's injected error
-    /// (docs/impl/region/owner.md § "Park/unpark symmetry" — "A payload the
-    /// RUNTIME built is released by the install that displaces it").
-    ///
-    /// A record is needed because the bits cannot say so. An io park is its
-    /// `SIG_IO` bit, but a denial parks under the WITHHELD capability's bits,
-    /// which an `(emit :fs v)` of a body-allocated value carries too — and only
-    /// the classifier (`handle_capability_denial`, its tail twin, and the JIT's
-    /// `jit_capability_denial`) knows which of the two it built.
-    ///
-    /// Like `emit_delivery`, this is an UNCOUNTED marker: only ever compared
-    /// bit-wise against the parked signal, never dereferenced, so it takes no
-    /// retain and the Fiber content scan records no edge for it. The counted
-    /// edge for the same value is `signal`'s. The comparison is what bounds a
-    /// stale record — a record that no longer names the parked payload releases
-    /// nothing — and the displacing install TAKES it, so no second install can
-    /// release the same reference.
-    pub denial_payload: Option<Value>,
+    /// The delivery ledger: how the current park's delivery references are
+    /// funded — the raise-minted payload, the bodyless (denial) payload, and
+    /// whether the resume value owes a mint. Written where a park is built,
+    /// consumed where the park ends, through a method-only surface
+    /// ([`Delivery`]; docs/impl/region/owner.md § "A park names its funding in
+    /// the delivery ledger").
+    pub delivery: Delivery,
     /// Suspended execution frames. Set when the fiber suspends; consumed
     /// when it resumes.
     ///
@@ -348,7 +294,7 @@ pub struct ParkedState {
     /// `elle test` harness dies on its own first file. What a terminal EMIT
     /// owes — the raise chain's own reference to a payload it allocated — is
     /// settled through [`Self::protect`] instead: the emit records its minted
-    /// delivery (`Fiber::emit_delivery`), the protection is withheld where the
+    /// delivery (the ledger's `record_mint`), the protection is withheld where the
     /// record matches, and the frames' owed-release tables carry the reference
     /// with their own receipts.
     pub signal: Option<(SignalBits, Value)>,
@@ -380,7 +326,7 @@ pub struct ParkedState {
     /// well hold the very value the payload names.
     ///
     /// `None` also where the raise MINTED the payload's delivery itself
-    /// (`Fiber::emit_delivery` matches the live signal): the frame's reference
+    /// (the ledger's `mint_names` answers for the live signal): the frame's reference
     /// funds nothing there, so the owed-release tables run in full and the one
     /// reference the raise chain held is reclaimed rather than stranded
     /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases
@@ -445,13 +391,6 @@ impl Fiber {
             }
             _ => None,
         };
-        // A discharged park is over, and the discharge below already runs its one
-        // decref — so the record must not survive to a later resume of this fiber
-        // (a hard kill leaves an `:error` fiber resumable). See
-        // [`Fiber::denial_payload`].
-        if signal.is_some() {
-            self.denial_payload = None;
-        }
         // The signal's payload leaves with the fiber's result — read through
         // `fiber/value`, or accounted by the signal discharge below — so a slot
         // naming its region is not this discharge's to release. Reported rather
@@ -462,7 +401,14 @@ impl Fiber {
         let protect = signal
             .or(self.signal)
             .map(|(_, v)| v)
-            .filter(|v| !self.emit_delivery.is_some_and(|m| m.bit_identical(*v)));
+            .filter(|v| !self.delivery.mint_names(*v));
+        // A discharged park is over, and the discharge below already runs its one
+        // decref — so no funding record survives to a later resume of this fiber
+        // (a hard kill leaves an `:error` fiber resumable, and it must find
+        // nothing to mint or release).
+        if signal.is_some() {
+            self.delivery.discharge();
+        }
         ParkedState {
             nodes,
             signal,
@@ -490,9 +436,7 @@ impl Fiber {
             param_borrows: Vec::new(),
             signal: None,
             error_loc: None,
-            emit_delivery: None,
-            resume_value_unfunded: false,
-            denial_payload: None,
+            delivery: Delivery::new(),
             suspended: None,
             activation_region_maps: vec![rustc_hash::FxHashMap::default()],
             activation_owner_nodes: vec![None],
@@ -528,9 +472,7 @@ impl Fiber {
             param_borrows: Vec::new(),
             signal: None,
             error_loc: None,
-            emit_delivery: None,
-            resume_value_unfunded: false,
-            denial_payload: None,
+            delivery: Delivery::new(),
             suspended: None,
             activation_region_maps: vec![rustc_hash::FxHashMap::default()],
             activation_owner_nodes: vec![None],

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -145,7 +145,7 @@ pub struct Fiber {
     ///
     /// - an `emit` raise — the `EmitEscape` retain `handle_emit` (and its JIT
     ///   mirror) takes, which the resumer's release of the resume result consumes;
-    /// - the same raise leaving the emit PRIMITIVE in tail position, where the
+    /// - the same raise leaving the emit PRIMITIVE, in either position, where the
     ///   signal exit takes that retain in `handle_emit`'s place
     ///   (`VM::mint_raised_argument_delivery`);
     /// - an injected `fiber/abort` / `fiber/refuse` payload — the `AbortDelivery`

--- a/src/value/fiber/delivery.rs
+++ b/src/value/fiber/delivery.rs
@@ -1,0 +1,190 @@
+//! The delivery ledger: how the current park's delivery references are funded.
+//!
+//! Every value that crosses a fiber boundary carries exactly one delivery
+//! reference, minted by the crossing and consumed by exactly one reader on the
+//! other side. Which side mints, and what else the park owes, depends on the
+//! park's shape — and only the site that builds the park knows the shape. The
+//! ledger is the one record that carries the answer from the park to the seam
+//! that ends it (docs/impl/region/owner.md § "A park names its funding in the
+//! delivery ledger").
+//!
+//! The fields are private: a park names its funding through a method or not at
+//! all, and each method carries the invariant its transition upholds. The
+//! ledger is uncounted throughout — the payloads it names are only ever
+//! compared bit-wise, never dereferenced, so it takes no retain and the Fiber
+//! content scan records no edge for them. The counted edge for the same value
+//! is `Fiber::signal`'s.
+
+use crate::value::Value;
+
+/// The funding record of a fiber's current park. One instance rides each
+/// `Fiber` (`Fiber::delivery`); see the module doc for the model and
+/// docs/impl/region/owner.md for the per-shape rules the methods encode.
+#[derive(Default)]
+pub struct Delivery {
+    /// The parked `SIG_ERROR` payload whose delivery reference the raise or
+    /// injection minted, rather than this fiber's frames: an `emit` raise
+    /// (`EmitEscape`, taken by `handle_emit` and its JIT mirror), the same
+    /// raise leaving the emit primitive in either position
+    /// (`VM::mint_raised_argument_delivery`), or an injected `fiber/abort` /
+    /// `fiber/refuse` payload (`AbortDelivery`). While this names the live
+    /// signal's payload, the payload exemption on the abandoned-frame walk and
+    /// the parked frame's discharge is withdrawn: a frame's own reference funds
+    /// no delivery, so every release the tables name is genuinely owed
+    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases
+    /// it still owes"). A native install records nothing here — its delivery is
+    /// the payload's birth reference or the frame's left-standing one, which
+    /// the exemption preserves.
+    minted: Option<Value>,
+    /// The capability-denial payload parked in `Fiber::signal`, whose region
+    /// the install that displaces it owes one decref. The denial path builds
+    /// the `{:error :capability-denied …}` struct itself, so the body never
+    /// names it and no `decref_point` names its region; the reference the
+    /// allocation left is owed by whatever replaces the payload in the slot —
+    /// a resume's delivery, or an abort's / refusal's injected error
+    /// (docs/impl/region/owner.md § "Park/unpark symmetry" — "A payload the
+    /// RUNTIME built is released by the install that displaces it"). Carried
+    /// as the payload rather than a flag so the release is gated on
+    /// representation identity with the live parked signal, and TAKEN by the
+    /// displacing install ([`Self::take_bodyless`]) so no second install can
+    /// release the same reference.
+    bodyless: Option<Value>,
+    /// Whether this fiber's innermost suspension is a PRIMITIVE call, whose
+    /// resume value therefore arrives owing one reference. A parked frame
+    /// re-enters at its suspending call's continuation, which runs that call's
+    /// compiler-emitted result release; a bytecode callee funds that reference
+    /// with its `Return` mint, but a primitive that suspends never returns, so
+    /// the delivery mints it instead (docs/impl/region/owner.md § "A delivery
+    /// into a replayed frame carries one owning reference"). Rides the fiber
+    /// rather than the frame because a tail suspend's park is built later and
+    /// elsewhere, by a driver that never saw the primitive.
+    resume_unfunded: bool,
+}
+
+impl Delivery {
+    /// A fresh ledger: no park, nothing owed.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A suspending PRIMITIVE parked (a yielding io op, a dynamic `emit`): the
+    /// resume value owes one `ResumeDelivery` mint at the delivery funnel.
+    /// Callers: `handle_primitive_signal[_tail]`'s Suspend arms and their JIT
+    /// twin (`jit_handle_primitive_signal`).
+    pub(crate) fn park_primitive(&mut self) {
+        self.assert_consumed();
+        self.resume_unfunded = true;
+    }
+
+    /// A capability denial parked: a primitive park (the denied call never
+    /// returns) whose payload also has no body reference, so the resume owes
+    /// its region one decref besides the mint. Callers:
+    /// `handle_capability_denial[_tail]` and `jit_capability_denial`.
+    pub(crate) fn park_denial(&mut self, payload: Value) {
+        self.assert_consumed();
+        self.resume_unfunded = true;
+        self.bodyless = Some(payload);
+    }
+
+    /// The net for a park shape wired without a consume seam: every route out
+    /// of a park passes [`Self::take_resume_funding`], [`Self::install_abort`],
+    /// or [`Self::discharge`], so a park write finding the previous park's
+    /// funding still standing means some route skipped all three — one region
+    /// leaked per cycle in release builds, a panic here.
+    #[track_caller]
+    fn assert_consumed(&self) {
+        debug_assert!(
+            !self.resume_unfunded,
+            "delivery ledger: parking over an unconsumed park — a route ended \
+             the previous park without consuming its resume funding \
+             (docs/impl/region/owner.md § \"A park names its funding in the \
+             delivery ledger\")",
+        );
+    }
+
+    /// A raise minted the parked payload's delivery itself, so the frames'
+    /// owed releases run in full. Callers: `handle_emit` and its JIT mirror,
+    /// `VM::mint_raised_argument_delivery`, and `VM::park_propagating_abort`
+    /// (the mint there is the injection's, travelling with the payload).
+    pub(crate) fn record_mint(&mut self, payload: Value) {
+        self.minted = Some(payload);
+    }
+
+    /// An abort injection installed its payload over the park: the injection's
+    /// mint is recorded, the displaced park's payload records leave with its
+    /// payload, and no resume value is owed — an abort delivers none (the
+    /// replayed frame re-enters with `SIG_ERROR` set and leaves before the
+    /// parked call's result release). Caller: `do_fiber_abort`.
+    pub(crate) fn install_abort(&mut self, payload: Value) {
+        self.minted = Some(payload);
+        self.bodyless = None;
+        self.resume_unfunded = false;
+    }
+
+    /// The delivery funnel takes the park's funding with the parked signal:
+    /// clears the mint record (the payload it named leaves the slot) and
+    /// answers whether the resume value owes the `ResumeDelivery` mint, so a
+    /// later park of a different shape starts from nothing. Callers:
+    /// `do_fiber_resume_single` and the WASM tier's `handle_fiber_resume` —
+    /// one method for both tiers, so they cannot drift.
+    pub(crate) fn take_resume_funding(&mut self) -> bool {
+        self.minted = None;
+        std::mem::take(&mut self.resume_unfunded)
+    }
+
+    /// An install replaced the parked payload without delivering it (the
+    /// trampoline's `FiberResume` short-circuit): the payload-named records
+    /// describe a value no longer in the slot, so they go with it. The
+    /// displacing installs consume the bodyless record's release through
+    /// `release_displaced_denial_payload` ([`Self::take_bodyless`]) before
+    /// this runs, so the clear here is the mint record's. `resume_unfunded`
+    /// survives — the funnel that consumes it has not run yet, and the
+    /// replayed frame still owes its resume value the mint.
+    pub(crate) fn displace(&mut self) {
+        self.minted = None;
+        self.bodyless = None;
+    }
+
+    /// `Fiber::take_parked_state` consumed the park of a fiber that can never
+    /// run again: no funding survives, so a later (invalid) resume of a killed
+    /// fiber mints nothing.
+    pub(crate) fn discharge(&mut self) {
+        self.minted = None;
+        self.bodyless = None;
+        self.resume_unfunded = false;
+    }
+
+    /// Whether the raise minted the delivery of exactly this payload
+    /// (representation identity, never structural equality) — the gate the
+    /// abandoned-frame walk and the parked frame's discharge read to withdraw
+    /// the payload exemption. A stale record matches nothing and withholds
+    /// nothing.
+    pub(crate) fn mint_names(&self, payload: Value) -> bool {
+        self.minted.is_some_and(|m| m.bit_identical(payload))
+    }
+
+    /// Take the recorded bodyless (denial) payload — the one consuming read,
+    /// run by `release_displaced_denial_payload` at every install that
+    /// replaces the parked signal. Taking is the receipt: a second install
+    /// finds nothing and releases nothing.
+    pub(crate) fn take_bodyless(&mut self) -> Option<Value> {
+        self.bodyless.take()
+    }
+
+    /// The recorded bodyless payload, without consuming it — a read for tests;
+    /// the consuming read is [`Self::take_bodyless`].
+    #[cfg(test)]
+    pub(crate) fn bodyless(&self) -> Option<Value> {
+        self.bodyless
+    }
+
+    /// Whether the next delivery owes the resume value a mint — a read for
+    /// tests; the consuming read is [`Self::take_resume_funding`].
+    #[cfg(test)]
+    pub(crate) fn resume_unfunded(&self) -> bool {
+        self.resume_unfunded
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/value/fiber/delivery/tests.rs
+++ b/src/value/fiber/delivery/tests.rs
@@ -1,0 +1,124 @@
+//! The ledger's transitions: each park write, each consume seam, and the
+//! debug net for a park shape wired without a consume.
+
+use super::*;
+
+/// A heap-shaped payload stand-in. The ledger never dereferences what it
+/// names — identity is bit-wise — so any distinct non-nil values serve.
+fn payload() -> Value {
+    Value::int(1)
+}
+
+fn other() -> Value {
+    Value::int(2)
+}
+
+#[test]
+fn a_primitive_park_funds_exactly_one_resume() {
+    let mut d = Delivery::new();
+    d.park_primitive();
+    assert!(
+        d.take_resume_funding(),
+        "the park's resume value owes a mint"
+    );
+    assert!(
+        !d.take_resume_funding(),
+        "a second take finds nothing — a later park of a different shape starts from false",
+    );
+}
+
+#[test]
+fn a_denial_park_records_both_facts() {
+    let mut d = Delivery::new();
+    d.park_denial(payload());
+    assert_eq!(
+        d.bodyless().map(|p| p.bit_identical(payload())),
+        Some(true),
+        "the denial payload is recorded for the resume's decref",
+    );
+    assert!(d.take_resume_funding(), "a denial is a primitive park too");
+}
+
+#[test]
+fn an_abort_install_displaces_the_park_and_records_the_mint() {
+    let mut d = Delivery::new();
+    d.park_denial(payload());
+    d.install_abort(other());
+    assert!(
+        d.bodyless().is_none(),
+        "the displaced denial record left with its payload"
+    );
+    assert!(
+        d.mint_names(other()),
+        "the injection's mint travels with the new payload"
+    );
+    assert!(
+        !d.take_resume_funding(),
+        "an abort delivers no resume value, so the park's mint obligation goes with it",
+    );
+}
+
+#[test]
+fn the_mint_gate_is_representation_identity() {
+    let mut d = Delivery::new();
+    d.record_mint(payload());
+    assert!(d.mint_names(payload()));
+    assert!(
+        !d.mint_names(other()),
+        "a record naming a value no longer in the slot withholds nothing",
+    );
+}
+
+#[test]
+fn a_displace_clears_the_payload_records_but_keeps_the_resume_funding() {
+    let mut d = Delivery::new();
+    d.park_denial(payload());
+    d.record_mint(payload());
+    d.displace();
+    assert!(d.bodyless().is_none());
+    assert!(!d.mint_names(payload()));
+    // The trampoline's FiberResume short-circuit installs the resume value and
+    // displaces, but the delivery funnel that consumes the funding runs later —
+    // clearing it here would skip the ResumeDelivery mint the replayed frame's
+    // result release consumes.
+    assert!(
+        d.take_resume_funding(),
+        "the funnel still owes the replayed frame its resume-value mint",
+    );
+}
+
+#[test]
+fn a_discharge_leaves_no_funding() {
+    let mut d = Delivery::new();
+    d.park_denial(payload());
+    d.record_mint(payload());
+    d.discharge();
+    assert!(d.bodyless().is_none());
+    assert!(!d.mint_names(payload()));
+    assert!(
+        !d.take_resume_funding(),
+        "a discharged park is over — a later resume of the killed fiber must mint nothing",
+    );
+}
+
+/// The net for a new park shape wired without a consume seam: parking over an
+/// unconsumed park means some route ended the previous park without passing
+/// `take_resume_funding`, `install_abort`, or `discharge` — a leak of one
+/// region per cycle in release builds, a panic here.
+#[test]
+#[should_panic(expected = "unconsumed")]
+#[cfg(debug_assertions)]
+fn a_second_park_over_an_unconsumed_one_panics() {
+    let mut d = Delivery::new();
+    d.park_primitive();
+    d.park_primitive();
+}
+
+#[test]
+#[should_panic(expected = "unconsumed")]
+#[cfg(debug_assertions)]
+fn a_denial_park_over_an_unconsumed_one_panics() {
+    let mut d = Delivery::new();
+    d.park_primitive();
+    d.park_denial(payload());
+}

--- a/src/value/repr/mod.rs
+++ b/src/value/repr/mod.rs
@@ -94,7 +94,7 @@ impl Value {
     /// object — never structural equality (`PartialEq` compares immutable heap
     /// contents, so two distinct allocations can be `==` while living in
     /// different regions). Use this where a match stands for "the very value
-    /// recorded earlier", e.g. `Fiber::emit_delivery`.
+    /// recorded earlier", e.g. the delivery ledger's records (`Fiber::delivery`).
     #[inline]
     pub(crate) fn bit_identical(self, other: Value) -> bool {
         self.tag == other.tag && self.payload == other.payload

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -175,8 +175,7 @@ On resume, the VM wires up the parent/child chain (Janet semantics):
 | `signal` | `Option<(SignalBits, Value)>` | Signal from execution (errors, yields) |
 | `error_loc` | `Option<(Value, SourceLoc)>` | The parked `SIG_ERROR` payload and where it was raised. Parked by `absorbs`, read back by `fiber/propagate` so a re-raised error keeps its raising form |
 | `suspended` | `Option<Vec<SuspendedFrame>>` | Suspended execution frames (for yield/signal resumption) |
-| `resume_value_unfunded` | `bool` | Whether the innermost suspension is a PRIMITIVE call, so the next delivery owes its resume value one reference (docs/impl/region/owner.md § "A delivery into a replayed frame carries one owning reference") |
-| `denial_payload` | `Option<Value>` | The capability-denial payload this fiber has parked. The runtime built it, so no continuation of the body releases it and the install that displaces the park owes that release; the bits cannot say so, a denial parking under the withheld capability's own bits (docs/impl/region/owner.md § "A payload the RUNTIME built is released by the install that displaces it") |
+| `delivery` | `Delivery` | The delivery ledger: how the current park's delivery references are funded — the raise-minted payload, the bodyless (denial) payload whose release the displacing install owes, and whether the resume value owes a mint. Method-only surface (docs/impl/region/owner.md § "A park names its funding in the delivery ledger") |
 | `signal_mask` | `SignalBits` | Which signals this fiber catches |
 | `param_frames` | `Vec<Vec<(Value, Value)>>` | Parameter binding frames (stack of frames, each frame is vec of (param, value) pairs) |
 | `parent` | `Option<WeakFiberHandle>` | Weak back-pointer to parent fiber |
@@ -231,18 +230,20 @@ When a fiber suspends (via yield instruction or `emit`):
 A park at a suspending PRIMITIVE call — a dynamic `emit`, a capability denial —
 resumes into that call's continuation, which releases the call's result. The
 primitive never returns, so nothing mints the reference that release consumes:
-`handle_primitive_signal` and the denial path record the shape on the fiber
-(`resume_value_unfunded`) and `do_fiber_resume_single` mints it as it delivers.
+`handle_primitive_signal` and the denial path record the shape in the delivery
+ledger (`Fiber::delivery` — `park_primitive` / `park_denial`) and
+`do_fiber_resume_single` takes it (`take_resume_funding`) as it delivers.
 
 The denial owes one more, in the other direction. Its payload is the RUNTIME's,
 so the body names it nowhere and no continuation releases it — the install that
 displaces the park does, through `release_displaced_denial_payload` off the
-`denial_payload` record: `fiber/resume`, the `fiber/abort` / `fiber/refuse`
-injection, and the three `FiberResume` deliveries that reach an inner fiber
-directly. `fiber/resume` asks the record before `release_parked_signal`'s io arm
-and skips that arm when the record claims the park, a fiber denied `:io` parking
-under the same `SIG_IO` bit an io request does. See docs/impl/region/owner.md
-§ "A payload the RUNTIME built is released by the install that displaces it".
+ledger's record (`park_denial` writes it, `take_bodyless` consumes it):
+`fiber/resume`, the `fiber/abort` / `fiber/refuse` injection, and the three
+`FiberResume` deliveries that reach an inner fiber directly. `fiber/resume` asks
+the record before `release_parked_signal`'s io arm and skips that arm when the
+record claims the park, a fiber denied `:io` parking under the same `SIG_IO` bit
+an io request does. See docs/impl/region/owner.md § "A payload the RUNTIME built
+is released by the install that displaces it".
 
 Key methods:
 - `execute_bytecode_from_ip`: Executes from a given IP with Rc bytecode/constants

--- a/src/vm/call/inner.rs
+++ b/src/vm/call/inner.rs
@@ -98,6 +98,24 @@ impl VM {
             // pass-through retain. Shared with the JIT (`elle_jit_call`) so both
             // tiers account identically; see `VM::dispatch_native_call`.
             let (bits, value) = self.dispatch_native_call(def, args.as_slice(), region_id);
+            // A terminal :error hands the payload to a catcher, whose read
+            // consumes one reference this frame's own routes do not fund — so the
+            // raise mints it here where the payload is an argument of this call,
+            // the Call-position twin of the tail exit's mint (`tail_call_inner`).
+            // The site's own payload retain, where the compiler took one, is left
+            // standing for the continuation past this call: a restart replays it,
+            // and a fiber nobody restarts reaches it through the frame's release
+            // table. A HALT takes no mint, for the reason `handle_emit` takes none.
+            // Minted before the handler, which is where this fiber stops being the
+            // one whose frames hold the payload. The `is_empty` test keeps the
+            // classification off the ordinary-completion path, which every native
+            // call takes.
+            if !bits.is_empty()
+                && crate::signals::dispatch::classify(bits, &value)
+                    == crate::signals::dispatch::SignalAction::Error
+            {
+                self.mint_raised_argument_delivery(args.as_slice(), value);
+            }
             return self.handle_primitive_signal(bits, value, code, closure_env, ip);
         }
 

--- a/src/vm/call/inner/tail.rs
+++ b/src/vm/call/inner/tail.rs
@@ -56,43 +56,6 @@ impl VM {
         regions
     }
 
-    /// Mint the DELIVERY reference of a payload this tail call is RAISING, where
-    /// the payload is one of the call's own arguments — the shape a dynamic
-    /// `emit` takes, its non-literal first argument making the raise an ordinary
-    /// native call (docs/impl/region/mechanism.md § "What the fall-through owes,
-    /// a signal exit owes too").
-    ///
-    /// The catcher's read of the signal consumes exactly one reference, and every
-    /// reference this frame holds answers to the frame's own release routes: the
-    /// borrowed-argument retain is consumed by the exit (and no-oped at a
-    /// restart's replay by its nil stamp), an owned argument's release sits in the
-    /// abandoned block for the walk or that same replay to run. So the delivery is
-    /// minted here, exactly as `handle_emit` mints it on the literal path — and
-    /// recorded with it (`Fiber::emit_delivery`), so the abandoned-frame walk and
-    /// the parked frame's discharge stop exempting the payload's region and
-    /// reclaim the frame's own reference to a payload it allocated.
-    ///
-    /// A payload the native BUILT — a fresh error struct — is nobody's argument
-    /// and funds the delivery with its birth reference, so the identity test is
-    /// what keeps this off every ordinary native raise.
-    fn mint_raised_argument_delivery(&mut self, args: &[Value], payload: Value) {
-        if !args.iter().any(|a| a.bit_identical(payload)) {
-            return;
-        }
-        let heap = unsafe { &mut *self.heap_ptr };
-        // An immediate payload crosses no region, so there is nothing to fund and
-        // nothing for the record to say stands.
-        let Some(region) = crate::value::arena::region_of(heap, payload) else {
-            return;
-        };
-        crate::value::arena::incref_for_escape(
-            heap,
-            Some(region),
-            crate::value::arena::EscapeSite::EmitEscape,
-        );
-        self.fiber.emit_delivery = Some(payload);
-    }
-
     /// Release the regions [`Self::take_borrowed_arg_retains`] resolved. Split
     /// from the resolution so the signal handler runs between the two — see that
     /// method for why.

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -432,6 +432,32 @@ impl VM {
                 self.heap().decref_region_if_present(node);
             }
         }
+        // The abandoned park's funding has no consumer — the delivery funnel
+        // that would have taken it will never run for these frames.
+        self.fiber.delivery.discharge();
+    }
+
+    /// A host that drives a thunk on the CURRENT fiber (`eval`, `import`,
+    /// `arena/allocs`, `compile/run-on`, the root driver) refuses a
+    /// suspend-class signal it cannot host: it extracts the signal as a value
+    /// or reports it, and the fiber runs on. The park that raised the signal
+    /// is dead at that moment, so its funding record must not survive into
+    /// the fiber's next park — the delivery funnel that would consume it
+    /// belongs to a resume no host will ever run (docs/impl/region/owner.md
+    /// § "A park names its funding in the delivery ledger"). A no-op for a
+    /// completion, an error (an `:error` fiber is resumable and its records
+    /// are identity-gated), a halt, or the switch trampoline — none of those
+    /// abandons a suspend-class park.
+    pub(crate) fn abandon_hosted_park(&mut self, bits: SignalBits) {
+        use crate::value::{SIG_ERROR, SIG_HALT, SIG_SWITCH};
+        if bits.is_empty()
+            || bits.intersects(SIG_ERROR)
+            || bits.intersects(SIG_HALT)
+            || bits == SIG_SWITCH
+        {
+            return;
+        }
+        self.fiber.delivery.discharge();
     }
 
     /// Record a closure call and return whether it's "hot" (called N+ times,

--- a/src/vm/core/region.rs
+++ b/src/vm/core/region.rs
@@ -409,7 +409,7 @@ impl VM {
     /// and `protect` delivers it to the catcher as data — the raising frame's
     /// reference IS the delivery, so a slot naming the payload's region is
     /// skipped and its release stays owed. An emit-raised error minted the
-    /// delivery itself (`Fiber::emit_delivery`), so nothing is exempt and the
+    /// delivery itself (the ledger's `record_mint`), so nothing is exempt and the
     /// frame's reference is reclaimed here.
     ///
     /// Both tiers walk here. The compiled tier arrives through
@@ -448,7 +448,7 @@ impl VM {
     }
     /// The payload region the abandoned-frame walk must leave standing, or
     /// `None` when nothing is exempt: an immediate payload has no region, and an
-    /// emit-raised error minted its own delivery (`Fiber::emit_delivery`
+    /// emit-raised error minted its own delivery (the ledger's `mint_names`
     /// matches), so the frame's reference funds nothing and every owed release
     /// runs.
     fn unminted_payload_region(
@@ -456,11 +456,7 @@ impl VM {
         heap: &mut crate::value::fiberheap::FiberHeap,
         payload: Value,
     ) -> Option<RuntimeRegion> {
-        if self
-            .fiber
-            .emit_delivery
-            .is_some_and(|m| m.bit_identical(payload))
-        {
+        if self.fiber.delivery.mint_names(payload) {
             return None;
         }
         crate::value::arena::region_of(heap, payload)

--- a/src/vm/core/region/tests.rs
+++ b/src/vm/core/region/tests.rs
@@ -223,7 +223,6 @@ fn a_compiled_frames_spilled_walk_skips_an_unminted_payload() {
         let spill = [payload];
         // A native raise installs the payload with no retain of its own, so the
         // frame's reference IS the delivery and its release stays owed.
-        vm.fiber.emit_delivery = None;
         vm.release_abandoned(&[0], &[], payload, FrameLocals::Spilled(&spill));
         assert_eq!(
             vm.heap().region_rc(region),
@@ -231,7 +230,7 @@ fn a_compiled_frames_spilled_walk_skips_an_unminted_payload() {
             "the skipped release is the delivery the catcher reads the payload by",
         );
         // An emit-raised error minted the delivery itself, so nothing is exempt.
-        vm.fiber.emit_delivery = Some(payload);
+        vm.fiber.delivery.record_mint(payload);
         vm.release_abandoned(&[0], &[], payload, FrameLocals::Spilled(&spill));
         assert_eq!(
             vm.heap().region_rc(region),

--- a/src/vm/dispatch.rs
+++ b/src/vm/dispatch.rs
@@ -74,7 +74,7 @@ impl VM {
             // (docs/impl/region/mechanism.md § "An abandoned frame runs the
             // releases it still owes").
             if signal_bits.intersects(SIG_ERROR) {
-                self.fiber.emit_delivery = Some(value);
+                self.fiber.delivery.record_mint(value);
             }
         }
 

--- a/src/vm/eval.rs
+++ b/src/vm/eval.rs
@@ -213,10 +213,14 @@ fn eval_inner(
             let (_, err_value) = vm.fiber.signal.take().unwrap_or((SIG_ERROR, Value::NIL));
             Err(LError::generic(vm.format_error_with_location(err_value)))
         }
-        _ => Err(LError::generic(format!(
-            "eval: unexpected signal: {}",
-            bits
-        ))),
+        _ => {
+            // The refused suspend-class park is abandoned with its host.
+            vm.abandon_hosted_park(bits);
+            Err(LError::generic(format!(
+                "eval: unexpected signal: {}",
+                bits
+            )))
+        }
     }
 }
 

--- a/src/vm/fiber/abort.rs
+++ b/src/vm/fiber/abort.rs
@@ -25,7 +25,7 @@ impl VM {
     pub(in crate::vm::fiber) fn park_propagating_abort(&mut self, bits: SignalBits, value: Value) {
         self.fiber.signal = Some((bits, value));
         if bits.intersects(SIG_ERROR) {
-            self.fiber.emit_delivery = Some(value);
+            self.fiber.delivery.record_mint(value);
         }
     }
 

--- a/src/vm/fiber/refcount.rs
+++ b/src/vm/fiber/refcount.rs
@@ -172,13 +172,15 @@ pub(crate) fn release_displaced_terminal_signal(
 /// bit that arm reads, so there the io request and the denial payload cannot be
 /// told apart by bits — and one reference is owed, not two.
 ///
-/// [`Fiber::denial_payload`]: crate::value::fiber::Fiber::denial_payload
+/// The record is the delivery ledger's (`park_denial` writes it, this take
+/// consumes it; docs/impl/region/owner.md § "A park names its funding in the
+/// delivery ledger").
 pub(crate) fn release_displaced_denial_payload(
     heap: &mut crate::value::fiberheap::FiberHeap,
     handle: &crate::value::fiber::FiberHandle,
 ) -> bool {
     let displaced = handle.with_mut(|fiber| {
-        let record = fiber.denial_payload.take()?;
+        let record = fiber.delivery.take_bodyless()?;
         let (_, payload) = fiber.signal?;
         record.bit_identical(payload).then_some(payload)
     });

--- a/src/vm/fiber/refcount/tests.rs
+++ b/src/vm/fiber/refcount/tests.rs
@@ -45,7 +45,9 @@ fn parked_fiber(bits: SignalBits, parked: Value, record: Option<Value>) -> Fiber
     let handle = FiberHandle::new(Fiber::new(test_closure(), SignalBits::ALL));
     handle.with_mut(|f| {
         f.signal = Some((bits, parked));
-        f.denial_payload = record;
+        if let Some(payload) = record {
+            f.delivery.park_denial(payload);
+        }
     });
     handle
 }

--- a/src/vm/fiber/resume.rs
+++ b/src/vm/fiber/resume.rs
@@ -38,13 +38,11 @@ impl VM {
         let (resume_value, is_first_resume, child_params_seeded, unfunded) =
             child_handle.with_mut(|child| {
                 let rv = child.signal.take().map(|(_, v)| v).unwrap_or(Value::NIL);
-                // The resume consumes the parked signal, and with it any recorded
-                // emit-minted delivery: the payload this record named is gone from
-                // the slot, and a later raise records its own.
-                child.emit_delivery = None;
-                // …and with it the park's delivery obligation, so a park of a
-                // different shape later starts from `false`.
-                let unfunded = std::mem::take(&mut child.resume_value_unfunded);
+                // The resume consumes the parked signal, and with it the park's
+                // funding: the payload the mint record named is gone from the
+                // slot, and a later park of a different shape starts from
+                // nothing (the delivery funnel's take).
+                let unfunded = child.delivery.take_resume_funding();
                 let first = child.status == FiberStatus::New;
                 (rv, first, !child.param_frames.is_empty(), unfunded)
             });
@@ -144,22 +142,20 @@ impl VM {
 
                 // Deliver the resume value to the inner fiber (matches what
                 // resume_suspended does at the FiberResume arm). The install
-                // displaces any parked signal, so a recorded emit-minted
-                // delivery no longer names the slot's payload — and a park whose
-                // payload the RUNTIME built is owed the release its body has
-                // none for, exactly as at `fiber/resume` itself. This is the
-                // route a `protect`ed body's denial takes: the denial parks in
-                // the inner fiber, which the outer one awaits through a
-                // `FiberResume` frame (docs/impl/region/owner.md § "Park/unpark
-                // symmetry").
+                // displaces any parked signal, so the payload-named funding
+                // records leave with it: a park whose payload the RUNTIME built
+                // is owed the release its body has none for, exactly as at
+                // `fiber/resume` itself — this is the route a `protect`ed
+                // body's denial takes, the denial parking in the inner fiber
+                // the outer one awaits through a `FiberResume` frame
+                // (docs/impl/region/owner.md § "Park/unpark symmetry") — and
+                // the displace clears the mint record. The resume funding
+                // survives for the delivery funnel that runs when the
+                // trampoline descends.
                 crate::vm::fiber::release_displaced_denial_payload(self.heap(), &inner_handle);
                 inner_handle.with_mut(|f| {
                     f.signal = Some((SIG_OK, resume_value));
-                    f.emit_delivery = None;
-                    // …nor a denial park's left-over payload reference, whose
-                    // record lives exactly as long as the park does
-                    // (`Fiber::denial_payload`).
-                    f.denial_payload = None;
+                    f.delivery.displace();
                 });
 
                 // Set up the trampoline to descend into the inner fiber.
@@ -340,15 +336,13 @@ impl VM {
             // (docs/impl/region/mechanism.md § "An abandoned frame runs the
             // releases it still owes"). A fiber handed the same value it is
             // aborted with is the shape that reaches this — the record is what
-            // keeps its release owed.
-            vm.fiber.emit_delivery = Some(error_value);
-            // An abort delivers no resume value — the replayed frame re-enters
-            // with `SIG_ERROR` set and leaves before the parked call's result
-            // release — so the park's delivery obligation goes with the signal it
-            // rode in on. Each arm below funds what it does hand over
-            // (docs/impl/region/owner.md § "A delivery into a replayed frame
-            // carries one owning reference").
-            vm.fiber.resume_value_unfunded = false;
+            // keeps its release owed. An abort delivers no resume value — the
+            // replayed frame re-enters with `SIG_ERROR` set and leaves before the
+            // parked call's result release — so the displaced park's funding goes
+            // with the signal it rode in on; each arm below funds what it does
+            // hand over (docs/impl/region/owner.md § "A delivery into a replayed
+            // frame carries one owning reference").
+            vm.fiber.delivery.install_abort(error_value);
 
             let frames = match vm.fiber.suspended.take() {
                 Some(frames) => frames,

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -272,7 +272,9 @@ impl VM {
                 // report answers for all of it: `:yield` is not privileged
                 // among the bits that reach the root (docs/signals/protocol.md
                 // § "Reaching the root"). The keywords are what the author of
-                // the emitting call can act on; the mask alone is not.
+                // the emitting call can act on; the mask alone is not. The
+                // refused park is abandoned with its host.
+                self.abandon_hosted_park(bits);
                 self.fiber.signal.take();
                 break Err(format!(
                     "Unhandled signal {} outside fiber context",

--- a/src/vm/run_on/bytecode.rs
+++ b/src/vm/run_on/bytecode.rs
@@ -66,6 +66,10 @@ impl VM {
             return self.fiber.signal.take().unwrap();
         }
 
+        // A suspend-class signal leaves this forced-tier entry as a value; the
+        // park it names is abandoned with its host (`abandon_hosted_park`).
+        self.abandon_hosted_park(bits);
+
         // Other errors: extract from fiber signal.
         if let Some((sig_bits, val)) = self.fiber.signal.take() {
             return (sig_bits, val);

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -18,6 +18,47 @@ mod modules;
 mod config;
 
 impl VM {
+    /// Mint the DELIVERY reference of a payload a native call is RAISING, where
+    /// the payload is one of the call's own arguments — the shape a dynamic
+    /// `emit` takes, its non-literal first argument making the raise an ordinary
+    /// native call (docs/impl/region/owner.md § "What yields is the emit
+    /// OPERATION, not the `Emit` node").
+    ///
+    /// The catcher's read of the signal consumes exactly one reference, and every
+    /// other reference the raising frame holds answers to that frame's own release
+    /// routes. So the delivery is minted here, exactly as `handle_emit` mints it on
+    /// the literal path — and recorded with it (`Fiber::emit_delivery`), so the
+    /// abandoned-frame walk and the parked frame's discharge stop exempting the
+    /// payload's region and run those routes in full.
+    ///
+    /// Both positions raise through this. Which route the frame's own reference
+    /// then takes is theirs to arrange: a tail exit consumes its borrowed-argument
+    /// retains and nil-stamps their stashes, while a Call-position site's payload
+    /// stash is a recorded value route the replay or the walk runs
+    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    /// still owes").
+    ///
+    /// A payload the native BUILT — a fresh error struct — is nobody's argument
+    /// and funds the delivery with its birth reference, so the identity test is
+    /// what keeps this off every ordinary native raise.
+    pub(crate) fn mint_raised_argument_delivery(&mut self, args: &[Value], payload: Value) {
+        if !args.iter().any(|a| a.bit_identical(payload)) {
+            return;
+        }
+        let heap = unsafe { &mut *self.heap_ptr };
+        // An immediate payload crosses no region, so there is nothing to fund and
+        // nothing for the record to say stands.
+        let Some(region) = crate::value::arena::region_of(heap, payload) else {
+            return;
+        };
+        crate::value::arena::incref_for_escape(
+            heap,
+            Some(region),
+            crate::value::arena::EscapeSite::EmitEscape,
+        );
+        self.fiber.emit_delivery = Some(payload);
+    }
+
     /// Handle signal bits returned by a primitive in a Call position.
     ///
     /// Returns `None` to continue the dispatch loop, or `Some(bits)` to

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -27,7 +27,7 @@ impl VM {
     /// The catcher's read of the signal consumes exactly one reference, and every
     /// other reference the raising frame holds answers to that frame's own release
     /// routes. So the delivery is minted here, exactly as `handle_emit` mints it on
-    /// the literal path — and recorded with it (`Fiber::emit_delivery`), so the
+    /// the literal path — and recorded with it (the ledger's `record_mint`), so the
     /// abandoned-frame walk and the parked frame's discharge stop exempting the
     /// payload's region and run those routes in full.
     ///
@@ -56,7 +56,7 @@ impl VM {
             Some(region),
             crate::value::arena::EscapeSite::EmitEscape,
         );
-        self.fiber.emit_delivery = Some(payload);
+        self.fiber.delivery.record_mint(payload);
     }
 
     /// Handle signal bits returned by a primitive in a Call position.
@@ -136,7 +136,7 @@ impl VM {
                 // release — is funded by the delivery instead of by a `Return`
                 // mint (docs/impl/region/owner.md § "A delivery into a replayed
                 // frame carries one owning reference").
-                self.fiber.resume_value_unfunded = true;
+                self.fiber.delivery.park_primitive();
                 let saved_stack: Vec<Value> = self.fiber.stack.drain(..).collect();
                 let activation_region_map = self
                     .fiber
@@ -226,7 +226,7 @@ impl VM {
                 // the delivery. The frame that driver parks resumes into the
                 // post-`TailCall` block, whose result release the missing `Return`
                 // mint would have funded.
-                self.fiber.resume_value_unfunded = true;
+                self.fiber.delivery.park_primitive();
                 self.fiber.signal = Some((bits, value));
                 bits
             }
@@ -275,14 +275,14 @@ impl VM {
         // The denied primitive never runs, let alone returns, so the mediating
         // parent's resume value takes the place of its result — and the frame's
         // continuation releases that result (see the `SignalAction::Suspend` arm).
-        self.fiber.resume_value_unfunded = true;
         // Which is why the payload's own birth reference reaches no consumer past
         // the park: the continuation's release names the resume value, not this
-        // struct. Record it, because the install that displaces the park owes that
-        // reference and only this classifier can tell a denial from an `(emit …)`
+        // struct. The park records both facts — the delivery mint the resume
+        // owes, and the payload whose release the displacing install owes —
+        // because only this classifier can tell a denial from an `(emit …)`
         // under the same withheld bits (docs/impl/region/owner.md § "Park/unpark
         // symmetry").
-        self.fiber.denial_payload = Some(payload);
+        self.fiber.delivery.park_denial(payload);
 
         // Save the stack and build a suspended frame (same as suspending signals)
         let saved_stack: Vec<Value> = self.fiber.stack.drain(..).collect();
@@ -339,8 +339,7 @@ impl VM {
         // Tail-position mirror of the Call-position denial park (see
         // `handle_capability_denial`), delivery obligation and left-over payload
         // reference alike.
-        self.fiber.resume_value_unfunded = true;
-        self.fiber.denial_payload = Some(payload);
+        self.fiber.delivery.park_denial(payload);
         self.fiber.signal = Some((blocked, payload));
         blocked
     }

--- a/src/vm/signal/config.rs
+++ b/src/vm/signal/config.rs
@@ -266,7 +266,10 @@ impl VM {
         let bits = self.run_thunk_to_completion(&closure.template.code(), &thunk_env);
 
         if !bits.is_empty() {
-            // Propagate the error/signal — fiber.signal is already set by inner execution.
+            // Propagate the error/signal — fiber.signal is already set by inner
+            // execution. A suspend-class park leaves as a value, abandoned with
+            // its host.
+            self.abandon_hosted_park(bits);
             let (sig, val) = self.fiber.signal.take().unwrap_or((SIG_ERROR, Value::NIL));
             return (sig, val);
         }

--- a/src/vm/signal/modules.rs
+++ b/src/vm/signal/modules.rs
@@ -402,13 +402,17 @@ impl VM {
                 let (_, e) = self.fiber.signal.take().unwrap_or((SIG_ERROR, Value::NIL));
                 (SIG_ERROR, e)
             }
-            other => (
-                SIG_ERROR,
-                ctx.error(
-                    "barrier-error",
-                    format!("compile/whole-module-syntax: unexpected signal {}", other),
-                ),
-            ),
+            other => {
+                // The refused suspend-class park is abandoned with its host.
+                self.abandon_hosted_park(other);
+                (
+                    SIG_ERROR,
+                    ctx.error(
+                        "barrier-error",
+                        format!("compile/whole-module-syntax: unexpected signal {}", other),
+                    ),
+                )
+            }
         }
     }
     /// `(compile/dumps source name)` — compile a module once and return its

--- a/src/vm/signal/tests.rs
+++ b/src/vm/signal/tests.rs
@@ -297,3 +297,66 @@ fn an_ordinary_suspend_records_no_payload_to_release() {
         );
     })
 }
+
+// -- the raised delivery's identity gate --
+
+/// A raised payload that IS one of the call's arguments gets the delivery minted
+/// and recorded; a payload the native BUILT does not. Both positions raise through
+/// this, so the gate is what keeps the mint off every ordinary native raise — a
+/// fresh error struct funds its delivery with its birth reference, and a second
+/// one is stranded per raised-and-caught error.
+#[test]
+fn a_raised_argument_takes_the_delivery_and_a_built_payload_does_not() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        let (payload, region) = crate::value::arena::alloc_in_fresh_region(
+            unsafe { &mut *vm.heap_ptr },
+            crate::value::heap::HeapObject::Pair(crate::value::heap::Pair::new(
+                Value::int(1),
+                Value::NIL,
+            )),
+        );
+        let before = vm.heap().region_rc(region);
+
+        // Nobody's argument: the native built it, so its birth reference is the
+        // delivery and a mint here would out-count the catcher's single release.
+        vm.mint_raised_argument_delivery(&[Value::int(9)], payload);
+        assert_eq!(
+            vm.heap().region_rc(region),
+            before,
+            "a payload the native built funds its own delivery",
+        );
+        assert!(
+            vm.fiber.emit_delivery.is_none(),
+            "an unminted delivery must leave the frames' payload exemption standing",
+        );
+
+        // The call's own argument handed back: the frame's references all answer
+        // to the frame's own routes, so the catcher's read needs one of its own.
+        vm.mint_raised_argument_delivery(&[Value::int(9), payload], payload);
+        assert_eq!(
+            vm.heap().region_rc(region),
+            before + 1,
+            "a raised argument's delivery is minted at the signal exit",
+        );
+        assert_eq!(
+            vm.fiber.emit_delivery,
+            Some(payload),
+            "the record is what withdraws the walk's payload exemption",
+        );
+    })
+}
+
+/// An IMMEDIATE payload crosses no region, so there is nothing to fund — and
+/// recording it would withdraw the exemption for a value no walk can release.
+#[test]
+fn an_immediate_raised_argument_takes_no_delivery() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        vm.mint_raised_argument_delivery(&[Value::int(9)], Value::int(9));
+        assert!(
+            vm.fiber.emit_delivery.is_none(),
+            "an immediate payload has no region for the record to speak for",
+        );
+    })
+}

--- a/src/vm/signal/tests.rs
+++ b/src/vm/signal/tests.rs
@@ -172,7 +172,7 @@ fn a_suspending_primitive_park_owes_its_resume_value_a_reference() {
 
         assert_eq!(result, Some(SIG_YIELD));
         assert!(
-            vm.fiber.resume_value_unfunded,
+            vm.fiber.delivery.resume_unfunded(),
             "the park at a suspending primitive call owes its resume value a reference",
         );
     })
@@ -190,7 +190,7 @@ fn a_tail_suspending_primitive_park_owes_its_resume_value_a_reference() {
 
         assert_eq!(result, SIG_YIELD);
         assert!(
-            vm.fiber.resume_value_unfunded,
+            vm.fiber.delivery.resume_unfunded(),
             "a tail suspend at a primitive owes its resume value a reference too",
         );
     })
@@ -213,7 +213,7 @@ fn a_completing_primitive_owes_its_resume_value_nothing() {
             "a completing primitive continues dispatch"
         );
         assert!(
-            !vm.fiber.resume_value_unfunded,
+            !vm.fiber.delivery.resume_unfunded(),
             "a primitive that returns funds its own result — nothing is owed",
         );
     })
@@ -247,7 +247,10 @@ fn a_capability_denial_park_records_the_payload_it_leaves_over() {
         assert_eq!(result, Some(blocked));
         let (_, payload) = vm.fiber.signal.expect("the denial parks its payload");
         assert_eq!(
-            vm.fiber.denial_payload.map(|p| p.bit_identical(payload)),
+            vm.fiber
+                .delivery
+                .bodyless()
+                .map(|p| p.bit_identical(payload)),
             Some(true),
             "the denial records the very payload it parked, so the resume can \
              match the record against the live signal",
@@ -269,7 +272,10 @@ fn a_tail_capability_denial_park_records_the_payload_it_leaves_over() {
         assert_eq!(result, blocked);
         let (_, payload) = vm.fiber.signal.expect("the tail denial parks its payload");
         assert_eq!(
-            vm.fiber.denial_payload.map(|p| p.bit_identical(payload)),
+            vm.fiber
+                .delivery
+                .bodyless()
+                .map(|p| p.bit_identical(payload)),
             Some(true),
             "a tail denial records its payload too — the frame it resumes into is \
              built by a driver that never saw the denied call",
@@ -292,7 +298,7 @@ fn an_ordinary_suspend_records_no_payload_to_release() {
 
         assert_eq!(result, Some(SIG_YIELD));
         assert!(
-            vm.fiber.denial_payload.is_none(),
+            vm.fiber.delivery.bodyless().is_none(),
             "a yielded payload is body-owned — the resume owes it no release",
         );
     })
@@ -327,7 +333,7 @@ fn a_raised_argument_takes_the_delivery_and_a_built_payload_does_not() {
             "a payload the native built funds its own delivery",
         );
         assert!(
-            vm.fiber.emit_delivery.is_none(),
+            !vm.fiber.delivery.mint_names(payload),
             "an unminted delivery must leave the frames' payload exemption standing",
         );
 
@@ -339,9 +345,8 @@ fn a_raised_argument_takes_the_delivery_and_a_built_payload_does_not() {
             before + 1,
             "a raised argument's delivery is minted at the signal exit",
         );
-        assert_eq!(
-            vm.fiber.emit_delivery,
-            Some(payload),
+        assert!(
+            vm.fiber.delivery.mint_names(payload),
             "the record is what withdraws the walk's payload exemption",
         );
     })
@@ -355,8 +360,53 @@ fn an_immediate_raised_argument_takes_no_delivery() {
         let mut vm = VM::new();
         vm.mint_raised_argument_delivery(&[Value::int(9)], Value::int(9));
         assert!(
-            vm.fiber.emit_delivery.is_none(),
+            !vm.fiber.delivery.mint_names(Value::int(9)),
             "an immediate payload has no region for the record to speak for",
+        );
+    })
+}
+
+// -- a host that refuses a suspend-class signal abandons the park's funding --
+
+/// A host driving a thunk on the current fiber (`eval`, `import`,
+/// `compile/run-on`, the root driver) can refuse a suspend-class signal it
+/// cannot host: the park is dead, and its funding must not survive into the
+/// fiber's next park — a stale record there would mint a `ResumeDelivery`
+/// retain no consumer ever releases, one region per refused park.
+#[test]
+fn a_refused_hosted_park_leaves_no_funding() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        let (code, env) = test_fixtures();
+        let mut ip = 0usize;
+
+        vm.handle_primitive_signal(SIG_YIELD, Value::int(1), &code, &env, &mut ip);
+        assert!(vm.fiber.delivery.resume_unfunded());
+
+        vm.abandon_hosted_park(SIG_YIELD);
+        assert!(
+            !vm.fiber.delivery.resume_unfunded(),
+            "the refused park's funding is consumed by the abandonment",
+        );
+    })
+}
+
+/// The counter-factual: an error is not an abandonment — an `:error` fiber is
+/// resumable and its payload-named records are identity-gated — so the
+/// abandonment seam leaves an error's ledger alone.
+#[test]
+fn an_error_exit_abandons_no_funding() {
+    with_test_region(|| {
+        let mut vm = VM::new();
+        let (code, env) = test_fixtures();
+        let mut ip = 0usize;
+
+        vm.handle_primitive_signal(SIG_YIELD, Value::int(1), &code, &env, &mut ip);
+        vm.abandon_hosted_park(crate::value::SIG_ERROR);
+        assert!(
+            vm.fiber.delivery.resume_unfunded(),
+            "an error exit is not a refusal of the park — the funding stays for \
+             the delivery funnel",
         );
     })
 }

--- a/src/wasm/resume.rs
+++ b/src/wasm/resume.rs
@@ -361,10 +361,11 @@ pub(super) fn handle_fiber_resume(
         let closure = fiber.closure.clone();
         let resume_value = fiber.signal.take().map(|(_, v)| v).unwrap_or(Value::NIL);
         let status = fiber.status;
-        // The park's delivery obligation travels with the parked signal, exactly
-        // as it does in the VM's fiber driver (`do_fiber_resume_single`), so every
-        // delivery route consumes it once.
-        let unfunded = std::mem::take(&mut fiber.resume_value_unfunded);
+        // The park's funding travels with the parked signal, taken through the
+        // same delivery funnel the VM's fiber driver uses
+        // (`do_fiber_resume_single`), so every delivery route consumes it once
+        // and the two tiers cannot drift.
+        let unfunded = fiber.delivery.take_resume_funding();
         (closure, resume_value, status, unfunded)
     });
 

--- a/tests/elle/oracle.lisp
+++ b/tests/elle/oracle.lisp
@@ -1570,6 +1570,33 @@
     (fn [j]
       (let [f (fiber/new (fn [] (emit emit-error-sig (string "v" j))) |:error|)]
         (fiber/resume f)
+        (fiber/resume f))) 0]  # The same raise OFF TAIL POSITION, where the site
+   # takes the retain instead of the call's argument convention and the exit leaves
+   # it standing for the continuation past the call (docs/impl/region/owner.md
+   # § "What yields is the emit OPERATION, not the `Emit` node"). CLOSED controls
+   # (undeclared, like `rest-array-copy`). What each reads is where that retain's one
+   # consumer is: `emit-dyn-error-discard` above resumes once, so no replay arrives
+   # and the frames' own release table is the only route to it — the face that goes
+   # open by one region per op if the site's stash stops recording there, or if the
+   # raise stops recording its mint. `emit-dyn-stmt-error-restart` resumes twice, so
+   # the replay runs that release instead, and `emit-dyn-stmt-error-fresh` allocates
+   # its payload in the body, where the site mints nothing and the body's own release
+   # is what the two routes carry. All three read the mint's ARITY: withholding it
+   # over-frees, which no leak gauge sees and
+   # tests/elle/region-dynamic-emit-statement-uaf.lisp reports.
+   ["emit-dyn-stmt-error-restart"
+    (fn [j]
+      (let [f (fiber/new (fn []
+                           (emit emit-error-sig emit-subject)
+                           9) |:error|)]
+        (fiber/resume f)
+        (fiber/resume f))) 0]
+   ["emit-dyn-stmt-error-fresh"
+    (fn [j]
+      (let [f (fiber/new (fn []
+                           (emit emit-error-sig (string "v" j))
+                           9) |:error|)]
+        (fiber/resume f)
         (fiber/resume f))) 0]  # An emit-raised error's payload keeps
    # every frame-owed release: `(error v)` mints the payload's delivery itself (the
    # `EmitEscape` retain the resumer's release of the resume result consumes), so the

--- a/tests/elle/region-dynamic-emit-statement-uaf.lisp
+++ b/tests/elle/region-dynamic-emit-statement-uaf.lisp
@@ -1,0 +1,324 @@
+(elle/epoch 12)
+# A raised payload's DELIVERY reference is the one the catcher's read consumes, and
+# the site's own retain answers to the continuation past the call — two references,
+# two consumers, wherever the raise leaves the emit PRIMITIVE (docs/impl/region/owner.md
+# § "What yields is the emit OPERATION, not the `Emit` node").
+#
+# A first argument the compiler cannot read as a keyword set falls through to that
+# primitive (docs/signals/emit.md § "Dynamic emit"), so a raise OFF TAIL POSITION is an
+# ordinary native call whose site mints one retain at the payload argument and releases
+# it in the continuation. The signal is a runtime value, so that retain is taken
+# whatever the signal turns out to be — and a terminal `:error` adds the catcher beside
+# the continuation. An `:error` fiber is resumable, so both consumers run: the catcher
+# at the raise, the continuation at a restart's replay. The raise therefore mints the
+# delivery itself at the signal exit and records it, and the site's retain is left to
+# the continuation.
+#
+# The trap: with a single `fiber/resume` the shape reads correct either way. The parked
+# frame never replays, so the site's retain reaches no consumer but the catcher and
+# stands in for the delivery. Only a RESTART brings the second consumer, which is why
+# every witness here resumes twice and control (o) — the same body resumed once —
+# stays clean.
+#
+# The counter-factual the record answers for: a fiber nobody restarts reaches the
+# continuation only through the frames' own release table, so the site's stash must be
+# a recorded value route (docs/impl/region/mechanism.md § "An abandoned frame runs the
+# releases it still owes"). Mint the delivery without recording the route and the same
+# programs strand one region per raise instead — the growth gate at the bottom refuses
+# that trade.
+#
+# Every witness reads its payload after the raise has left the fiber — through the
+# resume result, through `fiber/value`, through the borrow's own holder, and through a
+# container — so an over-free faults at the deref rather than reading stale but mapped
+# bytes. A fresh subject per iteration keeps region ids churning, so a recycled id
+# detonates on its generation stamp.
+#
+# Run under `--trace=guardfree` by the subprocess pin
+# `region_dynamic_emit_statement_uaf` in tests/integration/elle_scripts.rs.
+
+(def sig :error)
+
+# ── (a) a module-level borrow, raised in statement position, then RESTARTED ──
+# Nothing in the body releases `shared`, so the frame's only reference to it is the
+# retain the site minted — and the replayed continuation is what releases that.
+(def shared (string "shared-subject"))
+(defn w-module [i]
+  (let [f (fiber/new (fn ()
+                       (emit sig shared)
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length shared))))))
+
+# ── (b) a captured `let`-local ───────────────────────────────────────────────
+(defn w-local [i]
+  (let [s (string "local" i)]
+    (let [f (fiber/new (fn ()
+                         (emit sig s)
+                         9) |:error|)]
+      (let [v (fiber/resume f)]
+        (let [n (length v)]
+          (try
+            (fiber/resume f)
+            (catch e nil))
+          (%add n (length s)))))))
+
+# ── (c) a captured PARAMETER of the enclosing frame ──────────────────────────
+(defn w-param [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length s))))))
+
+# ── (d) a body-ALLOCATED payload ─────────────────────────────────────────────
+# The body owns a reference of its own here, so the site mints none — what the
+# restart's replay releases is the body's, and the catcher's is the delivery.
+(defn w-owned [i]
+  (let [f (fiber/new (fn ()
+                       (emit sig (string "owned" i))
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length v))))))
+
+# ── (e) the payload read through `fiber/value` after the restart ─────────────
+(defn w-fiber-value [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (fiber/resume f)
+    (let [n (length (fiber/value f))]
+      (try
+        (fiber/resume f)
+        (catch e nil))
+      (%add n (length s)))))
+
+# ── (f) the borrow outlives the fiber in a container ─────────────────────────
+(def @sink @[])
+(defn w-stored [s]
+  (push sink s)
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        n))))
+
+# ── (g) the raise the fiber's mask does NOT catch, then a restart ────────────
+# The signal propagates out of the fiber and the caller's `catch` binds the
+# payload, so the delivery is consumed one frontier further out.
+(defn w-propagated [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) 0)]
+    (let [n (try
+              (fiber/resume f)
+              (catch e (length e)))]
+      (try
+        (fiber/resume f)
+        (catch e nil))
+      (+ n (length s)))))
+
+# ── (h) TWO restarts of one raise ────────────────────────────────────────────
+# The replay runs the continuation's release once; the third resume finds the
+# fiber dead and must not reach it a second time.
+(defn w-twice [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length s))))))
+
+# ── (i) one region named through BOTH arguments ──────────────────────────────
+# The signal and the payload are one value, so the identity gate matches on the
+# payload and the delivery is minted once out of two names for it.
+(defn w-repeat []
+  (let [f (fiber/new (fn ()
+                       (let [t (set :error)]
+                         (emit t t)
+                         9)) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        n))))
+
+# ── controls — remove one ingredient each; correct with no delivery mint ─────
+
+# (j) the LITERAL path, whose `Emit` terminator mints no body reference for a
+# terminal signal at all, so its replayed continuation releases nothing.
+(defn c-literal [s]
+  (let [f (fiber/new (fn ()
+                       (emit :error s)
+                       9) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length s))))))
+
+# (k) TAIL position: the exit consumes the borrowed-argument retain itself and
+# nil-stamps its stash, so the replay finds an immediate there.
+(defn c-tail [s]
+  (let [f (fiber/new (fn () (emit sig s)) |:error|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (try
+          (fiber/resume f)
+          (catch e nil))
+        (%add n (length s))))))
+
+# (l) an immediate payload crosses no region at all.
+(defn c-immediate [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig (length s))
+                       9) |:error|)]
+    (fiber/resume f)
+    (try
+      (fiber/resume f)
+      (catch e nil))
+    (length s)))
+
+# (m) the SUSPENDING twin: the site's retain is the body reference the park owes,
+# and the resume replays the very continuation that releases it — one consumer.
+(defn c-yield [s]
+  (let [f (fiber/new (fn ()
+                       (emit :yield s)
+                       9) |:yield|)]
+    (let [v (fiber/resume f)]
+      (let [n (length v)]
+        (fiber/resume f)
+        (%add n (length s))))))
+
+# (n) the DYNAMIC suspending twin, where the site mints the same retain but the
+# signal resolves to a park rather than a raise.
+(defn c-yield-dyn [s]
+  (let [ysig :yield]
+    (let [f (fiber/new (fn ()
+                         (emit ysig s)
+                         9) |:yield|)]
+      (let [v (fiber/resume f)]
+        (let [n (length v)]
+          (fiber/resume f)
+          (%add n (length s)))))))
+
+# (o) NO restart: the parked frame never replays, so the site's retain reaches
+# only the catcher. This is the shape that reads correct either way.
+(defn c-once [s]
+  (let [f (fiber/new (fn ()
+                       (emit sig s)
+                       9) |:error|)]
+    (let [n (length (fiber/resume f))]
+      (%add n (length s)))))
+
+# ── drive: a fresh subject per iteration; an over-free faults on the read ─────
+
+(defn drive [reps]
+  (var i 0)
+  (var a 0)
+  (var b 0)
+  (var c 0)
+  (var d 0)
+  (var e 0)
+  (var f 0)
+  (var g 0)
+  (var h 0)
+  (var k 0)
+  (var l 0)
+  (var m 0)
+  (var n 0)
+  (var o 0)
+  (var p 0)
+  (var q 0)
+  (while (%lt i reps)
+    (assign a (w-module i))
+    (assign b (w-local i))
+    (assign c (w-param (string "param" i)))
+    (assign d (w-owned i))
+    (assign e (w-fiber-value (string "value" i)))
+    (assign f (w-stored (string "stored" i)))
+    (assign g (w-propagated (string "prop" i)))
+    (assign h (w-twice (string "twice" i)))
+    (assign k (w-repeat))
+    (assign l (c-literal (string "lit" i)))
+    (assign m (c-tail (string "tail" i)))
+    (assign n (c-immediate (string "imm" i)))
+    (assign o (c-yield (string "yield" i)))
+    (assign p (c-yield-dyn (string "ydyn" i)))
+    (assign q (c-once (string "once" i)))
+    # The (f) sink is a module-level container by design: read the stored borrow
+    # back out — it must still be alive — then drain, so the driver's own
+    # retention stays flat.
+    (assert (%gt (length (get sink (%sub (length sink) 1))) 0)
+            "stored borrow freed by the restarted fiber's replay")
+    (assign sink @[])
+    (assign i (%add i 1)))
+  (list a b c d e f g h k l m n o p q))
+
+(let [r (drive 400)]
+  (assert (> (get r 9) 0)
+          "control: literal statement raise mis-read (harness broken)")
+  (assert (> (get r 10) 0) "control: tail raise mis-read")
+  (assert (> (get r 11) 0) "control: immediate payload mis-read")
+  (assert (> (get r 12) 0) "control: literal suspending emit mis-read")
+  (assert (> (get r 13) 0) "control: dynamic suspending emit mis-read")
+  (assert (> (get r 14) 0) "control: unrestarted raise mis-read")
+  (assert (> (get r 0) 0)
+          "statement raise: module-level borrow freed by the restart's replay")
+  (assert (> (get r 1) 0)
+          "statement raise: captured local freed by the restart's replay")
+  (assert (> (get r 2) 0)
+          "statement raise: captured parameter freed by the restart's replay")
+  (assert (> (get r 3) 0)
+          "statement raise: body-allocated payload freed by the restart's replay")
+  (assert (> (get r 4) 0)
+          "statement raise: payload freed under a `fiber/value` read")
+  (assert (> (get r 5) 0)
+          "statement raise: stored borrow freed under the container read")
+  (assert (> (get r 6) 0)
+          "statement raise: propagated payload freed under the catcher")
+  (assert (> (get r 7) 0) "statement raise: payload freed by the second restart")
+  (assert (> (get r 8) 0)
+          "statement raise: two-name payload freed by the restart's replay"))
+
+# The module-level subject must survive every fiber that raised it.
+(assert (%gt (length shared) 0)
+        "module-level borrow freed by a restarted statement-position raise")
+
+# ── the leak face: one delivery per raise, and one consumer per retain ───────
+# The mint answers to the catcher's single release and the site's retain to the
+# continuation — which a fiber nobody restarts reaches only through the frames'
+# own release table. A mint with no such route strands one region per raise.
+(drive 100)
+(let [before (arena/region-count)]
+  (drive 400)
+  (let [growth (%sub (arena/region-count) before)]
+    (assert (%lt growth 40)
+            (string "statement dynamic-emit delivery strands regions: live count "
+                    "grew by " growth " over 400 iterations of fifteen raises "
+                    "each (expected flat)"))))
+
+(println "region-dynamic-emit-statement-uaf: ok")

--- a/tests/elle/region-fiber-abort-delivery-uaf.lisp
+++ b/tests/elle/region-fiber-abort-delivery-uaf.lisp
@@ -133,8 +133,8 @@
 # The fiber holds the very value it is aborted with — handed to it as an owned
 # parameter — so its abandoned frame owes that value a release. With the
 # delivery minted at the injection the frame's reference funds nothing, so the
-# injection records the mint (`Fiber::emit_delivery`) and the abandoned-frame
-# walk stops exempting the payload's region.
+# injection records the mint in the delivery ledger (`Fiber::delivery`) and the
+# abandoned-frame walk stops exempting the payload's region.
 (defn hold-then-yield [q]
   (yield q)
   2)

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -553,6 +553,30 @@ fn region_dynamic_emit_terminal_uaf() {
     );
 }
 
+// Guard — the same raised delivery where the raise leaves the emit PRIMITIVE OFF
+// TAIL POSITION (docs/impl/region/owner.md § "What yields is the emit OPERATION, not
+// the `Emit` node"). There the site takes the retain, so the exit mints the delivery
+// and leaves that retain to the continuation past the call. An `:error` fiber is
+// resumable, so a RESTART replays that continuation: without the mint the replay
+// releases the very reference the catcher already consumed, and every holder that
+// outlives the fiber reads freed memory. Nine witnesses drive one raise each past a
+// restart — a module-level binding, a captured local, a captured parameter, a
+// body-allocated payload, a `fiber/value` read, a container, an uncaught propagation,
+// a second restart, and one region named through both arguments — and read the
+// payload afterwards, so an over-free faults under guardfree. Six controls remove one
+// ingredient each and must stay clean, the sharpest being the same body resumed ONCE:
+// with no replay the site's retain reaches only the catcher, which is why the shape
+// reads correct until a restart claims it twice. A growth gauge refuses the trade in
+// the other direction — a mint whose retain no route reaches strands one region per
+// raise.
+#[test]
+fn region_dynamic_emit_statement_uaf() {
+    run_elle_script_with_args(
+        "region-dynamic-emit-statement-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — a resume value delivered into a frame parked at a suspending PRIMITIVE
 // call carries one owning reference (docs/impl/region/owner.md § "A delivery into
 // a replayed frame carries one owning reference"). The replayed frame re-enters at


### PR DESCRIPTION
A park's delivery accounting lived in three parallel `Fiber` fields — `emit_delivery`, `resume_value_unfunded`, `denial_payload` — each written by its own park shape and cleared by hand at every seam that ends a park. Each new park shape started the discipline from zero, and no mechanism noticed a route that ended a park without consuming its funding.

One record replaces them: `Fiber::delivery` (`value/fiber/delivery.rs`), a `Delivery` whose fields are private to its module. A park names its funding through a method or not at all: `park_primitive`, `park_denial`, `record_mint`, and `install_abort` write; `take_resume_funding` (the delivery funnel, shared by the VM and WASM tiers), `take_bodyless` (consumed by `release_displaced_denial_payload` at every displacing install — taking is the receipt), `displace`, and `discharge` consume; `mint_names` answers the abandoned-frame walk and the parked frame's discharge through an identity gate. A park write asserts (debug builds) that the previous park's funding was consumed, so a route that skips every consume seam panics at the next park instead of leaking one region per cycle.

The assert immediately named such a route: a host that drives a thunk on the current fiber (`eval`, `import`, `arena/allocs`, `compile/run-on`, the root driver) and refuses a suspend-class signal it cannot host left the dead park's funding standing, so the fiber's next resume minted a `ResumeDelivery` retain no consumer ever releases. All six hosts now cross one seam, `VM::abandon_hosted_park`, which discharges the ledger; the squelch/abort discard chokepoint and `take_parked_state` discharge the same way, so a killed fiber's later (invalid) resume mints nothing. The refused park's stranded escape retain and abandoned chain remain #894's scope (noted there).

Pinned by `value::fiber::delivery::tests` (each transition, the displace/discharge split, the double-park panic — each red before its mechanism landed), `vm::signal::tests` (the refused-host seam and its error-exit counter-factual, the raised-delivery identity gate through the ledger), and the previously wedge-vulnerable `timeout_capture` integration tests. Full smoke (VM + JIT corpus, doctests, embedding), the full unit and integration suites, clippy, crosscheck, and fmt are green on this branch; the fiber/emit/denial corpus subset — including this branch's `region-denial-park` and `region-dynamic-emit-statement-uaf` pins — is panic-clean under a debug build with the assert armed.