### PR TITLE
pipeline: the import projection probe compiles in the caller's symbol table

### DIFF
--- a/src/hir/analyze/call.rs
+++ b/src/hir/analyze/call.rs
@@ -120,7 +120,7 @@ impl<'a> Analyzer<'a> {
                             // analysis — the import keeps the conservative
                             // `Polymorphic` projection.
                             self.last_import_projection = self.import_ctx.and_then(|ptr| unsafe {
-                                (*ptr).get_or_compile_projection(&resolved)
+                                (*ptr).get_or_compile_projection(&resolved, self.symbols)
                             });
                         }
                     }

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -267,7 +267,8 @@ impl CompileCtx {
     /// on the shared expander, and its quoted literals bind to whichever table
     /// compiled it. A throwaway table here would cache transformers carrying ids
     /// no later expansion can read (pinned by
-    /// `import_projection_probe_interns_into_the_callers_symbol_table`).
+    /// `import_projection_probe_interns_into_the_callers_symbol_table` and
+    /// `each_keeps_its_collection_when_an_import_probe_expanded_the_macro_first`).
     pub fn get_or_compile_projection(
         &mut self,
         resolved_path: &str,

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -266,9 +266,8 @@ impl CompileCtx {
     /// macros: a transformer compiles lazily on its first expansion and caches
     /// on the shared expander, and its quoted literals bind to whichever table
     /// compiled it. A throwaway table here would cache transformers carrying ids
-    /// no later expansion can read — `each` compares
-    /// `(= (syntax->datum iter-or-in) 'in)`, and a stale `'in` silently drops
-    /// the `in` form's collection argument.
+    /// no later expansion can read (pinned by
+    /// `import_projection_probe_interns_into_the_callers_symbol_table`).
     pub fn get_or_compile_projection(
         &mut self,
         resolved_path: &str,

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -257,21 +257,29 @@ impl CompileCtx {
 
     /// Look up or compute the signal projection for an imported file.
     ///
-    /// On a miss, compiles the file (with a throwaway `SymbolTable`, in THIS
-    /// instance's context) and caches the projection from the resulting
+    /// On a miss, compiles the file in the caller's `SymbolTable` and this
+    /// instance's context, then caches the projection from the resulting
     /// bytecode. Returns `None` if the file's return value is not a projectable
     /// struct (cached as `None` to avoid recompiling).
+    ///
+    /// The table is the caller's, not a fresh one, because this compile expands
+    /// macros: a transformer compiles lazily on its first expansion and caches
+    /// on the shared expander, and its quoted literals bind to whichever table
+    /// compiled it. A throwaway table here would cache transformers carrying ids
+    /// no later expansion can read — `each` compares
+    /// `(= (syntax->datum iter-or-in) 'in)`, and a stale `'in` silently drops
+    /// the `in` form's collection argument.
     pub fn get_or_compile_projection(
         &mut self,
         resolved_path: &str,
+        symbols: &mut SymbolTable,
     ) -> Option<HashMap<String, Signal>> {
         if let Some(proj) = self.projections.get(resolved_path) {
             return proj.clone();
         }
 
         let source = std::fs::read_to_string(resolved_path).ok()?;
-        let mut symbols = SymbolTable::new();
-        let projection = super::compile::compile_file(&source, &mut symbols, self, resolved_path)
+        let projection = super::compile::compile_file(&source, symbols, self, resolved_path)
             .ok()
             .and_then(|result| result.bytecode.signal_projection);
 

--- a/tests/integration/projection.rs
+++ b/tests/integration/projection.rs
@@ -242,3 +242,54 @@ fn test_projection_yields_function() {
         ":producer should be yields"
     );
 }
+
+// ============================================================================
+// 4. THE PROBE COMPILES IN THE CALLER'S SYMBOL TABLE
+// ============================================================================
+
+#[test]
+fn import_projection_probe_interns_into_the_callers_symbol_table() {
+    // `((import "…"))` makes the analyzer compile the imported file to read its
+    // signal projection (src/hir/analyze/call.rs § "Import projection
+    // detection"). Which symbol table that compile runs in is not an internal
+    // detail: macro transformers compile lazily on first expansion and cache on
+    // the shared expander, and a transformer's quoted literals bind to the table
+    // that compiled it. A probe running in a throwaway table therefore caches
+    // transformers whose ids mean nothing in the instance's table, and a later
+    // expansion comparing against an instance-table symbol takes the wrong
+    // branch — `each`'s `(= (syntax->datum iter-or-in) 'in)` is the shape that
+    // bites.
+    //
+    // The caller's table learning the module's quoted symbol is the observable
+    // form of the invariant: `compile_file` never executes the import, so the
+    // probe is the only thing that could have interned it.
+    let dir = std::env::temp_dir().join(format!(
+        "elle-projection-probe-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let module = dir.join("probe_module.lisp");
+    // A quoted symbol is runtime data, so compiling this file must intern
+    // `probe-only-marker` — unlike a binding name, which analysis resolves into
+    // the binding arena instead.
+    std::fs::write(
+        &module,
+        "(fn [] (def marker 'probe-only-marker) {:marker marker})\n",
+    )
+    .expect("write module");
+
+    let mut symbols = SymbolTable::new();
+    let source = format!("(def m ((import \"{}\")))\nm\n", module.display());
+    let _ = compile_file(&source, &mut symbols, "<probe-main>");
+
+    let learned = symbols.get("probe-only-marker");
+    std::fs::remove_dir_all(&dir).ok();
+
+    assert!(
+        learned.is_some(),
+        "the import projection probe must compile in the caller's symbol table; \
+         compiling in a throwaway one leaves the instance's table without the \
+         module's symbols and caches transformers bound to a table nothing else \
+         can read"
+    );
+}

--- a/tests/integration/projection.rs
+++ b/tests/integration/projection.rs
@@ -277,10 +277,9 @@ fn import_projection_probe_interns_into_the_callers_symbol_table() {
 
     let mut symbols = SymbolTable::new();
     let source = format!("(def m ((import \"{}\")))\nm\n", module.display());
-    let _ = compile_file(&source, &mut symbols, "<probe-main>");
+    compile_file(&source, &mut symbols, "<probe-main>").expect("main file compiles");
 
     let learned = symbols.get("probe-only-marker");
-    std::fs::remove_dir_all(&dir).ok();
 
     assert!(
         learned.is_some(),

--- a/tests/integration/projection.rs
+++ b/tests/integration/projection.rs
@@ -289,3 +289,78 @@ fn import_projection_probe_interns_into_the_callers_symbol_table() {
          can read"
     );
 }
+
+#[test]
+fn each_keeps_its_collection_when_an_import_probe_expanded_the_macro_first() {
+    // The trap: `each` decides whether it was written in `in` form with
+    // `(= (syntax->datum iter-or-in) 'in)` (src/prelude.lisp § each). That `'in`
+    // is a quoted literal in the transformer's own bytecode, so it carries the
+    // `SymbolId` of whichever table compiled the transformer — and a transformer
+    // compiles once, lazily, on its first expansion, then caches on the shared
+    // expander (`ensure_transformer`, src/syntax/expand/macro_expand.rs). The
+    // first expansion in an instance therefore fixes the id every later
+    // expansion compares against.
+    //
+    // Here the import projection probe expands `each` first: this runtime loads
+    // no stdlib, so nothing has warmed the transformer against the instance's
+    // table, and compiling the main file runs the probe over a module that uses
+    // `each`. The second compile, on the same context, is the one that must
+    // still read its `in`.
+    //
+    // The counter-factual: with the probe compiling in a throwaway table, the
+    // comparison against the instance table's `in` is false, so `each` takes the
+    // symbol `in` itself as the collection and shifts `'(1 2 3)` into the body —
+    // the second compile then fails with `undefined variable: in`. The assertion
+    // names the elements the loop visited rather than settling for a successful
+    // compile, because the same shift is silent wherever `in` is bound.
+    //
+    // Both files define `pair?` themselves: `each`'s `:list` arm calls it, it is
+    // the one name in the expansion that is not a primitive, and no stdlib is
+    // loaded here. Prelude template symbols carry `ScopeId(0)`, so this
+    // file-scope definition is what the expansion resolves.
+    const PAIR_P: &str = "(defn pair? [x] (%pair? x))\n";
+
+    let tmp = tempfile::tempdir().expect("scratch dir");
+    let module = tmp.path().join("each_module.lisp");
+    std::fs::write(
+        &module,
+        format!(
+            "{PAIR_P}\
+             (fn []\n  \
+             {{:visit (fn [xs]\n    \
+             (def @seen ())\n    \
+             (each x in xs (assign seen (%pair x seen)))\n    \
+             seen)}})\n"
+        ),
+    )
+    .expect("write module");
+
+    let mut rt = elle::runtime::Runtime::without_stdlib();
+    let (vm, symbols, cctx) = rt.parts();
+
+    let main = format!("(def m ((import \"{}\")))\nm\n", module.display());
+    elle::pipeline::compile_file(&main, symbols, cctx, "<each-probe-main>")
+        .expect("main file compiles");
+
+    let visited = elle::eval_all(
+        &format!(
+            "{PAIR_P}\
+             (def @seen ())\n\
+             (each x in '(1 2 3) (assign seen (%pair x seen)))\n\
+             seen\n"
+        ),
+        symbols,
+        vm,
+        cctx,
+        "<each-after-probe>",
+    );
+
+    assert_eq!(
+        visited.as_ref().map(|v| v.to_string()).as_deref(),
+        Ok("(3 2 1)"),
+        "`each` must still read its `in` form after the import projection probe \
+         expanded the macro; a probe in a throwaway table caches a transformer \
+         whose quoted `'in` no instance-table expansion can match, and the \
+         collection is dropped from the loop"
+    );
+}

--- a/tests/integration/projection.rs
+++ b/tests/integration/projection.rs
@@ -263,11 +263,8 @@ fn import_projection_probe_interns_into_the_callers_symbol_table() {
     // The caller's table learning the module's quoted symbol is the observable
     // form of the invariant: `compile_file` never executes the import, so the
     // probe is the only thing that could have interned it.
-    let dir = std::env::temp_dir().join(format!(
-        "elle-projection-probe-{}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let tmp = tempfile::tempdir().expect("scratch dir");
+    let dir = tmp.path();
     let module = dir.join("probe_module.lisp");
     // A quoted symbol is runtime data, so compiling this file must intern
     // `probe-only-marker` — unlike a binding name, which analysis resolves into


### PR DESCRIPTION
## What was wrong

`((import "literal"))` makes the analyzer compile the imported file to read its
signal projection (src/hir/analyze/call.rs § "Import projection detection").
That compile ran in a fresh `SymbolTable`.

Which table it runs in is not an internal detail. The compile expands macros; a
transformer compiles lazily on its first expansion and caches on the shared
expander; the transformer's quoted literals bind to whichever table compiled it.
A probe in a throwaway table caches transformers carrying ids no later expansion
can read. `each` decides its `in` form with
`(= (syntax->datum iter-or-in) 'in)`, and against a stale `'in` that comparison
is false — the collection argument is dropped and the body shifts by one form.

The table also decides what two shared registries record. Every compile threads
the instance's `DispatchWrapperRegistry` and `FnInlineRegistry`
(`compile_file_frontend` → `compile_registries_mut`), and both key on
`SymbolId`. The old probe wrote the imported module's entries into those
instance registries under throwaway-table ids, where they collide with real
instance ids.

## What the change does

Threads the caller's `SymbolTable` through `get_or_compile_projection` instead
of allocating a fresh one. One table then serves the probe, the two registries,
and every later expansion.

## Tests

`import_projection_probe_interns_into_the_callers_symbol_table` pins the
invariant. `compile_file` never executes an import, so the probe is the only
thing that can intern a symbol quoted in the module; the test asserts the
caller's table holds it. Against the code before this change it does not.

The test needs no disk cache to reach the fault. `CompileCtx::new()` loads the
prelude in a throwaway table it then drops, so a fresh context already has no
transformer warmed against an instance table — which is the state the probe
would meet.

`each_keeps_its_collection_when_an_import_probe_expanded_the_macro_first` pins
the defect the invariant prevents. One `Runtime::without_stdlib()` compiles a
main file whose probe imports an `each`-using module, then evaluates
`(each x in '(1 2 3) …)` on the same context and asserts which elements the loop
visited. Loading no stdlib is what gives the probe the first `each` expansion: a
stdlib-loaded runtime hides the fault, because the stdlib compile warms the
transformer against the instance table first. Against the code before this
change the second compile fails with `undefined variable: in` — `each` read the
`in` symbol itself as the collection.

`cargo test --test lib`: 1232 passed, 0 failed. `cargo test -p elle --lib`:
2272 passed, 0 failed. `make smoke`: all smoke tests passed. `cargo fmt
--check` and `cargo clippy --workspace --all-targets` clean.
