### PR TITLE
oracle: extract the estimator into a shared library, and split the io dimension into plumb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,16 @@ define RUN_ORACLE
 		|| { echo "FAILED: oracle.lisp ($(1))"; exit 1; }
 endef
 
+# The io leak dashboard rides the same shape: pulled out of every batch, run
+# under its own timed budget (io probes cost wall-clock; read the number from
+# a timed run, as with ORACLE_TIMEOUT above).
+PLUMB_TIMEOUT ?= 60s
+PLUMB_FILE    := tests/elle/plumb.lisp
+define RUN_PLUMB
+	@timeout $(PLUMB_TIMEOUT) $(ELLE) $(1) $(PLUMB_FILE) \
+		|| { echo "FAILED: plumb.lisp ($(1))"; exit 1; }
+endef
+
 # One corpus pass with ONE PROCESS PER FILE, under a wall-clock TIMEOUT. Each
 # file starts, runs as a whole program, and exits — the shape `elle test` never
 # takes, and the only one that covers program teardown and process-global modes.
@@ -57,7 +67,7 @@ define RUN_PER_FILE
 	@mkdir -p target
 	@rm -f target/smoke-$(4).joblog
 	@printf '%s\n' tests/elle/*.lisp \
-		| grep -v $(1) | grep -v $(ORACLE_FILE) \
+		| grep -v $(1) | grep -v $(ORACLE_FILE) | grep -v $(PLUMB_FILE) \
 		| parallel -j $(JOBS) --tag --joblog target/smoke-$(4).joblog \
 			'timeout $(TIMEOUT) $(ELLE) $(2) {}' \
 		|| { \
@@ -172,7 +182,7 @@ fmt-check: elle  ## Check Elle formatting (exit 1 on diff)
 # the worker's all-blocked signal mask across fork/exec, so SIGTERM never landed
 # and subprocess/wait wedged. Fixed by resetting the child's mask in pre_exec;
 # see src/io/request.rs reset_child_signals + docs/posix-signals.md.)
-ELLE_TEST_SKIP := $(ORACLE_FILE)
+ELLE_TEST_SKIP := $(ORACLE_FILE) $(PLUMB_FILE)
 
 # Per-pass skip lists for the DIRECT-RUN tier targets only (smoke-vm/jit/noffi).
 # jit-rejections    — requires JIT active (tests rejection tracking)
@@ -242,6 +252,8 @@ define RUN_CORPUS
 		|| { echo "FAILED: elle test — a batch failed or was killed; query the session DB (docs/testing.md § Reading a run)"; exit 1; }
 	$(call RUN_ORACLE,--jit=off)
 	$(call RUN_ORACLE,--jit=eager)
+	$(call RUN_PLUMB,--jit=off)
+	$(call RUN_PLUMB,--jit=eager)
 endef
 
 smoke-elle: elle  ## Run the whole corpus through `elle test` (vm + jit + divergence)
@@ -252,6 +264,7 @@ smoke-vm: elle
 	@echo "=== elle tests (VM, no JIT) ==="
 	$(call RUN_PER_FILE,$(ELLE_SKIP_VM),--jit=off --mlir=off,VM-only pass (no JIT),vm)
 	$(call RUN_ORACLE,--jit=off --mlir=off)
+	$(call RUN_PLUMB,--jit=off --mlir=off)
 
 elle-noffi:           ## Build elle with no features (for smoke-noffi)
 	@echo "=== build elle with no features ==="
@@ -261,11 +274,13 @@ smoke-noffi: elle-noffi
 	@echo "=== elle tests (VM, no features) ==="
 	$(call RUN_PER_FILE,$(ELLE_SKIP_VM) $(ELLE_SKIP_FFI),--jit=off,VM-only pass (no features),noffi)
 	$(call RUN_ORACLE,--jit=off)
+	$(call RUN_PLUMB,--jit=off)
 
 smoke-jit: elle
 	@echo "=== elle tests (eager JIT) ==="
 	$(call RUN_PER_FILE,$(ELLE_SKIP_JIT),--jit=eager,JIT pass (eager),jit)
 	$(call RUN_ORACLE,--jit=eager)
+	$(call RUN_PLUMB,--jit=eager)
 
 # The thread-pool I/O backend, on a Linux box. `create_platform_backend` picks
 # the ring here and the pool on every other platform, so a Linux-only gate runs
@@ -290,9 +305,11 @@ smoke-nouring: elle  ## Corpus per-file passes on the thread-pool backend (what 
 	@echo "=== elle tests (thread-pool backend, VM) ==="
 	$(call RUN_PER_FILE,$(ELLE_SKIP_VM),--no-uring --jit=off --mlir=off,thread-pool VM pass,nouring-vm)
 	$(call RUN_ORACLE,--no-uring --jit=off --mlir=off)
+	$(call RUN_PLUMB,--no-uring --jit=off --mlir=off)
 	@echo "=== elle tests (thread-pool backend, eager JIT) ==="
 	$(call RUN_PER_FILE,$(ELLE_SKIP_JIT),--no-uring --jit=eager,thread-pool JIT pass,nouring-jit)
 	$(call RUN_ORACLE,--no-uring --jit=eager)
+	$(call RUN_PLUMB,--no-uring --jit=eager)
 
 elle-mlir:   ## Build elle with MLIR support (for smoke-mlir)
 	@echo "=== build elle with MLIR ==="
@@ -303,11 +320,12 @@ smoke-mlir: elle-mlir  ## Corpus via elle test (+ mlir-cpu tier) + whole-file --
 	$(RUN_CORPUS)
 	@echo "=== elle tests (eager MLIR, whole-file) ==="
 	@printf '%s\n' tests/elle/*.lisp | \
-		grep -v $(ORACLE_FILE) | \
+		grep -v $(ORACLE_FILE) | grep -v $(PLUMB_FILE) | \
 		parallel -j $(JOBS) --tag \
 			'timeout $(TIMEOUT) $(ELLE) --mlir=eager {}' \
 		|| { echo "FAILED: elle tests MLIR pass (eager)"; exit 1; }
 	$(call RUN_ORACLE,--mlir=eager)
+	$(call RUN_PLUMB,--mlir=eager)
 
 elle-wasm:   ## Build elle with WASM support (for check-wasm/smoke-wasm)
 	@echo "=== build elle with WASM ==="

--- a/tests/elle/lib/estimator.lisp
+++ b/tests/elle/lib/estimator.lisp
@@ -1,0 +1,342 @@
+(elle/epoch 12)
+# estimator.lisp — the shared measurement core and ledger for the leak
+# dashboards (oracle.lisp, plumb.lisp). Each dashboard splices this file with
+# the top-level `include-file` directive (docs/modules.md § "Compile-Time
+# Inclusion"), so every dashboard compiles its own copy: fresh ledger state
+# per process — which is why each must run its own gauge-live discriminators
+# (oracle.lisp § "The gauge-live discriminator"); a gauge is proven live per
+# process, never per library — and the `check` macro crosses, splicing
+# preceding expansion. This directory is outside the corpus glob
+# (`tests/elle/*.lisp`), so the library is never run as a test itself.
+
+# ── Empirical-Bernstein half-width ────────────────────────────────────
+# Total error budget δ, spent across an unbounded number of peeks via a per-m
+# union bound: δ_m = δ·(6/π²)/m², so Σ_m δ_m ≤ δ and the interval is valid at
+# EVERY block boundary (no optional-stopping inflation — the classic trap of
+# "peek at the CI and stop when it looks tight").
+(def EB-DELTA 0.000001)
+# 1e-6 — two-sided, anytime-valid
+(def INV-PI2-6 0.6079271018540267)
+# 6/π², the union-bound normalizer
+
+(defn eb-halfwidth [m var rng]
+  "Anytime-valid empirical-Bernstein half-width on the per-op-rate mean after m
+   block samples with sample variance VAR and observed range RNG. The linear
+   term uses the OBSERVED range, so a deterministic leak (rng 0, var 0) has
+   half-width 0 and converges at the floor. Maurer–Pontil form; instrument
+   only (the soundness oracle is --trace=guardfree)."
+  (if (< m 2)
+    (math/inf)
+    (let [dm (/ (* EB-DELTA INV-PI2-6) (* m m))
+          l (math/log (/ 3.0 dm))]
+      (+ (math/sqrt (/ (* 2.0 (* var l)) m)) (/ (* 3.0 (* rng l)) m)))))
+
+# ── The gauges ────────────────────────────────────────────────────────
+(defn count-gauge []
+  (arena/count))
+# object-count gauge
+(defn bytes-gauge []
+  (arena/bytes))
+# bump-arena bytes gauge
+(defn region-gauge []
+  (arena/region-count))
+# live-region-entry gauge — every active RegionEntry counts, a pages-less owner
+# node included. What the object count cannot see is a ZERO-OBJECT entry: an
+# owner node (docs/impl/region/owner.md § "Owner nodes"), or a region emptied
+# of objects but pinned by an unbalanced count.
+(defn ids-gauge []
+  (arena/region-ids))
+# physical-id issuance gauge — `next_physical`, the dimension every other gauge
+# is blind to (docs/impl/region/diagnostics.md § the `arena/region-ids` bullet).
+# A physical id minted for a call whose callee allocates nothing never becomes a
+# live region, so it holds no object, no page, no bytes and no reference count,
+# and `count-gauge`/`bytes-gauge`/`region-gauge` all read flat while it strands.
+# A mint that finds an id on the free list leaves `next_physical` alone, so a
+# steady-state loop holds this gauge flat and every unit of rate is an id that
+# did not come back. `arena/region-table` is NOT a second gauge here: it is sized
+# by the largest id ever made live from EITHER id source — the per-heap counter
+# this gauge reads, and the raw static-slot ids whose range sits far above it —
+# so its high-water mark is already past anything a loop driving the counter can
+# reach, and it cannot move for any probe shape. An unmovable gauge paints every
+# verdict green, which is what the discriminator discipline exists to refuse.
+
+# ── The sequential estimator (general core) ───────────────────────────
+# RUN-BLOCK is (fn [b]) that performs b ops on the heap; GAUGE is (fn []) that
+# returns the heap measure (object count or bytes). Parameterizing both lets one
+# estimator serve every probe shape: a while-loop of thunks, a tail-recursion, a
+# fiber driven by external resumes, and a bytes gauge — the per-op rate is
+# (Δgauge)/b per block regardless of HOW the b ops ran.
+(defn measure-core [label run-block gauge block minb maxb epsilon tau]
+  "Adaptive empirical-Bernstein leak-rate estimator. Returns a struct with the
+   measured :rate, :half (half-width), :blocks, :ops, and a :verdict:
+     :closed       — rate + half < TAU   (reclaimed / bounded)
+     :open         — rate - half > TAU   (leaking at ≥ TAU per op)
+     :inconclusive — the interval straddles TAU.
+   The first block is warmup (discarded — it carries the one-time intercept)."
+  # every caller is in another compile unit, so no call-site param join can
+  # prove these; the allocation-free diverging guards do.
+  (when (%not (%int? block)) (error :block-not-int))
+  (when (%not (%int? minb)) (error :minb-not-int))
+  (when (%not (%int? maxb)) (error :maxb-not-int))
+  (run-block block)  # warmup block, discarded
+  (def @m 0)
+  (def @mean 0.0)
+  (def @m2 0.0)
+  (def @lo (math/inf))
+  (def @hi (math/-inf))
+  (def @half (math/inf))
+  (def @blk 0)
+  (while (and (%lt blk maxb) (or (%lt blk minb) (not (< half epsilon))))
+    (let [before (gauge)]
+      (run-block block)
+      # GAUGE is a closure VALUE, so its results are untyped; the diverging
+      # %int? guards prove them for the %sub operand contract. Single-opcode
+      # predicates, placed after BOTH reads — nothing they do can land inside
+      # the [before, after] measurement window.
+      (let [after (gauge)]
+        (when (%not (%int? before)) (error :gauge-not-integer))
+        (when (%not (%int? after)) (error :gauge-not-integer))
+        (let [net (%sub after before)
+              x (/ (float net) (float block))]
+          (assign m (%add m 1))
+          (let [delta (- x mean)]
+            (assign mean (+ mean (/ delta m)))
+            (assign m2 (+ m2 (* delta (- x mean)))))  # Welford: uses updated mean
+          (when (< x lo) (assign lo x))
+          (when (> x hi) (assign hi x))
+          (assign
+            half
+            (eb-halfwidth m (if (< m 2) 0.0 (/ m2 (- m 1))) (- hi lo))))))
+    (assign blk (%add blk 1)))
+  (let [verdict (cond
+                  (< (+ mean half) tau) :closed
+                  (> (- mean half) tau) :open
+                  :inconclusive)]
+    {:label label
+     :rate mean
+     :half half
+     :blocks blk
+     :ops (%mul blk block)
+     :verdict verdict}))
+
+(defn run-thunk-block [probe b]
+  "Run PROBE b times, passing the iteration index — the run-block for direct-loop
+   probes. PROBE is (fn [j]): j varies the input so a body cannot constant-fold,
+   faithful to the originals' use of the loop variable i."
+  # b arrives through a closure value (untyped); the allocation-free diverging
+  # guard proves it for the loop's %lt. PROBE is a closure, so a blanket
+  # (numeric!) would be wrong here.
+  (when (%not (%int? b)) (error :block-not-int))
+  (def @j 0)
+  (while (%lt j b)
+    (probe j)
+    (assign j (%add j 1))))
+
+(defn stmt-run [thunk]
+  "Run THUNK b times as a discarded STATEMENT (non-tail) — the while-loop shape
+   a per-call leak needs to surface; a thunk wrapper's return convention would
+   reclaim the discarded-statement over-keep on its own."
+  (fn [b]
+    (when (%not (%int? b)) (error :block-not-int))
+    (def @i 0)
+    (while (%lt i b)
+      (thunk)
+      (assign i (%add i 1)))))
+
+(defn measure [label probe block minb maxb epsilon tau]
+  "Direct-loop wrapper: PROBE is a per-op thunk, gauge is the object count."
+  (measure-core label (fn [b] (run-thunk-block probe b)) count-gauge block minb
+                maxb epsilon tau))
+
+# ── B-invariance: the instrument's second self-test ───────────────────
+# A measured rate is a true PER-OP rate only if it is invariant to the block
+# size B. If the gauge accumulates a fixed constant per BLOCK (a scheduler pump
+# allocating once per batch, say), then net/B = true_rate + C/B, which SHIFTS
+# with B — a confidently-wrong number. So a reported leak rate is measured at
+# two block sizes (b and 2b) and the intervals must overlap; if they do not,
+# the rate is not a per-op rate and the verdict is :contaminated, NOT a number.
+# This is the peer of the gauge-live discriminator: that proves the gauge
+# moves, this proves the rate means what it claims.
+(defn agree? [a b]
+  "Do two measurements' rate intervals overlap (a consistent per-op rate)?"
+  (not (or (< (+ (get a :rate) (get a :half)) (- (get b :rate) (get b :half)))
+           (< (+ (get b :rate) (get b :half)) (- (get a :rate) (get a :half))))))
+
+(defn measure-stable [label probe b minb maxb epsilon tau]
+  "Measure PROBE at block sizes b and 2b and cross-check B-invariance. Returns
+   the finer (larger-B) measurement, carrying :alt-rate (the rate at b) and a
+   :verdict overridden to :contaminated when the two intervals do not overlap."
+  (when (%not (%int? b)) (error :block-not-int))
+  (let [a (measure label probe b minb maxb epsilon tau)
+        c (measure label probe (%mul 2 b) minb maxb epsilon tau)]
+    (put (put c :alt-rate (get a :rate))
+         :verdict (if (agree? a c) (get c :verdict) :contaminated))))
+
+# ── The two-gauge reading — one drive, one verdict per (probe, gauge) ─
+# Both gauges sample around the SAME blocks, so the two verdicts price the same
+# ops and the second reading adds two primitive calls per block, never a second
+# run of the probe. Both gauges are Immediate, so one gauge's read inside the
+# other's [before, after] window moves nothing. Each gauge keeps its own
+# estimator state, epsilon, and tau, and blocks continue until BOTH half-widths
+# are under their own epsilon (bounded by maxb); each verdict comes from its
+# own gauge's interval. δ is spent once per gauge per measurement — at 1e-6 the
+# union over a whole dashboard run stays below 2e-4.
+(defn measure-2 [label run-block ga ea ta suffix gb eb tb block minb maxb]
+  "Drive RUN-BLOCK once per block, sampling gauges GA and GB before and after;
+   return [result-a result-b]. Result b is labelled label@SUFFIX — a full label
+   of its own everywhere (`by-design`, `declare-root`, the pins), so each
+   dimension is independently a closed control or a declared defect."
+  (when (%not (%int? block)) (error :block-not-int))
+  (when (%not (%int? minb)) (error :minb-not-int))
+  (when (%not (%int? maxb)) (error :maxb-not-int))
+  (run-block block)  # warmup block, discarded
+  (def @ma 0)
+  (def @meana 0.0)
+  (def @m2a 0.0)
+  (def @loa (math/inf))
+  (def @hia (math/-inf))
+  (def @halfa (math/inf))
+  (def @mb 0)
+  (def @meanb 0.0)
+  (def @m2b 0.0)
+  (def @lob (math/inf))
+  (def @hib (math/-inf))
+  (def @halfb (math/inf))
+  (def @blk 0)
+  (while (and (%lt blk maxb)
+              (or (%lt blk minb) (not (and (< halfa ea) (< halfb eb)))))
+    (let [before-a (ga)
+          before-b (gb)]
+      (run-block block)
+      (let [after-a (ga)
+            after-b (gb)]
+        # gauge results arrive through closure values (untyped); the diverging
+        # %int? guards prove them for %sub, placed after ALL FOUR reads so
+        # nothing they do can land inside either measurement window.
+        (when (%not (%int? before-a)) (error :gauge-not-integer))
+        (when (%not (%int? before-b)) (error :gauge-not-integer))
+        (when (%not (%int? after-a)) (error :gauge-not-integer))
+        (when (%not (%int? after-b)) (error :gauge-not-integer))
+        (let [xa (/ (float (%sub after-a before-a)) (float block))
+              xb (/ (float (%sub after-b before-b)) (float block))]
+          (assign ma (%add ma 1))
+          (let [da (- xa meana)]
+            (assign meana (+ meana (/ da ma)))
+            (assign m2a (+ m2a (* da (- xa meana)))))
+          (when (< xa loa) (assign loa xa))
+          (when (> xa hia) (assign hia xa))
+          (assign
+            halfa
+            (eb-halfwidth ma (if (< ma 2) 0.0 (/ m2a (- ma 1))) (- hia loa)))
+          (assign mb (%add mb 1))
+          (let [db (- xb meanb)]
+            (assign meanb (+ meanb (/ db mb)))
+            (assign m2b (+ m2b (* db (- xb meanb)))))
+          (when (< xb lob) (assign lob xb))
+          (when (> xb hib) (assign hib xb))
+          (assign
+            halfb
+            (eb-halfwidth mb (if (< mb 2) 0.0 (/ m2b (- mb 1))) (- hib lob))))))
+    (assign blk (%add blk 1)))
+  [{:label label
+    :rate meana
+    :half halfa
+    :blocks blk
+    :ops (%mul blk block)
+    :verdict (cond
+               (< (+ meana halfa) ta) :closed
+               (> (- meana halfa) ta) :open
+               :inconclusive)}
+   {:label (string label "@" suffix)
+    :rate meanb
+    :half halfb
+    :blocks blk
+    :ops (%mul blk block)
+    :verdict (cond
+               (< (+ meanb halfb) tb) :closed
+               (> (- meanb halfb) tb) :open
+               :inconclusive)}])
+
+# ── The ledger ────────────────────────────────────────────────────────
+# The failure-accumulating runner. Each (check …) evaluates its body under
+# protect and RECORDS a blown assertion instead of aborting the file, so one
+# red probe never masks the rest; (report) at the end re-raises ONE assertion
+# naming every failure (non-zero exit).
+(def @failures @[])
+(defn fail! [msg]
+  (push failures msg))
+(defmacro check (& body)
+  `(let [[ok? v] (protect ,;body)]
+     (unless ok?
+       (fail! (if (struct? v) (get v :message) (string v))))))
+(defn report []
+  (assert (= (length failures) 0)
+          (string (length failures) " probe(s) failed:\n  "
+                  (string/join failures "\n  "))))
+
+# The defect / by-design split. The dashboard populates `by-design` (its fixed
+# growth set) and calls `declare-root` for its open probes; `classify` folds
+# each measured verdict into the split accumulators, and `stats` hands them
+# back for the headline and the completeness gates. A by-design open probe
+# DISPLAYS :growth so `grep -c '^  open'` counts defects alone; the measured
+# :verdict is untouched, so gates that read it are unaffected.
+(def @by-design @{})
+(def @root-of @{})
+(defn declare-root [root labels]
+  (each l in labels
+    (put root-of l root)))
+(def @n-defects 0)
+(def @n-by-design 0)
+(def @roots-seen @{})
+(def @unclassified @[])
+(defn classify [label verdict]
+  "Fold one probe's MEASURED verdict into the split accumulators and return its
+   DISPLAY verdict. A by-design open probe shows :growth (tallied by-design); a
+   classified defect shows :open (tallied, its root recorded); an open probe in
+   NEITHER table shows :open and is recorded unclassified — the completeness gate
+   fails on it. :closed / :inconclusive pass through untallied."
+  (if (not= verdict :open)
+    verdict
+    (if (get by-design label)
+      (begin
+        (assign n-by-design (%add n-by-design 1))
+        :growth)
+      (begin
+        (assign n-defects (%add n-defects 1))
+        (let [root (get root-of label)]
+          (if (nil? root) (push unclassified label) (put roots-seen root true)))
+        :open))))
+
+(defn show [r]
+  "Print one measured class as a dashboard line."
+  (let [alt (get r :alt-rate)]
+    (println "  " (classify (get r :label) (get r :verdict)) "  " (get r :label)
+             ": rate=" (get r :rate) " ±" (get r :half)
+             (if (nil? alt) "" (string " [B-check " alt "]")) "  (" (get r :ops)
+             " ops / " (get r :blocks) " blocks)")))
+
+# A pinned rate is an exact number (matched within ±0.5 — integer resolution on
+# the real-valued estimate) or a [lo hi] inclusive range (for the rare shape
+# whose true rate genuinely spans across tiers).
+(defn match-rate? [got want]
+  (if (array? want)
+    (and (not (< got (get want 0))) (not (< (get want 1) got)))
+    (and (< (- got want) 0.5) (< (- want got) 0.5))))
+
+(defn pin [r want]
+  "The single assertion shape for every class — table-driven or bespoke.
+   Shrink-only: a fix LOWERS the pin."
+  (show r)
+  (let [[ok? v] (protect (assert (match-rate? (get r :rate) want)
+                                 (string (get r :label) ": pinned " want
+                                 ", measured " (get r :rate) " ("
+                                 (get r :verdict) ") — shrink-only")))]
+    (unless ok?
+      (fail! (if (struct? v) (get v :message) (string v))))))
+
+(defn stats []
+  "The split accumulators, read at a run's end for the headline and gates."
+  {:defects n-defects
+   :by-design n-by-design
+   :roots (length (keys roots-seen))
+   :unclassified unclassified})

--- a/tests/elle/oracle.lisp
+++ b/tests/elle/oracle.lisp
@@ -57,247 +57,11 @@
 # a probe open on two dimensions is two defects, two verdicts from two
 # instruments.
 #
-# The failure-accumulating runner. Each (check …) evaluates its body under
-# protect and RECORDS a blown assertion instead of aborting the file, so one red
-# probe never masks the rest; (report) at the end re-raises ONE assertion naming
-# every failure (non-zero exit).
-(def @failures @[])
-(defmacro check (& body)
-  `(let [[ok? v] (protect ,;body)]
-     (unless ok?
-       (push failures (if (struct? v) (get v :message) (string v))))))
-(defn report []
-  (assert (= (length failures) 0)
-          (string (length failures) " probe(s) failed:\n  "
-                  (string/join failures "\n  "))))
-
-# ── Empirical-Bernstein half-width ────────────────────────────────────
-# Total error budget δ, spent across an unbounded number of peeks via a per-m
-# union bound: δ_m = δ·(6/π²)/m², so Σ_m δ_m ≤ δ and the interval is valid at
-# EVERY block boundary (no optional-stopping inflation — the classic trap of
-# "peek at the CI and stop when it looks tight").
-(def EB-DELTA 0.000001)
-# 1e-6 — two-sided, anytime-valid
-(def INV-PI2-6 0.6079271018540267)
-# 6/π², the union-bound normalizer
-
-(defn eb-halfwidth [m var rng]
-  "Anytime-valid empirical-Bernstein half-width on the per-op-rate mean after m
-   block samples with sample variance VAR and observed range RNG. The linear
-   term uses the OBSERVED range, so a deterministic leak (rng 0, var 0) has
-   half-width 0 and converges at the floor. Maurer–Pontil form; instrument
-   only (the soundness oracle is --trace=guardfree)."
-  (if (< m 2)
-    (math/inf)
-    (let [dm (/ (* EB-DELTA INV-PI2-6) (* m m))
-          l (math/log (/ 3.0 dm))]
-      (+ (math/sqrt (/ (* 2.0 (* var l)) m)) (/ (* 3.0 (* rng l)) m)))))
-
-# ── The sequential estimator (general core) ───────────────────────────
-# RUN-BLOCK is (fn [b]) that performs b ops on the heap; GAUGE is (fn []) that
-# returns the heap measure (object count or bytes). Parameterizing both lets one
-# estimator serve every probe shape: a while-loop of thunks, a tail-recursion, a
-# fiber driven by external resumes, and a bytes gauge — the per-op rate is
-# (Δgauge)/b per block regardless of HOW the b ops ran.
-(defn measure-core [label run-block gauge block minb maxb epsilon tau]
-  "Adaptive empirical-Bernstein leak-rate estimator. Returns a struct with the
-   measured :rate, :half (half-width), :blocks, :ops, and a :verdict:
-     :closed       — rate + half < TAU   (reclaimed / bounded)
-     :open         — rate - half > TAU   (leaking at ≥ TAU per op)
-     :inconclusive — the interval straddles TAU.
-   The first block is warmup (discarded — it carries the one-time intercept)."
-  (run-block block)  # warmup block, discarded
-  (def @m 0)
-  (def @mean 0.0)
-  (def @m2 0.0)
-  (def @lo (math/inf))
-  (def @hi (math/-inf))
-  (def @half (math/inf))
-  (def @blk 0)
-  (while (and (%lt blk maxb) (or (%lt blk minb) (not (< half epsilon))))
-    (let [before (gauge)]
-      (run-block block)
-      # GAUGE is a closure VALUE, so its results are untyped; the diverging
-      # %int? guards prove them for the %sub operand contract. Single-opcode
-      # predicates, placed after BOTH reads — nothing they do can land inside
-      # the [before, after] measurement window.
-      (let [after (gauge)]
-        (when (%not (%int? before)) (error :gauge-not-integer))
-        (when (%not (%int? after)) (error :gauge-not-integer))
-        (let [net (%sub after before)
-              x (/ (float net) (float block))]
-          (assign m (%add m 1))
-          (let [delta (- x mean)]
-            (assign mean (+ mean (/ delta m)))
-            (assign m2 (+ m2 (* delta (- x mean)))))  # Welford: uses updated mean
-          (when (< x lo) (assign lo x))
-          (when (> x hi) (assign hi x))
-          (assign
-            half
-            (eb-halfwidth m (if (< m 2) 0.0 (/ m2 (- m 1))) (- hi lo))))))
-    (assign blk (%add blk 1)))
-  (let [verdict (cond
-                  (< (+ mean half) tau) :closed
-                  (> (- mean half) tau) :open
-                  :inconclusive)]
-    {:label label
-     :rate mean
-     :half half
-     :blocks blk
-     :ops (%mul blk block)
-     :verdict verdict}))
-
-(defn run-thunk-block [probe b]
-  "Run PROBE b times, passing the iteration index — the run-block for direct-loop
-   probes. PROBE is (fn [j]): j varies the input so a body cannot constant-fold,
-   faithful to the originals' use of the loop variable i."
-  # b arrives through a closure value (untyped); the allocation-free diverging
-  # guard proves it for the loop's %lt. PROBE is a closure, so a blanket
-  # (numeric!) would be wrong here.
-  (when (%not (%int? b)) (error :block-not-int))
-  (def @j 0)
-  (while (%lt j b)
-    (probe j)
-    (assign j (%add j 1))))
-
-(defn count-gauge []
-  (arena/count))
-# object-count gauge
-(defn bytes-gauge []
-  (arena/bytes))
-# bump-arena bytes gauge
-(defn region-gauge []
-  (arena/region-count))
-# live-region-entry gauge — every active RegionEntry counts, a pages-less owner
-# node included. What the object count cannot see is a ZERO-OBJECT entry: an
-# owner node (docs/impl/region/owner.md § "Owner nodes"), or a region emptied
-# of objects but pinned by an unbalanced count.
-(defn ids-gauge []
-  (arena/region-ids))
-# physical-id issuance gauge — `next_physical`, the dimension every other gauge
-# is blind to (docs/impl/region/diagnostics.md § the `arena/region-ids` bullet).
-# A physical id minted for a call whose callee allocates nothing never becomes a
-# live region, so it holds no object, no page, no bytes and no reference count,
-# and `count-gauge`/`bytes-gauge`/`region-gauge` all read flat while it strands.
-# A mint that finds an id on the free list leaves `next_physical` alone, so a
-# steady-state loop holds this gauge flat and every unit of rate is an id that
-# did not come back. `arena/region-table` is NOT a second gauge here: it is sized
-# by the largest id ever made live from EITHER id source — the per-heap counter
-# this gauge reads, and the raw static-slot ids whose range sits far above it —
-# so its high-water mark is already past anything a loop driving the counter can
-# reach, and it cannot move for any shape below. An unmovable gauge paints every
-# verdict green, which is what the discriminator discipline exists to refuse.
-
-(defn measure [label probe block minb maxb epsilon tau]
-  "Direct-loop wrapper: PROBE is a per-op thunk, gauge is the object count."
-  (measure-core label (fn [b] (run-thunk-block probe b)) count-gauge block minb
-                maxb epsilon tau))
-
-# ── B-invariance: the instrument's second self-test ───────────────────
-# A measured rate is a true PER-OP rate only if it is invariant to the block
-# size B. If the gauge accumulates a fixed constant per BLOCK (a scheduler pump
-# allocating once per batch, say), then net/B = true_rate + C/B, which SHIFTS
-# with B — a confidently-wrong number. So a reported leak rate is measured at
-# two block sizes (b and 2b) and the intervals must overlap; if they do not,
-# the rate is not a per-op rate and the verdict is :contaminated, NOT a number.
-# This is the peer of the gauge-live discriminator: that proves the gauge
-# moves, this proves the rate means what it claims.
-(defn agree? [a b]
-  "Do two measurements' rate intervals overlap (a consistent per-op rate)?"
-  (not (or (< (+ (get a :rate) (get a :half)) (- (get b :rate) (get b :half)))
-           (< (+ (get b :rate) (get b :half)) (- (get a :rate) (get a :half))))))
-
-(defn measure-stable [label probe b minb maxb epsilon tau]
-  "Measure PROBE at block sizes b and 2b and cross-check B-invariance. Returns
-   the finer (larger-B) measurement, carrying :alt-rate (the rate at b) and a
-   :verdict overridden to :contaminated when the two intervals do not overlap."
-  (let [a (measure label probe b minb maxb epsilon tau)
-        c (measure label probe (%mul 2 b) minb maxb epsilon tau)]
-    (put (put c :alt-rate (get a :rate))
-         :verdict (if (agree? a c) (get c :verdict) :contaminated))))
-
-# ── The two-gauge reading — one drive, one verdict per (probe, gauge) ─
-# Both gauges sample around the SAME blocks, so the two verdicts price the same
-# ops and the second reading adds two primitive calls per block, never a second
-# run of the probe. Both gauges are Immediate, so one gauge's read inside the
-# other's [before, after] window moves nothing. Each gauge keeps its own
-# estimator state, epsilon, and tau, and blocks continue until BOTH half-widths
-# are under their own epsilon (bounded by maxb); each verdict comes from its
-# own gauge's interval. δ is spent once per gauge per measurement — at 1e-6 the
-# union over the whole run stays below 2e-4.
-(defn measure-2 [label run-block ga ea ta suffix gb eb tb block minb maxb]
-  "Drive RUN-BLOCK once per block, sampling gauges GA and GB before and after;
-   return [result-a result-b]. Result b is labelled label@SUFFIX — a full label
-   of its own everywhere (`@by-design`, `declare-root`, the pins), so each
-   dimension is independently a closed control or a declared defect."
-  (run-block block)  # warmup block, discarded
-  (def @ma 0)
-  (def @meana 0.0)
-  (def @m2a 0.0)
-  (def @loa (math/inf))
-  (def @hia (math/-inf))
-  (def @halfa (math/inf))
-  (def @mb 0)
-  (def @meanb 0.0)
-  (def @m2b 0.0)
-  (def @lob (math/inf))
-  (def @hib (math/-inf))
-  (def @halfb (math/inf))
-  (def @blk 0)
-  (while (and (%lt blk maxb)
-              (or (%lt blk minb) (not (and (< halfa ea) (< halfb eb)))))
-    (let [before-a (ga)
-          before-b (gb)]
-      (run-block block)
-      (let [after-a (ga)
-            after-b (gb)]
-        # gauge results arrive through closure values (untyped); the diverging
-        # %int? guards prove them for %sub, placed after ALL FOUR reads so
-        # nothing they do can land inside either measurement window.
-        (when (%not (%int? before-a)) (error :gauge-not-integer))
-        (when (%not (%int? before-b)) (error :gauge-not-integer))
-        (when (%not (%int? after-a)) (error :gauge-not-integer))
-        (when (%not (%int? after-b)) (error :gauge-not-integer))
-        (let [xa (/ (float (%sub after-a before-a)) (float block))
-              xb (/ (float (%sub after-b before-b)) (float block))]
-          (assign ma (%add ma 1))
-          (let [da (- xa meana)]
-            (assign meana (+ meana (/ da ma)))
-            (assign m2a (+ m2a (* da (- xa meana)))))
-          (when (< xa loa) (assign loa xa))
-          (when (> xa hia) (assign hia xa))
-          (assign
-            halfa
-            (eb-halfwidth ma (if (< ma 2) 0.0 (/ m2a (- ma 1))) (- hia loa)))
-          (assign mb (%add mb 1))
-          (let [db (- xb meanb)]
-            (assign meanb (+ meanb (/ db mb)))
-            (assign m2b (+ m2b (* db (- xb meanb)))))
-          (when (< xb lob) (assign lob xb))
-          (when (> xb hib) (assign hib xb))
-          (assign
-            halfb
-            (eb-halfwidth mb (if (< mb 2) 0.0 (/ m2b (- mb 1))) (- hib lob))))))
-    (assign blk (%add blk 1)))
-  [{:label label
-    :rate meana
-    :half halfa
-    :blocks blk
-    :ops (%mul blk block)
-    :verdict (cond
-               (< (+ meana halfa) ta) :closed
-               (> (- meana halfa) ta) :open
-               :inconclusive)}
-   {:label (string label "@" suffix)
-    :rate meanb
-    :half halfb
-    :blocks blk
-    :ops (%mul blk block)
-    :verdict (cond
-               (< (+ meanb halfb) tb) :closed
-               (> (- meanb halfb) tb) :open
-               :inconclusive)}])
-
+# The estimator, the gauges, the ledger, and the `check` macro live in
+# lib/estimator.lisp, shared with the io dashboard (plumb.lisp) and spliced
+# here at compile time — each dashboard compiles its own copy, so ledger state
+# is fresh per process.
+(include-file "lib/estimator.lisp")
 # ── The defect / by-design split — the instrument owns the burndown headline ──
 # Every leak class has a ROOT (F1a/F1b/F2/F3/F4/F5), declared below. A small fixed set
 # of probes read open BY DESIGN — one live-growth discriminator per gauge (object
@@ -322,16 +86,10 @@
 # block-local, so it frees at the block's return. A CLOSED control now that the
 # scratch is reclaimed — undeclared, so a regression to open trips the completeness
 # gate as an F1a defect rather than being absorbed as growth.
-(def @by-design
-  @{"discriminator (live-growth)" true
-    "id discriminator (live-growth)" true
-    "region discriminator (live-growth)" true
-    "bytes discriminator (live-growth)" true
-    "sub-integer (1-in-3 retain)" true})
-(def @root-of @{})
-(defn declare-root [root labels]
-  (each l in labels
-    (put root-of l root)))
+(each l in ["discriminator (live-growth)" "id discriminator (live-growth)"
+            "region discriminator (live-growth)"
+            "bytes discriminator (live-growth)" "sub-integer (1-in-3 retain)"]
+  (put by-design l true))
 # `rest-array-copy` is a CLOSED control (the native fresh-result invariant, not F1a
 # stdlib-body scratch) — undeclared like `slice`/`to-array`, so a regression to open
 # trips the completeness gate loudly rather than being silently absorbed as F1a.
@@ -406,9 +164,9 @@
 # holder — the park's `EmitEscape` retain going out, the resume value's own mint
 # coming back — so the admission rides it and only the containment facets refuse
 # (docs/impl/region/mechanism.md § "A fiber crossing is a counted holder too").
-# `io-yield ev/sleep` is a CLOSED control (undeclared, like `rest-array-copy`): a
-# pumped io op strands nothing, so a regression to open must trip the completeness
-# gate loudly rather than be absorbed under a root.
+# The io round trip (`io-yield ev/sleep`) and the displaced io park are gauged
+# by the io dashboard, tests/elle/plumb.lisp — every probe whose drive reaches
+# the io backend lives there, under this same ledger discipline.
 # F4 has NO declared probe: the returned closure cycle is closed for every body shape,
 # including the one bound OUT of its frame's tail position, where the merge follows the
 # handed-out member to the release point the last-use rule already computed for it. Its
@@ -514,35 +272,6 @@
     "adopt-before-park-cancel" 0})
 (def @dual-read-seen @{})
 
-(def @n-defects 0)
-(def @n-by-design 0)
-(def @roots-seen @{})
-(def @unclassified @[])
-(defn classify [label verdict]
-  "Fold one probe's MEASURED verdict into the split accumulators and return its
-   DISPLAY verdict. A by-design open probe shows :growth (tallied by-design); a
-   classified defect shows :open (tallied, its root recorded); an open probe in
-   NEITHER table shows :open and is recorded unclassified — the completeness gate
-   fails on it. :closed / :inconclusive pass through untallied."
-  (if (not= verdict :open)
-    verdict
-    (if (get by-design label)
-      (begin
-        (assign n-by-design (%add n-by-design 1))
-        :growth)
-      (begin
-        (assign n-defects (%add n-defects 1))
-        (let [root (get root-of label)]
-          (if (nil? root) (push unclassified label) (put roots-seen root true)))
-        :open))))
-
-(defn show [r]
-  "Print one measured class as a dashboard line."
-  (let [alt (get r :alt-rate)]
-    (println "  " (classify (get r :label) (get r :verdict)) "  " (get r :label)
-             ": rate=" (get r :rate) " ±" (get r :half)
-             (if (nil? alt) "" (string " [B-check " alt "]")) "  (" (get r :ops)
-             " ops / " (get r :blocks) " blocks)")))
 
 # ── Probes ────────────────────────────────────────────────────────────
 
@@ -585,21 +314,6 @@
 # reclaimed baseline (the leak suite pins this at slope 0). Should read :closed.
 (defn probe-bounded [j]
   {:x j :y 2})
-
-# A yielding io op, the whole round trip: ev/sleep is the clean shape (portless,
-# nil result), so what the gauge sees is the scheduler pump's own per-op cost. The
-# op suspends with an IoRequest, the pump reads a completion out of
-# `(io/wait backend …)` and resumes the fiber with it, and every region on that
-# path is released — the request's park retain at the resume, the completion array
-# and the structs it carries at the pump's own `DecrefValueRegion`, both being one
-# region (docs/impl/region/ctx.md § "A helper reached from inside a call allocates
-# through THAT call's ctx"). (The IN-LAMBDA self-recursive letrec closure `+`/`<` build over
-# their varargs is cell-free — its self-reference resolves to the executing closure, no
-# cell↔closure cycle — reclaimed per call by ordinary RC / the tail-call deferred release,
-# docs/impl/selfrec.md; that class is pinned directly by the `recur-local-self` probe
-# below.)
-(defn probe-io-yield [j]
-  (ev/sleep 0))
 
 # Sub-integer leak: leaks one object every 3 ops = 0.333/op. The OLD integer
 # slope floors this to 0 ("reclaimed") — a real unbounded leak made invisible.
@@ -667,19 +381,7 @@
                (string "bounded shape leaked: " (get bnd :verdict) " rate="
                        (get bnd :rate))))
 
-# 3. The io round trip reclaims. Measured with the B-invariance self-test, so a
-#    reading of 0 is a per-op rate rather than a per-block artifact.
-(def io (measure-stable "io-yield ev/sleep" probe-io-yield 200 8 80 0.4 0.5))
-(show io)
-(check (assert (not= (get io :verdict) :contaminated)
-               (string "io-yield rate is block-dependent (B vs 2B): "
-                       (get io :rate) " vs " (get io :alt-rate)
-                       " — a per-block artifact, not a per-op rate")))
-(check (assert (= (get io :verdict) :closed)
-               (string "io-yield leaked: " (get io :verdict) " rate="
-                       (get io :rate))))
-
-# 4. Sub-integer leak the integer slope cannot see. Tight tau/epsilon; reads
+# 3. Sub-integer leak the integer slope cannot see. Tight tau/epsilon; reads
 #    :open at ≈0.33 where `slope` reported 0.
 (def sub (measure "sub-integer (1-in-3 retain)" probe-third 300 8 200 0.05 0.1))
 (show sub)
@@ -1958,22 +1660,6 @@
    ["module-cell-read-window" (fn [j] (mod-cell-immediate)) 0]
    ["module-cell-heap-init" (fn [j] (mod-cell-heap)) 0]])
 
-# A pinned rate is an exact number (matched within ±0.5 — integer resolution on
-# the real-valued estimate) or a [lo hi] inclusive range (for the rare shape
-# whose true rate genuinely spans across tiers).
-(defn match-rate? [got want]
-  (if (array? want)
-    (and (not (< got (get want 0))) (not (< (get want 1) got)))
-    (and (< (- got want) 0.5) (< (- want got) 0.5))))
-
-# pin is the single assertion shape for every class — table-driven or
-# bespoke. Shrink-only: a fix LOWERS the pin.
-(defn pin [r want]
-  (show r)
-  (check (assert (match-rate? (get r :rate) want)
-                 (string (get r :label) ": pinned " want ", measured "
-                         (get r :rate) " (" (get r :verdict) ") — shrink-only"))))
-
 (println "── folded suite: direct-loop class ──")
 (each entry suite-classes
   (let [label (get entry 0)
@@ -2314,13 +2000,6 @@
 # leak whole REGIONS without growing the object count (a native fresh-result
 # region whose contents are few). `stmt-run` drives a thunk b times as a discarded
 # STATEMENT (non-tail), the while-loop shape a per-call leak needs to surface.
-(defn stmt-run [thunk]
-  (fn [b]
-    (when (%not (%int? b)) (error :block-not-int))
-    (def @i 0)
-    (while (%lt i b)
-      (thunk)
-      (assign i (%add i 1)))))
 # Native pass-through / closure tail-returns, for the discarded-tail-return class.
 (defn ora-ret-first [xs]
   (first xs))
@@ -3628,13 +3307,15 @@
 # when the last defect closes). UNCLASSIFIED is appended only when a probe leaked
 # without a declaration — a stale ledger, gated below so it can never pass silently.
 (println "── split ──")
-(println "open defects: " n-defects " across " (length (keys roots-seen))
-         " roots; by-design: " n-by-design
-         (if (= (length unclassified) 0)
+(def split-tally (stats))
+(println "open defects: " split-tally:defects " across " split-tally:roots
+         " roots; by-design: " split-tally:by-design
+         (if (= (length split-tally:unclassified) 0)
            ""
-           (string "; UNCLASSIFIED: " (length unclassified) " " unclassified)))
-(check (assert (= (length unclassified) 0)
-               (string "unclassified open probe(s): " unclassified
+           (string "; UNCLASSIFIED: " (length split-tally:unclassified) " "
+                   split-tally:unclassified)))
+(check (assert (= (length split-tally:unclassified) 0)
+               (string "unclassified open probe(s): " split-tally:unclassified
                        " — every open probe must be a declared root or by-design "
                        "(the split ledger is stale)")))
 # The dual-read half of the same gate: the table is the coverage authority, so
@@ -3649,8 +3330,8 @@
                        dual-unread
                        " — the coverage table names probes the runner never "
                        "read on the region dimension")))
-(check (assert (= n-by-design 5)
-               (string "by-design tally " n-by-design
+(check (assert (= split-tally:by-design 5)
+               (string "by-design tally " split-tally:by-design
                        " ≠ 5 — the growth probes (the object-count, "
                        "physical-id, region, and bytes live-growth "
                        "discriminators, the sub-integer estimator self-test) "

--- a/tests/elle/plumb.lisp
+++ b/tests/elle/plumb.lisp
@@ -1,0 +1,132 @@
+(elle/epoch 12)
+# plumb.lisp — the io leak dashboard: every probe whose drive reaches the io
+# backend. oracle.lisp is the pure region dashboard and owns the discipline
+# this file follows — the estimator, the gauge-live discriminator rule, the
+# defect/by-design split, and the completeness gate (oracle.lisp's header;
+# lib/estimator.lisp is the shared instrument). Split from the oracle because
+# io probes need axes it lacks: fixtures with setup and teardown, wall-clock
+# tolerance in their own epsilons, the backend as a run dimension, and later a
+# descriptor gauge — while an io fixture failure must not void the pure
+# dashboard's verdicts. Every probe here is read on the object count AND the
+# region count in one drive (`measure-2`): io machinery moves whole region
+# entries between fibers, the scheduler, and requests, so the region dimension
+# is representable for every shape in the file and no dual-read table is
+# needed until a probe diverges.
+
+# The estimator, the gauges, the ledger, and the `check` macro — spliced at
+# compile time, so this dashboard compiles its own copy with fresh ledger
+# state.
+(include-file "lib/estimator.lisp")
+
+# This process's gauges must prove live on their own — a discriminator's
+# verdict never carries across processes.
+(each l in ["discriminator (live-growth)" "region discriminator (live-growth)"]
+  (put by-design l true))
+# An io park displaced by `fiber/abort` or `fiber/refuse` strands the
+# `IoRequest` region the runtime built for it: `release_parked_signal` runs on
+# the resume path only, and the injection site runs the displaced-terminal and
+# denial releases but nothing for an io request (docs/impl/region/owner.md
+# § "Park/unpark symmetry" — a park with no body reference owes one release
+# where it is displaced). One region and the request it holds, per op, on both
+# displacing routes; `io-drop` is the reclaiming control, the same park whose
+# fiber nobody displaces, covered by the free-path discharge.
+(declare-root :f2 ["io-abort" "io-abort@regions" "io-refuse" "io-refuse@regions"])
+
+# ── Discriminators ────────────────────────────────────────────────────
+(def @disc-sink @[])
+(defn probe-disc [j]
+  (push disc-sink {:k j}))
+(def @region-disc-sink @[])
+(defn probe-region-disc [j]
+  (push region-disc-sink {:k j}))
+
+(println "── plumb: io leak dashboard ──")
+(def disc (measure "discriminator (live-growth)" probe-disc 200 6 60 0.4 0.5))
+(show disc)
+(check (assert (= (get disc :verdict) :open)
+               (string "GAUGE DEAD: discriminator read " (get disc :verdict)
+                       " — every 'closed' verdict this run is void")))
+(def region-disc
+  (measure-core "region discriminator (live-growth)"
+                (fn [b] (run-thunk-block probe-region-disc b)) region-gauge 200
+                6 60 0.4 0.5))
+(show region-disc)
+(check (assert (= (get region-disc :verdict) :open)
+               (string "REGION GAUGE DEAD: region discriminator read "
+                       (get region-disc :verdict)
+                       " — every region-gauge 'closed' verdict this run is "
+                       "void")))
+
+# ── The pumped round trip ─────────────────────────────────────────────
+# A yielding io op, the whole round trip: ev/sleep is the clean shape
+# (portless, nil result), so what the gauge sees is the scheduler pump's own
+# per-op cost. The op suspends with an IoRequest, the pump reads a completion
+# out of `(io/wait backend …)` and resumes the fiber with it, and every region
+# on that path is released — the request's park retain at the resume, the
+# completion array and the structs it carries at the pump's own
+# `DecrefValueRegion`, both being one region (docs/impl/region/ctx.md § "A
+# helper reached from inside a call allocates through THAT call's ctx").
+# Measured with the B-invariance self-test, so a reading of 0 is a per-op rate
+# rather than a per-block artifact.
+(defn probe-io-yield [j]
+  (ev/sleep 0))
+(def io (measure-stable "io-yield ev/sleep" probe-io-yield 200 8 80 0.4 0.5))
+(show io)
+(check (assert (not= (get io :verdict) :contaminated)
+               (string "io-yield rate is block-dependent (B vs 2B): "
+                       (get io :rate) " vs " (get io :alt-rate)
+                       " — a per-block artifact, not a per-op rate")))
+(check (assert (= (get io :verdict) :closed)
+               (string "io-yield leaked: " (get io :verdict) " rate="
+                       (get io :rate))))
+
+# ── The displaced io park ─────────────────────────────────────────────
+# The three exits of a parked io op — see the F2 declaration above for the
+# mechanism. The three must stay together: `io-drop` removes the displacing
+# install, so the gap between it and either displacing route isolates the
+# install's owed release from the park itself.
+(defn mk-io []
+  (fiber/new (fn []
+               (let [r (ev/sleep 10000)]
+                 5)) |:io :error|))
+(defn probe-io-drop [j]
+  (let [f (mk-io)]
+    (fiber/resume f)
+    3))
+(defn probe-io-abort [j]
+  (let [f (mk-io)]
+    (fiber/resume f)
+    (fiber/abort f "no")))
+(defn probe-io-refuse [j]
+  (let [f (mk-io)]
+    (fiber/resume f)
+    (fiber/refuse f "no")))
+(defn pin-io-2 [label probe opin rpin]
+  (let [[r rr] (measure-2 label (fn [b] (run-thunk-block probe b)) count-gauge
+                          0.4 0.5 "regions" region-gauge 0.4 0.5 100 6 60)]
+    (pin r opin)
+    (pin rr rpin)))
+(pin-io-2 "io-drop" probe-io-drop 0 0)
+(pin-io-2 "io-abort" probe-io-abort 1 1)
+(pin-io-2 "io-refuse" probe-io-refuse 1 1)
+
+# ── The split headline ────────────────────────────────────────────────
+(println "── split ──")
+(def split-tally (stats))
+(println "open defects: " split-tally:defects " across " split-tally:roots
+         " roots; by-design: " split-tally:by-design
+         (if (= (length split-tally:unclassified) 0)
+           ""
+           (string "; UNCLASSIFIED: " (length split-tally:unclassified) " "
+                   split-tally:unclassified)))
+(check (assert (= (length split-tally:unclassified) 0)
+               (string "unclassified open probe(s): " split-tally:unclassified
+                       " — every open probe must be a declared root or "
+                       "by-design (the split ledger is stale)")))
+(check (assert (= split-tally:by-design 2)
+               (string "by-design tally " split-tally:by-design
+                       " ≠ 2 — the object-count and region live-growth "
+                       "discriminators must each read open")))
+
+(report)
+(println "plumb: ok")


### PR DESCRIPTION
Stacked on #1008 (base `io-worker-pool`; retarget to main when it merges).
Closes the remaining half of #982's amended design and lands #993.

**The shared library.** The estimator, gauges, ledger, and the `check` macro
move to `tests/elle/lib/estimator.lisp`, spliced into each dashboard by the
top-level `include-file` directive (docs/modules.md § "Compile-Time
Inclusion") — resolution is relative to the including file, splicing precedes
macro expansion so `check` crosses, and each dashboard compiles its own copy:
fresh ledger state per process, each proving its own gauges live. The `lib/`
directory sits outside the corpus glob, so the library never runs as a test.

**plumb, the io leak dashboard** (#993). `tests/elle/plumb.lisp` takes every
probe whose drive reaches the io backend, each read on the object count and
the region count in one drive. `io-yield` moves here from the oracle,
unchanged (B-invariance self-test, closed at 0). `io-abort` and `io-refuse`
gauge the displaced io park (#979) at 1.0 objects + 1.0 regions per op each,
declared F2 with pins at the measured rate; `io-drop` is the reclaiming
control at 0 — the gap isolates the displacing install's owed release from
the park itself. Its own discriminators (object + region), split headline
(`open defects: 4 across 1 roots; by-design: 2`), and completeness gate.
Red-green: a dead region gauge trips `REGION GAUGE DEAD` here as in the
oracle.

**Makefile.** `RUN_PLUMB` mirrors `RUN_ORACLE` in every smoke pass — pulled
out of the batches and the per-file passes, driven under its own timed budget
(60s against a ~5s debug run) on the same tier flags.

Both dashboards read identically under `--jit=off` and `--jit=eager`, debug
and release, from the repo root and from inside `tests/elle/`.

