### PR TITLE
symbol: identity is the name hash, spellings live in the per-instance memo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,8 @@ bytecode. Error messages include file:line:col information.
 - **`error`** — `LocationMap` for bytecode offset → source location mapping
 - **`runtime`** — Per-instance `Runtime`/`RuntimeCore` owning the VM, symbol
   table, compile context, and heap; handed out via `rt.parts()`
-- **`symbol`** — Symbol interning table
+- **`symbol`** — Symbol identity (the name's FNV-1a hash) and the process-global
+  hash→name registry. See [`docs/impl/symbol.md`](docs/impl/symbol.md)
 - **`config`** — Global CLI configuration (parsed once at startup)
 
 **Backends:**

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -91,6 +91,7 @@ make smoke                 # run all tests (~30s)
 | [spirv](docs/impl/spirv.md) | SPIR-V emission for GPU compute |
 | [gpu](docs/impl/gpu.md) | End-to-end GPU compute (Vulkan) |
 | [values](docs/impl/values.md) | Value representation, tagged union |
+| [symbol](docs/impl/symbol.md) | Symbol and keyword identity: name hash, per-instance display memo, ordering |
 | [image](docs/impl/image.md) | Image persistence design: boot image, environment save/load |
 
 ## Reference

--- a/demos/embedding/src/lib.rs
+++ b/demos/embedding/src/lib.rs
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn elle_eval(ctx: *mut c_void, src: *const u8, len: usize)
     // bytecode under the async scheduler.
     let (vm, symbols, cctx) = ctx.runtime.parts();
     match compile_file(source, symbols, cctx, "<embed>") {
-        Ok(compiled) => match vm.execute_scheduled(&compiled.bytecode, symbols, cctx) {
+        Ok(compiled) => match vm.execute_scheduled(&compiled.bytecode, cctx) {
             Ok(value) => {
                 ctx.last_result = Some(value);
                 0

--- a/demos/embedding/src/main.rs
+++ b/demos/embedding/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
     let (vm, symbols, cctx) = rt.parts();
     let compiled = compile_file(&source, symbols, cctx, "hello.lisp").expect("compilation failed");
     let result = vm
-        .execute_scheduled(&compiled.bytecode, symbols, cctx)
+        .execute_scheduled(&compiled.bytecode, cctx)
         .expect("execution failed");
 
     // 6. Extract result

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -50,6 +50,7 @@ Design documents, language references, and contributor guides for Elle.
 | `impl/gpu.md` | End-to-end GPU compute (MLIR + SPIR-V + Vulkan) |
 | `impl/differential.md` | Cross-tier agreement: `compile/run-on` + the runner's diverge status |
 | `impl/values.md` | Value representation, tagged union |
+| `impl/symbol.md` | Symbol and keyword identity: name hash, per-instance display memo, collision rule |
 
 ### Reference Material
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ Focused files covering one topic each, all runnable via `elle docs/<file>.md`.
 
 | Directory | Content |
 |-----------|---------|
-| [impl/](impl/) | Reader, HIR, LIR, bytecode, VM, JIT, WASM, MLIR, SPIR-V, GPU, values |
+| [impl/](impl/) | Reader, HIR, LIR, bytecode, VM, JIT, WASM, MLIR, SPIR-V, GPU, values, symbols |
 
 ## Reference
 

--- a/docs/impl/image.md
+++ b/docs/impl/image.md
@@ -138,50 +138,26 @@ image first would mean shipping remap passes, re-sort passes, and a syntax
 codec whose only purpose is to compensate for representations we intend to
 fix anyway.
 
-### Stable symbol identity
+### Stable symbol identity — landed
 
-`SymbolId` is a dense per-table index minted in first-intern order — a
-process-local accident. Everything downstream compensates: every code object
-carries a `symbol_names` map for cross-table remap, `send` re-interns by
-name, `CompileCtx` leans on a fragile "registration order is deterministic"
+A `SymbolId` used to be a dense per-table index minted in first-intern order —
+a process-local accident. Everything downstream compensated: every code object
+carried a `symbol_names` map for cross-table remap, `send` re-interned by name,
+`CompileCtx` leaned on a fragile "registration order is deterministic"
 invariant, and — the sharpest edge — immutable structs and sets are *sorted
-arrays* whose order (`TableKey`/`Value` compare symbols by raw id) is
-process-local, so a persisted sorted container is correct only where it was
+arrays* whose order (`TableKey`/`Value` compare symbols by raw id) was
+process-local, so a persisted sorted container was correct only where it was
 built.
 
-The fix is the identity model keywords already use: the id is a 64-bit
-FNV-1a hash of the name, stable across tables, processes, and builds. Then
-symbol values are as portable as keyword values; sort orders are stable by
-construction; the image needs no symbol remap pass, no re-sort pass, no
-symbol watermark; templates lose their `symbol_names` maps; `send` stops
-re-interning for identity; the `CompileCtx` ordering invariant dissolves.
+A `SymbolId` is now the 64-bit FNV-1a hash of the name, and a name lives in a
+per-instance display memo rather than a process-wide table
+([symbol.md](symbol.md) owns the model). Symbol values are as portable as
+keyword values, and sort orders are stable by construction, so the image needs
+no symbol remap pass, no re-sort pass, and no symbol watermark.
 
-No global registry backs this. Minting an id consults nothing — the hash
-is the id — so the only remaining jobs are display (hash→name) and
-collision detection, and both stay per instance. `SymbolTable` survives as
-an instance-local hash→name **display memo** on the plumbing it rides
-today: no lock, because no structure is shared; teardown drops the memo
-with its instance, so the leak guarantee holds without a carve-out. The
-memo learns names at the boundaries where names already travel — the
-reader, `send`'s name field (now display-only data the receiver records),
-hydration's name-table replay, `ConstTemplate` decode — and every learning
-site doubles as the collision check: recording a hash the memo maps to a
-different name is the panic. That catches cross-thread, cross-image, and
-cross-build collisions at the moment they would first confuse a reader,
-which one process-wide table cannot. A CI test hashes every static name —
-the primitive tables and aliases, every symbol read from core, prelude,
-and stdlib — and asserts distinctness, so the built-in vocabulary is
-proven collision-free per build; the runtime panic covers dynamic names,
-where the 64-bit birthday bound is ~3×10⁻¹⁰ at 10⁵ symbols. The keyword
-registry takes the same demotion in this migration.
-
-Migration notes: `SymbolId(u32)` widens to `u64` (the `Value` payload
-already is one); the `SYNTHETIC` sentinel survives as a reserved hash;
-struct and set iteration order changes from intern-order to hash-order —
-deterministic, and measured to churn nothing. Risk item 4 records the
-full site audit and the measured cost: no bytecode operand carries a
-symbol id, no live dense-index site exists, and the widening is ~75
-mechanical seam edits.
+Identity comes free; display does not. A hydrating instance holds none of the
+dump's names, which is what the name table below is for, and replaying it is
+also where a cross-build collision is caught.
 
 ### Region-native immutable structs
 
@@ -199,7 +175,7 @@ inline `RegionSlice<u8>`. Flatten every field: constants as
 `RegionSlice<Value>`, masks and release tables as inline slices, the location
 map as a sorted `RegionSlice<(u32, PackedLoc)>` over an interned file table,
 `child_protos` as `RegionSlice<Value>` of sibling templates, name and doc as
-region strings (`symbol_names` is gone per the above). Payoff now:
+region strings. Payoff now:
 `MakeClosure` clones the blueprint — ~20 `Rc` bumps per closure creation —
 into the instance region; a flattened template is referenced, not cloned.
 Payoff for images: code objects become body data.
@@ -338,7 +314,7 @@ One image is one file (or one embedded blob):
 | relocations | pointer stream: (slot offset, target segment, target offset); primitive stream: (slot offset); reconstruction stream: (slot offset, constructor tag). Offsets are region-relative bytes: the hydrated region is one contiguous interval (Hydration step 3), so `base + offset` names any slot or target in O(1) and the (page, offset) pair collapses |
 | object index | (offset, tag) per heap object, sorted — rebuilds `dtors`/`ref_objs` and drives the verifier |
 | primitive table | primitive names in dump-time `prim_id` order |
-| name table | symbol and keyword names in the body — hashes are stable, but the hydrating instance's display memos must learn them |
+| name table | symbol and keyword names in the body — hashes are stable, but the hydrating instance's display memo must learn them |
 | signal table | user-defined signal names in dump-time bit order |
 | watermarks | dump-time counters: parameter id, static-region mint, hygiene scope id, next signal bit |
 | manifest | bindings: name, kind (function / macro / core), value location, signal, arity, doc location; macro entries add parameter lists, template-syntax and transformer-cache locations; inline-fn syntax locations; plus root locations and dependency fingerprints |
@@ -410,8 +386,8 @@ migration.
 
 1. Validate the fingerprint; on failure, fall back (boot: compile sources;
    environment: report the mismatch).
-2. Register the name table in the hydrating instance's symbol and keyword
-   display memos.
+2. Register the name table in the hydrating instance's display memo (one
+   map serves both vocabularies).
    Replay the signal table so user signal bits land where the dump minted
    them. Check the primitive table against the live registry.
 3. Mint a region and map the page section: reserve an aligned `PROT_NONE`
@@ -757,9 +733,10 @@ wrong about. Run these before the foundations land, in this order:
 Foundations first — each lands green on the existing corpus with no image
 code, and each deletes image machinery:
 
-1. **symbol** — stable content-addressed symbol identity; deletes the
-   symbol remap pass, the sorted-container re-sort hazard, `symbol_names`
-   maps, and `send`'s re-interning.
+1. **symbol** — landed. Stable content-addressed symbol identity
+   ([symbol.md](symbol.md)); deleted the symbol remap pass, the
+   sorted-container re-sort hazard, the `symbol_names` maps, and `send`'s
+   re-interning.
 2. **struct** — region-native immutable struct payloads.
 3. **template** — the flattened, region-resident `ClosureTemplate`;
    `MakeClosure` references instead of clones.

--- a/docs/impl/lir.md
+++ b/docs/impl/lir.md
@@ -55,12 +55,11 @@ structure shares that one region. Normal escape RC keeps any escaped copy alive
 past its `decref_point`. Only immediates (numbers, bools, nil, interned
 keyword/symbol) remain as plain pool constants loaded by `Const`/`ValueConst`.
 
-A template carries symbols **by name**, not by interned id: ids are
-per-symbol-table (per-instance), so a raw id would name a different symbol after
-the template crosses a `sys/spawn` boundary. `materialize` re-interns the name
-into the executing instance's table (the explicitly-threaded `SymbolTable`),
-exactly as a sent symbol `Value` re-interns. This makes the template
-self-contained and portable.
+A template carries symbols **by name**, not by interned id. The id would in fact
+survive a `sys/spawn` boundary now that it is the name's hash
+([symbol.md](symbol.md)), but the name is what makes the template readable and
+self-describing; `materialize` interns it, which records the spelling for
+display and returns that same id.
 
 See [region/model.md](region/model.md) — *Constants lower as ordinary
 allocations* — for why a code-object-lifetime "constant-pool region" is forbidden.

--- a/docs/impl/region/ctx.md
+++ b/docs/impl/region/ctx.md
@@ -183,47 +183,24 @@ reached as `ctx.vm().field`:
   `(backend? :tier)`. Set/restored around the dispatch in
   `dispatch_compile_run_on`.
 
-## Symbols through the ctx — per-instance name resolution
+## Symbols are not a per-instance capability
 
-The symbol table is reached the same way as the VM and for the same reason: name
-resolution binds to the instance that owns it, so two embedded instances on one
-thread resolve names independently. It is a per-instance capability
-— a `RuntimeCore` sibling of the `VM`/`SymbolTable`/`CompileCtx` (the boxed
-`SymbolTable` has a stable address), with the VM holding a pointer to it
-(`VM::set_symbols`, the `heap_ptr`/`compile_ctx_ptr` idiom).
+A symbol id is the name's hash and the hash→name registry is process-global
+([impl/symbol.md](../symbol.md)), so name resolution needs no instance, no ctx,
+and no threading. `crate::symbol::name(id)` answers anywhere — inside
+`Display`/`Debug for Value`, inside a panic message, inside a unit test with no
+`Runtime` at all. There is no lost-names case to work around.
 
-Two reach paths, by what is in scope:
+The `SymbolTable` a `RuntimeCore` owns is a handle onto that registry, not a
+table of its own. It is still threaded through the pipeline (`&mut SymbolTable`
+where interning happens, `vm.symbols()` / `ctx.vm().symbols()` where a VM is in
+scope), because interning is a compile-time capability — but two instances
+cannot disagree about a name, and none of the reach paths above affects what a
+symbol means.
 
-- **A driving VM is in scope** — the runtime `eval` instruction, the dispatch
-  `SIG_QUERY` answers, and `MaterializeConst` read `vm.symbols()` directly; a
-  primitive reads `ctx.vm().symbols()`. Both return `Option<&mut SymbolTable>`
-  (`None` for a bare VM with no `RuntimeCore`; the readers then error or skip name
-  resolution). A primitive that needs a `&SymbolTable` *and* allocates through the
-  same `ctx` in one expression reads the raw `ctx.vm().symbols_ptr` first (a
-  `Copy` pointer that borrows nothing), then derefs — so the symbol borrow and the
-  `ctx.*` allocation borrow do not collide (the `compile/*` reflection primitives).
-- **No VM is in scope** — the table is threaded as an explicit `&SymbolTable` /
-  `&mut SymbolTable` parameter: the `send` serializer resolves symbol ids to names
-  against the sender's table (`SerContext`), the deserializer re-interns names into
-  the receiver's table (`DeserContext`), and the `os/spawn` worker threads its own
-  table to both.
-
-`Display`/`Debug for Value` (and for `TableKey`) **cannot** accept a table — the
-`fmt` trait signatures are fixed and a 16-byte `Value` carries none. So the
-rendering body is a free `fmt_value(v, symbols: Option<&SymbolTable>,
-debug, f)` (and `fmt_table_key`) that recurses by calling itself: bare
-`Display`/`Debug` pass `None` and render a symbol as `#<sym:id>`, while
-`value.display_with(symbols)` / `value.debug_with(symbols)` wrappers pass `Some`
-and thread names all the way down. Every *user-facing* render has a table:
-`VM::format_error_with_location` uses `self.symbols()`, and the `string`/`print`
-path resolves through `ctx.vm().symbols()`. Only bare `{:?}`/`{}` in internal Rust
-logging and panics loses names — acceptable, and noted in
-[docs/testing.md](../../testing.md) so the cold reader knows why a unit-test `{:?}`
-on a symbol-bearing `Value` prints `#<sym:id>` (reach for `debug_with`).
-
-Pinned by `two_instances_resolve_their_own_symbols` (`src/runtime/tests/lifecycle.rs`): two
-`Runtime`s on one thread each convert a symbol unique to themselves, and each
-resolves it through its own table — a single shared table fails it.
+Pinned by `two_instances_agree_on_every_symbol_name`
+(`src/runtime/tests/lifecycle.rs`): a symbol one `Runtime` compiled is the same
+symbol in the other.
 
 ## JIT intrinsic helpers reach the VM through a `JitCtx`
 
@@ -327,7 +304,7 @@ load rather than mismatching the calling convention.
 | A native allocates into a region its caller already released | the ctx owns a fresh per-call region; nothing hands a native another |
 | A save/restore imbalance corrupting a sibling call's region | each call's region is private to its ctx |
 | A native reaching a different instance's VM | `ctx.vm()` resolves the call's own driving VM |
-| A native resolving/interning a name in a different instance's symbol table | name resolution reads `ctx.vm().symbols()` / a threaded `&SymbolTable` |
+| A native resolving a symbol to a different instance's name | a symbol id is the name's hash ([impl/symbol.md](../symbol.md)); there is no per-instance name to get wrong |
 | A `vm()` call on a context that has no VM | only `NativeCtx` (always VM-bearing) has `vm()`; an allocation-only site holds an `Alloc`, which has none |
 | `exit`-trap / FFI-callback-error / active-tier state leaking between coexisting instances | each is a `VM` field |
 

--- a/docs/impl/symbol.md
+++ b/docs/impl/symbol.md
@@ -1,0 +1,151 @@
+# Symbols and keywords — identity is the name hash
+
+A `SymbolId` is the 64-bit FNV-1a hash of the symbol's name. Nothing mints it
+and no table owns it: the same name yields the same id in every symbol table,
+every thread, every process, and every build.
+
+```rust
+pub struct SymbolId(pub u64);
+SymbolId::of("map") == SymbolId::of("map")   // always, everywhere
+```
+
+A keyword's payload is the same hash of the same name, through the same
+function (`src/namehash.rs`), so `TAG_SYMBOL` and `TAG_KEYWORD` carry the same
+kind of payload: a name hash, not an index. The tag alone separates the two
+vocabularies; `map` and `:map` are different values with equal payloads.
+
+## What the property buys
+
+A symbol value is portable. It survives a copy to another thread, a write to a
+file, and a hydration into a fresh process, because its bytes mean the same
+thing on both sides. Everything that used to compensate for a process-local id
+is gone: no per-code-object `symbol_names` map, no re-interning of symbol data
+crossing a thread boundary, and no rule that two symbol tables must intern the
+same names in the same order to agree.
+
+Sorted containers get the property for free. An immutable struct and an
+immutable set are sorted arrays, and `TableKey`/`Value` order symbols by raw
+id. Under mint order that arrangement was correct only in the process that
+built it. Under hash order it is correct everywhere. The order is hash order,
+not alphabetical: sorting by name would cost a memo lookup on every
+comparison, and every struct probe is a binary search over those comparisons.
+Build and probe share the comparator, so the containers stay correct; the
+order is deterministic but carries no lexicographic meaning, and no part of the
+language promises one.
+
+[image.md](image.md) § "Stable symbol identity" owns the argument for why the
+image work needs this property.
+
+## The display memo
+
+Identity needs no table. Display does, because a hash cannot be printed as a
+name — and display is now the only thing a symbol table is for.
+
+`SymbolTable` is that table: one hash → spelling map per instance, serving
+both vocabularies. A symbol and a keyword with the same spelling share one
+entry — the map's domain is spellings, not values, and the tag that separates
+`map` from `:map` lives in the `Value`, not in the memo. It takes no lock,
+because it is not shared, and it is dropped with the instance that owns it, so
+no name outlives the run that learned it.
+
+- `intern(&mut self, name)` hashes, records the spelling, and returns the
+  `SymbolId`.
+- `name(&self, id)` returns the recorded spelling, or `None`.
+- `keyword(&mut self, name)` and `keyword_name(&self, hash)` are the keyword
+  entry points onto the same map, keyed by the raw hash (a keyword payload is
+  not a `SymbolId`).
+- `SymbolId::of(name)` / `keyword_hash(name)` hash without recording, and need
+  no table at all. Both are `const fn`, so a well-known id can be a constant.
+
+A memo learns a name where names already travel, and nowhere else:
+
+| Site | What arrives |
+|------|--------------|
+| the reader | every identifier and keyword token in the source text |
+| primitives | every keyword a native mints through its `NativeCtx` |
+| the plugin ABI | every keyword a plugin mints through `make_keyword`'s call ctx |
+| `send` | the bundle's name table (symbols, named from the sender's memo) and the inline names keywords already carry, replayed into the receiver's memo |
+| hydration | the image's name table, replayed into the hydrating instance |
+| `ConstTemplate` decode | symbols and keywords encoded by name in the constant pool |
+
+Because a name is recorded only at those sites, a memo answers for the names
+its instance has actually met. That is the whole contract: a value whose name
+was never recorded is still a perfectly good value, and still compares
+correctly. It just has no name to print.
+
+## Reading a name, and not reading one
+
+Identity questions never touch the memo. Asking whether a binding is `count` is
+`bi.name == SymbolId::of("count")` — one integer compare against a constant,
+with no table in scope and no allocation. Every such site in the compiler is
+written that way; a lookup that returns a `&str` only to compare it against a
+literal is the shape to avoid.
+
+Display threads the memo explicitly. `Value::display_with(Option<&SymbolTable>)`
+and `Value::debug_with` carry it into the formatter; the bare `Display` and
+`Debug` impls cannot, because `fmt` takes only `&self` and a formatter. A symbol
+formatted without a memo renders `#<symbol:hash>`; a keyword renders
+`#<keyword:hash>`. With a memo they render the bare name and `:name`
+respectively (`map`, not `'map` — the quote is reader syntax for `quote`, not
+part of the printed form).
+
+The unresolved forms are deliberately not keyword or symbol spellings: any
+rendering that parses as a literal (`:0xcbf2…`, `:unknown`) denotes a real
+value — the wrong one. `#<…>` is the codebase's marker for an object the
+printer cannot render faithfully, and here it doubles as a canary: every mint
+site is a learning site, so an unresolved form in user-facing output points at
+a missed one, or at a formatter that failed to thread the memo.
+
+## Collisions are fatal
+
+Two different names that hash alike would make two names one name, silently and
+everywhere at once. So every learning site is also the collision check:
+recording a hash the memo already maps to a different name panics. Nothing
+recovers — a collision is a property of the program's vocabulary, not of one
+execution, so retrying or falling back would only move the corruption.
+
+Checking at the learning site rather than in one process-wide table is what
+extends the check past this process. A name arriving from a dump or from another
+build is checked against the receiving instance's names as it lands, which is
+the moment it would first confuse a reader.
+
+The payload is a full `u64` — the tag lives in the `Value`'s separate tag word,
+so all 64 bits carry discrimination. For a program with 10,000 distinct names
+the birthday bound puts the collision probability near 3 in 10^12. That bound
+covers names built at run time; the built-in vocabulary is proven rather than
+estimated, by a test that hashes every static name — the primitive tables and
+their aliases, and every symbol read from core, prelude, and stdlib — and
+asserts they are distinct, so a build whose own vocabulary collides fails CI.
+
+`SymbolId::SYNTHETIC` (`u64::MAX`) marks a compiler-generated binding with no
+source-level name — a phi temporary, a desugaring's scratch variable. It is
+reserved: `intern` panics if a real name hashes onto it, so the sentinel can
+never be mistaken for a symbol somebody wrote.
+
+Because the memo is one map, the collision check spans both vocabularies: a
+keyword spelling colliding with a symbol spelling is caught by the same guard,
+at whichever learning site meets the second spelling first.
+
+## Keywords in the plugin ABI
+
+A stable-ABI plugin mints a keyword through `make_keyword`, which — like every
+other constructor in the ABI — takes the per-call `CallCtx`. The ctx carries
+the owning instance's memo, so a plugin keyword is learned by the instance the
+call belongs to, and `keyword_name`/`as_keyword_name` read back through the
+same ctx. `intern_keyword` is a pure hash: it records nothing and needs no
+ctx. `Value::keyword(&str)` in the host is equally pure — construction is
+identity only, and naming happens at the learning sites above.
+
+## Where the id appears
+
+| Site | Form |
+|------|------|
+| `Value` | `Value::symbol(SymbolId)`, `as_symbol() -> Option<SymbolId>`; `Value::keyword(&str)`, `keyword_hash() -> Option<u64>` |
+| Struct and set keys | `TableKey::Symbol(SymbolId)` and `TableKey::Keyword(u64)`, ordered by hash |
+| HIR bindings | `BindingInner::name`, `SymbolId::SYNTHETIC` for temporaries |
+| LIR constants | `LirConst::Symbol(SymbolId)`, `LirConst::Keyword(u64)` |
+| Bytecode | none directly — a symbol reaches bytecode as a constant-pool `Value` (a `u16` pool index) or inside a `ConstTemplate`, which encodes symbols by name |
+
+`Value::symbol` takes a `SymbolId`, not a bare `u64`, because a keyword hash is
+also a `u64`: the newtype is what stops `Value::symbol(keyword_hash(s))` from
+compiling.

--- a/docs/impl/values.md
+++ b/docs/impl/values.md
@@ -25,8 +25,8 @@ TAG_NIL (2)         unused
 TAG_TRUE (3)        unused
 TAG_FALSE (4)       unused
 TAG_EMPTY_LIST (5)  unused
-TAG_SYMBOL (6)      SymbolId (interned)
-TAG_KEYWORD (7)     keyword hash (intern_keyword)
+TAG_SYMBOL (6)      SymbolId — the name's FNV-1a hash (impl/symbol.md)
+TAG_KEYWORD (7)     keyword hash (keyword_hash — the name hash)
 TAG_UNDEFINED (8)   unused (compiler sentinel; never user-visible)
 TAG_CPOINTER (9)    raw C pointer address
 TAG_NATIVE_FN (10)  prim_id (index into the primitive registry)

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -346,8 +346,8 @@ is returned unchanged.
 ### Implementation
 
 Both are runtime primitives in `src/primitives/meta.rs`. They reach the
-symbol table through their `NativeCtx` — `ctx.vm().symbols()` — which
-resolves in the running instance's own table.
+symbol table through their `NativeCtx` — `ctx.vm().symbols()` — to intern
+the names they build.
 
 The `scope_exempt: bool` field on `Syntax` is the mechanism that
 prevents intro scope stamping. `add_scope_recursive` checks this flag

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -199,7 +199,7 @@ Every compilation path follows the same five phases:
    `analyzer.analyze(&expanded)` → `AnalysisResult { hir, .. }`
 4. **Tail call marking**: `mark_tail_calls(&mut analysis.hir)` (mutates HIR in place)
 5. **Lower + Emit**: `Lowerer::new().with_intrinsics(intrinsics).lower(&hir)` →
-   `LirFunction` → `Emitter::new_with_symbols(snapshot).emit(&lir_func)` → `Bytecode`
+   `LirFunction` → `Emitter::new().emit(&lir_func)` → `Bytecode`
 
 `analyze` and `analyze_file` stop after phase 3 (no lowering or emission).
 
@@ -230,8 +230,6 @@ own VM.
 - Prelude must be 100% defmacro (no runtime definitions)
 - Primitives must be registered in the context's macro VM at construction
 - Pipeline functions are not re-entrant (no nested compile/compile_file)
-- Primitive registration order is deterministic (ALL_TABLES), so the baked
-  `SymbolId`s match any table that interned the primitives in the same order
 
 ## Known issues
 

--- a/docs/structs.md
+++ b/docs/structs.md
@@ -84,13 +84,16 @@ reference for mutable).
 ## Introspection
 
 ```lisp
-(keys {:a 1 :b 2})         # => (:a :b)   (sorted order)
+(keys {:a 1 :b 2})         # => (:a :b)   (deterministic key order)
 (values {:a 1 :b 2})       # => (1 2)     (matching key order)
 (pairs {:a 1 :b 2})        # => ([a 1] [b 2])  (list of [key value] arrays)
 (from-pairs [[:a 1] [:b 2]])  # => {:a 1 :b 2}
 ```
 
-`pairs` returns a list of `[key value]` arrays in sorted key order.
+`pairs` returns a list of `[key value]` arrays in the struct's key order.
+Key order is deterministic — the same in every run, thread, and process —
+but carries no alphabetical meaning: symbol and keyword keys sort by their
+name hash (docs/impl/symbol.md § "What the property buys").
 Combined with `from-pairs`, structs can be round-tripped through list
 operations:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -254,13 +254,14 @@ what kind of Rust test to write and where, see [`tests/AGENTS.md`](../tests/AGEN
 [`docs/analysis/testing.md`](analysis/testing.md). (`elle test --rust`, which folds
 the cargo suite into the same DB, is specced but not yet implemented.)
 
-**Symbol names in assertions.** Symbol name resolution is per-instance
-(docs/impl/region/ctx.md § "Symbols through the ctx"). So a
-bare `{:?}`/`{}` on a symbol-bearing `Value` (as in `assert_eq!` output) renders
-`#<sym:id>`, not the bare `name`, because the trait `fmt` has no table to thread.
-When a failing assertion needs readable names, put `v.debug_with(symbols)` /
-`v.display_with(symbols)` in the assert message — those carry the table (a symbol
-then renders as its bare `name`, matching Scheme/CL — no leading `'`).
+**Symbol names in assertions.** A name lives in the owning instance's display
+memo, not in a global table (docs/impl/symbol.md), and `fmt` cannot reach it. So
+a bare `{:?}`/`{}` on a symbol-bearing `Value` renders `#<symbol:hash>`. To read
+names in assertion output, thread the table:
+`format!("{}", v.display_with(Some(&symbols)))`, which renders the bare `name`
+with no leading `'` (matching Scheme/CL). Comparing a symbol against a known
+name needs no table and no formatting at all — use
+`v.as_symbol() == Some(SymbolId::of("map"))`.
 
 ## Known gaps
 

--- a/docs/threads.md
+++ b/docs/threads.md
@@ -52,17 +52,15 @@ only whether stdlib *functions* (`+`, `map`, …) are present.
 (sys/join (sys/spawn (fn [] (eval '(map inc [1 2 3])))))   # => [2 3 4]
 ```
 
-#### Quoted symbols cross the boundary by name
+#### Quoted symbols cross the boundary unchanged
 
 A deep-copied value (closure, quoted datum, channel message) crosses threads via
-`SendValue`. A worker's symbol table is its own — interned IDs are not comparable
-across threads — so any **symbol value** in the copied data is serialized with its
-*name* and **re-interned** into the receiving thread's table (exactly as keywords
-are). This is what lets `(eval '(begin …))` work in a worker: the analyzer matches
-special forms by name, and the name survives the copy even though `begin`'s ID in
-the worker's table differs from the sender's. (Symbol references baked into
-compiled *bytecode* travel separately, via the closure template's `symbol_names`
-map; this paragraph is about symbols that appear as runtime *data*.)
+`SendValue`. A symbol id is the FNV-1a hash of its name
+([impl/symbol.md](impl/symbol.md)), so it means the same thing on both sides and
+copies verbatim — as an immediate, with no name and no re-interning. This is what
+lets `(eval '(begin …))` work in a worker: `begin`'s id in the worker is
+`begin`'s id everywhere. The same holds for symbols baked into compiled
+*bytecode*, which needs no name table to travel.
 
 Aliases: `sys/spawn` = `os/spawn` (heavy); `sys/spawn-vm` = `os/spawn-vm` (light).
 There is no bare `spawn` — it was an ambiguous global (it collides with the

--- a/elle-plugin/src/accessors.rs
+++ b/elle-plugin/src/accessors.rs
@@ -91,9 +91,14 @@ impl Api {
         }
     }
 
-    pub fn get_struct_key<'a>(&self, v: ElleValue, idx: usize) -> Option<&'a str> {
+    pub fn get_struct_key<'a>(
+        &self,
+        ctx: *mut ElleCtx,
+        v: ElleValue,
+        idx: usize,
+    ) -> Option<&'a str> {
         let mut len = 0usize;
-        let ptr = (self.struct_key)(v, idx, &mut len);
+        let ptr = (self.struct_key)(ctx, v, idx, &mut len);
         if ptr.is_null() {
             None
         } else {
@@ -106,14 +111,14 @@ impl Api {
     }
 
     /// Iterate struct entries as (key, value) pairs.
-    pub fn struct_entries(&self, v: ElleValue) -> Vec<(&str, ElleValue)> {
+    pub fn struct_entries(&self, ctx: *mut ElleCtx, v: ElleValue) -> Vec<(&str, ElleValue)> {
         let n = match self.get_struct_len(v) {
             Some(n) => n,
             None => return Vec::new(),
         };
         let mut out = Vec::with_capacity(n);
         for i in 0..n {
-            if let Some(k) = self.get_struct_key(v, i) {
+            if let Some(k) = self.get_struct_key(ctx, v, i) {
                 out.push((k, self.get_struct_value(v, i)));
             }
         }
@@ -124,9 +129,9 @@ impl Api {
         (self.intern_keyword)(name.as_ptr(), name.len())
     }
 
-    pub fn kw_name<'a>(&self, hash: u64) -> Option<&'a str> {
+    pub fn kw_name<'a>(&self, ctx: *mut ElleCtx, hash: u64) -> Option<&'a str> {
         let mut len = 0usize;
-        let ptr = (self.keyword_name)(hash, &mut len);
+        let ptr = (self.keyword_name)(ctx, hash, &mut len);
         if ptr.is_null() {
             None
         } else {
@@ -167,9 +172,9 @@ impl Api {
         (self.is_external)(v)
     }
 
-    pub fn get_keyword_name<'a>(&self, v: ElleValue) -> Option<&'a str> {
+    pub fn get_keyword_name<'a>(&self, ctx: *mut ElleCtx, v: ElleValue) -> Option<&'a str> {
         let mut len = 0usize;
-        let ptr = (self.as_keyword_name)(v, &mut len);
+        let ptr = (self.as_keyword_name)(ctx, v, &mut len);
         if ptr.is_null() {
             None
         } else {

--- a/elle-plugin/src/lib.rs
+++ b/elle-plugin/src/lib.rs
@@ -181,7 +181,7 @@ elle_api! {
     fn make_nil() -> ElleValue;
     fn make_string(*mut ElleCtx, *const u8, usize) -> ElleValue;
     fn make_bytes(*mut ElleCtx, *const u8, usize) -> ElleValue;
-    fn make_keyword(*const u8, usize) -> ElleValue;
+    fn make_keyword(*mut ElleCtx, *const u8, usize) -> ElleValue;
     fn make_array(*mut ElleCtx, *const ElleValue, usize) -> ElleValue;
     fn make_struct(*mut ElleCtx, *const ElleKV, usize) -> ElleValue;
     fn make_set(*mut ElleCtx, *const ElleValue, usize) -> ElleValue;
@@ -218,12 +218,12 @@ elle_api! {
     fn is_external(ElleValue) -> bool;
 
     // ── Keyword access ────────────────────────────────────────────
-    fn as_keyword_name(ElleValue, *mut usize) -> *const u8;
+    fn as_keyword_name(*mut ElleCtx, ElleValue, *mut usize) -> *const u8;
 
     // ── Struct access ─────────────────────────────────────────────
     fn struct_get(ElleValue, *const u8, usize) -> ElleValue;
     fn struct_len(ElleValue) -> isize;
-    fn struct_key(ElleValue, usize, *mut usize) -> *const u8;
+    fn struct_key(*mut ElleCtx, ElleValue, usize, *mut usize) -> *const u8;
     fn struct_value(ElleValue, usize) -> ElleValue;
 
     // ── Array access ──────────────────────────────────────────────
@@ -241,7 +241,7 @@ elle_api! {
 
     // ── Keyword interning ─────────────────────────────────────────
     fn intern_keyword(*const u8, usize) -> u64;
-    fn keyword_name(u64, *mut usize) -> *const u8;
+    fn keyword_name(*mut ElleCtx, u64, *mut usize) -> *const u8;
 }
 
 // ── Safe wrappers ─────────────────────────────────────────────────────
@@ -271,8 +271,8 @@ impl Api {
         (self.make_bytes)(ctx, b.as_ptr(), b.len())
     }
 
-    pub fn keyword(&self, s: &str) -> ElleValue {
-        (self.make_keyword)(s.as_ptr(), s.len())
+    pub fn keyword(&self, ctx: *mut ElleCtx, s: &str) -> ElleValue {
+        (self.make_keyword)(ctx, s.as_ptr(), s.len())
     }
 
     pub fn array(&self, ctx: *mut ElleCtx, elems: &[ElleValue]) -> ElleValue {

--- a/lib/http2/session.lisp
+++ b/lib/http2/session.lisp
@@ -12,13 +12,14 @@
 ##           :send-data-with-flow-control :ack-settings-received
 ##           :default-settings :initial-window :max-frame :test}
 ##
-## The SETTINGS-ACK latch key comes from `(gensym)`, a process-global
+## The SETTINGS-ACK latch key comes from `(sys/unique)`, a process-global
 ## primitive counter, NOT a module-local counter.  `(import ...)` returns
 ## a fresh module instance each call, so a module-local counter would
 ## restart in every importer and hand out colliding keys; since the
 ## scheduler's park-queue is process-global, acking one session's SETTINGS
 ## would then wake another session's settings-waiter (same elle bug class
-## as the lib/sync futex-key collision, #861).
+## as the lib/sync futex-key collision, #861).  An integer key also
+## interns nothing, where a gensym key retained one symbol per session.
 
 (fn [&named frame stream hpack]
   (def C frame:constants)
@@ -109,7 +110,7 @@
     "Send SETTINGS and start a 30s timeout for the ACK."
     (let [[ftype flags sid payload] (frame:make-settings-frame settings)]
       (send-frame session ftype flags sid payload))
-    (let [latch-key (gensym)
+    (let [latch-key (sys/unique)
           latch-box (box 0)]
       (put session :settings-ack-latch @{:key latch-key :box latch-box})
       (ev/spawn (fn []

--- a/lib/http2/stream.lisp
+++ b/lib/http2/stream.lisp
@@ -7,13 +7,16 @@
 ##
 ## No sync dependency — uses bare ev/futex-wait and ev/futex-wake.
 ##
-## Futex keys come from `(gensym)`, a process-global primitive counter,
-## NOT a module-local counter.  `(import ...)` returns a fresh module
-## instance each call, so a module-local counter would restart at 0 in
-## every importer and hand out colliding keys — and since the scheduler's
-## park-queue is process-global (one key -> one wait list), a wake on one
-## channel/flow-control futex would unpark a waiter on another instance's
-## (same elle bug class as the lib/sync futex-key collision, #861).
+## Futex keys come from `(sys/unique)`, a process-global primitive
+## counter, NOT a module-local counter.  `(import ...)` returns a fresh
+## module instance each call, so a module-local counter would restart at
+## 0 in every importer and hand out colliding keys — and since the
+## scheduler's park-queue is process-global (one key -> one wait list), a
+## wake on one channel/flow-control futex would unpark a waiter on
+## another instance's (same elle bug class as the lib/sync futex-key
+## collision, #861).  An integer key also interns nothing, where a gensym
+## key retained one symbol per stream (tests/elle/sync-keys.lisp pins the
+## property for the sync constructors).
 ##
 ## Exports: {:make-stream :make-channel :transition :make-flow-control :test}
 
@@ -24,7 +27,7 @@
   ## single-threaded cooperative runtime.
 
   (defn make-channel []
-    (let [key (gensym)
+    (let [key (sys/unique)
           bx (box 0)
           buf @[]
           @closed false
@@ -107,7 +110,7 @@
   ## ── Flow control ───────────────────────────────────────────────────────
 
   (defn make-flow-control [initial-window]
-    (let [key (gensym)
+    (let [key (sys/unique)
           bx (box 0)]
       @{:send-window initial-window
         :recv-window initial-window

--- a/lib/resource.lisp
+++ b/lib/resource.lisp
@@ -22,10 +22,7 @@
 
   (defn snapshot []
     "Capture all resource counters at a point in time."
-    {:objects (arena/count)
-     :bytes (arena/bytes)
-     :symbols (debug/symbol-count)
-     :keywords (debug/keyword-count)})
+    {:objects (arena/count) :bytes (arena/bytes) :symbols (debug/symbol-count)})
 
   ## ── Measure ─────────────────────────────────────────────────────────
 
@@ -48,7 +45,6 @@
     (let* [b-objects (arena/count)
            b-bytes (arena/bytes)
            b-symbols (debug/symbol-count)
-           b-keywords (debug/keyword-count)
            _ (arena/reset-peak)
            pair (arena/allocs thunk)
            peak (- (arena/peak) b-objects peak-overhead)]
@@ -56,8 +52,7 @@
        :allocs (rest pair)
        :peak peak
        :bytes (- (arena/bytes) b-bytes)
-       :symbols (- (debug/symbol-count) b-symbols)
-       :keywords (- (debug/keyword-count) b-keywords)}))
+       :symbols (- (debug/symbol-count) b-symbols)}))
 
   ## ── Report ──────────────────────────────────────────────────────────
 
@@ -76,7 +71,7 @@
     "Format a measurement as a tab-separated key=value line."
     (let [n (pad-right name 24)]
       (string n "\tallocs=" (m :allocs) "\tpeak=" (m :peak) "\tbytes="
-              (m :bytes) "\tsymbols=" (m :symbols) "\tkeywords=" (m :keywords))))
+              (m :bytes) "\tsymbols=" (m :symbols))))
 
   ## ── Suite ───────────────────────────────────────────────────────────
 

--- a/lib/sync.lisp
+++ b/lib/sync.lisp
@@ -18,12 +18,13 @@
 ## colliding keys, and since the scheduler's park-queue is process-global
 ## (one key → one wait list), a wake on one futex would unpark a waiter
 ## on the other (which re-checks its unchanged value and re-parks),
-## losing the intended wakeup.  `gensym` is a process-global primitive
-## counter, so keys are globally unique regardless of how many times the
-## module is imported.
+## losing the intended wakeup.  `sys/unique` is a process-global
+## primitive counter, so keys are globally unique regardless of how many
+## times the module is imported — and unlike a gensym, an integer key
+## interns nothing into the symbol table (tests/elle/sync-keys.lisp).
 (defn make-futex [initial]
   "Low-level futex. Wraps a box with park/notify."
-  (let [key (gensym)
+  (let [key (sys/unique)
         bx (box initial)]
     {:wait (fn [expected]
              (while (= (unbox bx) expected) (ev/futex-wait key bx expected)))

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -46,7 +46,7 @@ Provide the complete Elle implementation:
 | `primitives` | Built-in functions (arithmetic, list, string, I/O, concurrency, etc.) |
 | `pipeline` | Compilation entry points (`compile`, `analyze`, `eval`) |
 | `repl` | Interactive REPL |
-| `symbol` | Symbol table and interning |
+| `symbol` | Symbol identity (name hash) and the per-instance display memo |
 | `port` | I/O port abstraction |
 
 ## Compilation pipeline

--- a/src/compiler/bytecode.rs
+++ b/src/compiler/bytecode.rs
@@ -13,10 +13,6 @@ pub use instruction::*;
 pub struct Bytecode {
     pub instructions: Vec<u8>,
     pub constants: Vec<Value>,
-    /// Symbol ID → name mapping for cross-thread portability.
-    /// When bytecode is sent to a new thread, symbol IDs may differ.
-    /// This map allows remapping globals to the correct IDs.
-    pub symbol_names: std::collections::HashMap<u32, String>,
     /// Bytecode offset → source location mapping for error reporting.
     /// Maps instruction offsets to their source locations.
     pub location_map: LocationMap,
@@ -64,7 +60,6 @@ impl Bytecode {
         Bytecode {
             instructions: Vec::new(),
             constants: Vec::new(),
-            symbol_names: std::collections::HashMap::new(),
             location_map: LocationMap::new(),
             signal: crate::signals::Signal::silent(),
             signal_projection: None,
@@ -90,15 +85,6 @@ impl Bytecode {
             span.col as usize,
         );
         self.location_map.insert(offset, loc);
-    }
-
-    /// Add a symbol constant and record its name for portability.
-    /// This enables cross-thread symbol ID remapping.
-    pub fn add_symbol(&mut self, id: u32, name: &str) -> u16 {
-        self.symbol_names
-            .entry(id)
-            .or_insert_with(|| name.to_string());
-        self.add_constant(Value::symbol(id))
     }
 
     /// Add a constant and return its index

--- a/src/dump/escape.rs
+++ b/src/dump/escape.rs
@@ -57,16 +57,14 @@ use crate::hir::region::{Region, RegionInfo, StaticRegion};
 use crate::hir::{Binding, BindingArena, CaptureKind, EscapeInfo, Hir, HirId, HirKind};
 use crate::lir::{LirFunction, LirInstr, LirModule};
 
-type Names = HashMap<u32, String>;
-
 /// Render the normalized escape snapshot for a compiled module.
 pub fn escape_module(
     hir: &Hir,
     arena: &BindingArena,
-    names: &Names,
     escape: &EscapeInfo,
     ri: &RegionInfo,
     module: &LirModule,
+    symbols: Option<&crate::symbol::SymbolTable>,
 ) -> String {
     // The return frontier — escape's authoritative return verdict projected onto
     // regions. A flat region set; its members feed both the region normalization
@@ -102,7 +100,7 @@ pub fn escape_module(
     // identically. Names without a trailing-digit suffix (`x`, `down`, `~`) are
     // left verbatim. Hygiene does not depend on the counter (it is carried by
     // scopes), so this is display-only.
-    let name_label = build_name_labels(&binding_order, arena, names);
+    let name_label = build_name_labels(&binding_order, arena, symbols);
     let h = |id: HirId| -> String {
         match hir_norm.get(&id) {
             Some(n) => format!("#{n}"),
@@ -305,15 +303,14 @@ fn blabel(
 fn build_name_labels(
     order: &[Binding],
     arena: &BindingArena,
-    names: &Names,
+    symbols: Option<&crate::symbol::SymbolTable>,
 ) -> HashMap<Binding, String> {
     let mut out: HashMap<Binding, String> = HashMap::new();
     let mut by_raw: HashMap<String, String> = HashMap::new();
     let mut base_ctr: HashMap<String, usize> = HashMap::new();
     for &b in order {
-        let raw = names
-            .get(&arena.get(b).name.0)
-            .map(String::as_str)
+        let raw = symbols
+            .and_then(|s| s.name(arena.get(b).name))
             .unwrap_or("~")
             .to_string();
         let label = by_raw.entry(raw.clone()).or_insert_with(|| {

--- a/src/dump/mod.rs
+++ b/src/dump/mod.rs
@@ -67,20 +67,20 @@ pub fn render_all(
     // artifacts (held in `fhir`) — the `escape` dump below reuses this HIR/arena.
     crate::signals::registry::restore_registry(registry_baseline.clone());
     let fhir = crate::pipeline::compile_file_to_fhir(contents, symbols, cctx, source_name).ok();
-    if let Some((hir, arena, names)) = &fhir {
+    if let Some((hir, arena)) = &fhir {
         out.insert(
             "fhir".to_string(),
-            crate::hir::display::display_hir(hir, arena, names),
+            crate::hir::display::display_hir(hir, arena, Some(symbols)),
         );
         let info = crate::hir::analyze_dataflow(hir);
         out.insert(
             "defuse".to_string(),
-            crate::hir::format_dataflow(&info, arena, names),
+            crate::hir::format_dataflow(&info, arena, Some(symbols)),
         );
         let rinfo = crate::hir::analyze_regions(hir, arena);
         out.insert(
             "regions".to_string(),
-            crate::hir::format_regions(&rinfo, arena, names),
+            crate::hir::format_regions(&rinfo, arena, Some(symbols)),
         );
     }
 
@@ -101,16 +101,15 @@ pub fn render_all(
     // the bare `analyze_regions` used for the `regions` dump above omits the
     // native effects the lowerer actually consumes, so escape facts (tail
     // regions, escape-return sites) would diverge from what was emitted.
-    if let (Some((hir, arena, names)), Some(module)) = (&fhir, &module) {
-        let pc =
-            crate::lir::intrinsics::PrimitiveClassification::new(symbols, cctx.primitive_meta());
+    if let (Some((hir, arena)), Some(module)) = (&fhir, &module) {
+        let pc = crate::lir::intrinsics::PrimitiveClassification::new(cctx.primitive_meta());
         let rinfo = crate::hir::analyze_regions_with(hir, arena, pc.call_classification.clone());
         // Escape is the authority the snapshot's return-frontier section reads; run
         // it with the same real classification the solver and lowerer consumed.
         let escape = crate::hir::analyze_escape(hir, arena, &pc.call_classification);
         out.insert(
             "escape".to_string(),
-            escape::escape_module(hir, arena, names, &escape, &rinfo, module),
+            escape::escape_module(hir, arena, &escape, &rinfo, module, Some(symbols)),
         );
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,14 +1,14 @@
 //! Runtime/compile error formatting (human and JSON).
 
-use super::*;
-
-/// Format a runtime error with symbol resolution
-pub(super) fn format_runtime_error(error: &str, symbols: &SymbolTable) -> String {
+/// Format a runtime error, naming any `SymbolId(N)` it carries through
+/// `symbols` — the instance that raised the error, and so the only memo that
+/// can hold the name (docs/impl/symbol.md).
+pub(super) fn format_runtime_error(error: &str, symbols: &elle::symbol::SymbolTable) -> String {
     // Check for SymbolId pattern and resolve it
     if let Some(start) = error.find("SymbolId(") {
         if let Some(end) = error[start..].find(')') {
             let id_str = &error[start + 9..start + end];
-            if let Ok(id) = id_str.parse::<u32>() {
+            if let Ok(id) = id_str.parse::<u64>() {
                 let name = symbols
                     .name(elle::value::SymbolId(id))
                     .unwrap_or("<unknown>");

--- a/src/hir/analyze/call.rs
+++ b/src/hir/analyze/call.rs
@@ -234,10 +234,12 @@ impl<'a> Analyzer<'a> {
         self.is_primitive_named(func, "import")
     }
 
-    /// Check if a callee HIR node refers to a named primitive.
+    /// Check if a callee HIR node refers to a named primitive — one hash
+    /// compare, no memo (docs/impl/symbol.md § "Reading a name, and not
+    /// reading one").
     fn is_primitive_named(&self, func: &Hir, name: &str) -> bool {
         if let HirKind::Var(binding) = &func.kind {
-            self.symbols.name(self.arena.get(*binding).name) == Some(name)
+            self.arena.get(*binding).name == crate::value::SymbolId::of(name)
         } else {
             false
         }

--- a/src/hir/analyze/fileletrec.rs
+++ b/src/hir/analyze/fileletrec.rs
@@ -224,8 +224,7 @@ impl<'a> Analyzer<'a> {
             // Struct literal: (struct :key1 val1 :key2 val2 ...)
             HirKind::Call { func, args, .. } => {
                 if let HirKind::Var(binding) = &func.kind {
-                    let name = self.symbols.name(self.arena.get(*binding).name)?;
-                    if name != "struct" {
+                    if self.arena.get(*binding).name != crate::value::SymbolId::of("struct") {
                         return None;
                     }
                     // Parse alternating keyword-value pairs

--- a/src/hir/analyze/forms/special.rs
+++ b/src/hir/analyze/forms/special.rs
@@ -26,13 +26,13 @@ impl<'a> Analyzer<'a> {
         let ref_scopes: &[crate::syntax::ScopeId] = &items[0].scopes;
 
         // Collect all lexical (non-primitive) bindings from all scopes.
-        // Inner scopes shadow outer: track seen names.
+        // Inner scopes shadow outer: track seen ids.
         let mut seen = std::collections::HashSet::new();
-        let mut pairs: Vec<(String, Binding)> = Vec::new();
+        let mut pairs: Vec<(SymbolId, Binding)> = Vec::new();
 
         for scope in self.scopes.iter().rev() {
-            for (name, candidates) in &scope.bindings {
-                if seen.contains(name) {
+            for (&sym, candidates) in &scope.bindings {
+                if seen.contains(&sym) {
                     continue;
                 }
                 // Resolve like `lookup`: the binding's scopes must be a
@@ -48,11 +48,11 @@ impl<'a> Analyzer<'a> {
                     if self.primitive_values.contains_key(&binding)
                         || self.arena.get(binding).is_synthetic
                     {
-                        seen.insert(name.clone());
+                        seen.insert(sym);
                         continue;
                     }
-                    pairs.push((name.clone(), binding));
-                    seen.insert(name.clone());
+                    pairs.push((sym, binding));
+                    seen.insert(sym);
                 }
             }
         }
@@ -62,16 +62,15 @@ impl<'a> Analyzer<'a> {
         let func = Hir::new(HirKind::Var(struct_binding), span.clone(), Signal::silent());
 
         let mut args = Vec::new();
-        for (name, binding) in &pairs {
-            let sym_id = self.symbols.intern(name);
+        for &(sym_id, binding) in &pairs {
             // quoted symbol key
-            let key = Hir::silent(HirKind::Quote(Value::symbol(sym_id.0)), span.clone());
+            let key = Hir::silent(HirKind::Quote(Value::symbol(sym_id)), span.clone());
             args.push(crate::hir::expr::CallArg {
                 expr: key,
                 spliced: false,
             });
             // variable reference
-            let var = Hir::silent(HirKind::Var(*binding), span.clone());
+            let var = Hir::silent(HirKind::Var(binding), span.clone());
             args.push(crate::hir::expr::CallArg {
                 expr: var,
                 spliced: false,

--- a/src/hir/analyze/mod.rs
+++ b/src/hir/analyze/mod.rs
@@ -115,9 +115,17 @@ fn is_scope_subset(subset: &[ScopeId], superset: &[ScopeId]) -> bool {
 
 /// A lexical scope
 struct Scope {
-    /// Bindings in this scope, by name. Multiple bindings per name are possible
-    /// when macro expansion introduces bindings with different scope sets.
-    bindings: HashMap<String, Vec<ScopedBinding>>,
+    /// Bindings in this scope, keyed by the name's `SymbolId`. Multiple
+    /// bindings per name are possible when macro expansion introduces bindings
+    /// with different scope sets.
+    ///
+    /// The key is the id, not the spelling, because resolution is an identity
+    /// question: the id is the name's hash, so it answers without a display
+    /// memo (docs/impl/symbol.md § "Reading a name, and not reading one"). A
+    /// name-keyed map would make binding resolution depend on whichever memo
+    /// happened to have learned the spelling — and `bind_primitives` receives
+    /// ids minted against the compile context's own table, not this one's.
+    bindings: HashMap<SymbolId, Vec<ScopedBinding>>,
     /// Is this a function scope (creates new capture boundary)
     is_function: bool,
     /// Is this a definition-environment frame — the global frame or a file's
@@ -377,6 +385,10 @@ impl<'a> Analyzer<'a> {
 
     /// Analyze a syntax tree into HIR
     pub fn analyze(&mut self, syntax: &crate::syntax::Syntax) -> Result<AnalysisResult, String> {
+        // Keyword pre-pass: keywords reach HIR through many arms (literals,
+        // pattern keys, struct literals, quoted data), so their spellings are
+        // learned in one walk rather than per arm.
+        crate::syntax::convert::learn_keywords(syntax, self.symbols);
         let hir = self.analyze_expr(syntax)?;
         let errors = std::mem::take(&mut self.errors);
         Ok(AnalysisResult { hir, errors })
@@ -461,13 +473,20 @@ impl<'a> Analyzer<'a> {
     }
 
     /// Find bindings in scope with names similar to `name` (edit distance <= 2).
+    ///
+    /// Spelling-based, so unlike resolution this does need the memo. A binding
+    /// whose name this instance never learned simply cannot be suggested — the
+    /// message degrades, nothing resolves differently.
     fn suggest_similar(&self, name: &str) -> Vec<String> {
         let mut candidates: Vec<(usize, String)> = Vec::new();
         for scope in self.scopes.iter().rev() {
-            for scope_name in scope.bindings.keys() {
+            for scope_sym in scope.bindings.keys() {
+                let Some(scope_name) = self.symbols.name(*scope_sym) else {
+                    continue;
+                };
                 let dist = Self::levenshtein(name, scope_name);
                 if dist > 0 && dist <= 2 && !candidates.iter().any(|(_, n)| n == scope_name) {
-                    candidates.push((dist, scope_name.clone()));
+                    candidates.push((dist, scope_name.to_string()));
                 }
             }
         }

--- a/src/hir/analyze/scopes.rs
+++ b/src/hir/analyze/scopes.rs
@@ -66,7 +66,7 @@ impl<'a> Analyzer<'a> {
         if let Some(scope_frame) = self.scopes.last_mut() {
             scope_frame
                 .bindings
-                .entry(name.to_string())
+                .entry(SymbolId::of(name))
                 .or_default()
                 .push(ScopedBinding {
                     scopes: scopes.to_vec(),
@@ -86,7 +86,7 @@ impl<'a> Analyzer<'a> {
         if let Some(scope_frame) = self.scopes.last_mut() {
             scope_frame
                 .bindings
-                .entry(name.to_string())
+                .entry(SymbolId::of(name))
                 .or_default()
                 .push(ScopedBinding {
                     scopes: scopes.to_vec(),
@@ -99,20 +99,17 @@ impl<'a> Analyzer<'a> {
     }
     /// Bind a symbol by its already-interned SymbolId.
     ///
-    /// Used by `bind_primitives` where we already have SymbolIds from
-    /// PrimitiveMeta and need to resolve the name for scope registration.
+    /// Used by `bind_primitives`, which holds ids from `PrimitiveMeta`. The id
+    /// is the scope key, so this needs no spelling — and must not want one:
+    /// those ids were minted against the compile context's table, which is not
+    /// this analyzer's.
     pub(super) fn bind_by_sym(&mut self, sym: SymbolId, scope: BindingScope) -> Binding {
-        let name = self
-            .symbols
-            .name(sym)
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| format!("sym#{}", sym.0));
         let binding = self.arena.alloc(sym, scope);
 
         if let Some(scope_frame) = self.scopes.last_mut() {
             scope_frame
                 .bindings
-                .entry(name)
+                .entry(sym)
                 .or_default()
                 .push(ScopedBinding {
                     scopes: Vec::new(), // primitives have empty scopes (visible everywhere)
@@ -131,7 +128,7 @@ impl<'a> Analyzer<'a> {
 
         // Walk scopes from innermost to outermost
         for (depth, scope) in self.scopes.iter().enumerate().rev() {
-            if let Some(candidates) = scope.bindings.get(name) {
+            if let Some(candidates) = scope.bindings.get(&SymbolId::of(name)) {
                 // Find the best candidate: binding's scopes must be a subset of
                 // the reference's scopes, and the largest scope set wins.
                 // When multiple candidates share the largest scope-set size,
@@ -304,13 +301,16 @@ impl<'a> Analyzer<'a> {
         ref_scopes: &[ScopeId],
     ) -> Option<Binding> {
         self.scopes.last().and_then(|scope| {
-            scope.bindings.get(name).and_then(|candidates| {
-                candidates
-                    .iter()
-                    .filter(|c| is_scope_subset(&c.scopes, ref_scopes))
-                    .max_by_key(|c| c.scopes.len())
-                    .map(|c| c.binding)
-            })
+            scope
+                .bindings
+                .get(&SymbolId::of(name))
+                .and_then(|candidates| {
+                    candidates
+                        .iter()
+                        .filter(|c| is_scope_subset(&c.scopes, ref_scopes))
+                        .max_by_key(|c| c.scopes.len())
+                        .map(|c| c.binding)
+                })
         })
     }
 }

--- a/src/hir/dataflow.rs
+++ b/src/hir/dataflow.rs
@@ -67,25 +67,25 @@ pub fn analyze_dataflow(hir: &Hir) -> DataflowInfo {
 pub fn format_dataflow(
     info: &DataflowInfo,
     arena: &BindingArena,
-    names: &HashMap<u32, String>,
+    symbols: Option<&crate::symbol::SymbolTable>,
 ) -> String {
     use std::fmt::Write;
     let mut buf = String::new();
 
-    fn bname(b: Binding, arena: &BindingArena, names: &HashMap<u32, String>) -> String {
+    let bname = |b: Binding, arena: &BindingArena| -> String {
         let sym = arena.get(b).name;
-        let base = names
-            .get(&sym.0)
-            .cloned()
+        let base = symbols
+            .and_then(|s| s.name(sym))
+            .map(|n| n.to_string())
             .unwrap_or_else(|| format!("_{}", b.0));
         format!("{}#{}", base, b.0)
-    }
+    };
 
     writeln!(buf, ";; ── def-use chains ──").unwrap();
     let mut bindings: Vec<_> = info.def_site.keys().copied().collect();
     bindings.sort_by_key(|b| b.0);
     for b in &bindings {
-        let name = bname(*b, arena, names);
+        let name = bname(*b, arena);
         let def = info.def_site.get(b).map(|id| id.0).unwrap_or(0);
         let use_count = info.uses.get(b).map(|v| v.len()).unwrap_or(0);
         let use_ids: Vec<u32> = info
@@ -108,7 +108,7 @@ pub fn format_dataflow(
     for (id, origin) in &origins {
         let origin_str = match origin {
             ValueOrigin::Immediate => "immediate".to_string(),
-            ValueOrigin::Binding(b) => format!("binding({})", bname(*b, arena, names)),
+            ValueOrigin::Binding(b) => format!("binding({})", bname(*b, arena)),
             ValueOrigin::CallResult => "call-result".to_string(),
             ValueOrigin::Allocation => "allocation".to_string(),
             ValueOrigin::CellDeref => "cell-deref".to_string(),
@@ -127,7 +127,7 @@ pub fn format_dataflow(
         }
         let live_names: Vec<String> = live
             .iter()
-            .map(|idx| bname(info.index_binding[idx], arena, names))
+            .map(|idx| bname(info.index_binding[idx], arena))
             .collect();
         writeln!(
             buf,

--- a/src/hir/display.rs
+++ b/src/hir/display.rs
@@ -5,21 +5,21 @@
 use super::arena::BindingArena;
 use super::binding::Binding;
 use super::expr::{Hir, HirKind};
-use std::collections::HashMap;
+use crate::symbol::SymbolTable;
 use std::fmt::Write;
 
 /// Pretty-print a HIR tree as an s-expression string.
-pub fn display_hir(hir: &Hir, arena: &BindingArena, names: &HashMap<u32, String>) -> String {
+pub fn display_hir(hir: &Hir, arena: &BindingArena, symbols: Option<&SymbolTable>) -> String {
     let mut buf = String::new();
-    write_hir(&mut buf, hir, arena, names, 0);
+    write_hir(&mut buf, hir, arena, symbols, 0);
     buf
 }
 
-fn binding_name(b: Binding, arena: &BindingArena, names: &HashMap<u32, String>) -> String {
+fn binding_name(b: Binding, arena: &BindingArena, symbols: Option<&SymbolTable>) -> String {
     let sym = arena.get(b).name;
-    let base = names
-        .get(&sym.0)
-        .cloned()
+    let base = symbols
+        .and_then(|s| s.name(sym))
+        .map(|n| n.to_string())
         .unwrap_or_else(|| format!("_{}", b.0));
     // Append binding ID to disambiguate SSA versions
     format!("{}#{}", base, b.0)
@@ -35,7 +35,7 @@ fn write_hir(
     buf: &mut String,
     hir: &Hir,
     arena: &BindingArena,
-    names: &HashMap<u32, String>,
+    symbols: Option<&SymbolTable>,
     depth: usize,
 ) {
     match &hir.kind {
@@ -52,7 +52,7 @@ fn write_hir(
         HirKind::Error => buf.push_str("<error>"),
 
         HirKind::Var(b) => {
-            buf.push_str(&binding_name(*b, arena, names));
+            buf.push_str(&binding_name(*b, arena, symbols));
         }
 
         HirKind::Let { bindings, body } => {
@@ -62,13 +62,13 @@ fn write_hir(
                     buf.push('\n');
                     indent(buf, depth + 3);
                 }
-                buf.push_str(&binding_name(*b, arena, names));
+                buf.push_str(&binding_name(*b, arena, symbols));
                 buf.push(' ');
-                write_hir(buf, init, arena, names, depth + 3);
+                write_hir(buf, init, arena, symbols, depth + 3);
             }
             buf.push_str("]\n");
             indent(buf, depth + 1);
-            write_hir(buf, body, arena, names, depth + 1);
+            write_hir(buf, body, arena, symbols, depth + 1);
             buf.push(')');
         }
 
@@ -79,13 +79,13 @@ fn write_hir(
                     buf.push('\n');
                     indent(buf, depth + 5);
                 }
-                buf.push_str(&binding_name(*b, arena, names));
+                buf.push_str(&binding_name(*b, arena, symbols));
                 buf.push(' ');
-                write_hir(buf, init, arena, names, depth + 5);
+                write_hir(buf, init, arena, symbols, depth + 5);
             }
             buf.push_str("]\n");
             indent(buf, depth + 1);
-            write_hir(buf, body, arena, names, depth + 1);
+            write_hir(buf, body, arena, symbols, depth + 1);
             buf.push(')');
         }
 
@@ -101,11 +101,11 @@ fn write_hir(
                 if i > 0 {
                     buf.push(' ');
                 }
-                buf.push_str(&binding_name(*p, arena, names));
+                buf.push_str(&binding_name(*p, arena, symbols));
             }
             if let Some(rp) = rest_param {
                 buf.push_str(" & ");
-                buf.push_str(&binding_name(*rp, arena, names));
+                buf.push_str(&binding_name(*rp, arena, symbols));
             }
             buf.push(']');
             if !captures.is_empty() {
@@ -114,13 +114,13 @@ fn write_hir(
                     if i > 0 {
                         buf.push_str(", ");
                     }
-                    buf.push_str(&binding_name(c.binding, arena, names));
+                    buf.push_str(&binding_name(c.binding, arena, symbols));
                 }
                 buf.push(']');
             }
             buf.push('\n');
             indent(buf, depth + 1);
-            write_hir(buf, body, arena, names, depth + 1);
+            write_hir(buf, body, arena, symbols, depth + 1);
             buf.push(')');
         }
 
@@ -130,13 +130,13 @@ fn write_hir(
             else_branch,
         } => {
             buf.push_str("(if ");
-            write_hir(buf, cond, arena, names, depth + 1);
+            write_hir(buf, cond, arena, symbols, depth + 1);
             buf.push('\n');
             indent(buf, depth + 2);
-            write_hir(buf, then_branch, arena, names, depth + 2);
+            write_hir(buf, then_branch, arena, symbols, depth + 2);
             buf.push('\n');
             indent(buf, depth + 2);
-            write_hir(buf, else_branch, arena, names, depth + 2);
+            write_hir(buf, else_branch, arena, symbols, depth + 2);
             buf.push(')');
         }
 
@@ -145,7 +145,7 @@ fn write_hir(
             for e in exprs {
                 buf.push('\n');
                 indent(buf, depth + 1);
-                write_hir(buf, e, arena, names, depth + 1);
+                write_hir(buf, e, arena, symbols, depth + 1);
             }
             buf.push(')');
         }
@@ -158,14 +158,14 @@ fn write_hir(
             for e in body {
                 buf.push('\n');
                 indent(buf, depth + 1);
-                write_hir(buf, e, arena, names, depth + 1);
+                write_hir(buf, e, arena, symbols, depth + 1);
             }
             buf.push(')');
         }
 
         HirKind::Break { value, .. } => {
             buf.push_str("(break ");
-            write_hir(buf, value, arena, names, depth + 1);
+            write_hir(buf, value, arena, symbols, depth + 1);
             buf.push(')');
         }
 
@@ -178,39 +178,39 @@ fn write_hir(
             if *is_tail {
                 buf.push_str("/*tail*/ ");
             }
-            write_hir(buf, func, arena, names, depth + 1);
+            write_hir(buf, func, arena, symbols, depth + 1);
             for a in args {
                 buf.push(' ');
                 if a.spliced {
                     buf.push(';');
                 }
-                write_hir(buf, &a.expr, arena, names, depth + 1);
+                write_hir(buf, &a.expr, arena, symbols, depth + 1);
             }
             buf.push(')');
         }
 
         HirKind::Assign { target, value } => {
             buf.push_str("(assign ");
-            buf.push_str(&binding_name(*target, arena, names));
+            buf.push_str(&binding_name(*target, arena, symbols));
             buf.push(' ');
-            write_hir(buf, value, arena, names, depth + 1);
+            write_hir(buf, value, arena, symbols, depth + 1);
             buf.push(')');
         }
 
         HirKind::Define { binding, value } => {
             buf.push_str("(define ");
-            buf.push_str(&binding_name(*binding, arena, names));
+            buf.push_str(&binding_name(*binding, arena, symbols));
             buf.push(' ');
-            write_hir(buf, value, arena, names, depth + 1);
+            write_hir(buf, value, arena, symbols, depth + 1);
             buf.push(')');
         }
 
         HirKind::While { cond, body } => {
             buf.push_str("(while ");
-            write_hir(buf, cond, arena, names, depth + 1);
+            write_hir(buf, cond, arena, symbols, depth + 1);
             buf.push('\n');
             indent(buf, depth + 1);
-            write_hir(buf, body, arena, names, depth + 1);
+            write_hir(buf, body, arena, symbols, depth + 1);
             buf.push(')');
         }
 
@@ -220,13 +220,13 @@ fn write_hir(
                 if i > 0 {
                     buf.push_str(", ");
                 }
-                buf.push_str(&binding_name(*b, arena, names));
+                buf.push_str(&binding_name(*b, arena, symbols));
                 buf.push(' ');
-                write_hir(buf, init, arena, names, depth + 3);
+                write_hir(buf, init, arena, symbols, depth + 3);
             }
             buf.push_str("]\n");
             indent(buf, depth + 1);
-            write_hir(buf, body, arena, names, depth + 1);
+            write_hir(buf, body, arena, symbols, depth + 1);
             buf.push(')');
         }
 
@@ -234,57 +234,57 @@ fn write_hir(
             buf.push_str("(recur");
             for a in args {
                 buf.push(' ');
-                write_hir(buf, a, arena, names, depth + 1);
+                write_hir(buf, a, arena, symbols, depth + 1);
             }
             buf.push(')');
         }
 
         HirKind::MakeCell { value } => {
             buf.push_str("(make-cell ");
-            write_hir(buf, value, arena, names, depth + 1);
+            write_hir(buf, value, arena, symbols, depth + 1);
             buf.push(')');
         }
 
         HirKind::DerefCell { cell } => {
             buf.push_str("(deref-cell ");
-            write_hir(buf, cell, arena, names, depth + 1);
+            write_hir(buf, cell, arena, symbols, depth + 1);
             buf.push(')');
         }
 
         HirKind::SetCell { cell, value } => {
             buf.push_str("(set-cell ");
-            write_hir(buf, cell, arena, names, depth + 1);
+            write_hir(buf, cell, arena, symbols, depth + 1);
             buf.push(' ');
-            write_hir(buf, value, arena, names, depth + 1);
+            write_hir(buf, value, arena, symbols, depth + 1);
             buf.push(')');
         }
 
         HirKind::Emit { signal, value } => {
             write!(buf, "(emit {:?} ", signal).unwrap();
-            write_hir(buf, value, arena, names, depth + 1);
+            write_hir(buf, value, arena, symbols, depth + 1);
             buf.push(')');
         }
 
         HirKind::Return { value } => {
             buf.push_str("(return ");
-            write_hir(buf, value, arena, names, depth + 1);
+            write_hir(buf, value, arena, symbols, depth + 1);
             buf.push(')');
         }
 
         HirKind::Match { value, arms } => {
             buf.push_str("(match ");
-            write_hir(buf, value, arena, names, depth + 1);
+            write_hir(buf, value, arena, symbols, depth + 1);
             for (pat, guard, body) in arms {
                 buf.push('\n');
                 indent(buf, depth + 1);
                 write!(buf, "{:?}", pat).unwrap();
                 if let Some(g) = guard {
                     buf.push_str(" when ");
-                    write_hir(buf, g, arena, names, depth + 2);
+                    write_hir(buf, g, arena, symbols, depth + 2);
                 }
                 buf.push('\n');
                 indent(buf, depth + 2);
-                write_hir(buf, body, arena, names, depth + 2);
+                write_hir(buf, body, arena, symbols, depth + 2);
             }
             buf.push(')');
         }
@@ -297,17 +297,17 @@ fn write_hir(
             for (c, b) in clauses {
                 buf.push('\n');
                 indent(buf, depth + 1);
-                write_hir(buf, c, arena, names, depth + 1);
+                write_hir(buf, c, arena, symbols, depth + 1);
                 buf.push('\n');
                 indent(buf, depth + 2);
-                write_hir(buf, b, arena, names, depth + 2);
+                write_hir(buf, b, arena, symbols, depth + 2);
             }
             if let Some(e) = else_branch {
                 buf.push('\n');
                 indent(buf, depth + 1);
                 buf.push_str("else\n");
                 indent(buf, depth + 2);
-                write_hir(buf, e, arena, names, depth + 2);
+                write_hir(buf, e, arena, symbols, depth + 2);
             }
             buf.push(')');
         }
@@ -316,7 +316,7 @@ fn write_hir(
             buf.push_str("(and");
             for e in exprs {
                 buf.push(' ');
-                write_hir(buf, e, arena, names, depth + 1);
+                write_hir(buf, e, arena, symbols, depth + 1);
             }
             buf.push(')');
         }
@@ -325,22 +325,22 @@ fn write_hir(
             buf.push_str("(or");
             for e in exprs {
                 buf.push(' ');
-                write_hir(buf, e, arena, names, depth + 1);
+                write_hir(buf, e, arena, symbols, depth + 1);
             }
             buf.push(')');
         }
 
         HirKind::Destructure { pattern, value, .. } => {
             write!(buf, "(destructure {:?} ", pattern).unwrap();
-            write_hir(buf, value, arena, names, depth + 1);
+            write_hir(buf, value, arena, symbols, depth + 1);
             buf.push(')');
         }
 
         HirKind::Eval { expr, env } => {
             buf.push_str("(eval ");
-            write_hir(buf, expr, arena, names, depth + 1);
+            write_hir(buf, expr, arena, symbols, depth + 1);
             buf.push(' ');
-            write_hir(buf, env, arena, names, depth + 1);
+            write_hir(buf, env, arena, symbols, depth + 1);
             buf.push(')');
         }
 
@@ -351,14 +351,14 @@ fn write_hir(
                     buf.push_str(", ");
                 }
                 buf.push('(');
-                write_hir(buf, k, arena, names, depth + 1);
+                write_hir(buf, k, arena, symbols, depth + 1);
                 buf.push(' ');
-                write_hir(buf, v, arena, names, depth + 1);
+                write_hir(buf, v, arena, symbols, depth + 1);
                 buf.push(')');
             }
             buf.push_str("]\n");
             indent(buf, depth + 1);
-            write_hir(buf, body, arena, names, depth + 1);
+            write_hir(buf, body, arena, symbols, depth + 1);
             buf.push(')');
         }
 
@@ -366,7 +366,7 @@ fn write_hir(
             write!(buf, "({}", op.name()).unwrap();
             for a in args {
                 buf.push(' ');
-                write_hir(buf, a, arena, names, depth + 1);
+                write_hir(buf, a, arena, symbols, depth + 1);
             }
             buf.push(')');
         }

--- a/src/hir/escape/tests/capture.rs
+++ b/src/hir/escape/tests/capture.rs
@@ -15,10 +15,10 @@ fn capture_by_called_in_place_closure_does_not_escape() {
     let src = "(def make (fn () (let [up \"x\"] \
                    (let [inner (fn () (length up))] \
                      (let [wrap (fn () (inner))] (wrap))))))";
-    let (hir, arena, names, escape) = escape_of(src);
+    let (hir, arena, escape) = escape_of(src);
     // `up` is captured (by `inner`) but its capturer never escapes, so `up` must
     // not escape its activation.
-    let up = bindings_named(&hir, &arena, &["up"], &names);
+    let up = bindings_named(&hir, &arena, &["up"]);
     assert!(!up.is_empty(), "missing `up` in `{src}`");
     assert!(
         up.iter().all(|b| !escape.binding_escapes_activation(*b)),
@@ -27,7 +27,7 @@ fn capture_by_called_in_place_closure_does_not_escape() {
     );
     // The lambda capturing `up` (`inner`) is itself called in place via `wrap`,
     // so it must not escape its definition.
-    let names_up = |b: &Binding| names.get(&arena.get(*b).name.0).map(String::as_str) == Some("up");
+    let names_up = |b: &Binding| arena.get(*b).name == crate::value::SymbolId::of("up");
     let mut found = false;
     for (lid, caps) in lambdas_with_captures(&hir) {
         if caps.iter().any(names_up) {
@@ -155,13 +155,13 @@ fn fiber_emit_value_escapes() {
 fn native_store_arg_escapes_send_message_not_channel() {
     let src = "(def f (fn (c) (let [m \"hi\"] (chan/send c m))))";
     let mut symbols = crate::symbol::SymbolTable::new();
-    let (hir, arena, names) = compile_fhir(src, &mut symbols);
+    let (hir, arena) = compile_fhir(src, &mut symbols);
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let escape = analyze_escape(&hir, &arena, &pc.call_classification);
 
-    let m = bindings_named(&hir, &arena, &["m"], &names);
-    let c = bindings_named(&hir, &arena, &["c"], &names);
+    let m = bindings_named(&hir, &arena, &["m"]);
+    let c = bindings_named(&hir, &arena, &["c"]);
     assert!(!m.is_empty() && !c.is_empty(), "missing m/c in `{src}`");
     // Positive: the message (the stored arg, a live local) escapes.
     assert!(

--- a/src/hir/escape/tests/flow.rs
+++ b/src/hir/escape/tests/flow.rs
@@ -61,12 +61,12 @@ fn def_callee_arg_does_not_escape_through_call() {
     // assert only about the argument binding here, by name.)
     let src = "(def id (fn (x) x)) (def f (fn (y) (id y))) (f 1)";
     let mut symbols = crate::symbol::SymbolTable::new();
-    let (hir, arena, names) = compile_fhir(src, &mut symbols);
+    let (hir, arena) = compile_fhir(src, &mut symbols);
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let escape = analyze_escape(&hir, &arena, &pc.call_classification);
 
-    let y = bindings_named(&hir, &arena, &["y"], &names);
+    let y = bindings_named(&hir, &arena, &["y"]);
     assert!(!y.is_empty(), "missing `y` in `{src}`");
     assert!(
         y.iter().all(|b| !escape.binding_escapes_activation(*b)),
@@ -95,11 +95,11 @@ fn arg_return_summary_chains_through_the_fixpoint() {
                          c (fn (w) 0)] \
                      (begin (id 1) (g 1) (k 1 2) (c 1)))";
     let mut symbols = crate::symbol::SymbolTable::new();
-    let (hir, arena, names) = compile_fhir(src, &mut symbols);
+    let (hir, arena) = compile_fhir(src, &mut symbols);
     let summary = compute_arg_return(&hir, &arena);
 
     let lookup = |name: &str| -> Vec<usize> {
-        let bs = bindings_named(&hir, &arena, &[name], &names);
+        let bs = bindings_named(&hir, &arena, &[name]);
         assert!(!bs.is_empty(), "missing `{name}` in `{src}`");
         summary.get(&bs[0]).cloned().unwrap_or_default()
     };
@@ -129,11 +129,11 @@ fn arg_return_summary_chains_through_the_fixpoint() {
 fn return_facet_is_narrower_than_full_escape() {
     let check = |src: &str, name: &str, want_full: bool, want_return: bool| {
         let mut symbols = crate::symbol::SymbolTable::new();
-        let (hir, arena, names) = compile_fhir(src, &mut symbols);
+        let (hir, arena) = compile_fhir(src, &mut symbols);
         let meta = crate::primitives::build_primitive_meta(&mut symbols);
-        let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+        let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
         let escape = analyze_escape(&hir, &arena, &pc.call_classification);
-        let bs = bindings_named(&hir, &arena, &[name], &names);
+        let bs = bindings_named(&hir, &arena, &[name]);
         assert!(!bs.is_empty(), "missing `{name}` in `{src}`");
         for b in bs {
             assert_eq!(

--- a/src/hir/escape/tests/mod.rs
+++ b/src/hir/escape/tests/mod.rs
@@ -10,11 +10,7 @@ use crate::hir::{Hir, HirId, HirKind};
 fn compile_fhir(
     src: &str,
     symbols: &mut crate::symbol::SymbolTable,
-) -> (
-    Hir,
-    crate::hir::BindingArena,
-    std::collections::HashMap<u32, String>,
-) {
+) -> (Hir, crate::hir::BindingArena) {
     let mut cctx = crate::pipeline::CompileCtx::new();
     crate::pipeline::compile_file_to_fhir(src, symbols, &mut cctx, "<test>").expect("compile")
 }
@@ -32,39 +28,32 @@ fn compile_with_cc(
     crate::hir::region::CallClassification,
 ) {
     let mut symbols = crate::symbol::SymbolTable::new();
-    let (hir, arena, _names) = compile_fhir(src, &mut symbols);
+    let (hir, arena) = compile_fhir(src, &mut symbols);
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     (hir, arena, pc.call_classification)
 }
 
 /// Compile a source under the real classification and return its
-/// `EscapeInfo` alongside the HIR/arena/names — the fixture every spec test
+/// `EscapeInfo` alongside the HIR and arena — the fixture every spec test
 /// reads. Escape is the **authority**; these tests assert its four-facet spec
 /// directly (`docs/impl/escape.md`), never agreement with any other analysis.
-fn escape_of(
-    src: &str,
-) -> (
-    Hir,
-    BindingArena,
-    std::collections::HashMap<u32, String>,
-    EscapeInfo,
-) {
+fn escape_of(src: &str) -> (Hir, BindingArena, EscapeInfo) {
     let mut symbols = crate::symbol::SymbolTable::new();
-    let (hir, arena, names) = compile_fhir(src, &mut symbols);
+    let (hir, arena) = compile_fhir(src, &mut symbols);
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let escape = analyze_escape(&hir, &arena, &pc.call_classification);
-    (hir, arena, names, escape)
+    (hir, arena, escape)
 }
 
 /// Assert the escape spec for named bindings: each `(name, escapes_activation,
 /// escapes_via_return)` triple is checked against every binding that name
 /// resolves to. The invariant `returned ⟹ escapes` is checked too.
 fn assert_binding_escape(src: &str, expect: &[(&str, bool, bool)]) {
-    let (hir, arena, names, escape) = escape_of(src);
+    let (hir, arena, escape) = escape_of(src);
     for &(name, esc, ret) in expect {
-        let bs = bindings_named(&hir, &arena, &[name], &names);
+        let bs = bindings_named(&hir, &arena, &[name]);
         assert!(!bs.is_empty(), "missing `{name}` in `{src}`");
         for b in bs {
             assert_eq!(
@@ -102,12 +91,7 @@ fn lambdas_with_captures(hir: &Hir) -> Vec<(HirId, Vec<Binding>)> {
 /// The binding(s) a `Var(name)` reference resolves to in a program, restricted
 /// to those whose name matches `wanted` — a small helper to point a scrutiny
 /// test at a specific source binding without depending on raw arena indices.
-fn bindings_named(
-    hir: &Hir,
-    arena: &BindingArena,
-    wanted: &[&str],
-    names: &std::collections::HashMap<u32, String>,
-) -> Vec<Binding> {
+fn bindings_named(hir: &Hir, arena: &BindingArena, wanted: &[&str]) -> Vec<Binding> {
     fn walk(h: &Hir, out: &mut Vec<Binding>) {
         if let HirKind::Var(b) = &h.kind {
             out.push(*b);
@@ -118,9 +102,8 @@ fn bindings_named(
     walk(hir, &mut all);
     all.into_iter()
         .filter(|b| {
-            names
-                .get(&arena.get(*b).name.0)
-                .is_some_and(|n| wanted.contains(&n.as_str()))
+            let id = arena.get(*b).name;
+            wanted.iter().any(|w| crate::value::SymbolId::of(w) == id)
         })
         .collect()
 }

--- a/src/hir/narrow.rs
+++ b/src/hir/narrow.rs
@@ -10,6 +10,7 @@ use super::expr::{CallArg, Hir, HirId, HirKind};
 use super::types::{TyId, TypeInterner};
 use crate::signals::Signal;
 use crate::value::fiber::SignalBits;
+use crate::value::SymbolId;
 
 use std::collections::HashMap;
 
@@ -19,7 +20,6 @@ pub(super) fn narrow_signals(
     hir: &mut Hir,
     interner: &TypeInterner,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     hir_types: &HashMap<HirId, TyId>,
     binding_min_length: &HashMap<Binding, usize>,
 ) {
@@ -28,61 +28,74 @@ pub(super) fn narrow_signals(
         let callee_binding = super::typeinfer::unwrap_callee_binding(func);
         if let Some(callee_binding) = callee_binding {
             let callee_sym = arena.get(callee_binding).name;
-            if let Some(name) = symbol_names.get(&callee_sym.0) {
-                let arg_tys: Vec<TyId> = args
-                    .iter()
-                    .map(|a| {
-                        hir_types
-                            .get(&a.expr.id)
-                            .copied()
-                            .unwrap_or(TypeInterner::TOP)
-                    })
-                    .collect();
-                if should_narrow_error(name, &arg_tys, args, interner, arena, binding_min_length) {
-                    let sig_error = SignalBits::from_bit(0); // SIG_ERROR = bit 0
-                    hir.signal.bits = hir.signal.bits.subtract(sig_error);
-                }
+            let arg_tys: Vec<TyId> = args
+                .iter()
+                .map(|a| {
+                    hir_types
+                        .get(&a.expr.id)
+                        .copied()
+                        .unwrap_or(TypeInterner::TOP)
+                })
+                .collect();
+            if should_narrow_error(
+                callee_sym,
+                &arg_tys,
+                args,
+                interner,
+                arena,
+                binding_min_length,
+            ) {
+                let sig_error = SignalBits::from_bit(0); // SIG_ERROR = bit 0
+                hir.signal.bits = hir.signal.bits.subtract(sig_error);
             }
         }
     }
 
     // Recurse into children
     hir.for_each_child_mut(|child| {
-        narrow_signals(
-            child,
-            interner,
-            arena,
-            symbol_names,
-            hir_types,
-            binding_min_length,
-        );
+        narrow_signals(child, interner, arena, hir_types, binding_min_length);
     });
 }
 
 /// Determine if a call's SIG_ERROR can be stripped based on argument types.
 fn should_narrow_error(
-    name: &str,
+    sym: SymbolId,
     arg_tys: &[TyId],
     args: &[CallArg],
     interner: &TypeInterner,
     _arena: &BindingArena,
     binding_min_length: &HashMap<Binding, usize>,
 ) -> bool {
-    match name {
+    // Const patterns over the name's hash rather than a resolved spelling:
+    // recognition is identity, so it needs no symbol table (docs/impl/symbol.md
+    // § "Reading a name, and not reading one").
+    const PTR_P: SymbolId = SymbolId::of("ptr?");
+    const POINTER_P: SymbolId = SymbolId::of("pointer?");
+    const TYPE: SymbolId = SymbolId::of("type");
+    const EMPTY_P: SymbolId = SymbolId::of("empty?");
+    const STRING: SymbolId = SymbolId::of("string");
+    const PUT: SymbolId = SymbolId::of("put");
+    const PUSH: SymbolId = SymbolId::of("push");
+    const HAS_P: SymbolId = SymbolId::of("has?");
+    const LENGTH: SymbolId = SymbolId::of("length");
+    const STRING_CONTAINS_SLASH: SymbolId = SymbolId::of("string/contains?");
+    const STRING_CONTAINS_DASH: SymbolId = SymbolId::of("string-contains?");
+    const NUMBER_TO_STRING: SymbolId = SymbolId::of("number->string");
+    match sym {
         // Type predicates: never error
-        "ptr?" | "pointer?" => true,
+        PTR_P | POINTER_P => true,
 
         // type: never errors
-        "type" => true,
+        TYPE => true,
 
         // empty?: never errors
-        "empty?" => true,
+        EMPTY_P => true,
 
         // string: all args must be stringifiable
-        "string" => arg_tys.iter().all(|t| interner.is_stringifiable(*t)),
+        STRING => arg_tys.iter().all(|t| interner.is_stringifiable(*t)),
 
         // put on MutableStruct with keyword key
-        "put" => {
+        PUT => {
             if arg_tys.len() >= 2 {
                 let target = arg_tys[0];
                 if target == TypeInterner::MUTABLE_STRUCT && arg_tys[1] == TypeInterner::KEYWORD {
@@ -108,25 +121,25 @@ fn should_narrow_error(
         }
 
         // push on MutableArray
-        "push" => arg_tys
+        PUSH => arg_tys
             .first()
             .is_some_and(|t| *t == TypeInterner::MUTABLE_ARRAY),
 
         // has?: arg0 must be struct-like
-        "has?" => arg_tys.first().is_some_and(|t| interner.is_struct(*t)),
+        HAS_P => arg_tys.first().is_some_and(|t| interner.is_struct(*t)),
 
         // length: arg0 is not Top (works on strings, arrays, lists)
-        "length" => arg_tys.first().is_some_and(|t| *t != TypeInterner::TOP),
+        LENGTH => arg_tys.first().is_some_and(|t| *t != TypeInterner::TOP),
 
         // string/contains?: both args must be String
-        "string/contains?" | "string-contains?" => {
+        STRING_CONTAINS_SLASH | STRING_CONTAINS_DASH => {
             arg_tys.len() >= 2
                 && arg_tys[0] == TypeInterner::STRING
                 && arg_tys[1] == TypeInterner::STRING
         }
 
         // number->string: arg0 must be Number
-        "number->string" => arg_tys
+        NUMBER_TO_STRING => arg_tys
             .first()
             .is_some_and(|t| interner.subtype(*t, TypeInterner::NUMBER)),
 

--- a/src/hir/region/infer/format.rs
+++ b/src/hir/region/infer/format.rs
@@ -6,19 +6,19 @@ use super::*;
 pub fn format_regions(
     info: &RegionInfo,
     arena: &BindingArena,
-    names: &HashMap<u32, String>,
+    symbols: Option<&crate::symbol::SymbolTable>,
 ) -> String {
     use std::fmt::Write;
     let mut buf = String::new();
 
-    fn bname(b: Binding, arena: &BindingArena, names: &HashMap<u32, String>) -> String {
+    let bname = |b: Binding, arena: &BindingArena| -> String {
         let sym = arena.get(b).name;
-        let base = names
-            .get(&sym.0)
-            .cloned()
+        let base = symbols
+            .and_then(|s| s.name(sym))
+            .map(|n| n.to_string())
             .unwrap_or_else(|| format!("_{}", b.0));
         format!("{}#{}", base, b.0)
-    }
+    };
 
     writeln!(buf, ";; ── region assignments ──").unwrap();
 
@@ -47,7 +47,7 @@ pub fn format_regions(
     let mut bindings: Vec<_> = info.binding_region.iter().collect();
     bindings.sort_by_key(|(b, _)| b.0);
     for (b, region) in &bindings {
-        let name = bname(**b, arena, names);
+        let name = bname(**b, arena);
         writeln!(buf, "  {:<20} → r{}", name, region.0).unwrap();
     }
 

--- a/src/hir/region/infer/tests/borrow.rs
+++ b/src/hir/region/infer/tests/borrow.rs
@@ -49,7 +49,7 @@ fn opcode_read_extends_container_decref_to_the_reader() {
     // decref_point` IS the `%get` node — the container's free-time cascade then drops the
     // element's last count and `length` derefs a freed page (the cascade face of
     // `region_container_read_borrow_uaf`). This assertion was RED before the borrow pin.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(let [c (@array) r (string \"s\")] (begin (%array-push c r) (length (%get c 0))))",
     );
     let order = compute_order(&hir);
@@ -69,7 +69,7 @@ fn opcode_read_extends_container_decref_to_the_reader() {
         !containers.is_empty(),
         "the %get read must record its container regions (uncounted_read_sites); got none",
     );
-    let c = find_binding_by_name(&hir, "c", &arena, &symbols).expect("binding c");
+    let c = find_binding_by_name(&hir, "c", &arena).expect("binding c");
     let c_regions = info
         .binding_source_regions
         .get(&c)
@@ -127,11 +127,11 @@ fn native_read_alias_outliving_the_container_refuses_the_adopt() {
 fn native_read_records_its_alias_and_container() {
     // The recorded fact the refusal and the release order both read: the native read's
     // call-result placeholder (the alias) paired with the container it reads out of.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(let [c (@array) r (string \"s\")] \
            (begin (%array-push c r) (let [x (get c 0)] (length x))))",
     );
-    let get_site = *find_calls_to_primitive(&hir, "get", &arena, &symbols)
+    let get_site = *find_calls_to_primitive(&hir, "get", &arena)
         .first()
         .expect("the shape has a `get` call");
     let pairs = counted_aliases(&info, get_site);
@@ -144,7 +144,7 @@ fn native_read_records_its_alias_and_container() {
         .alloc_region
         .get(&get_site)
         .expect("the read call mints a call-result region");
-    let c = find_binding_by_name(&hir, "c", &arena, &symbols).expect("binding c");
+    let c = find_binding_by_name(&hir, "c", &arena).expect("binding c");
     let c_regions = info
         .binding_source_regions
         .get(&c)
@@ -170,11 +170,11 @@ fn remove_read_is_not_a_borrow() {
     // reference. So the container is NOT borrowed from, and pinning its release to the
     // popped element's reader would be a pure over-keep. The moves-out natives are
     // excluded from the borrow face at the recording site.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(let [c (@array) r (string \"s\")] \
            (begin (%array-push c r) (let [x (%pop c)] (length x))))",
     );
-    let pop_sites = find_calls_to_primitive(&hir, "%pop", &arena, &symbols);
+    let pop_sites = find_calls_to_primitive(&hir, "%pop", &arena);
     assert!(
         !pop_sites.is_empty(),
         "precondition: the shape has a `pop` call; if the stdlib route changed, update it",
@@ -332,11 +332,11 @@ fn fresh_call_result_records_no_alias() {
     // every debug run — so it can hand back neither `c` nor anything inside it, and no
     // alias edge is recorded. A `Fresh` native that references an argument declares that
     // separately (`embeds` → a containment edge), which is a different relation.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(let [c (@array) r (string \"s\")] \
            (begin (%array-push c r) (length (string \"t\" c))))",
     );
-    let sites = find_calls_to_primitive(&hir, "string", &arena, &symbols);
+    let sites = find_calls_to_primitive(&hir, "string", &arena);
     assert!(
         !sites.is_empty(),
         "precondition: the shape has `string` calls to check; if the classification \
@@ -392,11 +392,11 @@ fn container_read_is_not_recorded_as_a_result_alias() {
     // the container — the one reading under which the funnel exemption would be plainly
     // wrong. They are excluded from both result-alias relations at the recording site;
     // the read edge carries them instead, with the tighter container and its own bound.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(let [c (@array) r (string \"s\")] \
            (begin (%array-push c r) (let [x (get c 0)] (length x))))",
     );
-    let sites = find_calls_to_primitive(&hir, "get", &arena, &symbols);
+    let sites = find_calls_to_primitive(&hir, "get", &arena);
     assert!(
         !sites.is_empty(),
         "precondition: the shape has a `get` call; if the stdlib route changed, update it",

--- a/src/hir/region/infer/tests/cells.rs
+++ b/src/hir/region/infer/tests/cells.rs
@@ -372,8 +372,8 @@ fn frame_held_names_a_yielded_capturers_forward_cell() {
     // is the refusal that keeps the projection honest.
     let mut symbols = SymbolTable::new();
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
-    let (hir, arena, _) = compile_fhir(
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
+    let (hir, arena) = compile_fhir(
         "(fiber/new (fn () \
            (letrec [helper (fn [x] (when (%not (%int? x)) (error :x)) (%sub x 1)) \
                     go (fn [m] (when (%not (%int? m)) (error :m)) \
@@ -408,8 +408,8 @@ fn frame_held_refuses_a_forward_cell_whose_binding_is_stored() {
     // must be refused there and its release must keep the baseline.
     let mut symbols = SymbolTable::new();
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
-    let (hir, arena, _) = compile_fhir(
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
+    let (hir, arena) = compile_fhir(
         "(defn h [n] \
            (letrec [helper (fn [x] (when (%not (%int? x)) (error :x)) (%sub x 1)) \
                     go (fn [m] (when (%not (%int? m)) (error :m)) \
@@ -466,14 +466,13 @@ fn letrec_init_does_not_overwrite_destructure_binding_regions() {
     // binding_regions[r].
     let source =
         "(begin (def (a & r) (list 1 2 3)) (length r)) (def (a b & r) (list 1 2)) (length r)";
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let info = analyze_regions(&hir, &arena);
     // Find the pattern binding `r` introduced by the destructure.
     // The arena names it from the source symbol, so we look it up
     // by name. The letrec also declares it; the destructure's
     // pattern shares the same Binding id.
-    let r_binding =
-        find_binding_by_name(&hir, "r", &arena, &symbols).expect("expected binding `r`");
+    let r_binding = find_binding_by_name(&hir, "r", &arena).expect("expected binding `r`");
     let r_regions = info
         .binding_source_regions
         .get(&r_binding)
@@ -487,7 +486,7 @@ fn letrec_init_does_not_overwrite_destructure_binding_regions() {
     // decref_point would be left at its destructure id and
     // `(length r)` inside the begin (which uses r while r still
     // points into the first list) would read a freed page.
-    let list_calls = find_calls_to_primitive(&hir, "list", &arena, &symbols);
+    let list_calls = find_calls_to_primitive(&hir, "list", &arena);
     assert_eq!(
         list_calls.len(),
         2,

--- a/src/hir/region/infer/tests/compensate.rs
+++ b/src/hir/region/infer/tests/compensate.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::SymbolId;
 
 // ── The return frontier is per-path ───────────────────────────────────
 //
@@ -28,12 +29,11 @@ fn first_match_arms(hir: &Hir) -> Option<Vec<HirId>> {
 fn arm_compensates(
     hir: &Hir,
     arena: &BindingArena,
-    symbols: &SymbolTable,
     info: &RegionInfo,
     name: &str,
     arm: HirId,
 ) -> bool {
-    let b = find_binding_by_name(hir, name, arena, symbols)
+    let b = find_binding_by_name(hir, name, arena)
         .unwrap_or_else(|| panic!("no binding named {}", name));
     let regions = match info.binding_source_regions.get(&b) {
         Some(rs) => rs,
@@ -54,12 +54,11 @@ fn arm_compensates(
 fn release_clears_the_arms(
     hir: &Hir,
     arena: &BindingArena,
-    symbols: &SymbolTable,
     info: &RegionInfo,
     name: &str,
     arms: &[HirId],
 ) -> bool {
-    let b = find_binding_by_name(hir, name, arena, symbols)
+    let b = find_binding_by_name(hir, name, arena)
         .unwrap_or_else(|| panic!("no binding named {}", name));
     let regions = match info.binding_source_regions.get(&b) {
         Some(rs) => rs,
@@ -79,7 +78,6 @@ fn release_clears_the_arms(
 fn binder_routes(
     hir: &Hir,
     arena: &BindingArena,
-    symbols: &SymbolTable,
     info: &RegionInfo,
     name: &str,
 ) -> Vec<(Binding, Region)> {
@@ -87,12 +85,11 @@ fn binder_routes(
         h: &Hir,
         name: &str,
         arena: &BindingArena,
-        symbols: &SymbolTable,
         info: &RegionInfo,
         out: &mut Vec<(Binding, Region)>,
     ) {
         let mut record = |b: &Binding, init: &Hir| {
-            if symbols.name(arena.get(*b).name) == Some(name) {
+            if arena.get(*b).name == SymbolId::of(name) {
                 out.extend(info.alloc_region.get(&init.id).map(|&r| (*b, r)));
             }
         };
@@ -105,10 +102,10 @@ fn binder_routes(
             HirKind::Define { binding, value, .. } => record(binding, value),
             _ => {}
         }
-        h.for_each_child(|c| walk(c, name, arena, symbols, info, out));
+        h.for_each_child(|c| walk(c, name, arena, info, out));
     }
     let mut out = Vec::new();
-    walk(hir, name, arena, symbols, info, &mut out);
+    walk(hir, name, arena, info, &mut out);
     assert!(!out.is_empty(), "`{name}` has no allocating binder");
     out
 }
@@ -154,14 +151,14 @@ fn a_returned_param_anchors_where_no_arm_leaves_the_frame() {
     // other handed nothing over (docs/impl/region/mechanism.md § "The return facet
     // costs the merge nothing"). So the one release moves to the branch and neither
     // compensation route fires.
-    let (hir, arena, symbols, info) = analyze_with_class("(fn (i xs) (if (%eq i 0) xs 7))");
+    let (hir, arena, _symbols, info) = analyze_with_class("(fn (i xs) (if (%eq i 0) xs 7))");
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &[then_id, else_id]),
         "a returned param's release must sit where both arms reach it"
     );
     assert!(
-        !arm_compensates(&hir, &arena, &symbols, &info, "xs", else_id),
+        !arm_compensates(&hir, &arena, &info, "xs", else_id),
         "the anchored release must not be doubled by a per-arm compensation"
     );
 }
@@ -170,14 +167,14 @@ fn a_returned_param_anchors_where_no_arm_leaves_the_frame() {
 fn a_returned_param_anchors_whichever_arm_carries_it_out() {
     // The mirror: `xs` leaves through the ELSE arm. Pins that the admission reads
     // arm structure and not arm position.
-    let (hir, arena, symbols, info) = analyze_with_class("(fn (i xs) (if (%eq i 0) 7 xs))");
+    let (hir, arena, _symbols, info) = analyze_with_class("(fn (i xs) (if (%eq i 0) 7 xs))");
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &[then_id, else_id]),
         "a returned param's release must sit where both arms reach it"
     );
     assert!(
-        !arm_compensates(&hir, &arena, &symbols, &info, "xs", then_id),
+        !arm_compensates(&hir, &arena, &info, "xs", then_id),
         "the anchored release must not be doubled by a per-arm compensation"
     );
 }
@@ -191,15 +188,15 @@ fn a_frame_exit_the_callee_cannot_reach_anchors_a_returned_param() {
     // `TailCall` is the region's last release (docs/impl/region/mechanism.md § "The
     // callee's return mint, and why the point owes it nothing"). So the branch
     // anchors the return facet here exactly as it does where the callee captures.
-    let (hir, arena, symbols, info) = analyze_with_class("(fn (i xs) (if (%eq i 0) xs (g 7)))");
+    let (hir, arena, _symbols, info) = analyze_with_class("(fn (i xs) (if (%eq i 0) xs (g 7)))");
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &[then_id, else_id]),
         "a frame exit the callee cannot reach must not decline the returned param"
     );
     assert!(
-        !arm_compensates(&hir, &arena, &symbols, &info, "xs", else_id)
-            && !arm_compensates(&hir, &arena, &symbols, &info, "xs", then_id),
+        !arm_compensates(&hir, &arena, &info, "xs", else_id)
+            && !arm_compensates(&hir, &arena, &info, "xs", then_id),
         "the anchored release must not be doubled by a per-arm compensation"
     );
 }
@@ -211,13 +208,13 @@ fn an_index_walk_fold_driver_anchors_its_accumulator() {
     // rather than `acc` itself. No route reaches `acc` at that point, so `acc`'s one
     // release anchors on the branch and each displaced accumulator is freed per step
     // (`fold`/`reduce`/`concat` are the callers).
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(begin (def step (fn (f n i acc) \
            (if (%lt i n) (step f n (%add i 1) (f acc i)) acc))) (step g 2 0 nil))",
     );
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "acc", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "acc", &[then_id, else_id]),
         "the fold driver's accumulator must be released where both arms reach it"
     );
 }
@@ -227,11 +224,11 @@ fn read_only_arm_release_clears_the_arms() {
     // Control: when no arm carries `xs` across the return frontier the same
     // anchoring applies. Guards against a change that treats the returned shape
     // specially by dropping the baseline.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (i xs) (if (%eq i 0) (length xs) 7))");
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &[then_id, else_id]),
         "a merely-read param's release must sit where both arms reach it"
     );
 }
@@ -241,13 +238,13 @@ fn match_arms_are_treated_like_if_arms() {
     // Every premise here is stated over ONE ARM and its siblings — never over the
     // branch's arity or kind. `v` is allocated before the dispatch, so it is
     // live-in on every arm and no arm may hold its only release.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(fn (t) (let [v (list 1 2 3)] (match t :use (length v) :skip 0 _ -1)))",
     );
     let arms = first_match_arms(&hir).expect("a Match node");
     assert_eq!(arms.len(), 3, "the dispatch has three arms");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "v", &arms),
+        release_clears_the_arms(&hir, &arena, &info, "v", &arms),
         "a Match's live-in local must be released where every arm reaches it"
     );
 }
@@ -263,10 +260,10 @@ fn a_frame_replacing_arm_anchors_a_value_routed_release() {
     // a replica, not the anchor"). Only a VALUE route is replicable, and a call
     // result is value-routed unconditionally — which is what the first assertion
     // states about this shape and the second relies on.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (i xs) (if (%eq i 0) (length xs) (g 7)))");
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
-    let b = find_binding_by_name(&hir, "xs", &arena, &symbols).expect("the param `xs`");
+    let b = find_binding_by_name(&hir, "xs", &arena).expect("the param `xs`");
     assert!(
         info.binding_source_regions.get(&b).is_some_and(
             |rs| !rs.is_empty() && rs.iter().all(|r| info.call_result_regions.contains(r))
@@ -275,11 +272,11 @@ fn a_frame_replacing_arm_anchors_a_value_routed_release() {
          to be one — a region released by id keeps the whole-branch decline"
     );
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &[then_id, else_id]),
         "a frame-replacing sibling arm must not decline a value-routed release"
     );
     assert!(
-        !arm_compensates(&hir, &arena, &symbols, &info, "xs", else_id),
+        !arm_compensates(&hir, &arena, &info, "xs", else_id),
         "the anchored release must not be doubled by a per-arm compensation"
     );
 }
@@ -294,10 +291,10 @@ fn a_frame_replacing_arm_anchors_a_binder_routed_release() {
     // release the relocation replicates names a VALUE, and a binder's slot supplies
     // that name"). The window asks that question rather than reading the region's
     // class, so this branch narrows to `xs` instead of declining it.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (i) (let [xs (%pair 1 nil)] (if (%eq i 0) (length xs) (g 7))))");
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
-    let b = find_binding_by_name(&hir, "xs", &arena, &symbols).expect("the binding `xs`");
+    let b = find_binding_by_name(&hir, "xs", &arena).expect("the binding `xs`");
     assert!(
         info.binding_source_regions.get(&b).is_some_and(
             |rs| !rs.is_empty() && rs.iter().all(|r| !info.call_result_regions.contains(r))
@@ -306,12 +303,12 @@ fn a_frame_replacing_arm_anchors_a_binder_routed_release() {
          which is what the class reading declined"
     );
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &[then_id, else_id]),
         "a frame-replacing sibling arm must not decline a binder-routed release"
     );
     assert!(
-        !arm_compensates(&hir, &arena, &symbols, &info, "xs", then_id)
-            && !arm_compensates(&hir, &arena, &symbols, &info, "xs", else_id),
+        !arm_compensates(&hir, &arena, &info, "xs", then_id)
+            && !arm_compensates(&hir, &arena, &info, "xs", else_id),
         "the anchored release must not be doubled by a per-arm compensation"
     );
 }
@@ -322,9 +319,9 @@ fn a_binders_allocation_is_value_routed() {
     // ordinary `let` binder's slot holds its init's value from the binder to the
     // release, so the region that init allocated can be released by value and
     // replicated into an arm.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (i) (let [xs (%pair 1 nil)] (if (%eq i 0) (length xs) (g 7))))");
-    let routes = binder_routes(&hir, &arena, &symbols, &info, "xs");
+    let routes = binder_routes(&hir, &arena, &info, "xs");
     assert!(
         routes
             .iter()
@@ -341,11 +338,11 @@ fn a_celled_binders_allocation_is_not_value_routed() {
     // slot a release would load holds the BOX. With no value route the frame-exit
     // relocation can replicate nothing, so the branch-arm window must keep the
     // whole-branch decline rather than anchor a release the exiting arm never runs.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(fn (i) (let [@xs (%pair 1 nil) f (fn () (length xs))] \
            (if (%eq i 0) (%add (length xs) (f)) (g 7))))",
     );
-    let routes = binder_routes(&hir, &arena, &symbols, &info, "xs");
+    let routes = binder_routes(&hir, &arena, &info, "xs");
     assert!(
         routes
             .iter()
@@ -365,10 +362,10 @@ fn a_callee_the_arm_tail_calls_keeps_its_in_arm_release() {
     // (docs/impl/region/mechanism.md § "What the exemption keeps, a channel must
     // still run"). Anchoring it at the merge would take it out of that channel's
     // reach and leave the arm with no release at all, so the branch declines it.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (xs) (letrec [go (fn (a b) a)] (if (%eq xs 0) 0 (go xs 1))))");
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
-    let routes = binder_routes(&hir, &arena, &symbols, &info, "go");
+    let routes = binder_routes(&hir, &arena, &info, "go");
     assert!(
         routes
             .iter()
@@ -397,12 +394,12 @@ fn a_reassigned_binder_versions_away_before_it_can_route() {
     // records no route. The refusal keeps the emitter's own
     // `reassigned_local_slots` reading honest where that does not hold; here it
     // costs nothing, and the route stays available.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(fn (@i n) (let [@xs (%pair 1 nil)] \
            (begin (while (%lt i n) (begin (assign xs (%pair i xs)) (assign i (%add i 1)))) \
              (if (%eq i 0) (length xs) (g 7)))))",
     );
-    let routes = binder_routes(&hir, &arena, &symbols, &info, "xs");
+    let routes = binder_routes(&hir, &arena, &info, "xs");
     assert!(
         routes
             .iter()
@@ -419,18 +416,18 @@ fn a_capturing_frame_exit_anchors_a_returned_param() {
     // region off zero until the walker's own `Return` mints the caller's reference
     // — the other end of the enumeration the shape above drives, and the branch
     // anchors the return facet on both.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(fn (dst n) (if (%eq n 0) dst \
            (letrec [go (fn (i) (if (%lt i n) (go (%add i 1)) dst))] (go 0))))",
     );
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "dst", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "dst", &[then_id, else_id]),
         "a capture-funded frame exit must not decline the returned param"
     );
     assert!(
-        !arm_compensates(&hir, &arena, &symbols, &info, "dst", then_id)
-            && !arm_compensates(&hir, &arena, &symbols, &info, "dst", else_id),
+        !arm_compensates(&hir, &arena, &info, "dst", then_id)
+            && !arm_compensates(&hir, &arena, &info, "dst", else_id),
         "the anchored release must not be doubled by a per-arm compensation"
     );
 }
@@ -440,11 +437,11 @@ fn a_native_tail_arm_does_not_decline_the_window() {
     // A tail call to a NATIVE pushes no frame and falls through to the merge, so
     // it is not a frame exit at all and the narrowing above never applies — the
     // distinction is the callee kind, not `is_tail`.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (i xs) (if (%eq i 0) (length xs) (length xs)))");
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &[then_id, else_id]),
         "a native tail call in an arm must not decline the window"
     );
 }
@@ -507,12 +504,12 @@ fn a_cond_clause_test_is_a_conditional_position() {
     // release left there fires on no such path at all. The arms of a `cond` are its
     // nested-`If` equivalent — the clause body, and the rest of the chain from the
     // next test on — so the one release anchors on the form's own merge.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (t xs) (cond (%eq t 0) 1 (%lt 0 (length xs)) 2 true 0))");
     let parts = first_cond_parts(&hir).expect("a Cond node");
     assert_eq!(parts.len(), 6, "three clauses, each a test and a body");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &parts),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &parts),
         "a live-in param whose last use is a later clause's TEST must be released \
          where every clause reaches it"
     );
@@ -523,11 +520,11 @@ fn a_cond_body_is_an_arm_like_any_other() {
     // The body half of the same decomposition: `xs`'s last use is the LAST clause's
     // body, so every earlier clause strands it. `Cond` is a branch, so its bodies
     // are arms exactly as an `If`'s and a `Match`'s are.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (t xs) (cond (%eq t 0) 1 (%eq t 1) (length xs) true 0))");
     let parts = first_cond_parts(&hir).expect("a Cond node");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &parts),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &parts),
         "a live-in param used by one clause body must be released where every \
          clause reaches it"
     );
@@ -538,12 +535,12 @@ fn a_short_circuit_tail_is_an_arm() {
     // `(or a b)` evaluates `b` only where `a` is falsy, so `b` is a conditional
     // position with no sibling body — a one-armed branch. `xs`'s last use sits
     // there, and the path that short-circuits must still release it.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (t xs) (if (or t (%lt 0 (length xs))) 1 2))");
     let parts = first_short_circuit_parts(&hir).expect("an Or node");
     assert_eq!(parts.len(), 2, "the `or` has two elements");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &parts[1..]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &parts[1..]),
         "a live-in param whose last use is a short-circuited tail must be released \
          where both paths reach it"
     );
@@ -552,12 +549,12 @@ fn a_short_circuit_tail_is_an_arm() {
 #[test]
 fn an_and_tail_is_an_arm_too() {
     // The `and` face of the same rule: the tail runs only where the head is truthy.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (t xs) (if (and t (%lt 0 (length xs))) 1 2))");
     let parts = first_short_circuit_parts(&hir).expect("an And node");
     assert_eq!(parts.len(), 2, "the `and` has two elements");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &parts[1..]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &parts[1..]),
         "a live-in param whose last use is a short-circuited `and` tail must be \
          released where both paths reach it"
     );
@@ -572,7 +569,7 @@ fn an_arm_whose_loop_reads_a_live_in_param_anchors_at_the_branch() {
     // per execution of the loop — the same count with which the merge is reached.
     // Reading the boundary as the closed subtree interval would leave the branch's
     // only release under the looping arm, stranding `xs` on every other arm.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(fn (t xs) (if t (length xs) \
            (begin (def @i 0) (while (%lt i 3) (length xs) (assign i (%add i 1))) 0)))",
     );
@@ -586,7 +583,7 @@ fn an_arm_whose_loop_reads_a_live_in_param_anchors_at_the_branch() {
         "the shape must contain an iterative scope for the boundary to be read"
     );
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &[then_id, else_id]),
         "a live-in param a nested loop merely READS must be released where every \
          arm reaches it"
     );
@@ -600,15 +597,15 @@ fn an_alias_the_arm_introduces_does_not_defeat_the_live_in_premise() {
     // slot and can never be the release's route
     // (docs/impl/region/mechanism.md § "The boundaries"). `w` here is such a
     // binding, so `xs` is still live-in and its one release moves to the merge.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (t xs) (if t (length xs) (let [w xs] (length w))))");
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &[then_id, else_id]),
         "an alias the arm introduces must not read as a birth in the arm"
     );
     assert!(
-        !arm_compensates(&hir, &arena, &symbols, &info, "xs", then_id),
+        !arm_compensates(&hir, &arena, &info, "xs", then_id),
         "the anchored release must not be doubled by a per-arm compensation"
     );
 }
@@ -632,7 +629,7 @@ fn a_reassigned_destructured_name_refuses_nothing() {
     // its `assign` repoints. The destructured list lives in the ANF temp that
     // produced it, whose own slot is bound once and never repointed — reassigning
     // one of the names the pattern introduced must not refuse it.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(begin (def (@a @b) (list 1 2)) (assign a 10) (length b))");
     let mutated: Vec<Binding> = info
         .binding_source_regions
@@ -646,16 +643,16 @@ fn a_reassigned_destructured_name_refuses_nothing() {
         "one reassigned binding; got {:?}",
         mutated
             .iter()
-            .map(|&b| symbols.name(arena.get(b).name))
+            .map(|&b| arena.get(b).name)
             .collect::<Vec<_>>()
     );
     let a = mutated[0];
     assert_eq!(
-        symbols.name(arena.get(a).name),
-        Some("a"),
+        arena.get(a).name,
+        SymbolId::of("a"),
         "precondition: the reassigned binding is the destructured `a`"
     );
-    let allocs = find_calls_to_primitive(&hir, "list", &arena, &symbols);
+    let allocs = find_calls_to_primitive(&hir, "list", &arena);
     assert_eq!(allocs.len(), 1, "one `list` literal; got {allocs:?}");
     let r = *info
         .alloc_region
@@ -685,9 +682,9 @@ fn a_reassigned_parameter_has_no_route_but_its_box() {
     // released by naming the BOX, which `populate_env` mints once per activation
     // and no `assign` repoints. So the prologue records no poisonable route, and
     // the call result the body assigns into the parameter keeps its own.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (t @p) (begin (assign p (rest p)) (if t (length p) 0)))");
-    let p = find_binding_by_name(&hir, "p", &arena, &symbols).expect("the param `p`");
+    let p = find_binding_by_name(&hir, "p", &arena).expect("the param `p`");
     assert!(
         arena.get(p).is_mutated && arena.get(p).needs_capture(),
         "precondition: a reassigned parameter is celled"
@@ -704,7 +701,7 @@ fn a_reassigned_parameter_has_no_route_but_its_box() {
                 .all(|r| info.cell_release_regions.contains(r)),
         "the celled parameter names its env cell and nothing else; p={p_regions:?}"
     );
-    let calls = find_calls_to_primitive(&hir, "rest", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "rest", &arena);
     assert_eq!(calls.len(), 1, "one `rest` call; got {calls:?}");
     let r = *info
         .alloc_region
@@ -726,17 +723,17 @@ fn a_cursor_an_arm_walks_does_not_refuse_the_live_in_release() {
     // cursor's init merely NAMES `xs`, so it allocates nothing and records no slot
     // — `xs`'s own untainted slot is still the release's one route, and the window
     // must anchor the release where every arm reaches it.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(fn (t xs) (if t (length xs) \
            (begin (def @cur xs) (assign cur (rest cur)) (length cur))))",
     );
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
-    let cur = find_binding_by_name(&hir, "cur", &arena, &symbols).expect("the cursor `cur`");
+    let cur = find_binding_by_name(&hir, "cur", &arena).expect("the cursor `cur`");
     assert!(
         arena.get(cur).is_mutated,
         "precondition: the cursor must be reassigned, or this pins nothing"
     );
-    let xs = find_binding_by_name(&hir, "xs", &arena, &symbols).expect("the param `xs`");
+    let xs = find_binding_by_name(&hir, "xs", &arena).expect("the param `xs`");
     let xs_regions = info
         .binding_source_regions
         .get(&xs)
@@ -761,7 +758,7 @@ fn a_cursor_an_arm_walks_does_not_refuse_the_live_in_release() {
         );
     }
     assert!(
-        release_clears_the_arms(&hir, &arena, &symbols, &info, "xs", &[then_id, else_id]),
+        release_clears_the_arms(&hir, &arena, &info, "xs", &[then_id, else_id]),
         "a live-in value an arm walks with a cursor must be released where every arm \
          reaches it"
     );
@@ -772,11 +769,11 @@ fn a_reassigned_allocating_binder_refuses_its_own_release() {
     // The refusal the reading keeps: here the mutated binding IS the route. `xs`'s
     // init allocated the region, so `region_to_slot` names `xs`'s own slot, and by
     // the release point that slot holds whatever the last `assign` stored.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(fn (t) (begin (def @xs (list 1 2 3)) \
            (if t (length xs) (begin (assign xs (rest xs)) (length xs)))))",
     );
-    let allocs = find_calls_to_primitive(&hir, "list", &arena, &symbols);
+    let allocs = find_calls_to_primitive(&hir, "list", &arena);
     assert_eq!(allocs.len(), 1, "one `list` literal; got {allocs:?}");
     let r = *info
         .alloc_region
@@ -797,11 +794,11 @@ fn a_value_allocated_in_an_arm_keeps_its_in_arm_release() {
     // The boundary the reading above preserves, and the one the premise exists
     // for: `x`'s allocation IS the arm, so its slot was never stored on the path
     // that skips the arm and a release at the merge would free whatever it finds.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (t) (if t (let [x (list 1 2 3)] (length x)) 0))");
     let (then_id, else_id) = first_if_arms(&hir).expect("an If node");
     assert!(
-        !release_clears_the_arms(&hir, &arena, &symbols, &info, "x", &[then_id, else_id]),
+        !release_clears_the_arms(&hir, &arena, &info, "x", &[then_id, else_id]),
         "a value allocated inside an arm must keep its release there"
     );
 }
@@ -855,12 +852,12 @@ fn the_match_arm_that_uses_the_value_takes_no_head_compensation() {
     // The over-free counterfactual for the arm route: the arm holding the
     // `decref_point` already releases `v` at its own last use. A head release there
     // would precede that use and free the value under it.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(fn (t) (let [v (list 1 2 3)] (match t :use (length v) :skip 0 _ -1)))",
     );
     let arms = first_match_arms(&hir).expect("a Match node");
     assert!(
-        !arm_compensates(&hir, &arena, &symbols, &info, "v", arms[0]),
+        !arm_compensates(&hir, &arena, &info, "v", arms[0]),
         "the arm that uses the local must not also take a head release"
     );
 }
@@ -870,12 +867,11 @@ fn the_match_arm_that_uses_the_value_takes_no_head_compensation() {
 fn arm_decrefs(
     hir: &Hir,
     arena: &BindingArena,
-    symbols: &SymbolTable,
     info: &RegionInfo,
     name: &str,
     node: HirId,
 ) -> bool {
-    let b = find_binding_by_name(hir, name, arena, symbols)
+    let b = find_binding_by_name(hir, name, arena)
         .unwrap_or_else(|| panic!("no binding named {}", name));
     let regions = match info.binding_source_regions.get(&b) {
         Some(rs) => rs,
@@ -907,7 +903,7 @@ fn the_walk_base_case_releases_at_its_return() {
     // The recursive arm STORES `xs` into a fresh cons, so escape marks it beyond the
     // return facet and the branch-arm window refuses it outright — which is what
     // leaves this route the one that discharges the base case.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(letrec [go (fn (i xs) (if (%eq i 0) xs (go (%sub i 1) (%pair xs 1))))] \
            (go 1 (list 1 2)))",
     );
@@ -928,7 +924,7 @@ fn the_walk_base_case_releases_at_its_return() {
     );
     assert!(
         rets.iter()
-            .any(|&n| arm_decrefs(&hir, &arena, &symbols, &info, "xs", n)),
+            .any(|&n| arm_decrefs(&hir, &arena, &info, "xs", n)),
         "the base case must release the arg at its Return, after the mint"
     );
 }
@@ -946,15 +942,9 @@ fn the_walk_base_case_releases_at_its_return() {
 
 /// The env-cell region of the binding named `name` — the `cell_release_regions`
 /// member among its source regions.
-fn env_cell_region(
-    hir: &Hir,
-    arena: &BindingArena,
-    symbols: &SymbolTable,
-    info: &RegionInfo,
-    name: &str,
-) -> Region {
-    let b = find_binding_by_name(hir, name, arena, symbols)
-        .unwrap_or_else(|| panic!("no binding named {name}"));
+fn env_cell_region(hir: &Hir, arena: &BindingArena, info: &RegionInfo, name: &str) -> Region {
+    let b =
+        find_binding_by_name(hir, name, arena).unwrap_or_else(|| panic!("no binding named {name}"));
     info.binding_source_regions
         .get(&b)
         .into_iter()
@@ -977,10 +967,10 @@ fn a_falling_through_arm_compensates_the_env_cell_its_sibling_relocated() {
     // relocation moves it ahead of that arm's `TailCall`). The ELSE arm reaches the
     // merge and names `c` nowhere, so it is a dead sibling arm and owes the head
     // release; without it the box strands once per call.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (n t) (def @c n) (let [g (fn () c)] (if t (g) 0)))");
     let (_then_id, else_id) = first_if_arms(&hir).expect("an If node");
-    let cell = env_cell_region(&hir, &arena, &symbols, &info, "c");
+    let cell = env_cell_region(&hir, &arena, &info, "c");
     assert!(
         info.branch_compensation
             .get(&else_id)
@@ -996,11 +986,11 @@ fn a_reassigned_holder_does_not_withdraw_its_env_cell_compensation() {
     // The mutated face. A reassigned holder poisons a release routed through its
     // SLOT, and this release names the box no `assign` repoints — so the same head
     // release is owed. Pins that the refusal is read per region, not per holder.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(fn (n t) (def @c n) (let [g (fn () (assign c (%add c 1)) c)] (if t (g) 0)))",
     );
     let (_then_id, else_id) = first_if_arms(&hir).expect("an If node");
-    let cell = env_cell_region(&hir, &arena, &symbols, &info, "c");
+    let cell = env_cell_region(&hir, &arena, &info, "c");
     assert!(
         info.branch_compensation
             .get(&else_id)
@@ -1021,9 +1011,9 @@ fn an_env_cell_takes_the_tail_route_on_the_arm_that_reads_it() {
     // after the read instead, and needs no same-node retain — the box's holders are
     // the frame's env slot plus one counted `closure ⊇ cell` edge per capturer, and
     // no use of the binding yields the box.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (n t) (def @c n) (let [g (fn () c)] (if t c (g))))");
-    let cell = env_cell_region(&hir, &arena, &symbols, &info, "c");
+    let cell = env_cell_region(&hir, &arena, &info, "c");
     assert!(
         info.branch_arm_decrefs
             .values()
@@ -1051,9 +1041,9 @@ fn an_unfunded_used_sibling_arm_takes_no_tail_route() {
     // Both arms name `xs` and neither node retains it — no store, no `-mut`
     // container, no return mint — so the arm that loses the `decref_point` max keeps
     // the conservative baseline. Only a cell release is admitted without one.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn (t xs) (let [n (if t (length xs) (length xs))] (%add n 1)))");
-    let b = find_binding_by_name(&hir, "xs", &arena, &symbols).expect("the param `xs`");
+    let b = find_binding_by_name(&hir, "xs", &arena).expect("the param `xs`");
     let regions: Vec<Region> = info
         .binding_source_regions
         .get(&b)
@@ -1076,10 +1066,10 @@ fn the_arm_that_returns_the_value_takes_no_compensation() {
     // caller must be left alone — its `decref_point` release, paired with the
     // mint, is the whole hand-over. A compensating release there would take the
     // caller's reference.
-    let (hir, arena, symbols, info) = analyze_with_class("(fn (i xs) (if (%eq i 0) xs 7))");
+    let (hir, arena, _symbols, info) = analyze_with_class("(fn (i xs) (if (%eq i 0) xs 7))");
     let (then_id, _else_id) = first_if_arms(&hir).expect("an If node");
     assert!(
-        !arm_compensates(&hir, &arena, &symbols, &info, "xs", then_id),
+        !arm_compensates(&hir, &arena, &info, "xs", then_id),
         "the returning arm must not also compensate — that frees the caller's value"
     );
 }

--- a/src/hir/region/infer/tests/effects.rs
+++ b/src/hir/region/infer/tests/effects.rs
@@ -17,8 +17,8 @@ fn effect_immediate_call_emits_no_arg_clique() {
     // `identical?` declares Immediate: returns a bool, stores nothing.
     // The call must record NO may-store edges between its two heap
     // (string-literal) arguments.
-    let (hir, arena, symbols, info) = analyze_with_class("(identical? \"a\" \"b\")");
-    let calls = find_calls_to_primitive(&hir, "identical?", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("(identical? \"a\" \"b\")");
+    let calls = find_calls_to_primitive(&hir, "identical?", &arena);
     assert_eq!(calls.len(), 1, "expected one (identical? ...) call");
     let edges = edges_at_site(&info, calls[0]);
     assert!(
@@ -38,8 +38,8 @@ fn effect_mixed_call_keeps_arg_clique() {
     // *declared* Mixed → clique), the boundary against over-deletion — not a forced
     // effect, which would merely re-exercise the solver's Mixed arm already covered
     // by `effect_unknown_call_keeps_arg_clique`.
-    let (hir, arena, symbols, info) = analyze_with_class("(git \"a\" \"b\")");
-    let calls = find_calls_to_primitive(&hir, "git", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("(git \"a\" \"b\")");
+    let calls = find_calls_to_primitive(&hir, "git", &arena);
     assert_eq!(calls.len(), 1, "expected one (git ...) call");
     let edges = edges_at_site(&info, calls[0]);
     let mutual = edges
@@ -65,11 +65,11 @@ fn effect_mixed_call_keeps_arg_clique() {
 /// template, a retention no compile-time seam records.
 #[test]
 fn effect_mixed_call_pairs_arguments_not_one_arguments_regions() {
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(let [k (if (%lt 1 0) (fn () 1) (fn () 2))] (git k))");
-    let calls = find_calls_to_primitive(&hir, "git", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "git", &arena);
     assert_eq!(calls.len(), 1, "expected one (git ...) call");
-    let reader = find_binding_by_name(&hir, "k", &arena, &symbols).expect("the reader binding k");
+    let reader = find_binding_by_name(&hir, "k", &arena).expect("the reader binding k");
     assert!(
         info.binding_source_regions
             .get(&reader)
@@ -100,8 +100,8 @@ fn effect_delivers_call_emits_no_arg_clique() {
     // (tests/elle/region-fiber-install-clique-leak.lisp). Uses the REAL
     // classification, so a regression that re-declares an installer `Mixed` fails
     // here as well as on the rate.
-    let (hir, arena, symbols, info) = analyze_with_class("(fiber/resume \"a\" \"b\")");
-    let calls = find_calls_to_primitive(&hir, "fiber/resume", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("(fiber/resume \"a\" \"b\")");
+    let calls = find_calls_to_primitive(&hir, "fiber/resume", &arena);
     assert_eq!(calls.len(), 1, "expected one (fiber/resume ...) call");
     let edges = edges_at_site(&info, calls[0]);
     assert!(
@@ -117,9 +117,9 @@ fn effect_unknown_call_keeps_arg_clique() {
     // primitives, plugin definitions, and user-supplied functions) is
     // operationally identical to Mixed: the full mutual clique.
     use crate::primitives::def::RegionEffect;
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_effect("(string \"a\" \"b\")", "string", RegionEffect::Unknown);
-    let calls = find_calls_to_primitive(&hir, "string", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "string", &arena);
     assert_eq!(calls.len(), 1, "expected one (string ...) call");
     let edges = edges_at_site(&info, calls[0]);
     let mutual = edges
@@ -136,9 +136,9 @@ fn effect_fresh_call_emits_no_arg_clique() {
     // Fresh: the result is freshly allocated, no argument is stored —
     // no may-store edges between heap args.
     use crate::primitives::def::RegionEffect;
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_effect("(string \"a\" \"b\")", "string", RegionEffect::Fresh);
-    let calls = find_calls_to_primitive(&hir, "string", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "string", &arena);
     assert_eq!(calls.len(), 1);
     let edges = edges_at_site(&info, calls[0]);
     assert!(
@@ -154,9 +154,9 @@ fn effect_passthrough_call_emits_no_arg_clique() {
     // is stored — no may-store edges; the dispatch pass-through retain
     // carries the result's lifetime at runtime.
     use crate::primitives::def::RegionEffect;
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_effect("(string \"a\" \"b\")", "string", RegionEffect::PassThrough);
-    let calls = find_calls_to_primitive(&hir, "string", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "string", &arena);
     assert_eq!(calls.len(), 1);
     let edges = edges_at_site(&info, calls[0]);
     assert!(
@@ -173,12 +173,12 @@ fn effect_stores_call_emits_directed_edges_only() {
     // nothing else. No reverse edges (unlike the Mixed/Unknown mutual
     // clique), no edges among the non-stored arguments.
     use crate::primitives::def::RegionEffect;
-    let (hir, arena, symbols, info) = analyze_with_effect(
+    let (hir, arena, _symbols, info) = analyze_with_effect(
         "(string \"a\" \"b\" \"c\")",
         "string",
         RegionEffect::Stores { args: &[0] },
     );
-    let calls = find_calls_to_primitive(&hir, "string", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "string", &arena);
     assert_eq!(calls.len(), 1);
     let r_a = string_literal_region(&hir, &info, "a");
     let r_b = string_literal_region(&hir, &info, "b");
@@ -212,12 +212,12 @@ fn effect_sends_call_emits_no_arg_clique() {
     // `effect_stores_call_emits_directed_edges_only`, with `string` declared
     // `Sends`.
     use crate::primitives::def::RegionEffect;
-    let (hir, arena, symbols, info) = analyze_with_effect(
+    let (hir, arena, _symbols, info) = analyze_with_effect(
         "(string \"a\" \"b\" \"c\")",
         "string",
         RegionEffect::Sends { args: &[0] },
     );
-    let calls = find_calls_to_primitive(&hir, "string", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "string", &arena);
     assert_eq!(calls.len(), 1);
     let edges = edges_at_site(&info, calls[0]);
     assert!(
@@ -240,8 +240,8 @@ fn hard_edge_sites_marks_native_uncounted_store_sites() {
     // (docs/impl/region/effects.md "Hard edges: how a may-store edge is emitted"). Pins
     // the inclusion side of the hard/soft split, the Mixed companion of
     // `hard_edge_sites_marks_declared_stores_sites`, through the REAL classification.
-    let (hir, arena, symbols, info) = analyze_with_class("(git \"a\" \"b\")");
-    let calls = find_calls_to_primitive(&hir, "git", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("(git \"a\" \"b\")");
+    let calls = find_calls_to_primitive(&hir, "git", &arena);
     assert_eq!(calls.len(), 1, "expected one (git ...) call");
     assert!(
         info.hard_edge_sites.contains(&calls[0]),
@@ -254,12 +254,12 @@ fn hard_edge_sites_marks_declared_stores_sites() {
     // A declared Stores site is hard for the same reason Mixed is: the
     // store is real and uncounted at compile time.
     use crate::primitives::def::RegionEffect;
-    let (hir, arena, symbols, info) = analyze_with_effect(
+    let (hir, arena, _symbols, info) = analyze_with_effect(
         "(string \"a\" \"b\")",
         "string",
         RegionEffect::Stores { args: &[0] },
     );
-    let calls = find_calls_to_primitive(&hir, "string", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "string", &arena);
     assert_eq!(calls.len(), 1);
     assert!(
         info.hard_edge_sites.contains(&calls[0]),
@@ -281,8 +281,8 @@ fn port_write_declares_immediate_no_arg_clique() {
     // result side is oracle-exempt (a SIG_YIELD return is not a normal
     // completion), so the declaration's clique effect is what guards the leak —
     // a regression back to Mixed reintroduces it and goes RED here.
-    let (hir, arena, symbols, info) = analyze_with_class("(port/write \"a\" \"b\")");
-    let calls = find_calls_to_primitive(&hir, "port/write", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("(port/write \"a\" \"b\")");
+    let calls = find_calls_to_primitive(&hir, "port/write", &arena);
     assert_eq!(calls.len(), 1, "expected one (port/write ...) call");
     let edges = edges_at_site(&info, calls[0]);
     assert!(
@@ -304,8 +304,8 @@ fn udp_send_to_declares_immediate_no_arg_clique() {
     // leak. Yielding, so oracle-exempt; the declaration's clique effect is the
     // guard. Sibling of `port_write_declares_immediate_no_arg_clique`, with a
     // wider clique (the >2-heap-arg case). RED under a regression to Mixed.
-    let (hir, arena, symbols, info) = analyze_with_class("(udp/send-to \"s\" \"d\" \"a\" 9000)");
-    let calls = find_calls_to_primitive(&hir, "udp/send-to", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("(udp/send-to \"s\" \"d\" \"a\" 9000)");
+    let calls = find_calls_to_primitive(&hir, "udp/send-to", &arena);
     assert_eq!(calls.len(), 1, "expected one (udp/send-to ...) call");
     let edges = edges_at_site(&info, calls[0]);
     assert!(
@@ -328,9 +328,9 @@ fn subprocess_exec_declares_opaque_no_arg_clique() {
     // (nothing is stored) — a per-call leak on a no-store primitive, exactly the
     // gap `Opaque` closes (docs/impl/region/effects.md § Opaque: the clique is
     // keyed on the store, not the result shape). RED under a regression to Mixed.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(subprocess/exec \"echo\" (list \"hi\"))");
-    let calls = find_calls_to_primitive(&hir, "subprocess/exec", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "subprocess/exec", &arena);
     assert_eq!(calls.len(), 1, "expected one (subprocess/exec ...) call");
     let edges = edges_at_site(&info, calls[0]);
     assert!(
@@ -354,8 +354,8 @@ fn has_declares_opaque_no_arg_clique() {
     // regions per call (tests/elle/region-has-clique-leak.lisp). The sibling of
     // `subprocess_exec_declares_opaque_no_arg_clique` on the trait-dispatch face; RED
     // under a regression to Mixed.
-    let (hir, arena, symbols, info) = analyze_with_class("(has? \"a\" \"b\")");
-    let calls = find_calls_to_primitive(&hir, "has?", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("(has? \"a\" \"b\")");
+    let calls = find_calls_to_primitive(&hir, "has?", &arena);
     assert_eq!(calls.len(), 1, "expected one (has? ...) call");
     let edges = edges_at_site(&info, calls[0]);
     assert!(
@@ -381,8 +381,8 @@ fn fiber_graph_natives_declare_opaque_and_git_keeps_the_hard_edge() {
     // § `Opaque`, "The child-chain WIRING is `Opaque` too"). The escape half is
     // `a_fiber_graph_write_does_not_seed_the_store_facet`.
     for name in ["fiber/child", "fiber/propagate"] {
-        let (hir, arena, symbols, info) = analyze_with_class(&format!("({name} \"f\")"));
-        let calls = find_calls_to_primitive(&hir, name, &arena, &symbols);
+        let (hir, arena, _symbols, info) = analyze_with_class(&format!("({name} \"f\")"));
+        let calls = find_calls_to_primitive(&hir, name, &arena);
         assert_eq!(calls.len(), 1, "expected one ({name} ...) call");
         assert!(
             !info.hard_edge_sites.contains(&calls[0]),
@@ -398,8 +398,8 @@ fn fiber_graph_natives_declare_opaque_and_git_keeps_the_hard_edge() {
     // records. Real, uncounted store: `Mixed`, and a hard-edge site. All three are
     // single-heap-arg, so the clique edge set is empty for each and `hard_edge_sites`
     // is the only thing that separates them.
-    let (hir, arena, symbols, info) = analyze_with_class("(git \"f\")");
-    let calls = find_calls_to_primitive(&hir, "git", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("(git \"f\")");
+    let calls = find_calls_to_primitive(&hir, "git", &arena);
     assert_eq!(calls.len(), 1, "expected one (git ...) call");
     assert!(
         info.hard_edge_sites.contains(&calls[0]),
@@ -418,8 +418,8 @@ fn import_declares_opaque_no_hard_edge() {
     // store-facet seed (`import_does_not_seed_the_store_facet`) are what a
     // regression to Mixed brings back. The result stays non-fresh — it lives in
     // neither the call's own region nor the specifier's.
-    let (hir, arena, symbols, info) = analyze_with_class("(import \"std/nonexistent\")");
-    let calls = find_calls_to_primitive(&hir, "import", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("(import \"std/nonexistent\")");
+    let calls = find_calls_to_primitive(&hir, "import", &arena);
     assert_eq!(calls.len(), 1, "expected one (import ...) call");
     assert!(
         !info.hard_edge_sites.contains(&calls[0]),
@@ -535,8 +535,8 @@ fn io_yield_pass_tightenings_drop_the_mixed_hard_edge() {
         ("(watch-next \"w\")", "watch-next", RegionEffect::Opaque),
     ];
     for (src, prim, effect) in cases {
-        let (hir, arena, symbols, info) = analyze_with_class(src);
-        let calls = find_calls_to_primitive(&hir, prim, &arena, &symbols);
+        let (hir, arena, _symbols, info) = analyze_with_class(src);
+        let calls = find_calls_to_primitive(&hir, prim, &arena);
         assert_eq!(
             calls.len(),
             1,
@@ -592,8 +592,8 @@ fn userfn_call_site_records_no_arg_clique() {
     // course also NOT a hard-edge site (only declared natives are).
     // (docs/impl/region/effects.md "What the solver derives", the
     // user-functions case.)
-    let (hir, arena, symbols, info) = analyze_with_class("((fn (h) (h \"a\" \"b\")) f)");
-    let calls = find_calls_to_primitive(&hir, "h", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("((fn (h) (h \"a\" \"b\")) f)");
+    let calls = find_calls_to_primitive(&hir, "h", &arena);
     assert_eq!(calls.len(), 1, "expected one (h ...) call");
     let edges = edges_at_site(&info, calls[0]);
     assert!(

--- a/src/hir/region/infer/tests/emit.rs
+++ b/src/hir/region/infer/tests/emit.rs
@@ -9,8 +9,8 @@ fn let_body_value_region_escapes_let_scope() {
     // `(fn () (let [x (string "a")] x))` — x's region's `decref_point`
     // is at the inner Var(x), NOT a Let HirId. A value's "scope" is
     // just its last-use HirId; the let does not own a region.
-    let (hir, arena, symbols, info) = analyze_with_hir("(fn () (let [x (string \"a\")] x))");
-    let allocs = find_calls_to_primitive(&hir, "string", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_hir("(fn () (let [x (string \"a\")] x))");
+    let allocs = find_calls_to_primitive(&hir, "string", &arena);
     assert_eq!(allocs.len(), 1, "expected one (string ...) call");
     let alloc = allocs[0];
 
@@ -39,9 +39,9 @@ fn yield_value_region_outlives_emit_scope() {
     // `decref_point` is at the Emit node (the last use). The runtime
     // incref at handle_emit keeps the region alive past the matching
     // DecrefRegion at the resume site.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_hir("(fn () (let [x (string \"a\")] (emit :yield x)))");
-    let allocs = find_calls_to_primitive(&hir, "string", &arena, &symbols);
+    let allocs = find_calls_to_primitive(&hir, "string", &arena);
     assert_eq!(allocs.len(), 1, "expected one (string ...) call");
     let alloc = allocs[0];
     let emit = find_first_emit(&hir).expect("emit present");
@@ -151,9 +151,9 @@ fn dynamic_emit_of_a_captured_payload_is_borrowed() {
     // `s` makes the signal a runtime value, so `(emit s x)` is a Call. `x` belongs
     // to the enclosing lambda, so the emitting body releases it nowhere and the
     // discharge would release the resumer's reference.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(let [s :yield] (fn () (let [x (string \"a\")] (fn () (emit s x)))))");
-    let calls = find_calls_to_primitive(&hir, "emit", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "emit", &arena);
     assert_eq!(calls.len(), 1, "expected one dynamic (emit …) call");
     assert!(
         info.borrowed_emit_payloads.contains(&calls[0]),
@@ -170,9 +170,9 @@ fn dynamic_emit_of_a_body_allocated_payload_is_not_borrowed() {
     // the call: the body allocates what it emits, so its `decref_point` sits in the
     // emitting lambda and a second reference would be stranded at every abandoned
     // park.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(let [s :yield] (fn () (let [x (string \"a\")] (emit s x))))");
-    let calls = find_calls_to_primitive(&hir, "emit", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "emit", &arena);
     assert_eq!(calls.len(), 1, "expected one dynamic (emit …) call");
     assert!(
         !info.borrowed_emit_payloads.contains(&calls[0]),
@@ -189,9 +189,9 @@ fn a_non_emit_delivers_call_records_no_emit_payload() {
     // shares with the other fiber value installers: `fiber/resume` hands its value
     // to a fiber that is already parked and yields nothing of its own, so naming its
     // argument here would mint a reference no park consumes.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(fn () (let [x (string \"a\")] (fn (h) (fiber/resume h x))))");
-    let calls = find_calls_to_primitive(&hir, "fiber/resume", &arena, &symbols);
+    let calls = find_calls_to_primitive(&hir, "fiber/resume", &arena);
     assert_eq!(calls.len(), 1, "expected one (fiber/resume …) call");
     assert!(
         !info.borrowed_emit_payloads.contains(&calls[0]),
@@ -212,9 +212,9 @@ fn funnel_containment_recorded_for_push() {
     // site, and `funnel_store_sites` records the stored value for the compensate
     // gate. Needs the real classification so the callee resolves to its declared
     // `Funnel` effect and the `@[]` collection to its MutableArray RetType.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(let [acc @[] x (string \"a\")] (begin (%array-push acc x) acc))");
-    let allocs = find_calls_to_primitive(&hir, "string", &arena, &symbols);
+    let allocs = find_calls_to_primitive(&hir, "string", &arena);
     assert_eq!(allocs.len(), 1, "expected one (string ...) call");
     let x_alloc = allocs[0];
     let x_region = info.alloc_region.get(&x_alloc).copied().expect("x region");

--- a/src/hir/region/infer/tests/escape.rs
+++ b/src/hir/region/infer/tests/escape.rs
@@ -340,7 +340,7 @@ fn push_inner_array_into_outer_widens_inner() {
     // Begin allocations that don't correspond to real heap objects.
     // The correct invariant is that chunk's @array alloc site resolves
     // to a region outside the inner scope.
-    let (hir, arena, info, names) = pipeline_with_names(
+    let (hir, arena, info) = pipeline(
         "(let [result @[]]\n\
              \x20 (let [chunk @[]]\n\
              \x20   (begin\n\
@@ -349,7 +349,7 @@ fn push_inner_array_into_outer_widens_inner() {
              \x20     (%array-push result chunk)\n\
              \x20     result)))",
     );
-    eprintln!("{}", format_regions(&info, &arena, &names));
+    eprintln!("{}", format_regions(&info, &arena, None));
 
     // Find the inner let scope region
     let lets = find_lets(&hir);
@@ -434,7 +434,7 @@ fn push_inner_array_into_outer_widens_inner() {
 fn partition_pattern_via_call_push() {
     // Same test but using %array-push directly. chunk is born in its
     // own region, distinct from the inner scope it is pushed past.
-    let (hir, arena, info, names) = pipeline_with_names(
+    let (hir, arena, info) = pipeline(
         "(let [result @[]]\n\
              \x20 (let [chunk @[]]\n\
              \x20   (begin\n\
@@ -443,7 +443,7 @@ fn partition_pattern_via_call_push() {
              \x20     (%array-push result chunk)\n\
              \x20     result)))",
     );
-    eprintln!("{}", format_regions(&info, &arena, &names));
+    eprintln!("{}", format_regions(&info, &arena, None));
 
     let lets = find_lets(&hir);
     assert!(

--- a/src/hir/region/infer/tests/helpers.rs
+++ b/src/hir/region/infer/tests/helpers.rs
@@ -1,14 +1,12 @@
 //! Shared helpers for the regions analysis tests. Free functions only —
 //! every `#[test]` lives in a themed sibling submodule (see `mod.rs`).
 use super::*;
+use crate::value::SymbolId;
 
 /// Compile Elle source to canonical (functionalized) HIR with a fresh per-call
 /// `CompileCtx` (every compile names its instance's compile state explicitly,
 /// threading the compile context as a parameter — docs/impl/region/ctx.md).
-pub(super) fn compile_fhir(
-    source: &str,
-    symbols: &mut SymbolTable,
-) -> (Hir, BindingArena, HashMap<u32, String>) {
+pub(super) fn compile_fhir(source: &str, symbols: &mut SymbolTable) -> (Hir, BindingArena) {
     let mut cctx = crate::pipeline::CompileCtx::new();
     crate::pipeline::compile_file_to_fhir(source, symbols, &mut cctx, "<test>").expect("compile")
 }
@@ -67,20 +65,9 @@ pub(super) fn count_empty_scopes(info: &RegionInfo) -> usize {
 /// arena, and RegionInfo.
 pub(super) fn pipeline(source: &str) -> (Hir, BindingArena, RegionInfo) {
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let info = analyze_regions(&hir, &arena);
     (hir, arena, info)
-}
-
-/// Same as `pipeline` but also returns the symbol names for dumping.
-pub(super) fn pipeline_with_names(
-    source: &str,
-) -> (Hir, BindingArena, RegionInfo, HashMap<u32, String>) {
-    let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
-    let info = analyze_regions(&hir, &arena);
-    let names = symbols.all_names();
-    (hir, arena, info, names)
 }
 
 /// Find the HirId of the Intrinsic node matching `op` inside a Loop body.
@@ -256,55 +243,44 @@ pub(super) fn analyze_with_hir(source: &str) -> (Hir, BindingArena, SymbolTable,
     (analysis.hir, arena, symbols, info)
 }
 
-pub(super) fn find_calls_to_primitive(
-    hir: &Hir,
-    name: &str,
-    arena: &BindingArena,
-    symbols: &SymbolTable,
-) -> Vec<HirId> {
+/// The trap these two share: a binding is found by *identity*, never by asking
+/// a memo for a spelling. A primitive's id is minted against the compile
+/// context's own table, so the caller's memo may never have learned the name —
+/// `SymbolId::of` sidesteps that entirely (docs/impl/symbol.md § "Reading a
+/// name, and not reading one").
+pub(super) fn find_calls_to_primitive(hir: &Hir, name: &str, arena: &BindingArena) -> Vec<HirId> {
     let mut out = Vec::new();
-    fn walk(
-        hir: &Hir,
-        name: &str,
-        arena: &BindingArena,
-        symbols: &SymbolTable,
-        out: &mut Vec<HirId>,
-    ) {
+    fn walk(hir: &Hir, want: SymbolId, arena: &BindingArena, out: &mut Vec<HirId>) {
         if let HirKind::Call { func, .. } = &hir.kind {
             if let HirKind::Var(b) = &func.kind {
-                if symbols.name(arena.get(*b).name) == Some(name) {
+                if arena.get(*b).name == want {
                     out.push(hir.id);
                 }
             }
         }
-        hir.for_each_child(|c| walk(c, name, arena, symbols, out));
+        hir.for_each_child(|c| walk(c, want, arena, out));
     }
-    walk(hir, name, arena, symbols, &mut out);
+    walk(hir, SymbolId::of(name), arena, &mut out);
     out
 }
 
 #[allow(dead_code)]
-pub(super) fn find_binding_by_name(
-    hir: &Hir,
-    name: &str,
-    arena: &BindingArena,
-    symbols: &SymbolTable,
-) -> Option<Binding> {
-    fn walk(hir: &Hir, name: &str, arena: &BindingArena, symbols: &SymbolTable) -> Option<Binding> {
+pub(super) fn find_binding_by_name(hir: &Hir, name: &str, arena: &BindingArena) -> Option<Binding> {
+    fn walk(hir: &Hir, want: SymbolId, arena: &BindingArena) -> Option<Binding> {
         if let HirKind::Var(b) = &hir.kind {
-            if symbols.name(arena.get(*b).name) == Some(name) {
+            if arena.get(*b).name == want {
                 return Some(*b);
             }
         }
         let mut found = None;
         hir.for_each_child(|c| {
             if found.is_none() {
-                found = walk(c, name, arena, symbols);
+                found = walk(c, want, arena);
             }
         });
         found
     }
-    walk(hir, name, arena, symbols)
+    walk(hir, SymbolId::of(name), arena)
 }
 
 /// The `(then_id, else_id)` body HirIds of the first `If` in the tree.
@@ -414,7 +390,7 @@ pub(super) fn analyze_with_class(source: &str) -> (Hir, BindingArena, SymbolTabl
     mark_tail_calls(&mut analysis.hir);
     functionalize(&mut analysis.hir, &mut arena);
     crate::hir::anf::anf_lift(&mut analysis.hir, &mut arena);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let info = analyze_regions_with(&analysis.hir, &arena, pc.call_classification);
     (analysis.hir, arena, symbols, info)
 }
@@ -455,9 +431,9 @@ pub(super) fn analyze_with_effect(
     mark_tail_calls(&mut analysis.hir);
     functionalize(&mut analysis.hir, &mut arena);
     crate::hir::anf::anf_lift(&mut analysis.hir, &mut arena);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let mut call_class = pc.call_classification;
-    let sym = symbols.get(prim).expect("primitive symbol");
+    let sym = crate::value::SymbolId::of(prim);
     call_class.effects.insert(sym, effect);
     let info = analyze_regions_with(&analysis.hir, &arena, call_class);
     (analysis.hir, arena, symbols, info)

--- a/src/hir/region/infer/tests/inline.rs
+++ b/src/hir/region/infer/tests/inline.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::SymbolId;
 
 // ── A call's result is named by the call's own region ─────────────────
 //
@@ -11,32 +12,26 @@ use super::*;
 
 /// The HirId of the first `Call` whose callee names `callee`, looking through the
 /// `DerefCell` wrapper functionalization puts around a `needs_capture` read.
-fn call_to(hir: &Hir, callee: &str, arena: &BindingArena, symbols: &SymbolTable) -> Option<HirId> {
-    fn names(func: &Hir, callee: &str, arena: &BindingArena, symbols: &SymbolTable) -> bool {
+fn call_to(hir: &Hir, callee: &str, arena: &BindingArena) -> Option<HirId> {
+    fn names(func: &Hir, callee: &str, arena: &BindingArena) -> bool {
         match &func.kind {
-            HirKind::Var(b) => symbols.name(arena.get(*b).name) == Some(callee),
-            HirKind::DerefCell { cell } => names(cell, callee, arena, symbols),
+            HirKind::Var(b) => arena.get(*b).name == SymbolId::of(callee),
+            HirKind::DerefCell { cell } => names(cell, callee, arena),
             _ => false,
         }
     }
-    fn walk(
-        hir: &Hir,
-        callee: &str,
-        arena: &BindingArena,
-        symbols: &SymbolTable,
-        found: &mut Option<HirId>,
-    ) {
+    fn walk(hir: &Hir, callee: &str, arena: &BindingArena, found: &mut Option<HirId>) {
         if found.is_none() {
             if let HirKind::Call { func, .. } = &hir.kind {
-                if names(func, callee, arena, symbols) {
+                if names(func, callee, arena) {
                     *found = Some(hir.id);
                 }
             }
         }
-        hir.for_each_child(|c| walk(c, callee, arena, symbols, found));
+        hir.for_each_child(|c| walk(c, callee, arena, found));
     }
     let mut found = None;
-    walk(hir, callee, arena, symbols, &mut found);
+    walk(hir, callee, arena, &mut found);
     found
 }
 
@@ -55,15 +50,15 @@ fn an_inlined_call_result_is_named_by_the_call_node() {
     // binding that holds the result must still name the CALL's own region — the
     // caller-side marker the value-resolved release resolves at runtime — and not
     // the region `mk`'s body minted for `(list 1 2)`.
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_class("(let [mk (fn () (list 1 2))] (let [v (mk)] (length v)))");
-    let call = call_to(&hir, "mk", &arena, &symbols).expect("a call to mk");
+    let call = call_to(&hir, "mk", &arena).expect("a call to mk");
     let call_r = info
         .alloc_region
         .get(&call)
         .copied()
         .expect("the call node has its own region");
-    let v = find_binding_by_name(&hir, "v", &arena, &symbols).expect("a binding named v");
+    let v = find_binding_by_name(&hir, "v", &arena).expect("a binding named v");
     assert_eq!(
         info.binding_source_regions.get(&v),
         Some(&vec![call_r]),
@@ -77,10 +72,10 @@ fn a_base_arms_result_is_released_in_the_base_arm() {
     // without the rule its result binding names the BASE arm's result region too —
     // and, being structurally later, takes that region's one release into an arm
     // mutually exclusive with the only path that mints it.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(letrec [go (fn (m) (if (%eq m 0) (list 1 2) (go (%sub m 1))))] (go 1))",
     );
-    let base = call_to(&hir, "list", &arena, &symbols).expect("a call to list");
+    let base = call_to(&hir, "list", &arena).expect("a call to list");
     let r = info
         .alloc_region
         .get(&base)
@@ -108,10 +103,10 @@ fn an_inlined_result_region_keeps_one_holder() {
     // holder binding in the sibling arm, and a two-holder region is refused the
     // single-slot value route `region::infer::compensate` needs to place a per-arm
     // release — so the arm the misplacement stranded cannot be compensated either.
-    let (hir, arena, symbols, info) = analyze_with_class(
+    let (hir, arena, _symbols, info) = analyze_with_class(
         "(letrec [go (fn (m) (if (%eq m 0) (list 1 2) (go (%sub m 1))))] (go 1))",
     );
-    let base = call_to(&hir, "list", &arena, &symbols).expect("a call to list");
+    let base = call_to(&hir, "list", &arena).expect("a call to list");
     let r = info
         .alloc_region
         .get(&base)

--- a/src/hir/region/infer/tests/looprc.rs
+++ b/src/hir/region/infer/tests/looprc.rs
@@ -20,11 +20,11 @@ fn begin_capture_cell_region_extends_to_binding_last_use_across_sibling_forms() 
     //      → MakeCaptureCell stamped at this Begin's HirId.
     //   2) `x` — a sibling top-level use of x, lexically after the begin.
     let source = "(begin (def x 100) (defn f [] x) (f)) x";
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let info = analyze_regions(&hir, &arena);
 
     // x's binding.
-    let x = find_binding_by_name(&hir, "x", &arena, &symbols).expect("expected binding `x`");
+    let x = find_binding_by_name(&hir, "x", &arena).expect("expected binding `x`");
 
     // Find the Begin node that pre-allocates a CaptureCell because it
     // contains a `(define x …)` whose binding `needs_capture()`.
@@ -158,7 +158,7 @@ fn env_cell_release_in_loop_hoisted_past_loop() {
                        (assign i (%add i 1))) \
                      acc)";
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let info = analyze_regions(&hir, &arena);
 
     // The env-cell release region for `s`: `env_cell_placeholder` (Define arm)
@@ -263,7 +263,7 @@ fn match_pattern_binding_keeps_scrutinee_release_inside_the_loop() {
                        (assign i (%add i 1))) \
                      i)";
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let info = analyze_regions(&hir, &arena);
 
     // Every iter-scope node (While OR Loop — `while` may lower to either).
@@ -373,7 +373,7 @@ fn loop_local_closure_tail_alloc_region_matches_return_frontier() {
                        (assign i (%add i 1))) \
                      i)";
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let info = analyze_regions(&hir, &arena);
 
     // Descend through tail-transparent wrappers (Let/Begin/Block/Return) to the

--- a/src/hir/region/infer/tests/merge.rs
+++ b/src/hir/region/infer/tests/merge.rs
@@ -78,9 +78,9 @@ fn analyze_cycle_with_effects(
     symbols: &mut SymbolTable,
 ) -> (Hir, BindingArena, RegionInfo) {
     let meta = crate::primitives::build_primitive_meta(symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let cc = pc.call_classification;
-    let (hir, arena, _) = compile_fhir(source, symbols);
+    let (hir, arena) = compile_fhir(source, symbols);
     let info = analyze_regions_with(&hir, &arena, cc);
     (hir, arena, info)
 }

--- a/src/hir/region/infer/tests/merge/escape.rs
+++ b/src/hir/region/infer/tests/merge/escape.rs
@@ -9,8 +9,8 @@ fn merge_self_edge_refuses_clique() {
     // distinct merge roots and the predicate must refuse it. Its balancing decref is the
     // target's runtime content scan; eliminating it trades a known leak for a possible
     // UAF. Uses the REAL classification (`git` genuinely Mixed), not a forced effect.
-    let (hir, arena, symbols, info) = analyze_with_class("(git \"a\" \"b\")");
-    let calls = find_calls_to_primitive(&hir, "git", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_class("(git \"a\" \"b\")");
+    let calls = find_calls_to_primitive(&hir, "git", &arena);
     assert_eq!(calls.len(), 1, "expected one (git ...) call");
     let edges = edges_at_site(&info, calls[0]);
     assert!(

--- a/src/hir/region/infer/tests/merge/recursion.rs
+++ b/src/hir/region/infer/tests/merge/recursion.rs
@@ -100,7 +100,7 @@ fn merge_mutual_recursion_cycle_drops_at_binding_scope_not_enclosing() {
     // letrec body (its true last use). This is the counterfactual for that
     // tightening: it FAILS while the drop sits at the enclosing post-dominator.
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(
+    let (hir, arena) = compile_fhir(
         "(begin (letrec [ping (fn [n] (if (%lt n 1) :done (pong (%sub n 1)))) \
                          pong (fn [n] (ping n))] \
                   (ping 3)) \
@@ -150,7 +150,7 @@ fn merge_collapses_in_lambda_mutual_recursion_letrec_closure_cycle() {
     // deferred release — and must be ADMITTED (the tail-strand refusal bites only a non-member
     // callee, `merge_refuses_in_lambda_cycle_with_foreign_tail_callee`).
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(
+    let (hir, arena) = compile_fhir(
         "(def f (fn [k] (letrec [ev (fn [m] (if (%lt m 1) :even (od (%sub m 1)))) \
                                  od (fn [m] (if (%lt m 1) :odd (ev (%sub m 1))))] \
                           (ev k)))) \
@@ -228,7 +228,7 @@ fn merge_admits_in_lambda_cycle_with_foreign_tail_callee() {
     // `merge_refuses_member_passed_by_move_to_foreign_tail`). `g` is a user closure,
     // so its `(g r)` tail is an ordinary `Call`.
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(
+    let (hir, arena) = compile_fhir(
         "(def g (fn [x] x)) \
          (def f (fn [k] (letrec [ev (fn [m] (if (%lt m 1) :even (od (%sub m 1)))) \
                                  od (fn [m] (if (%lt m 1) :odd (ev (%sub m 1))))] \
@@ -325,7 +325,7 @@ fn merge_refuses_member_passed_by_move_to_foreign_tail() {
     // prove its `m` — the diverging guard does (ev stays callee-only and is
     // proven by forwarding from od's `(ev (%sub m 1))`).
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(
+    let (hir, arena) = compile_fhir(
         "(def g (fn [x] x)) \
          (def f (fn [k] (letrec [ev (fn [m] (if (%lt m 1) :even (od (%sub m 1)))) \
                                  od (fn [m] (when (%not (%int? m)) (error :m)) \

--- a/src/hir/region/infer/tests/realalloc.rs
+++ b/src/hir/region/infer/tests/realalloc.rs
@@ -124,8 +124,8 @@ fn put_intrinsic_gets_a_call_result_region() {
     // arg[0] and manufacture no region, the freshly-copied immutable result
     // would have no region of its own to release — it must be born in its own
     // call-result region so the lowerer can free it.)
-    let (hir, arena, symbols, info) = analyze_with_hir("(let [m @{:a 1}] (%put m :b 2))");
-    let puts = find_calls_to_primitive(&hir, "%put", &arena, &symbols);
+    let (hir, arena, _symbols, info) = analyze_with_hir("(let [m @{:a 1}] (%put m :b 2))");
+    let puts = find_calls_to_primitive(&hir, "%put", &arena);
     assert_eq!(puts.len(), 1, "expected one %put funnel call");
     let put_id = puts[0];
     let put_region = info
@@ -185,11 +185,11 @@ fn freeze_and_thaw_get_a_real_region() {
     // each result is born in its own call-result region and released by value
     // (`DecrefValueRegion`). (This complements the negative tests above: these
     // two ops ARE allocating.)
-    let (hir, arena, symbols, info) =
+    let (hir, arena, _symbols, info) =
         analyze_with_hir("(let [m @[1 2]] (let [f (%freeze m)] (%thaw f)))");
-    let freezes = find_calls_to_primitive(&hir, "%freeze", &arena, &symbols);
+    let freezes = find_calls_to_primitive(&hir, "%freeze", &arena);
     assert_eq!(freezes.len(), 1, "expected one %freeze funnel call");
-    let thaws = find_calls_to_primitive(&hir, "%thaw", &arena, &symbols);
+    let thaws = find_calls_to_primitive(&hir, "%thaw", &arena);
     assert_eq!(thaws.len(), 1, "expected one %thaw funnel call");
     for (name, id) in [("%freeze", freezes[0]), ("%thaw", thaws[0])] {
         let r =

--- a/src/hir/region/infer/tests/support.rs
+++ b/src/hir/region/infer/tests/support.rs
@@ -50,7 +50,7 @@ pub(super) fn pair_store_edges(hir: &Hir, info: &RegionInfo) -> Vec<(Region, Reg
 /// so the seed input is exactly what `analyze_regions` saw.
 pub(super) fn shared_seeds(source: &str) -> (Hir, RegionInfo, rustc_hash::FxHashSet<Region>) {
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let info = analyze_regions(&hir, &arena);
     let escape = crate::hir::analyze_escape(&hir, &arena, &CallClassification::default());
     let seeds = super::ownership::compute_shared_seeds(&info, &escape);
@@ -66,9 +66,9 @@ pub(super) fn shared_seeds_with_effects(
     source: &str,
 ) -> (Hir, RegionInfo, rustc_hash::FxHashSet<Region>) {
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let cc = pc.call_classification;
     let info = analyze_regions_with(&hir, &arena, cc.clone());
     let escape = crate::hir::analyze_escape(&hir, &arena, &cc);
@@ -101,7 +101,7 @@ pub(super) fn owned_subtrees(
     rustc_hash::FxHashMap<Region, rustc_hash::FxHashSet<Region>>,
 ) {
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let mut info = analyze_regions(&hir, &arena);
     restore_pre_ownership_view(&mut info);
     let escape = crate::hir::analyze_escape(&hir, &arena, &CallClassification::default());
@@ -125,9 +125,9 @@ pub(super) fn owned_subtrees_with_effects(
     rustc_hash::FxHashMap<Region, rustc_hash::FxHashSet<Region>>,
 ) {
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let cc = pc.call_classification;
     let mut info = analyze_regions_with(&hir, &arena, cc.clone());
     restore_pre_ownership_view(&mut info);
@@ -156,9 +156,9 @@ pub(super) fn in_some_owned_subtree(
 /// `compute_adopt_edges` needs for the lifetime obligation.
 pub(super) fn adopt_edges(source: &str) -> (Hir, RegionInfo, super::ownership::AdoptEdges) {
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let cc = pc.call_classification;
     let mut info = analyze_regions_with(&hir, &arena, cc.clone());
     restore_pre_ownership_view(&mut info);
@@ -181,9 +181,9 @@ pub(super) fn capture_edges(
     source: &str,
 ) -> (Hir, BindingArena, RegionInfo, Vec<(HirId, Region, Region)>) {
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let cc = pc.call_classification;
     let info = analyze_regions_with(&hir, &arena, cc.clone());
     let edges = super::ownership::capture_containment_edges(&hir, &info, &arena);
@@ -196,9 +196,9 @@ pub(super) fn capture_edges(
 /// drop-site post-dominance check and the deterministic member emit-order.
 pub(super) fn owned_region_groups(source: &str) -> (Hir, RegionInfo, HashMap<HirId, Vec<Region>>) {
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let cc = pc.call_classification;
     let mut info = analyze_regions_with(&hir, &arena, cc.clone());
     restore_pre_ownership_view(&mut info);
@@ -216,9 +216,9 @@ pub(super) fn owned_region_groups(source: &str) -> (Hir, RegionInfo, HashMap<Hir
 /// so they exercise the same wiring `analyze_regions_with` hands the lowerer.
 pub(super) fn analyze_full(source: &str) -> (Hir, RegionInfo) {
     let mut symbols = SymbolTable::new();
-    let (hir, arena, _) = compile_fhir(source, &mut symbols);
+    let (hir, arena) = compile_fhir(source, &mut symbols);
     let meta = crate::primitives::build_primitive_meta(&mut symbols);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let info = analyze_regions_with(&hir, &arena, pc.call_classification);
     (hir, info)
 }

--- a/src/hir/regularize.rs
+++ b/src/hir/regularize.rs
@@ -32,14 +32,14 @@ pub(crate) fn regularize(
     dispatch_wrappers: &mut DispatchWrapperRegistry,
     fn_inline: &mut FnInlineRegistry,
 ) -> Result<TypeInfo, String> {
-    prune_typeof_match_arms(hir, arena, symbols);
+    prune_typeof_match_arms(hir, arena);
     // Closure dissolution: fuse `(map f xs)` / `(map g (map f xs))` over a proven
     // immutable array into an inlined index-walk loop, before functionalize sees
     // the tree so the loop lowers exactly as `map`'s own body does
     // (docs/impl/dissolution.md). Runs after pruning (which leaves map calls
     // untouched) and before tail-call marking, so the fused loop's `freeze` tail
     // is marked in place of the collapsed `map` call.
-    fuse_map_chains(hir, arena, symbols, fn_inline);
+    fuse_map_chains(hir, arena, fn_inline);
     // Dead binding elimination runs after pruning and fusion, which both make
     // bindings unused, and before functionalize, for the same reason pruning
     // does: the region solver runs after these transforms, so a call deleted
@@ -48,5 +48,5 @@ pub(crate) fn regularize(
     crate::hir::tailcall::mark_tail_calls(hir);
     crate::hir::functionalize::functionalize(hir, arena);
     crate::hir::anf::anf_lift(hir, arena);
-    infer_and_rewrite(hir, arena, symbols, dispatch_wrappers)
+    infer_and_rewrite(hir, arena, dispatch_wrappers)
 }

--- a/src/hir/return_incref/tests.rs
+++ b/src/hir/return_incref/tests.rs
@@ -24,7 +24,7 @@ use crate::symbol::SymbolTable;
 fn fhir(source: &str) -> Hir {
     let mut symbols = SymbolTable::new();
     let mut cctx = crate::pipeline::CompileCtx::new();
-    let (hir, _arena, _names) =
+    let (hir, _arena) =
         crate::pipeline::compile_file_to_fhir(source, &mut symbols, &mut cctx, "<test>")
             .expect("compile");
     hir

--- a/src/hir/typeinfer.rs
+++ b/src/hir/typeinfer.rs
@@ -19,7 +19,7 @@ use super::arena::BindingArena;
 use super::binding::Binding;
 use super::expr::{Hir, HirId, HirKind, IntrinsicOp};
 use super::types::{TyId, TypeInterner};
-use crate::symbol::SymbolTable;
+use crate::value::SymbolId;
 
 use std::collections::HashMap;
 
@@ -52,12 +52,10 @@ const MAX_ITERS: usize = 10;
 pub fn infer_and_rewrite(
     hir: &mut Hir,
     arena: &BindingArena,
-    symbols: &SymbolTable,
     dispatch_wrappers: &mut DispatchWrapperRegistry,
 ) -> Result<TypeInfo, String> {
     let interner = TypeInterner::new();
-    // Build name lookup: SymbolId → name string, for matching callees
-    let symbol_names = symbols.all_names();
+
     let mut binding_types: HashMap<Binding, TyId> = HashMap::new();
     let mut hir_types: HashMap<HirId, TyId> = HashMap::new();
     let mut binding_min_length: HashMap<Binding, usize> = HashMap::new();
@@ -77,7 +75,7 @@ pub fn infer_and_rewrite(
     // `(let [ta (type-of a)] (match ta …))` idiom narrows `a` like the inline
     // dispatch (`collect_typeof_aliases`).
     let mut typeof_aliases: HashMap<Binding, Binding> = HashMap::new();
-    collect_typeof_aliases(hir, arena, &symbol_names, &mut typeof_aliases);
+    collect_typeof_aliases(hir, arena, &mut typeof_aliases);
     // Kleene start: every parameter that CAN be proven by complete call-site
     // enumeration (callee-only binding, unmutated param) begins at BOTTOM, so
     // an identity-passed argument in a self/mutual recursion contributes
@@ -113,7 +111,6 @@ pub fn infer_and_rewrite(
             &mut hir_types,
             &lambda_params,
             &mut lambda_body_type,
-            &symbol_names,
             &mut binding_min_length,
             &value_used,
             &typeof_aliases,
@@ -144,24 +141,16 @@ pub fn infer_and_rewrite(
         hir,
         &hir_types,
         arena,
-        &symbol_names,
         &typeof_aliases,
         dispatch_wrappers,
     );
 
     // The prove-or-reject gate: every call-position %-intrinsic must discharge
     // its operand contract from the (narrowed, per-occurrence) inferred types.
-    contract::check_intrinsic_operand_proofs(hir, &hir_types, arena, &symbol_names)?;
+    contract::check_intrinsic_operand_proofs(hir, &hir_types, arena)?;
 
     // Signal narrowing: strip SIG_ERROR from calls with provably typed args
-    super::narrow::narrow_signals(
-        hir,
-        &interner,
-        arena,
-        &symbol_names,
-        &hir_types,
-        &binding_min_length,
-    );
+    super::narrow::narrow_signals(hir, &interner, arena, &hir_types, &binding_min_length);
 
     // Signal re-propagation: recompute parent signals bottom-up
     super::narrow::repropagate_signals(hir);
@@ -204,8 +193,19 @@ fn unwrap_to_call(hir: &Hir) -> Option<usize> {
 /// names matched here are stdlib *closures* (defined in stdlib.lisp,
 /// not in any primitive table) whose pass-through typing inference
 /// still wants.
-fn primitive_return_type(name: &str, arg_types: &[TyId], _interner: &TypeInterner) -> TyId {
+fn primitive_return_type(sym: SymbolId, arg_types: &[TyId], _interner: &TypeInterner) -> TyId {
     use crate::primitives::def::RetType;
+
+    // Recognition is by id, not by a resolved spelling: `SymbolId::of` is a
+    // `const fn` over the name's hash, so these are integer compares against
+    // constants and need no symbol table (docs/impl/symbol.md § "Reading a
+    // name, and not reading one"). That matters most for the stdlib closures
+    // below, which are in no primitive table — nothing build-time could hand
+    // back their names.
+    const PCT_THAW: SymbolId = SymbolId::of("%thaw");
+    const THAW: SymbolId = SymbolId::of("thaw");
+    const PCT_FREEZE: SymbolId = SymbolId::of("%freeze");
+    const FREEZE: SymbolId = SymbolId::of("freeze");
 
     // %thaw/thaw and %freeze/freeze map a container to its mutable/immutable
     // twin. The native's own RetType is polymorphic (Unknown), but the result
@@ -215,13 +215,13 @@ fn primitive_return_type(name: &str, arg_types: &[TyId], _interner: &TypeInterne
     // contract (e.g. `(%string-push @"" "x")`), and types explicit
     // `thaw`/`freeze` calls on a proven container likewise.
     let arg0 = || arg_types.first().copied().unwrap_or(TypeInterner::TOP);
-    match name {
-        "%thaw" | "thaw" => return mutable_twin(arg0()),
-        "%freeze" | "freeze" => return immutable_twin(arg0()),
+    match sym {
+        PCT_THAW | THAW => return mutable_twin(arg0()),
+        PCT_FREEZE | FREEZE => return immutable_twin(arg0()),
         _ => {}
     }
 
-    if let Some(def) = crate::primitives::registration::def_by_name(name) {
+    if let Some(def) = crate::primitives::registration::def_by_symbol(sym) {
         return match def.ret {
             RetType::Unknown => TypeInterner::TOP,
             RetType::Int => TypeInterner::INT,
@@ -248,18 +248,37 @@ fn primitive_return_type(name: &str, arg_types: &[TyId], _interner: &TypeInterne
         };
     }
 
-    match name {
+    const PUSH: SymbolId = SymbolId::of("push");
+    const PUT: SymbolId = SymbolId::of("put");
+    const ADD: SymbolId = SymbolId::of("+");
+    const SUB: SymbolId = SymbolId::of("-");
+    const MUL: SymbolId = SymbolId::of("*");
+    const DIV: SymbolId = SymbolId::of("/");
+    const REM: SymbolId = SymbolId::of("rem");
+    const MOD: SymbolId = SymbolId::of("mod");
+    const ABS: SymbolId = SymbolId::of("abs");
+    const MIN: SymbolId = SymbolId::of("min");
+    const MAX: SymbolId = SymbolId::of("max");
+    const INC: SymbolId = SymbolId::of("inc");
+    const DEC: SymbolId = SymbolId::of("dec");
+    const SUM: SymbolId = SymbolId::of("sum");
+    const PRODUCT: SymbolId = SymbolId::of("product");
+    const FLOOR: SymbolId = SymbolId::of("floor");
+    const CEIL: SymbolId = SymbolId::of("ceil");
+    const ROUND: SymbolId = SymbolId::of("round");
+    match sym {
         // stdlib.lisp closures (not primitives): mutating pass-throughs
         // that return their first argument.
-        "push" | "put" => arg_types.first().copied().unwrap_or(TypeInterner::TOP),
+        PUSH | PUT => arg_types.first().copied().unwrap_or(TypeInterner::TOP),
         // The arithmetic wrappers validate their operands and raise on
         // anything non-numeric, so on every path that RETURNS the result is a
         // Number — the same stable-name authority the guard recognition uses
         // for the predicates. This is what lets `(%lt (- b a) 2)`-style
         // measurement code prove its operands without a hand guard.
-        "+" | "-" | "*" | "/" | "rem" | "mod" | "abs" | "min" | "max" | "inc" | "dec" | "sum"
-        | "product" => TypeInterner::NUMBER,
-        "floor" | "ceil" | "round" => TypeInterner::NUMBER,
+        ADD | SUB | MUL | DIV | REM | MOD | ABS | MIN | MAX | INC | DEC | SUM | PRODUCT => {
+            TypeInterner::NUMBER
+        }
+        FLOOR | CEIL | ROUND => TypeInterner::NUMBER,
         _ => TypeInterner::TOP,
     }
 }

--- a/src/hir/typeinfer/contract.rs
+++ b/src/hir/typeinfer/contract.rs
@@ -67,9 +67,8 @@ pub(super) fn check_intrinsic_operand_proofs(
     hir: &Hir,
     hir_types: &HashMap<HirId, TyId>,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
 ) -> Result<(), String> {
     let interner = TypeInterner::new();
     let mut env = NonzeroEnv::default();
-    walk(hir, hir_types, arena, symbol_names, &interner, &mut env)
+    walk(hir, hir_types, arena, &interner, &mut env)
 }

--- a/src/hir/typeinfer/contract/walk.rs
+++ b/src/hir/typeinfer/contract/walk.rs
@@ -7,13 +7,12 @@ pub(super) fn walk(
     h: &Hir,
     hir_types: &HashMap<HirId, TyId>,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     interner: &TypeInterner,
     env: &mut NonzeroEnv,
 ) -> Result<(), String> {
     macro_rules! recurse {
         ($e:expr, $env:expr) => {
-            walk($e, hir_types, arena, symbol_names, interner, $env)
+            walk($e, hir_types, arena, interner, $env)
         };
     }
 
@@ -35,7 +34,8 @@ pub(super) fn walk(
             // argument list has no per-operand types to check; the native's
             // own runtime validation covers that (dynamic) shape.
             if let HirKind::Var(b) = &func.kind {
-                if let Some(name) = symbol_names.get(&arena.get(*b).name.0) {
+                if let Some(name) = crate::primitives::registration::static_name(arena.get(*b).name)
+                {
                     if name.starts_with('%') && !args.iter().any(|a| a.spliced) {
                         if let Some(op) = IntrinsicOp::from_name(name) {
                             let arg_refs: Vec<&Hir> = args.iter().map(|a| &a.expr).collect();
@@ -52,7 +52,7 @@ pub(super) fn walk(
             let saved = env.clone();
             for e in exprs {
                 recurse!(e, env)?;
-                env.apply(&guard::facts_after_statement(e, arena, symbol_names));
+                env.apply(&guard::facts_after_statement(e, arena));
             }
             *env = saved;
             Ok(())
@@ -61,7 +61,7 @@ pub(super) fn walk(
             let saved = env.clone();
             for e in body {
                 recurse!(e, env)?;
-                env.apply(&guard::facts_after_statement(e, arena, symbol_names));
+                env.apply(&guard::facts_after_statement(e, arena));
             }
             *env = saved;
             Ok(())
@@ -72,7 +72,7 @@ pub(super) fn walk(
             else_branch,
         } => {
             recurse!(cond, env)?;
-            let facts = guard::cond_facts(cond, arena, symbol_names);
+            let facts = guard::cond_facts(cond, arena);
             let mut then_env = env.clone();
             then_env.apply(&facts.when_true);
             recurse!(then_branch, &mut then_env)?;
@@ -99,7 +99,7 @@ pub(super) fn walk(
             let mut running = env.clone();
             for (test, body) in clauses {
                 recurse!(test, &mut running)?;
-                let facts = guard::cond_facts(test, arena, symbol_names);
+                let facts = guard::cond_facts(test, arena);
                 let mut body_env = running.clone();
                 body_env.apply(&facts.when_true);
                 recurse!(body, &mut body_env)?;

--- a/src/hir/typeinfer/fuse.rs
+++ b/src/hir/typeinfer/fuse.rs
@@ -108,7 +108,6 @@ use crate::hir::binding::{Binding, CaptureKind};
 use crate::hir::expr::{CallArg, Hir, HirKind};
 use crate::primitives::def::RetType;
 use crate::signals::{Signal, SIG_ERROR};
-use crate::symbol::SymbolTable;
 use crate::value::SymbolId;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::HashMap;
@@ -141,10 +140,8 @@ pub(crate) use registry::FnInlineRegistry;
 pub(crate) fn fuse_map_chains(
     hir: &mut Hir,
     arena: &mut BindingArena,
-    symbols: &SymbolTable,
     registry: &mut FnInlineRegistry,
 ) {
-    let symbol_names = symbols.all_names();
     // The same-unit function templates: a `Var` naming a non-capturing lambda
     // (a top-level `defn` or a `let`/`def`-bound `fn`) inlines like a literal
     // (docs/impl/dissolution.md § "Named same-unit functions"). Built once over
@@ -159,7 +156,7 @@ pub(crate) fn fuse_map_chains(
     // inert here — but the stdlib is exactly where the `inc`/`dec` templates that
     // later units inline are defined, so the recording must not sit behind that gate.
     record_cross_unit_fns(hir, arena, registry);
-    let Some(ops) = Ops::resolve(arena, &symbol_names) else {
+    let Some(ops) = Ops::resolve(arena) else {
         return;
     };
     // The sound `binding → type-of keyword` proof dead-arm pruning already
@@ -168,7 +165,7 @@ pub(crate) fn fuse_map_chains(
     // is what proves the alias `array`. Built once over the pre-rewrite tree — the
     // base-var bindings live in enclosing `let`s that fusion never mutates, so the
     // proof stays valid as inner map calls collapse.
-    let bases = concrete_init_keywords(hir, arena, &symbol_names);
+    let bases = concrete_init_keywords(hir, arena);
     // This unit's primitives by name, so a cross-unit template's free globals
     // (recorded by name in a different arena) re-resolve to this arena's bindings.
     // `bind_primitives` binds each primitive/stdlib-export once, so first-wins is
@@ -186,7 +183,7 @@ pub(crate) fn fuse_map_chains(
         registry,
         prim_by_name: &prim_by_name,
     };
-    rewrite(hir, arena, &symbol_names, &ops, &bases, &fns);
+    rewrite(hir, arena, &ops, &bases, &fns);
 }
 
 #[cfg(test)]

--- a/src/hir/typeinfer/fuse/chain.rs
+++ b/src/hir/typeinfer/fuse/chain.rs
@@ -23,15 +23,25 @@ pub(super) enum Hof {
 }
 
 impl Hof {
-    /// The canonical stdlib name this op is recognized by.
-    pub(super) fn from_name(name: &str) -> Option<Hof> {
-        match name {
-            "map" => Some(Hof::Map),
-            "map-indexed" => Some(Hof::MapIndexed),
-            "filter" => Some(Hof::Filter),
-            "take-while" => Some(Hof::TakeWhile),
-            "drop-while" => Some(Hof::DropWhile),
-            "mapcat" => Some(Hof::Mapcat),
+    /// The op a callee names, or `None` if it names none of them.
+    ///
+    /// By id, not by spelling: these are stdlib closures, in no primitive
+    /// table, and `SymbolId::of` is const, so recognition needs no memo
+    /// (docs/impl/symbol.md § "Reading a name, and not reading one").
+    pub(super) fn from_symbol(sym: SymbolId) -> Option<Hof> {
+        const MAP: SymbolId = SymbolId::of("map");
+        const MAP_INDEXED: SymbolId = SymbolId::of("map-indexed");
+        const FILTER: SymbolId = SymbolId::of("filter");
+        const TAKE_WHILE: SymbolId = SymbolId::of("take-while");
+        const DROP_WHILE: SymbolId = SymbolId::of("drop-while");
+        const MAPCAT: SymbolId = SymbolId::of("mapcat");
+        match sym {
+            MAP => Some(Hof::Map),
+            MAP_INDEXED => Some(Hof::MapIndexed),
+            FILTER => Some(Hof::Filter),
+            TAKE_WHILE => Some(Hof::TakeWhile),
+            DROP_WHILE => Some(Hof::DropWhile),
+            MAPCAT => Some(Hof::Mapcat),
             _ => None,
         }
     }
@@ -216,12 +226,16 @@ pub(super) enum Search {
 
 impl Search {
     /// The canonical stdlib name this search is recognized by.
-    pub(super) fn from_name(name: &str) -> Option<Search> {
-        match name {
-            "any?" => Some(Search::Any),
-            "all?" => Some(Search::All),
-            "find" => Some(Search::Find),
-            "find-index" => Some(Search::FindIndex),
+    pub(super) fn from_symbol(sym: SymbolId) -> Option<Search> {
+        const ANY_P: SymbolId = SymbolId::of("any?");
+        const ALL_P: SymbolId = SymbolId::of("all?");
+        const FIND: SymbolId = SymbolId::of("find");
+        const FIND_INDEX: SymbolId = SymbolId::of("find-index");
+        match sym {
+            ANY_P => Some(Search::Any),
+            ALL_P => Some(Search::All),
+            FIND => Some(Search::Find),
+            FIND_INDEX => Some(Search::FindIndex),
             _ => None,
         }
     }
@@ -310,7 +324,6 @@ pub(super) struct FoldTerminal {
 pub(super) fn fusable_hof_parts<'a>(
     hir: &'a Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
 ) -> Option<(Hof, &'a Hir, &'a Hir)> {
     let HirKind::Call { func, args, .. } = &hir.kind else {
         return None;
@@ -323,7 +336,7 @@ pub(super) fn fusable_hof_parts<'a>(
     if !bi.is_primitive {
         return None;
     }
-    let hof = Hof::from_name(symbol_names.get(&bi.name.0)?)?;
+    let hof = Hof::from_symbol(bi.name)?;
     Some((hof, &args[0].expr, &args[1].expr))
 }
 
@@ -338,7 +351,6 @@ pub(super) fn fusable_hof_parts<'a>(
 pub(super) fn fusable_fold_parts<'a>(
     hir: &'a Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
 ) -> Option<(&'a Hir, &'a Hir, &'a Hir)> {
     let HirKind::Call { func, args, .. } = &hir.kind else {
         return None;
@@ -351,8 +363,7 @@ pub(super) fn fusable_fold_parts<'a>(
     if !bi.is_primitive {
         return None;
     }
-    let name = symbol_names.get(&bi.name.0)?;
-    if name != "fold" && name != "reduce" {
+    if bi.name != SymbolId::of("fold") && bi.name != SymbolId::of("reduce") {
         return None;
     }
     Some((&args[0].expr, &args[1].expr, &args[2].expr))
@@ -370,7 +381,6 @@ pub(super) fn fusable_fold_parts<'a>(
 pub(super) fn fusable_count_parts<'a>(
     hir: &'a Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
 ) -> Option<(&'a Hir, &'a Hir)> {
     let HirKind::Call { func, args, .. } = &hir.kind else {
         return None;
@@ -380,7 +390,7 @@ pub(super) fn fusable_count_parts<'a>(
     }
     let callee = unwrap_callee_binding(func)?;
     let bi = arena.get(callee);
-    if !bi.is_primitive || symbol_names.get(&bi.name.0)? != "count" {
+    if !bi.is_primitive || bi.name != SymbolId::of("count") {
         return None;
     }
     Some((&args[0].expr, &args[1].expr))
@@ -398,7 +408,6 @@ pub(super) fn fusable_count_parts<'a>(
 pub(super) fn fusable_search_parts<'a>(
     hir: &'a Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
 ) -> Option<(Search, &'a Hir, &'a Hir)> {
     let HirKind::Call { func, args, .. } = &hir.kind else {
         return None;
@@ -411,7 +420,7 @@ pub(super) fn fusable_search_parts<'a>(
     if !bi.is_primitive {
         return None;
     }
-    let search = Search::from_name(symbol_names.get(&bi.name.0)?)?;
+    let search = Search::from_symbol(bi.name)?;
     Some((search, &args[0].expr, &args[1].expr))
 }
 
@@ -540,7 +549,6 @@ pub(super) struct ChainPlan {
 pub(super) fn validate_chain(
     hir: &Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     bases: &FxHashMap<Binding, &'static str>,
     fns: &FnResolver,
 ) -> Option<ChainPlan> {
@@ -556,19 +564,19 @@ pub(super) fn validate_chain(
     // count, or one of the four searches (1-param predicate). Asked before the
     // pipeline walk, so a `count` or a search — each of which wears a `filter`'s
     // two-argument shape — is never read as a stage.
-    let terminal = if let Some((lam, _init, coll)) = fusable_fold_parts(cur, arena, symbol_names) {
+    let terminal = if let Some((lam, _init, coll)) = fusable_fold_parts(cur, arena) {
         all_silent &= reorder_safe(fns.body_signal(lam, arena, 2)?);
         any_capturing |= captures_locals(lam);
         ops += 1;
         cur = coll;
         TerminalOp::Fold
-    } else if let Some((pred, coll)) = fusable_count_parts(cur, arena, symbol_names) {
+    } else if let Some((pred, coll)) = fusable_count_parts(cur, arena) {
         all_silent &= reorder_safe(fns.body_signal(pred, arena, 1)?);
         any_capturing |= captures_locals(pred);
         ops += 1;
         cur = coll;
         TerminalOp::Count
-    } else if let Some((search, pred, coll)) = fusable_search_parts(cur, arena, symbol_names) {
+    } else if let Some((search, pred, coll)) = fusable_search_parts(cur, arena) {
         all_silent &= reorder_safe(fns.body_signal(pred, arena, 1)?);
         any_capturing |= captures_locals(pred);
         ops += 1;
@@ -581,7 +589,7 @@ pub(super) fn validate_chain(
     // The inner pipeline. Every op's function takes the element alone but a
     // `map-indexed`'s, which takes the position first (`Hof::arity`).
     let mut kinds = Vec::new();
-    while let Some((hof, lam, coll)) = fusable_hof_parts(cur, arena, symbol_names) {
+    while let Some((hof, lam, coll)) = fusable_hof_parts(cur, arena) {
         all_silent &= reorder_safe(fns.body_signal(lam, arena, hof.arity())?);
         any_capturing |= captures_locals(lam);
         // A `mapcat` reads what its function returns as a COLLECTION and walks it,
@@ -589,7 +597,7 @@ pub(super) fn validate_chain(
         // where a list would make it quadratic. Every other op is indifferent to
         // what its function returns (dissolution.md § "Mapcat — the stage that fans
         // out").
-        if hof == Hof::Mapcat && !fns.result_is_array(lam, arena, symbol_names, bases) {
+        if hof == Hof::Mapcat && !fns.result_is_array(lam, arena, bases) {
             return None;
         }
         ops += 1;
@@ -618,7 +626,7 @@ pub(super) fn validate_chain(
             return None;
         }
     }
-    let base = classify_base(cur, arena, symbol_names, bases)?;
+    let base = classify_base(cur, arena, bases)?;
     // A mutable `@array` base fuses only a single `map`/`filter`/`mapcat`: the fused
     // loop
     // walks the base LIVE against a `len` captured once, which matches those stdlib
@@ -702,7 +710,6 @@ pub(super) enum BaseKind {
 pub(super) fn classify_base(
     expr: &Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     bases: &FxHashMap<Binding, &'static str>,
 ) -> Option<BaseKind> {
     if let HirKind::Var(b) = &expr.kind {
@@ -720,8 +727,7 @@ pub(super) fn classify_base(
     if !bi.is_primitive || !bi.is_immutable || bi.is_mutated {
         return None;
     }
-    let name = symbol_names.get(&bi.name.0)?;
-    match crate::primitives::registration::def_by_name(name).map(|d| d.ret) {
+    match crate::primitives::registration::def_by_symbol(bi.name).map(|d| d.ret) {
         Some(RetType::Array) => Some(BaseKind::Immutable),
         Some(RetType::MutableArray) => Some(BaseKind::Mutable),
         _ => None,

--- a/src/hir/typeinfer/fuse/clone.rs
+++ b/src/hir/typeinfer/fuse/clone.rs
@@ -297,17 +297,16 @@ pub(super) fn clone_template(t: &FnTemplate, arena: &mut BindingArena) -> (Vec<B
 pub(super) fn rewrite(
     hir: &mut Hir,
     arena: &mut BindingArena,
-    symbol_names: &HashMap<u32, String>,
     ops: &Ops,
     bases: &FxHashMap<Binding, &'static str>,
     fns: &FnResolver,
 ) {
-    if let Some(plan) = validate_chain(hir, arena, symbol_names, bases, fns) {
+    if let Some(plan) = validate_chain(hir, arena, bases, fns) {
         let sig = hir.signal;
         let span = hir.span.clone();
         let owned = std::mem::replace(hir, Hir::error(span.clone()));
         let chain = take_chain(owned, plan, arena, fns);
         *hir = build_loop(chain, arena, ops, sig, span);
     }
-    hir.for_each_child_mut(|c| rewrite(c, arena, symbol_names, ops, bases, fns));
+    hir.for_each_child_mut(|c| rewrite(c, arena, ops, bases, fns));
 }

--- a/src/hir/typeinfer/fuse/ops.rs
+++ b/src/hir/typeinfer/fuse/ops.rs
@@ -22,23 +22,21 @@ pub(super) struct Ops {
 }
 
 impl Ops {
-    pub(super) fn resolve(
-        arena: &BindingArena,
-        symbol_names: &HashMap<u32, String>,
-    ) -> Option<Ops> {
-        // Name → the first `is_primitive` binding for it (each global is bound
-        // once by `bind_primitives`, so first-wins is exact).
-        let mut prim: HashMap<&str, Binding> = HashMap::new();
+    pub(super) fn resolve(arena: &BindingArena) -> Option<Ops> {
+        // Id → the first `is_primitive` binding for it (each global is bound
+        // once by `bind_primitives`, so first-wins is exact). Keyed by id, not
+        // spelling: `push`, `<` and `freeze` reach the arena as stdlib exports,
+        // which are in no primitive table, and no instance memo is in scope
+        // here (docs/impl/symbol.md § "Reading a name, and not reading one").
+        let mut prim: HashMap<SymbolId, Binding> = HashMap::new();
         for i in 0..arena.len() as u32 {
             let b = Binding(i);
             let bi = arena.get(b);
             if bi.is_primitive {
-                if let Some(name) = symbol_names.get(&bi.name.0) {
-                    prim.entry(name.as_str()).or_insert(b);
-                }
+                prim.entry(bi.name).or_insert(b);
             }
         }
-        let find = |n: &str| prim.get(n).copied();
+        let find = |n: &str| prim.get(&SymbolId::of(n)).copied();
         Some(Ops {
             at_array: find("@array")?,
             length: find("length")?,

--- a/src/hir/typeinfer/fuse/registry.rs
+++ b/src/hir/typeinfer/fuse/registry.rs
@@ -272,7 +272,6 @@ impl FnResolver<'_> {
         &self,
         lam: &Hir,
         arena: &BindingArena,
-        symbol_names: &HashMap<u32, String>,
         bases: &FxHashMap<Binding, &'static str>,
     ) -> bool {
         let body = match &lam.kind {
@@ -283,7 +282,7 @@ impl FnResolver<'_> {
             },
             _ => return false,
         };
-        classify_base(body, arena, symbol_names, bases).is_some()
+        classify_base(body, arena, bases).is_some()
     }
 
     /// Resolve a HOF's function argument to owned `(params, body)`, ready to splice:

--- a/src/hir/typeinfer/fuse/tests/capture.rs
+++ b/src/hir/typeinfer/fuse/tests/capture.rs
@@ -15,8 +15,8 @@ use super::*;
 /// Fails while a capture declines: the `map` dispatch and the closure both survive.
 #[test]
 fn a_capture_from_two_function_levels_out_fuses() {
-    let (hir, arena, names) = compile("(let [k 10] ((fn [] (map (fn [x] (+ x k)) [1 2 3]))))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 10] ((fn [] (map (fn [x] (+ x k)) [1 2 3]))))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "the `map` dispatch must be gone; callees were {cs:?}",
@@ -38,8 +38,8 @@ fn a_capture_from_two_function_levels_out_fuses() {
 /// declines: the `map` dispatch survives.
 #[test]
 fn a_mutable_capture_fuses() {
-    let (hir, arena, names) = compile("(let [@k 1] (assign k 2) (map (fn [x] (+ x k)) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [@k 1] (assign k 2) (map (fn [x] (+ x k)) [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "the `map` dispatch must be gone; callees were {cs:?}",
@@ -53,8 +53,8 @@ fn a_mutable_capture_fuses() {
 /// The `map` call and its closure survive.
 #[test]
 fn a_self_reference_capture_declines() {
-    let (hir, arena, names) = compile("(def g (map (fn [x] (if (< x 2) x (g 1))) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(def g (map (fn [x] (if (< x 2) x (g 1))) [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map"),
         "a self-referencing lambda must not fuse; callees were {cs:?}",
@@ -69,9 +69,9 @@ fn a_self_reference_capture_declines() {
 /// op: exactly one `map` dispatch is left, and it is the capturing one.
 #[test]
 fn a_capture_declines_a_composition() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(let [k 2] (map (fn [y] (+ y k)) (map (fn [x] (* x 2)) [1 2 3])))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert_eq!(
         cs.iter().filter(|n| *n == "map").count(),
         1,
@@ -89,9 +89,9 @@ fn a_capture_declines_a_composition() {
 /// The `count` survives; the prefix, a lone chain on the recursion's retry, fuses.
 #[test]
 fn a_capturing_terminal_declines_over_a_prefix() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(let [k 2] (count (fn [x] (> x k)) (map (fn [x] (* x 2)) [1 2 3])))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "count"),
         "the capturing `count` must survive; callees were {cs:?}",
@@ -108,9 +108,9 @@ fn a_capturing_terminal_declines_over_a_prefix() {
 /// `map` survives with a fused loop underneath it.
 #[test]
 fn a_capturing_inner_stage_fuses_on_the_retry() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(let [k 2] (map (fn [y] (+ y 1)) (map (fn [x] (* x k)) [1 2 3])))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert_eq!(
         cs.iter().filter(|n| *n == "map").count(),
         1,

--- a/src/hir/typeinfer/fuse/tests/collect.rs
+++ b/src/hir/typeinfer/fuse/tests/collect.rs
@@ -7,8 +7,8 @@ use super::*;
 /// closure are both present.
 #[test]
 fn single_map_dissolves_the_closure_and_dispatch() {
-    let (hir, arena, names) = compile("(map (fn [x] (* x 2)) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map (fn [x] (* x 2)) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "the `map` dispatch must be gone; callees were {cs:?}",
@@ -40,8 +40,8 @@ fn single_map_dissolves_the_closure_and_dispatch() {
 /// closures, and (were only the single case built) two accumulators.
 #[test]
 fn composed_maps_fuse_to_one_loop() {
-    let (hir, arena, names) = compile("(map (fn [y] (+ y 1)) (map (fn [x] (* x 2)) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map (fn [y] (+ y 1)) (map (fn [x] (* x 2)) [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "both `map` dispatches must be gone; callees were {cs:?}",
@@ -63,8 +63,8 @@ fn composed_maps_fuse_to_one_loop() {
 /// `is_primitive`). The user's `map` call survives.
 #[test]
 fn user_shadowed_map_is_not_fused() {
-    let (hir, arena, names) = compile("(defn map [f xs] xs) (map (fn [x] x) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn map [f xs] xs) (map (fn [x] x) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map"),
         "a user `map` must not be rewritten; callees were {cs:?}",
@@ -92,25 +92,20 @@ fn user_shadowed_map_is_not_fused() {
 fn core_lisp_hof_exports_are_primitive_like_stdlib() {
     // The binding a `(name …)` call resolves to (the winning shadow).
     fn callee_is_primitive(src: &str, name: &str) -> bool {
-        let (hir, arena, names) = compile(src);
-        fn find(
-            h: &Hir,
-            arena: &BindingArena,
-            names: &HashMap<u32, String>,
-            want: &str,
-        ) -> Option<bool> {
+        let (hir, arena, _rt) = compile(src);
+        fn find(h: &Hir, arena: &BindingArena, want: &str) -> Option<bool> {
             if let HirKind::Call { func, .. } = &h.kind {
                 if let Some(b) = super::super::unwrap_callee_binding(func) {
-                    if names.get(&arena.get(b).name.0).map(String::as_str) == Some(want) {
+                    if arena.get(b).name == crate::value::SymbolId::of(want) {
                         return Some(arena.get(b).is_primitive);
                     }
                 }
             }
             let mut found = None;
-            h.for_each_child(|c| found = found.or_else(|| find(c, arena, names, want)));
+            h.for_each_child(|c| found = found.or_else(|| find(c, arena, want)));
             found
         }
-        find(&hir, &arena, &names, name).expect("call to the named op is present")
+        find(&hir, &arena, name).expect("call to the named op is present")
     }
     // core.lisp exports — primitive, exactly like the stdlib map/filter.
     assert!(
@@ -133,8 +128,8 @@ fn core_lisp_hof_exports_are_primitive_like_stdlib() {
 /// the gate refuses a capture: the `map` call and the closure both survive.
 #[test]
 fn capturing_lambda_fuses() {
-    let (hir, arena, names) = compile("(let [k 10] (map (fn [x] (+ x k)) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 10] (map (fn [x] (+ x k)) [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "the `map` dispatch must be gone; callees were {cs:?}",
@@ -151,8 +146,8 @@ fn capturing_lambda_fuses() {
 /// type proof selects.
 #[test]
 fn map_over_unproven_collection_is_not_fused() {
-    let (hir, arena, names) = compile("(defn f [xs] (map (fn [x] (* x 2)) xs))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn f [xs] (map (fn [x] (* x 2)) xs))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map"),
         "an unproven collection must not fuse; callees were {cs:?}",
@@ -167,8 +162,8 @@ fn map_over_unproven_collection_is_not_fused() {
 /// are both present and there is no synthesized `if`.
 #[test]
 fn single_filter_dissolves_to_guarded_push() {
-    let (hir, arena, names) = compile("(filter (fn [x] (> x 2)) [1 2 3 4])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(filter (fn [x] (> x 2)) [1 2 3 4])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "filter"),
         "the `filter` dispatch must be gone; callees were {cs:?}",
@@ -202,9 +197,9 @@ fn single_filter_dissolves_to_guarded_push() {
 /// carry only `SIG_ERROR`). Fails before fusion: two `filter` calls, two closures.
 #[test]
 fn composed_filters_fuse_to_one_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(filter (fn [y] (even? y)) (filter (fn [x] (integer? x)) [1 2 3 4 5]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "filter"),
         "both `filter` dispatches must be gone; callees were {cs:?}",
@@ -229,8 +224,8 @@ fn composed_filters_fuse_to_one_loop() {
 /// and the guarded-push shape compose.
 #[test]
 fn filter_over_var_bound_immutable_array_fuses() {
-    let (hir, arena, names) = compile("(let [xs [1 2 3 4]] (filter (fn [x] (> x 2)) xs))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [xs [1 2 3 4]] (filter (fn [x] (> x 2)) xs))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "filter"),
         "a Var-bound base must fuse; callees were {cs:?}",
@@ -250,8 +245,9 @@ fn filter_over_var_bound_immutable_array_fuses() {
 /// reorder-safe mixed case fusing into ONE loop is pinned below.
 #[test]
 fn mixed_chain_with_non_reorder_safe_stage_fuses_inner_only() {
-    let (hir, arena, names) = compile("(map (fn [x] (* x 2)) (filter (fn [w] (> w 1)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) =
+        compile("(map (fn [x] (* x 2)) (filter (fn [w] (> w 1)) [1 2 3 4]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map"),
         "the outer `map` must not fuse a non-reorder-safe composition; \
@@ -276,9 +272,9 @@ fn mixed_chain_with_non_reorder_safe_stage_fuses_inner_only() {
 /// the outer `map` survives as a plain call over the inner-fused filter.
 #[test]
 fn mixed_map_of_filter_reorder_safe_fuses_to_one_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(map (fn [x] (* x 10)) (filter (fn [y] (even? y)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map" || n == "filter"),
         "both HOF dispatches must be gone in a fused mixed chain; callees were {cs:?}",
@@ -306,9 +302,9 @@ fn mixed_map_of_filter_reorder_safe_fuses_to_one_loop() {
 /// the outer `filter` survives as a plain call over the inner-fused map.
 #[test]
 fn mixed_filter_of_map_reorder_safe_fuses_to_one_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(filter (fn [y] (even? y)) (map (fn [x] (* x 5)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map" || n == "filter"),
         "both HOF dispatches must be gone in a fused mixed chain; callees were {cs:?}",
@@ -334,12 +330,12 @@ fn mixed_filter_of_map_reorder_safe_fuses_to_one_loop() {
 /// depth across kinds, not just length 2.
 #[test]
 fn mixed_three_stage_tower_fuses_to_one_loop() {
-    let (hir, arena, names) = compile(
+    let (hir, arena, mut rt) = compile(
         "(map (fn [z] (+ z 1)) \
                (filter (fn [y] (even? y)) \
                  (map (fn [x] (* x 3)) [1 2 3 4])))",
     );
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map" || n == "filter"),
         "every HOF dispatch must be gone; callees were {cs:?}",
@@ -367,8 +363,8 @@ fn mixed_three_stage_tower_fuses_to_one_loop() {
 /// refuses a capture: the `filter` call and the closure both survive.
 #[test]
 fn capturing_predicate_fuses() {
-    let (hir, arena, names) = compile("(let [k 2] (filter (fn [x] (> x k)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 2] (filter (fn [x] (> x k)) [1 2 3 4]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "filter"),
         "the `filter` dispatch must be gone; callees were {cs:?}",
@@ -384,8 +380,8 @@ fn capturing_predicate_fuses() {
 /// both survive because the base is a `Var`, not a literal `array` call.
 #[test]
 fn map_over_var_bound_immutable_array_fuses() {
-    let (hir, arena, names) = compile("(let [xs [1 2 3]] (map (fn [x] (* x 2)) xs))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [xs [1 2 3]] (map (fn [x] (* x 2)) xs))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "a Var-bound immutable array must fuse; callees were {cs:?}",
@@ -401,8 +397,9 @@ fn map_over_var_bound_immutable_array_fuses() {
 /// aliases `xs` aliases the literal, so `(map f ys)` still fuses.
 #[test]
 fn map_over_aliased_var_immutable_array_fuses() {
-    let (hir, arena, names) = compile("(let [xs [1 2 3]] (let [ys xs] (map (fn [x] (* x 2)) ys)))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) =
+        compile("(let [xs [1 2 3]] (let [ys xs] (map (fn [x] (* x 2)) ys)))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "an aliased Var over an immutable array must fuse; callees were {cs:?}",
@@ -419,8 +416,8 @@ fn map_over_aliased_var_immutable_array_fuses() {
 /// the accumulator are two `@array` calls; neither is frozen.)
 #[test]
 fn single_map_over_mutable_array_fuses_unfrozen() {
-    let (hir, arena, names) = compile("(map (fn [x] (* x 2)) @[1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map (fn [x] (* x 2)) @[1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "a mutable `@array` base must fuse; callees were {cs:?}",
@@ -441,8 +438,8 @@ fn single_map_over_mutable_array_fuses_unfrozen() {
 /// the unfrozen index-walk loop, exactly as the call-site literal does.
 #[test]
 fn map_over_var_bound_mutable_array_fuses_unfrozen() {
-    let (hir, arena, names) = compile("(let [xs @[1 2 3]] (map (fn [x] (* x 2)) xs))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [xs @[1 2 3]] (map (fn [x] (* x 2)) xs))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "a Var-bound mutable `@array` base must fuse; callees were {cs:?}",
@@ -460,8 +457,8 @@ fn map_over_var_bound_mutable_array_fuses_unfrozen() {
 /// gone, the predicate inlines under an `if`, and no `freeze` runs.
 #[test]
 fn single_filter_over_mutable_array_fuses_unfrozen() {
-    let (hir, arena, names) = compile("(filter (fn [x] (> x 2)) @[1 2 3 4])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(filter (fn [x] (> x 2)) @[1 2 3 4])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "filter"),
         "a mutable `@array` base must fuse; callees were {cs:?}",
@@ -480,8 +477,8 @@ fn single_filter_over_mutable_array_fuses_unfrozen() {
 /// diverge from the stdlib fold. The `fold` call survives.
 #[test]
 fn fold_over_mutable_array_is_not_fused() {
-    let (hir, arena, names) = compile("(fold (fn [a x] (+ a x)) 0 @[1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(fold (fn [a x] (+ a x)) 0 @[1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "fold"),
         "a fold over a mutable base must not fuse; callees were {cs:?}",
@@ -499,10 +496,10 @@ fn fold_over_mutable_array_is_not_fused() {
 /// the inner transform inlines.
 #[test]
 fn composition_over_mutable_array_fuses_inner_only() {
-    let (hir, arena, names) = compile("(map (fn [y] (+ y 1)) (map (fn [x] (* x 2)) @[1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map (fn [y] (+ y 1)) (map (fn [x] (* x 2)) @[1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert_eq!(
-        count_callee(&hir, &arena, &names, "map"),
+        count_callee(&hir, &arena, &mut rt, "map"),
         1,
         "only the outer `map` survives a mutable-base composition; callees were {cs:?}",
     );

--- a/src/hir/typeinfer/fuse/tests/count.rs
+++ b/src/hir/typeinfer/fuse/tests/count.rs
@@ -8,8 +8,8 @@ use super::*;
 /// under.
 #[test]
 fn single_count_dissolves_to_scalar_tally() {
-    let (hir, arena, names) = compile("(count (fn [x] (even? x)) [1 2 3 4])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(count (fn [x] (even? x)) [1 2 3 4])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "count"),
         "the `count` dispatch must be gone; callees were {cs:?}",
@@ -20,7 +20,7 @@ fn single_count_dissolves_to_scalar_tally() {
         "the predicate must run inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "a count's accumulator is a scalar — no `@array`; callees were {cs:?}",
     );
@@ -37,9 +37,9 @@ fn single_count_dissolves_to_scalar_tally() {
 /// have built never exists.
 #[test]
 fn count_of_map_fuses_to_one_scalar_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(count (fn [y] (even? y)) (map (fn [x] (* x 3)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "count" || n == "map"),
         "both the `count` and `map` dispatches must be gone; callees were {cs:?}",
@@ -50,7 +50,7 @@ fn count_of_map_fuses_to_one_scalar_loop() {
         "both the predicate and the map transform must inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "map-into-count mints NO array — the mapped value feeds the guard; \
          callees were {cs:?}",
@@ -62,16 +62,16 @@ fn count_of_map_fuses_to_one_scalar_loop() {
 /// the filter's, then the count's — and no array between them.
 #[test]
 fn count_of_filter_fuses_to_one_scalar_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(count (fn [y] (even? y)) (filter (fn [x] (number? x)) [1 \"a\" 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "count" || n == "filter"),
         "both the `count` and `filter` dispatches must be gone; callees were {cs:?}",
     );
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "filter-into-count mints NO array; callees were {cs:?}",
     );
@@ -88,8 +88,8 @@ fn count_of_filter_fuses_to_one_scalar_loop() {
 /// body (`>` routes through `apply`).
 #[test]
 fn single_count_with_non_reorder_safe_body_still_fuses() {
-    let (hir, arena, names) = compile("(count (fn [x] (> x 2)) [1 2 3 4])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(count (fn [x] (> x 2)) [1 2 3 4])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "count"),
         "a lone count has no reorder gate and must fuse; callees were {cs:?}",
@@ -103,9 +103,9 @@ fn single_count_with_non_reorder_safe_body_still_fuses() {
 /// recursion, and the outer `count` stays a plain call over the fused loop.
 #[test]
 fn count_over_non_reorder_safe_prefix_fuses_inner_only() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(count (fn [y] (even? y)) (filter (fn [w] (> w 1)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "count"),
         "the outer `count` must not fuse a non-reorder-safe composition; \
@@ -123,8 +123,8 @@ fn count_over_non_reorder_safe_prefix_fuses_inner_only() {
 /// `count` call survives.
 #[test]
 fn count_over_mutable_array_is_not_fused() {
-    let (hir, arena, names) = compile("(count (fn [x] (even? x)) @[1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(count (fn [x] (even? x)) @[1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "count"),
         "a mutable `@array` base must not fuse a count; callees were {cs:?}",
@@ -135,8 +135,8 @@ fn count_over_mutable_array_is_not_fused() {
 /// non-primitive one, so it is never rewritten.
 #[test]
 fn user_shadowed_count_is_not_fused() {
-    let (hir, arena, names) = compile("(defn count [p c] 0) (count (fn [x] x) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn count [p c] 0) (count (fn [x] x) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "count"),
         "a user `count` must not be rewritten; callees were {cs:?}",
@@ -148,8 +148,8 @@ fn user_shadowed_count_is_not_fused() {
 /// while the gate refuses a capture: the `count` call and the closure both survive.
 #[test]
 fn capturing_count_predicate_fuses() {
-    let (hir, arena, names) = compile("(let [k 2] (count (fn [x] (> x k)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 2] (count (fn [x] (> x k)) [1 2 3 4]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "count"),
         "the `count` dispatch must be gone; callees were {cs:?}",
@@ -162,8 +162,8 @@ fn capturing_count_predicate_fuses() {
 /// requirement on how the function is resolved.
 #[test]
 fn named_count_predicate_inlines() {
-    let (hir, arena, names) = compile("(defn pos? [x] (> x 0)) (count pos? [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn pos? [x] (> x 0)) (count pos? [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "count"),
         "the `count` dispatch must be gone for a named predicate; callees were {cs:?}",
@@ -173,7 +173,7 @@ fn named_count_predicate_inlines() {
         "the named predicate's body must run inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "scalar tally accumulator; callees were {cs:?}",
     );
@@ -183,15 +183,15 @@ fn named_count_predicate_inlines() {
 /// the tally terminal compose, exactly as they do for `map`/`filter`/`fold`.
 #[test]
 fn count_over_var_bound_immutable_array_fuses() {
-    let (hir, arena, names) = compile("(let [xs [1 2 3 4]] (count (fn [x] (even? x)) xs))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [xs [1 2 3 4]] (count (fn [x] (even? x)) xs))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "count"),
         "a Var-bound base must fuse; callees were {cs:?}",
     );
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "scalar tally accumulator; callees were {cs:?}",
     );

--- a/src/hir/typeinfer/fuse/tests/drop.rs
+++ b/src/hir/typeinfer/fuse/tests/drop.rs
@@ -22,8 +22,8 @@ fn count_ands(h: &Hir) -> usize {
 /// itself, and the flag read that admits the rest of the pipeline.
 #[test]
 fn single_drop_while_dissolves_to_a_flag_gated_push() {
-    let (hir, arena, names) = compile("(drop-while (fn [x] (even? x)) [2 4 5 6])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(drop-while (fn [x] (even? x)) [2 4 5 6])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "drop-while"),
         "the `drop-while` dispatch must be gone; callees were {cs:?}",
@@ -34,7 +34,7 @@ fn single_drop_while_dissolves_to_a_flag_gated_push() {
         "the predicate must run inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator; callees were {cs:?}",
     );
@@ -59,9 +59,9 @@ fn single_drop_while_dissolves_to_a_flag_gated_push() {
 /// elements the drop-while passed on, which is what the staged form gives it.
 #[test]
 fn map_over_drop_while_fuses_to_one_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(map (fn [y] (* y 2)) (drop-while (fn [x] (even? x)) [2 4 5 6]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "drop-while" || n == "map"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -72,7 +72,7 @@ fn map_over_drop_while_fuses_to_one_loop() {
         "both the predicate and the transform must inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator, no intermediate; callees were {cs:?}",
     );
@@ -92,16 +92,16 @@ fn map_over_drop_while_fuses_to_one_loop() {
 /// exhaustive, so a prefix changes nothing about where the flag is read.
 #[test]
 fn drop_while_over_map_prefix_fuses_to_one_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(drop-while (fn [y] (even? y)) (map (fn [x] (* x 2)) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "drop-while" || n == "map"),
         "both dispatches must be gone; callees were {cs:?}",
     );
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator, no intermediate; callees were {cs:?}",
     );
@@ -118,16 +118,16 @@ fn drop_while_over_map_prefix_fuses_to_one_loop() {
 /// the terminal's seed however the stdlib op typed its intermediate.
 #[test]
 fn count_over_drop_while_fuses_to_one_scalar_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(count (fn [y] (number? y)) (drop-while (fn [x] (even? x)) [2 4 5 6]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "drop-while" || n == "count"),
         "both dispatches must be gone; callees were {cs:?}",
     );
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "a scalar terminal mints no array; callees were {cs:?}",
     );
@@ -145,8 +145,8 @@ fn count_over_drop_while_fuses_to_one_scalar_loop() {
 #[test]
 fn find_index_over_drop_while_counts_survivors() {
     let dropped = "(drop-while (fn [x] (even? x)) [2 4 5 7])";
-    let (hir, arena, names) = compile(&format!("(find-index (fn [y] (odd? y)) {dropped})"));
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile(&format!("(find-index (fn [y] (odd? y)) {dropped})"));
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "find-index" || n == "drop-while"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -160,8 +160,8 @@ fn find_index_over_drop_while_counts_survivors() {
 
     // A boolean search over the same prefix answers a value, not a position, so it
     // carries no counter.
-    let (hir, arena, names) = compile(&format!("(any? (fn [y] (odd? y)) {dropped})"));
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile(&format!("(any? (fn [y] (odd? y)) {dropped})"));
+    let cs = callees(&hir, &arena, &mut rt);
     assert_eq!(
         count_intrinsic(&hir, "%add"),
         1,
@@ -170,9 +170,9 @@ fn find_index_over_drop_while_counts_survivors() {
 
     // A `take-while` preserves every survivor's position, so the base index is
     // already the answer there.
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(find-index (fn [y] (odd? y)) (take-while (fn [x] (number? x)) [2 4 5 7]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert_eq!(
         count_intrinsic(&hir, "%add"),
         1,
@@ -196,8 +196,8 @@ fn drop_while_erroring_bodies_fuse() {
             "zero?",
         ),
     ] {
-        let (hir, arena, names) = compile(src);
-        let cs = callees(&hir, &arena, &names);
+        let (hir, arena, mut rt) = compile(src);
+        let cs = callees(&hir, &arena, &mut rt);
         assert!(
             !cs.iter().any(|n| n == "drop-while" || n == "map"),
             "an erroring body is reorder-safe and must fuse in {src}; callees were {cs:?}",
@@ -217,9 +217,9 @@ fn drop_while_erroring_bodies_fuse() {
 /// and the loop its accumulator. The inner `filter` still fuses on the recursion.
 #[test]
 fn drop_while_over_filter_prefix_declines() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(drop-while (fn [y] (even? y)) (filter (fn [x] (number? x)) [1 \"a\" 2]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "drop-while"),
         "a drop-while whose input's emptiness `len` cannot decide must not fuse; \
@@ -250,10 +250,10 @@ fn either_untyped_arm_inner_to_the_other_declines_the_outer() {
             "drop-while",
         ),
     ] {
-        let (hir, arena, names) = compile(src);
-        let cs = callees(&hir, &arena, &names);
+        let (hir, arena, mut rt) = compile(src);
+        let cs = callees(&hir, &arena, &mut rt);
         assert_eq!(
-            count_callee(&hir, &arena, &names, outer),
+            count_callee(&hir, &arena, &mut rt, outer),
             1,
             "exactly the outer op survives in {src}; callees were {cs:?}",
         );
@@ -265,8 +265,8 @@ fn either_untyped_arm_inner_to_the_other_declines_the_outer() {
 /// once, so a predicate that grows or shrinks the base would diverge.
 #[test]
 fn drop_while_over_mutable_array_is_not_fused() {
-    let (hir, arena, names) = compile("(drop-while (fn [x] (even? x)) @[2 4 5])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(drop-while (fn [x] (even? x)) @[2 4 5])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "drop-while"),
         "a mutable `@array` base must not fuse a drop-while; callees were {cs:?}",
@@ -277,8 +277,8 @@ fn drop_while_over_mutable_array_is_not_fused() {
 /// so it is never rewritten.
 #[test]
 fn user_shadowed_drop_while_is_not_fused() {
-    let (hir, arena, names) = compile("(defn drop-while [p c] c) (drop-while (fn [x] x) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn drop-while [p c] c) (drop-while (fn [x] x) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "drop-while"),
         "a user `drop-while` must not be rewritten; callees were {cs:?}",
@@ -291,8 +291,8 @@ fn user_shadowed_drop_while_is_not_fused() {
 /// both survive.
 #[test]
 fn capturing_drop_while_predicate_fuses() {
-    let (hir, arena, names) = compile("(let [k 2] (drop-while (fn [x] (> x k)) [3 4 1]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 2] (drop-while (fn [x] (> x k)) [3 4 1]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "drop-while"),
         "the `drop-while` dispatch must be gone; callees were {cs:?}",
@@ -305,8 +305,8 @@ fn capturing_drop_while_predicate_fuses() {
 /// requirement on how the function is resolved.
 #[test]
 fn named_drop_while_predicate_inlines() {
-    let (hir, arena, names) = compile("(defn small? [x] (< x 3)) (drop-while small? [1 2 5])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn small? [x] (< x 3)) (drop-while small? [1 2 5])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "drop-while"),
         "the dispatch must be gone for a named predicate; callees were {cs:?}",

--- a/src/hir/typeinfer/fuse/tests/fold.rs
+++ b/src/hir/typeinfer/fuse/tests/fold.rs
@@ -9,8 +9,8 @@ use super::*;
 
 #[test]
 fn single_fold_dissolves_to_scalar_accumulator() {
-    let (hir, arena, names) = compile("(fold (fn [a x] (+ a x)) 0 [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(fold (fn [a x] (+ a x)) 0 [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "fold"),
         "the `fold` dispatch must be gone; callees were {cs:?}",
@@ -21,7 +21,7 @@ fn single_fold_dissolves_to_scalar_accumulator() {
         "the fold body op `+` must run inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "a fold's accumulator is a scalar — no `@array`; callees were {cs:?}",
     );
@@ -40,8 +40,9 @@ fn single_fold_dissolves_to_scalar_accumulator() {
 /// exists). Fails before fold fusion: a `fold` and a `map` call, two closures.
 #[test]
 fn fold_of_map_fuses_to_one_scalar_loop() {
-    let (hir, arena, names) = compile("(fold (fn [a x] (+ a x)) 0 (map (fn [x] (* x 2)) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) =
+        compile("(fold (fn [a x] (+ a x)) 0 (map (fn [x] (* x 2)) [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "fold" || n == "map"),
         "both the `fold` and `map` dispatches must be gone; callees were {cs:?}",
@@ -52,7 +53,7 @@ fn fold_of_map_fuses_to_one_scalar_loop() {
         "both the fold step and the map transform must inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "map-into-fold mints NO array — the map's result feeds the fold step; \
              callees were {cs:?}",
@@ -68,9 +69,9 @@ fn fold_of_map_fuses_to_one_scalar_loop() {
 /// fusion: a `fold` and a `filter` call, two closures.
 #[test]
 fn fold_of_filter_fuses_to_one_scalar_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(fold (fn [a x] (+ a x)) 0 (filter (fn [y] (even? y)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "fold" || n == "filter"),
         "both the `fold` and `filter` dispatches must be gone; callees were {cs:?}",
@@ -81,7 +82,7 @@ fn fold_of_filter_fuses_to_one_scalar_loop() {
         "both the fold step and the predicate must inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "filter-into-fold mints NO array; callees were {cs:?}",
     );
@@ -92,15 +93,15 @@ fn fold_of_filter_fuses_to_one_scalar_loop() {
 /// name. `(reduce f init xs)` dissolves exactly as `fold` does.
 #[test]
 fn reduce_dissolves_like_fold() {
-    let (hir, arena, names) = compile("(reduce (fn [a x] (+ a x)) 0 [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(reduce (fn [a x] (+ a x)) 0 [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "reduce" || n == "fold"),
         "the `reduce` dispatch must be gone; callees were {cs:?}",
     );
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "reduce fuses to a scalar accumulator; callees were {cs:?}",
     );
@@ -112,8 +113,8 @@ fn reduce_dissolves_like_fold() {
 /// through `apply`). The single-op path carries no reorder requirement.
 #[test]
 fn single_fold_with_non_reorder_safe_body_still_fuses() {
-    let (hir, arena, names) = compile("(fold (fn [a x] (if (> a x) a x)) 0 [3 1 2])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(fold (fn [a x] (if (> a x) a x)) 0 [3 1 2])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "fold"),
         "a lone fold has no reorder gate and must fuse; callees were {cs:?}",
@@ -129,9 +130,9 @@ fn single_fold_with_non_reorder_safe_body_still_fuses() {
 /// argument spill keeps that sound — `call-arg-across-loop.lisp`.)
 #[test]
 fn fold_over_non_reorder_safe_prefix_fuses_inner_only() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(fold (fn [a x] (+ a x)) 0 (filter (fn [w] (> w 1)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "fold"),
         "the outer `fold` must not fuse a non-reorder-safe composition; \
@@ -147,8 +148,8 @@ fn fold_over_non_reorder_safe_prefix_fuses_inner_only() {
 /// non-primitive one, so it is never rewritten. The user's `fold` call survives.
 #[test]
 fn user_shadowed_fold_is_not_fused() {
-    let (hir, arena, names) = compile("(defn fold [f i c] i) (fold (fn [a x] a) 0 [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn fold [f i c] i) (fold (fn [a x] a) 0 [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "fold"),
         "a user `fold` must not be rewritten; callees were {cs:?}",
@@ -162,8 +163,8 @@ fn user_shadowed_fold_is_not_fused() {
 /// capture: the `fold` call and the closure both survive.
 #[test]
 fn capturing_fold_lambda_fuses() {
-    let (hir, arena, names) = compile("(let [k 10] (fold (fn [a x] (+ a (+ x k))) 0 [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 10] (fold (fn [a x] (+ a (+ x k))) 0 [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "fold"),
         "the `fold` dispatch must be gone; callees were {cs:?}",
@@ -175,15 +176,15 @@ fn capturing_fold_lambda_fuses() {
 /// the scalar terminal compose, exactly as they do for `map`/`filter`.
 #[test]
 fn fold_over_var_bound_immutable_array_fuses() {
-    let (hir, arena, names) = compile("(let [xs [1 2 3 4]] (fold (fn [a x] (+ a x)) 0 xs))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [xs [1 2 3 4]] (fold (fn [a x] (+ a x)) 0 xs))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "fold"),
         "a Var-bound base must fuse; callees were {cs:?}",
     );
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "scalar fold accumulator; callees were {cs:?}",
     );

--- a/src/hir/typeinfer/fuse/tests/indexed.rs
+++ b/src/hir/typeinfer/fuse/tests/indexed.rs
@@ -21,8 +21,8 @@ fn count_ands(h: &Hir) -> usize {
 /// reads is that index, never a survivor count.
 #[test]
 fn single_map_indexed_dissolves_to_an_indexed_push() {
-    let (hir, arena, names) = compile("(map-indexed (fn [i x] (* i x)) [10 20 30])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map-indexed (fn [i x] (* i x)) [10 20 30])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map-indexed"),
         "the `map-indexed` dispatch must be gone; callees were {cs:?}",
@@ -33,7 +33,7 @@ fn single_map_indexed_dissolves_to_an_indexed_push() {
         "the function's body op must run inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator; callees were {cs:?}",
     );
@@ -63,9 +63,9 @@ fn single_map_indexed_dissolves_to_an_indexed_push() {
 /// indexed one produced.
 #[test]
 fn map_over_map_indexed_fuses_to_one_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(map (fn [y] (+ y 1)) (map-indexed (fn [i x] (* i x)) [10 20 30]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map-indexed" || n == "map"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -76,7 +76,7 @@ fn map_over_map_indexed_fuses_to_one_loop() {
         "the indexed body must inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator, no intermediate; callees were {cs:?}",
     );
@@ -91,16 +91,16 @@ fn map_over_map_indexed_fuses_to_one_loop() {
 /// which a `map` preserves.
 #[test]
 fn map_indexed_over_map_prefix_fuses_to_one_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(map-indexed (fn [i y] (* i y)) (map (fn [x] (+ x 1)) [10 20 30]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map-indexed" || n == "map"),
         "both dispatches must be gone; callees were {cs:?}",
     );
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator, no intermediate; callees were {cs:?}",
     );
@@ -116,16 +116,16 @@ fn map_indexed_over_map_prefix_fuses_to_one_loop() {
 /// the terminal's seed however the stdlib op typed its intermediate.
 #[test]
 fn count_over_map_indexed_fuses_to_one_scalar_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(count (fn [y] (odd? y)) (map-indexed (fn [i x] (* i x)) [10 20 30]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map-indexed" || n == "count"),
         "both dispatches must be gone; callees were {cs:?}",
     );
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "a scalar terminal mints no array; callees were {cs:?}",
     );
@@ -141,15 +141,15 @@ fn map_indexed_inner_to_an_untyped_arm_fuses() {
         "(drop-while (fn [y] (odd? y)) (map-indexed (fn [i x] (* i x)) [10 20 30]))",
         "(map-indexed (fn [j y] (+ j y)) (map-indexed (fn [i x] (* i x)) [10 20 30]))",
     ] {
-        let (hir, arena, names) = compile(src);
-        let cs = callees(&hir, &arena, &names);
+        let (hir, arena, mut rt) = compile(src);
+        let cs = callees(&hir, &arena, &mut rt);
         assert!(
             !cs.iter()
                 .any(|n| n == "map-indexed" || n == "take-while" || n == "drop-while"),
             "a length-preserving inner stage must fuse whole in {src}; callees were {cs:?}",
         );
         assert_eq!(
-            count_callee(&hir, &arena, &names, "@array"),
+            count_callee(&hir, &arena, &mut rt, "@array"),
             1,
             "one accumulator, no intermediate in {src}; callees were {cs:?}",
         );
@@ -177,10 +177,10 @@ fn shortening_stage_inner_to_map_indexed_declines() {
             "drop-while",
         ),
     ] {
-        let (hir, arena, names) = compile(src);
-        let cs = callees(&hir, &arena, &names);
+        let (hir, arena, mut rt) = compile(src);
+        let cs = callees(&hir, &arena, &mut rt);
         assert_eq!(
-            count_callee(&hir, &arena, &names, "map-indexed"),
+            count_callee(&hir, &arena, &mut rt, "map-indexed"),
             1,
             "a map-indexed whose input's emptiness `len` cannot decide must not fuse \
              in {src}; callees were {cs:?}",
@@ -197,8 +197,8 @@ fn shortening_stage_inner_to_map_indexed_declines() {
 /// once, so a function that grows or shrinks the base would diverge.
 #[test]
 fn map_indexed_over_mutable_array_is_not_fused() {
-    let (hir, arena, names) = compile("(map-indexed (fn [i x] (* i x)) @[10 20 30])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map-indexed (fn [i x] (* i x)) @[10 20 30])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map-indexed"),
         "a mutable `@array` base must not fuse a map-indexed; callees were {cs:?}",
@@ -209,9 +209,9 @@ fn map_indexed_over_mutable_array_is_not_fused() {
 /// so it is never rewritten.
 #[test]
 fn user_shadowed_map_indexed_is_not_fused() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(defn map-indexed [f c] c) (map-indexed (fn [i x] x) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map-indexed"),
         "a user `map-indexed` must not be rewritten; callees were {cs:?}",
@@ -224,8 +224,8 @@ fn user_shadowed_map_indexed_is_not_fused() {
 /// both survive.
 #[test]
 fn capturing_map_indexed_fn_fuses() {
-    let (hir, arena, names) = compile("(let [k 2] (map-indexed (fn [i x] (* k x)) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 2] (map-indexed (fn [i x] (* k x)) [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map-indexed"),
         "the `map-indexed` dispatch must be gone; callees were {cs:?}",
@@ -238,8 +238,8 @@ fn capturing_map_indexed_fn_fuses() {
 /// declines rather than splicing a body with an unbound parameter.
 #[test]
 fn wrong_arity_map_indexed_fn_is_not_fused() {
-    let (hir, arena, names) = compile("(map-indexed (fn [x] (* x 2)) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map-indexed (fn [x] (* x 2)) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map-indexed"),
         "a one-parameter function must not fuse a map-indexed; callees were {cs:?}",
@@ -251,8 +251,8 @@ fn wrong_arity_map_indexed_fn_is_not_fused() {
 /// no new requirement on how the function is resolved.
 #[test]
 fn named_map_indexed_fn_inlines() {
-    let (hir, arena, names) = compile("(defn scale [i x] (* i x)) (map-indexed scale [10 20 30])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn scale [i x] (* i x)) (map-indexed scale [10 20 30])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map-indexed"),
         "the dispatch must be gone for a named function; callees were {cs:?}",

--- a/src/hir/typeinfer/fuse/tests/mapcat.rs
+++ b/src/hir/typeinfer/fuse/tests/mapcat.rs
@@ -20,8 +20,8 @@ fn count_loops(h: &Hir) -> usize {
 /// `(if (mutable? coll) acc (freeze acc))`.
 #[test]
 fn single_mapcat_dissolves_to_a_nested_walk() {
-    let (hir, arena, names) = compile("(mapcat (fn [x] [x (* x 10)]) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(mapcat (fn [x] [x (* x 10)]) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "mapcat"),
         "the `mapcat` dispatch must be gone; callees were {cs:?}",
@@ -33,17 +33,17 @@ fn single_mapcat_dissolves_to_a_nested_walk() {
     );
     assert_eq!(count_loops(&hir), 2, "the base walk, and the fan-out's own");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "length"),
+        count_callee(&hir, &arena, &mut rt, "length"),
         2,
         "one length per level: the base's and the per-element array's; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "get"),
+        count_callee(&hir, &arena, &mut rt, "get"),
         2,
         "one indexed read per level; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator, however many runs are spliced into it; callees were {cs:?}",
     );
@@ -59,9 +59,9 @@ fn single_mapcat_dissolves_to_a_nested_walk() {
 /// element — which is what the staged form gives it.
 #[test]
 fn map_over_mapcat_fuses_to_one_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(map (fn [y] (+ y 1)) (mapcat (fn [x] [x (* x 10)]) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "mapcat" || n == "map"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -73,7 +73,7 @@ fn map_over_mapcat_fuses_to_one_loop() {
     );
     assert_eq!(count_loops(&hir), 2, "one pair of loops, not two pairs");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator, no flat collection between the ops; callees were {cs:?}",
     );
@@ -88,8 +88,8 @@ fn map_over_mapcat_fuses_to_one_loop() {
 /// so `len` still decides the base's emptiness.
 #[test]
 fn mapcat_over_map_prefix_fuses_to_one_loop() {
-    let (hir, arena, names) = compile("(mapcat (fn [y] [y y]) (map (fn [x] (+ x 1)) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(mapcat (fn [y] [y y]) (map (fn [x] (+ x 1)) [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "mapcat" || n == "map"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -97,7 +97,7 @@ fn mapcat_over_map_prefix_fuses_to_one_loop() {
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(count_loops(&hir), 2, "one pair of loops");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator, no intermediate; callees were {cs:?}",
     );
@@ -107,9 +107,9 @@ fn mapcat_over_map_prefix_fuses_to_one_loop() {
 /// all — the flat collection the terminal would have walked never exists.
 #[test]
 fn count_over_mapcat_fuses_to_one_scalar_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(count (fn [y] (odd? y)) (mapcat (fn [x] [x (* x 10)]) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "mapcat" || n == "count"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -117,7 +117,7 @@ fn count_over_mapcat_fuses_to_one_scalar_loop() {
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(count_loops(&hir), 2, "one pair of loops");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "a scalar terminal mints no array; callees were {cs:?}",
     );
@@ -130,9 +130,9 @@ fn count_over_mapcat_fuses_to_one_scalar_loop() {
 /// two index walks need.
 #[test]
 fn find_index_over_mapcat_carries_a_survivor_count() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(find-index (fn [y] (even? y)) (mapcat (fn [x] [x x x]) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "mapcat" || n == "find-index"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -156,8 +156,8 @@ fn unproven_result_mapcat_is_not_fused() {
         "(mapcat (fn [x] (if (odd? x) [x] [])) [1 2 3])",
         "(mapcat (fn [x] x) [[1] [2]])",
     ] {
-        let (hir, arena, names) = compile(src);
-        let cs = callees(&hir, &arena, &names);
+        let (hir, arena, mut rt) = compile(src);
+        let cs = callees(&hir, &arena, &mut rt);
         assert!(
             cs.iter().any(|n| n == "mapcat"),
             "a function with no proven array result must not fuse in {src}; \
@@ -190,8 +190,8 @@ fn mapcat_inner_to_an_untyped_arm_declines() {
             "mapcat",
         ),
     ] {
-        let (hir, arena, names) = compile(src);
-        let cs = callees(&hir, &arena, &names);
+        let (hir, arena, mut rt) = compile(src);
+        let cs = callees(&hir, &arena, &mut rt);
         assert!(
             cs.iter().any(|n| n == outer),
             "a mapcat whose output's emptiness `len` cannot decide must not fuse \
@@ -208,15 +208,15 @@ fn length_preserving_stage_inner_to_mapcat_fuses() {
         "(mapcat (fn [y] [y y]) (map (fn [x] (+ x 1)) [1 2 3]))",
         "(mapcat (fn [y] [y y]) (map-indexed (fn [i x] (+ i x)) [1 2 3]))",
     ] {
-        let (hir, arena, names) = compile(src);
-        let cs = callees(&hir, &arena, &names);
+        let (hir, arena, mut rt) = compile(src);
+        let cs = callees(&hir, &arena, &mut rt);
         assert!(
             !cs.iter()
                 .any(|n| n == "mapcat" || n == "map" || n == "map-indexed"),
             "a length-preserving inner stage must fuse whole in {src}; callees were {cs:?}",
         );
         assert_eq!(
-            count_callee(&hir, &arena, &names, "@array"),
+            count_callee(&hir, &arena, &mut rt, "@array"),
             1,
             "one accumulator, no intermediate in {src}; callees were {cs:?}",
         );
@@ -227,10 +227,11 @@ fn length_preserving_stage_inner_to_mapcat_fuses() {
 /// shortening stage inner to any other untyped array arm does.
 #[test]
 fn shortening_stage_inner_to_mapcat_declines() {
-    let (hir, arena, names) = compile("(mapcat (fn [y] [y y]) (filter (fn [x] (odd? x)) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) =
+        compile("(mapcat (fn [y] [y y]) (filter (fn [x] (odd? x)) [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert_eq!(
-        count_callee(&hir, &arena, &names, "mapcat"),
+        count_callee(&hir, &arena, &mut rt, "mapcat"),
         1,
         "a mapcat whose input's emptiness `len` cannot decide must not fuse; \
          callees were {cs:?}",
@@ -247,8 +248,8 @@ fn shortening_stage_inner_to_mapcat_declines() {
 /// recursion fuses the innermost single op.
 #[test]
 fn lone_mapcat_over_mutable_array_fuses() {
-    let (hir, arena, names) = compile("(mapcat (fn [x] [x x]) @[1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(mapcat (fn [x] [x x]) @[1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "mapcat"),
         "a lone mapcat must fuse over a mutable base; callees were {cs:?}",
@@ -258,8 +259,8 @@ fn lone_mapcat_over_mutable_array_fuses() {
         "the mutable arm returns the accumulator unfrozen; callees were {cs:?}",
     );
 
-    let (hir, arena, names) = compile("(map (fn [y] (+ y 1)) (mapcat (fn [x] [x x]) @[1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map (fn [y] (+ y 1)) (mapcat (fn [x] [x x]) @[1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map"),
         "a composition over a mutable base must decline; callees were {cs:?}",
@@ -270,8 +271,8 @@ fn lone_mapcat_over_mutable_array_fuses() {
 /// so it is never rewritten.
 #[test]
 fn user_shadowed_mapcat_is_not_fused() {
-    let (hir, arena, names) = compile("(defn mapcat [f c] c) (mapcat (fn [x] [x]) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn mapcat [f c] c) (mapcat (fn [x] [x]) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "mapcat"),
         "a user `mapcat` must not be rewritten; callees were {cs:?}",
@@ -284,8 +285,8 @@ fn user_shadowed_mapcat_is_not_fused() {
 /// closure both survive.
 #[test]
 fn capturing_mapcat_fn_fuses() {
-    let (hir, arena, names) = compile("(let [k 2] (mapcat (fn [x] [x k]) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 2] (mapcat (fn [x] [x k]) [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "mapcat"),
         "the `mapcat` dispatch must be gone; callees were {cs:?}",
@@ -297,8 +298,8 @@ fn capturing_mapcat_fn_fuses() {
 /// cloning, and the array proof reads that body exactly as it reads a literal's.
 #[test]
 fn named_mapcat_fn_inlines() {
-    let (hir, arena, names) = compile("(defn pairup [x] [x (* x 10)]) (mapcat pairup [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn pairup [x] [x (* x 10)]) (mapcat pairup [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "mapcat"),
         "the dispatch must be gone for a named function; callees were {cs:?}",

--- a/src/hir/typeinfer/fuse/tests/mod.rs
+++ b/src/hir/typeinfer/fuse/tests/mod.rs
@@ -4,35 +4,43 @@
 
 use crate::hir::arena::BindingArena;
 use crate::hir::expr::{Hir, HirKind};
-use std::collections::HashMap;
 
 /// Compile a source form to functionalized HIR against a full stdlib.
-fn compile(src: &str) -> (Hir, BindingArena, HashMap<u32, String>) {
+///
+/// The `Runtime` comes back with the HIR because it owns the display memo, and
+/// most of the names these tests assert on — `map`, `*`, `push` — are stdlib
+/// exports that no build-time table can spell (docs/impl/symbol.md). Hold it
+/// for as long as you want to read a callee's name.
+fn compile(src: &str) -> (Hir, BindingArena, crate::runtime::Runtime) {
     let mut rt = crate::runtime::Runtime::new();
-    let (_vm, symbols, cctx) = rt.parts();
-    crate::pipeline::compile_file_to_fhir(src, symbols, cctx, "<test>").expect("compile")
+    let (hir, arena) = {
+        let (_vm, symbols, cctx) = rt.parts();
+        crate::pipeline::compile_file_to_fhir(src, symbols, cctx, "<test>").expect("compile")
+    };
+    (hir, arena, rt)
 }
 
 /// Names of every call callee (through the ANF/`Var` wrappers) in the tree.
 fn callee_names(
     h: &Hir,
     arena: &BindingArena,
-    names: &HashMap<u32, String>,
+    symbols: &crate::symbol::SymbolTable,
     out: &mut Vec<String>,
 ) {
     if let HirKind::Call { func, .. } = &h.kind {
         if let Some(b) = super::unwrap_callee_binding(func) {
-            if let Some(n) = names.get(&arena.get(b).name.0) {
-                out.push(n.clone());
+            if let Some(n) = symbols.name(arena.get(b).name) {
+                out.push(n.to_string());
             }
         }
     }
-    h.for_each_child(|c| callee_names(c, arena, names, out));
+    h.for_each_child(|c| callee_names(c, arena, symbols, out));
 }
 
-fn callees(h: &Hir, arena: &BindingArena, names: &HashMap<u32, String>) -> Vec<String> {
+fn callees(h: &Hir, arena: &BindingArena, rt: &mut crate::runtime::Runtime) -> Vec<String> {
     let mut out = Vec::new();
-    callee_names(h, arena, names, &mut out);
+    let (_vm, symbols, _cctx) = rt.parts();
+    callee_names(h, arena, symbols, &mut out);
     out
 }
 
@@ -53,11 +61,13 @@ fn count_ifs(h: &Hir) -> usize {
 }
 
 /// Count the calls to a given op name in the tree.
-fn count_callee(h: &Hir, arena: &BindingArena, names: &HashMap<u32, String>, want: &str) -> usize {
-    callees(h, arena, names)
-        .iter()
-        .filter(|n| *n == want)
-        .count()
+fn count_callee(
+    h: &Hir,
+    arena: &BindingArena,
+    rt: &mut crate::runtime::Runtime,
+    want: &str,
+) -> usize {
+    callees(h, arena, rt).iter().filter(|n| *n == want).count()
 }
 
 /// Count the call-position `%`-intrinsic nodes of a given op in the tree.

--- a/src/hir/typeinfer/fuse/tests/named.rs
+++ b/src/hir/typeinfer/fuse/tests/named.rs
@@ -10,14 +10,14 @@ use super::*;
 
 #[test]
 fn named_map_fn_inlines() {
-    let (hir, arena, names) = compile("(defn dbl [x] (* x 2)) (map dbl [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn dbl [x] (* x 2)) (map dbl [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "the `map` dispatch must be gone when the fn is a named defn; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "*"),
+        count_callee(&hir, &arena, &mut rt, "*"),
         2,
         "`dbl`'s body op appears twice — the surviving definition plus the \
              inlined copy; callees were {cs:?}",
@@ -27,7 +27,7 @@ fn named_map_fn_inlines() {
         "the fused loop freezes one accumulator; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one fused accumulator; callees were {cs:?}",
     );
@@ -40,19 +40,19 @@ fn named_map_fn_inlines() {
 /// `(+ i 1)` increment uses `+`, so `+` would not be a clean discriminator.
 #[test]
 fn named_fold_fn_inlines() {
-    let (hir, arena, names) = compile("(defn mul [a b] (* a b)) (fold mul 1 [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn mul [a b] (* a b)) (fold mul 1 [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "fold"),
         "the `fold` dispatch must be gone for a named combinator; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "*"),
+        count_callee(&hir, &arena, &mut rt, "*"),
         2,
         "`mul`'s body op appears twice (definition + inlined); callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "a fold accumulator is scalar — no `@array`; callees were {cs:?}",
     );
@@ -64,19 +64,19 @@ fn named_fold_fn_inlines() {
 /// over a single accumulator.
 #[test]
 fn named_fn_composition_fuses_to_one_loop() {
-    let (hir, arena, names) = compile("(defn dbl [x] (* x 2)) (map dbl (map dbl [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn dbl [x] (* x 2)) (map dbl (map dbl [1 2 3]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "both `map` dispatches must be gone; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "*"),
+        count_callee(&hir, &arena, &mut rt, "*"),
         3,
         "definition + two inlined copies of `dbl`; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one loop, one accumulator — the intermediate array is gone; callees were {cs:?}",
     );
@@ -90,20 +90,20 @@ fn named_fn_composition_fuses_to_one_loop() {
 /// declines and the `map` call survives.
 #[test]
 fn named_fn_with_let_body_inlines() {
-    let (hir, arena, names) = compile("(defn g [x] (let [y (* x 2)] (+ y 1))) (map g [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn g [x] (let [y (* x 2)] (+ y 1))) (map g [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "a named fn with a `let` body must inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "*"),
+        count_callee(&hir, &arena, &mut rt, "*"),
         2,
         "`g`'s `*` appears twice — the surviving definition plus the inlined \
              copy; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one fused accumulator; callees were {cs:?}",
     );
@@ -117,8 +117,8 @@ fn named_fn_with_let_body_inlines() {
 /// correct-by-construction.
 #[test]
 fn named_fn_with_match_body_declines() {
-    let (hir, arena, names) = compile("(defn g [x] (match x _ (* x 2))) (map g [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn g [x] (match x _ (* x 2))) (map g [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map"),
         "a named fn with a `match` body must not inline; callees were {cs:?}",
@@ -135,20 +135,20 @@ fn named_fn_with_match_body_declines() {
 /// increment also uses `+`.)
 #[test]
 fn named_let_body_fn_composition_fuses_to_one_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(defn g [x] (let [y (* x 2)] (+ y 1))) (map g (map g [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "both `map` dispatches must be gone; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "*"),
+        count_callee(&hir, &arena, &mut rt, "*"),
         3,
         "definition + two inlined copies of `g`'s `*`; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one loop, one accumulator — the intermediate array is gone; callees were {cs:?}",
     );
@@ -162,8 +162,8 @@ fn named_let_body_fn_composition_fuses_to_one_loop() {
 /// (docs/impl/dissolution.md § "Captures"). The `map` call survives.
 #[test]
 fn named_capturing_local_fn_declines() {
-    let (hir, arena, names) = compile("(let [k 10] (let [g (fn [x] (+ x k))] (map g [1 2 3])))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 10] (let [g (fn [x] (+ x k))] (map g [1 2 3])))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map"),
         "a capturing local fn must not inline; callees were {cs:?}",
@@ -175,8 +175,8 @@ fn named_capturing_local_fn_declines() {
 /// the `map` call survives.
 #[test]
 fn named_non_lambda_var_declines() {
-    let (hir, arena, names) = compile("(def h 5) (map h [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(def h 5) (map h [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map"),
         "a non-lambda Var arg must not inline; callees were {cs:?}",
@@ -195,15 +195,15 @@ fn named_non_lambda_var_declines() {
 /// survives and no `-` appears at all (dec's body is not in this tree).
 #[test]
 fn named_map_cross_unit_stdlib_fn_inlines() {
-    let (hir, arena, names) = compile("(map dec [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map dec [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "the `map` dispatch must be gone for a cross-unit stdlib fn; callees were {cs:?}",
     );
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "-"),
+        count_callee(&hir, &arena, &mut rt, "-"),
         1,
         "`dec`'s body op `-` is spliced in exactly once — the definition stays in \
              the stdlib unit, so there is no surviving copy; callees were {cs:?}",
@@ -213,7 +213,7 @@ fn named_map_cross_unit_stdlib_fn_inlines() {
         "the fused loop freezes one accumulator; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one fused accumulator; callees were {cs:?}",
     );
@@ -225,8 +225,8 @@ fn named_map_cross_unit_stdlib_fn_inlines() {
 /// as an inlineable template, and `(map distinct …)` stays a plain `map` call.
 #[test]
 fn cross_unit_non_inlineable_stdlib_fn_declines() {
-    let (hir, arena, names) = compile("(map distinct [[1] [2]])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map distinct [[1] [2]])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map"),
         "a cross-unit fn with a non-whitelisted body must not inline; callees were {cs:?}",
@@ -239,8 +239,8 @@ fn cross_unit_non_inlineable_stdlib_fn_declines() {
 /// inline cloned it rather than consuming it).
 #[test]
 fn named_fn_inlined_and_still_first_class() {
-    let (hir, arena, names) = compile("(defn dbl [x] (* x 2)) (def ys (map dbl [1 2 3])) (dbl 9)");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn dbl [x] (* x 2)) (def ys (map dbl [1 2 3])) (dbl 9)");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "the `map` must fuse; callees were {cs:?}",

--- a/src/hir/typeinfer/fuse/tests/numeric.rs
+++ b/src/hir/typeinfer/fuse/tests/numeric.rs
@@ -13,8 +13,8 @@ use super::*;
 
 #[test]
 fn numeric_declared_intrinsic_body_map_fuses() {
-    let (hir, arena, names) = compile("(map (fn [x] (numeric!) (%add x 1)) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map (fn [x] (numeric!) (%add x 1)) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "a `(numeric!)`-declared intrinsic kernel must fuse; callees were {cs:?}",
@@ -26,7 +26,7 @@ fn numeric_declared_intrinsic_body_map_fuses() {
         "the kernel's `%add` runs inline in the fused loop, beside the index walk's own",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one fused accumulator; callees were {cs:?}",
     );
@@ -39,8 +39,8 @@ fn numeric_declared_intrinsic_body_map_fuses() {
 /// site's proof depends on. The `map` call survives.
 #[test]
 fn undeclared_intrinsic_body_declines() {
-    let (hir, arena, names) = compile("(map (fn [x] (%add 1 2)) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map (fn [x] (%add 1 2)) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "map"),
         "an intrinsic body without `(numeric!)` must not fuse; callees were {cs:?}",
@@ -55,8 +55,8 @@ fn undeclared_intrinsic_body_declines() {
 /// `compile`'s expect would surface.)
 #[test]
 fn numeric_declared_div_intrinsic_body_fuses() {
-    let (hir, arena, names) = compile("(map (fn [x] (numeric!) (%div x 2)) [4 6 8])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(map (fn [x] (numeric!) (%div x 2)) [4 6 8])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "a `%div` kernel with a literal divisor must fuse; callees were {cs:?}",
@@ -74,8 +74,8 @@ fn numeric_declared_div_intrinsic_body_fuses() {
 /// accumulator is a scalar.
 #[test]
 fn numeric_declared_intrinsic_fold_fuses() {
-    let (hir, arena, names) = compile("(fold (fn [a x] (numeric!) (%add a x)) 0 [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(fold (fn [a x] (numeric!) (%add a x)) 0 [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "fold"),
         "a `(numeric!)`-declared intrinsic combinator must fuse; callees were {cs:?}",
@@ -87,7 +87,7 @@ fn numeric_declared_intrinsic_fold_fuses() {
         "the fold step inlines, beside the index walk's own bump",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "a fold accumulator is scalar; callees were {cs:?}",
     );
@@ -98,8 +98,8 @@ fn numeric_declared_intrinsic_fold_fuses() {
 /// comparable-family obligation over the spliced binding.
 #[test]
 fn numeric_declared_intrinsic_predicate_filter_fuses() {
-    let (hir, arena, names) = compile("(filter (fn [x] (numeric!) (%gt x 2)) [1 2 3 4])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(filter (fn [x] (numeric!) (%gt x 2)) [1 2 3 4])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "filter"),
         "a `(numeric!)`-declared intrinsic predicate must fuse; callees were {cs:?}",
@@ -119,8 +119,8 @@ fn numeric_declared_intrinsic_predicate_filter_fuses() {
 /// TWICE: the surviving definition plus the inlined copy.
 #[test]
 fn numeric_declared_intrinsic_named_fn_inlines() {
-    let (hir, arena, names) = compile("(defn sq [x] (numeric!) (%mul x x)) (map sq [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn sq [x] (numeric!) (%mul x x)) (map sq [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "a named numeric kernel must inline; callees were {cs:?}",
@@ -138,11 +138,11 @@ fn numeric_declared_intrinsic_named_fn_inlines() {
 /// opcodes inline over a single accumulator — the intermediate array is gone.
 #[test]
 fn numeric_declared_intrinsic_composition_fuses_to_one_loop() {
-    let (hir, arena, names) = compile(
+    let (hir, arena, mut rt) = compile(
         "(map (fn [y] (numeric!) (%add y 1)) \
                (map (fn [x] (numeric!) (%mul x 2)) [1 2 3]))",
     );
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "map"),
         "both `map` dispatches must be gone; callees were {cs:?}",
@@ -155,7 +155,7 @@ fn numeric_declared_intrinsic_composition_fuses_to_one_loop() {
     );
     assert_eq!(count_intrinsic(&hir, "%mul"), 1, "the inner kernel inlines");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one loop, one accumulator — the intermediate array is gone; \
              callees were {cs:?}",

--- a/src/hir/typeinfer/fuse/tests/search.rs
+++ b/src/hir/typeinfer/fuse/tests/search.rs
@@ -18,8 +18,8 @@ fn count_ands(h: &Hir) -> usize {
 /// condition reads the `more` sentinel the deciding element clears.
 #[test]
 fn single_any_dissolves_to_sentinel_loop() {
-    let (hir, arena, names) = compile("(any? (fn [x] (even? x)) [1 2 3 4])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(any? (fn [x] (even? x)) [1 2 3 4])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "any?"),
         "the `any?` dispatch must be gone; callees were {cs:?}",
@@ -30,7 +30,7 @@ fn single_any_dissolves_to_sentinel_loop() {
         "the predicate must run inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "a search's accumulator is a scalar — no `@array`; callees were {cs:?}",
     );
@@ -55,8 +55,8 @@ fn single_any_dissolves_to_sentinel_loop() {
 /// scalar accumulator, and the sentinel condition.
 #[test]
 fn single_all_dissolves_to_sentinel_loop() {
-    let (hir, arena, names) = compile("(all? (fn [x] (even? x)) [1 2 3 4])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(all? (fn [x] (even? x)) [1 2 3 4])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "all?" || n == "any?"),
         "the `all?` dispatch (and the `any?` it may delegate to) must be gone; \
@@ -68,7 +68,7 @@ fn single_all_dissolves_to_sentinel_loop() {
         "the predicate must run inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "a search's accumulator is a scalar — no `@array`; callees were {cs:?}",
     );
@@ -93,15 +93,15 @@ fn find_and_find_index_dissolve_to_sentinel_loops() {
         "(find (fn [x] (even? x)) [1 2 3 4])",
         "(find-index (fn [x] (even? x)) [1 2 3 4])",
     ] {
-        let (hir, arena, names) = compile(src);
-        let cs = callees(&hir, &arena, &names);
+        let (hir, arena, mut rt) = compile(src);
+        let cs = callees(&hir, &arena, &mut rt);
         assert!(
             !cs.iter().any(|n| n == "find" || n == "find-index"),
             "the search dispatch must be gone for {src}; callees were {cs:?}",
         );
         assert_eq!(count_lambdas(&hir), 0, "no closure may survive for {src}");
         assert_eq!(
-            count_callee(&hir, &arena, &names, "@array"),
+            count_callee(&hir, &arena, &mut rt, "@array"),
             0,
             "scalar accumulator for {src}; callees were {cs:?}",
         );
@@ -126,8 +126,8 @@ fn search_over_a_map_prefix_fuses_to_one_loop() {
         "(find (fn [y] (even? y)) (map (fn [x] (* x 3)) [1 2 3 4]))",
         "(find-index (fn [y] (even? y)) (map (fn [x] (* x 3)) [1 2 3 4]))",
     ] {
-        let (hir, arena, names) = compile(src);
-        let cs = callees(&hir, &arena, &names);
+        let (hir, arena, mut rt) = compile(src);
+        let cs = callees(&hir, &arena, &mut rt);
         assert!(
             !cs.iter()
                 .any(|n| n == "any?" || n == "all?" || n == "find" || n == "find-index"),
@@ -139,7 +139,7 @@ fn search_over_a_map_prefix_fuses_to_one_loop() {
         );
         assert_eq!(count_lambdas(&hir), 0, "no closure may survive for {src}");
         assert_eq!(
-            count_callee(&hir, &arena, &names, "@array"),
+            count_callee(&hir, &arena, &mut rt, "@array"),
             0,
             "map-into-search mints NO intermediate array for {src}; \
              callees were {cs:?}",
@@ -170,8 +170,8 @@ fn search_over_a_map_prefix_fuses_to_one_loop() {
 #[test]
 fn find_index_over_a_filter_prefix_counts_survivors() {
     let filtered = "(filter (fn [w] (number? w)) [1 \"a\" 2 3])";
-    let (hir, arena, names) = compile(&format!("(find-index (fn [y] (even? y)) {filtered})"));
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile(&format!("(find-index (fn [y] (even? y)) {filtered})"));
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "find-index" || n == "filter"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -189,8 +189,8 @@ fn find_index_over_a_filter_prefix_counts_survivors() {
     );
 
     // The same prefix under a boolean search carries no counter.
-    let (hir, arena, names) = compile(&format!("(any? (fn [y] (even? y)) {filtered})"));
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile(&format!("(any? (fn [y] (even? y)) {filtered})"));
+    let cs = callees(&hir, &arena, &mut rt);
     assert_eq!(
         count_intrinsic(&hir, "%add"),
         1,
@@ -199,9 +199,9 @@ fn find_index_over_a_filter_prefix_counts_survivors() {
 
     // A `map` prefix preserves both count and order, so the base index is already
     // the answer — no counter there either.
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(find-index (fn [y] (even? y)) (map (fn [x] (* x 3)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert_eq!(
         count_intrinsic(&hir, "%add"),
         1,
@@ -216,9 +216,9 @@ fn find_index_over_a_filter_prefix_counts_survivors() {
 /// gauge if the chain fused.
 #[test]
 fn search_prefix_with_erroring_predicate_fuses() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(find (fn [y] (even? (/ 6 y))) (map (fn [x] (* x 1)) [3 0]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "find" || n == "map"),
         "an erroring predicate is reorder-safe and must fuse; callees were {cs:?}",
@@ -235,8 +235,8 @@ fn search_prefix_with_erroring_predicate_fuses() {
 /// `map`.
 #[test]
 fn search_over_non_reorder_safe_prefix_fuses_inner_only() {
-    let (hir, arena, names) = compile("(any? (fn [y] (> y 9)) (map (fn [x] (* x 3)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(any? (fn [y] (> y 9)) (map (fn [x] (* x 3)) [1 2 3 4]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "any?"),
         "the outer `any?` must not fuse a non-reorder-safe composition; \
@@ -259,8 +259,8 @@ fn heap_valued_prefixes_fuse() {
         "(find (fn [s] (= (length s) 3)) (map (fn [s] (string s \"!\")) [\"a\" \"bb\"]))",
         "(find-index (fn [s] (= (length s) 3)) (filter (fn [s] (string? s)) [1 \"a\" \"ccc\"]))",
     ] {
-        let (hir, arena, names) = compile(src);
-        let cs = callees(&hir, &arena, &names);
+        let (hir, arena, mut rt) = compile(src);
+        let cs = callees(&hir, &arena, &mut rt);
         assert!(
             !cs.iter()
                 .any(|n| n == "find" || n == "find-index" || n == "map" || n == "filter"),
@@ -275,8 +275,8 @@ fn heap_valued_prefixes_fuse() {
 /// `len` once, so a predicate that grows or shrinks the base would diverge.
 #[test]
 fn search_over_mutable_array_is_not_fused() {
-    let (hir, arena, names) = compile("(find (fn [x] (even? x)) @[1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(find (fn [x] (even? x)) @[1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "find"),
         "a mutable `@array` base must not fuse a search; callees were {cs:?}",
@@ -287,8 +287,8 @@ fn search_over_mutable_array_is_not_fused() {
 /// non-primitive one, so it is never rewritten.
 #[test]
 fn user_shadowed_search_is_not_fused() {
-    let (hir, arena, names) = compile("(defn find [p c] nil) (find (fn [x] x) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn find [p c] nil) (find (fn [x] x) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "find"),
         "a user `find` must not be rewritten; callees were {cs:?}",
@@ -300,8 +300,8 @@ fn user_shadowed_search_is_not_fused() {
 /// while the gate refuses a capture: the `any?` call and the closure both survive.
 #[test]
 fn capturing_search_predicate_fuses() {
-    let (hir, arena, names) = compile("(let [k 2] (any? (fn [x] (> x k)) [1 2 3 4]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 2] (any? (fn [x] (> x k)) [1 2 3 4]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "any?"),
         "the `any?` dispatch must be gone; callees were {cs:?}",
@@ -314,8 +314,8 @@ fn capturing_search_predicate_fuses() {
 /// requirement to either proof.
 #[test]
 fn named_search_predicate_and_var_base_fuse() {
-    let (hir, arena, names) = compile("(defn pos? [x] (> x 0)) (let [xs [1 2 3]] (all? pos? xs))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn pos? [x] (> x 0)) (let [xs [1 2 3]] (all? pos? xs))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "all?"),
         "a named predicate over a Var-bound base must fuse; callees were {cs:?}",
@@ -325,7 +325,7 @@ fn named_search_predicate_and_var_base_fuse() {
         "the named predicate's body must run inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "scalar accumulator; callees were {cs:?}",
     );

--- a/src/hir/typeinfer/fuse/tests/take.rs
+++ b/src/hir/typeinfer/fuse/tests/take.rs
@@ -19,8 +19,8 @@ fn count_ands(h: &Hir) -> usize {
 /// array arm has no `(if (mutable? coll) acc (freeze acc))`.
 #[test]
 fn single_take_while_dissolves_to_sentinel_loop() {
-    let (hir, arena, names) = compile("(take-while (fn [x] (even? x)) [2 4 5 6])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(take-while (fn [x] (even? x)) [2 4 5 6])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "take-while"),
         "the `take-while` dispatch must be gone; callees were {cs:?}",
@@ -31,7 +31,7 @@ fn single_take_while_dissolves_to_sentinel_loop() {
         "the predicate must run inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator; callees were {cs:?}",
     );
@@ -58,9 +58,9 @@ fn single_take_while_dissolves_to_sentinel_loop() {
 /// nothing.
 #[test]
 fn map_over_take_while_fuses_to_one_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(map (fn [y] (* y 2)) (take-while (fn [x] (even? x)) [2 4 5 6]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "take-while" || n == "map"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -71,7 +71,7 @@ fn map_over_take_while_fuses_to_one_loop() {
         "both the predicate and the transform must inline; callees were {cs:?}",
     );
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         1,
         "one accumulator, no intermediate; callees were {cs:?}",
     );
@@ -91,9 +91,9 @@ fn map_over_take_while_fuses_to_one_loop() {
 /// test and the sentinel gates the `take-while`'s own stage instead.
 #[test]
 fn take_while_over_map_prefix_keeps_the_walk_exhaustive() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(take-while (fn [y] (even? y)) (map (fn [x] (* x 2)) [1 2 3]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "take-while" || n == "map"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -118,16 +118,16 @@ fn take_while_over_map_prefix_keeps_the_walk_exhaustive() {
 /// with the terminal's seed however the stdlib op typed its intermediate.
 #[test]
 fn count_over_take_while_fuses_to_one_scalar_loop() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(count (fn [y] (number? y)) (take-while (fn [x] (even? x)) [2 4 5 6]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "take-while" || n == "count"),
         "both dispatches must be gone; callees were {cs:?}",
     );
     assert_eq!(count_lambdas(&hir), 0, "no closure may survive");
     assert_eq!(
-        count_callee(&hir, &arena, &names, "@array"),
+        count_callee(&hir, &arena, &mut rt, "@array"),
         0,
         "a scalar terminal mints no array; callees were {cs:?}",
     );
@@ -149,9 +149,9 @@ fn count_over_take_while_fuses_to_one_scalar_loop() {
 /// under a `map` prefix.
 #[test]
 fn search_over_take_while_gates_its_own_stage() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(any? (fn [y] (number? y)) (take-while (fn [x] (even? x)) [2 4 5 6]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "take-while" || n == "any?"),
         "both dispatches must be gone; callees were {cs:?}",
@@ -176,9 +176,9 @@ fn search_over_take_while_gates_its_own_stage() {
 /// fuses on the recursion.
 #[test]
 fn take_while_over_filter_prefix_declines() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(take-while (fn [y] (even? y)) (filter (fn [x] (number? x)) [1 \"a\" 2]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "take-while"),
         "a take-while whose input's emptiness `len` cannot decide must not fuse; \
@@ -196,11 +196,11 @@ fn take_while_over_filter_prefix_declines() {
 /// gate that can be doing the declining.
 #[test]
 fn take_while_over_take_while_declines_the_outer() {
-    let (hir, arena, names) =
+    let (hir, arena, mut rt) =
         compile("(take-while (fn [y] (number? y)) (take-while (fn [x] (even? x)) [2 4 5]))");
-    let cs = callees(&hir, &arena, &names);
+    let cs = callees(&hir, &arena, &mut rt);
     assert_eq!(
-        count_callee(&hir, &arena, &names, "take-while"),
+        count_callee(&hir, &arena, &mut rt, "take-while"),
         1,
         "exactly the outer take-while survives; callees were {cs:?}",
     );
@@ -211,8 +211,8 @@ fn take_while_over_take_while_declines_the_outer() {
 /// once, so a predicate that grows or shrinks the base would diverge.
 #[test]
 fn take_while_over_mutable_array_is_not_fused() {
-    let (hir, arena, names) = compile("(take-while (fn [x] (even? x)) @[2 4 5])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(take-while (fn [x] (even? x)) @[2 4 5])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "take-while"),
         "a mutable `@array` base must not fuse a take-while; callees were {cs:?}",
@@ -223,8 +223,8 @@ fn take_while_over_mutable_array_is_not_fused() {
 /// so it is never rewritten.
 #[test]
 fn user_shadowed_take_while_is_not_fused() {
-    let (hir, arena, names) = compile("(defn take-while [p c] c) (take-while (fn [x] x) [1 2 3])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn take-while [p c] c) (take-while (fn [x] x) [1 2 3])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         cs.iter().any(|n| n == "take-while"),
         "a user `take-while` must not be rewritten; callees were {cs:?}",
@@ -236,8 +236,8 @@ fn user_shadowed_take_while_is_not_fused() {
 /// the gate refuses a capture: the `take-while` call and the closure both survive.
 #[test]
 fn capturing_take_while_predicate_fuses() {
-    let (hir, arena, names) = compile("(let [k 2] (take-while (fn [x] (> x k)) [3 4 1]))");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(let [k 2] (take-while (fn [x] (> x k)) [3 4 1]))");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "take-while"),
         "the `take-while` dispatch must be gone; callees were {cs:?}",
@@ -250,8 +250,8 @@ fn capturing_take_while_predicate_fuses() {
 /// requirement on how the function is resolved.
 #[test]
 fn named_take_while_predicate_inlines() {
-    let (hir, arena, names) = compile("(defn small? [x] (< x 3)) (take-while small? [1 2 5])");
-    let cs = callees(&hir, &arena, &names);
+    let (hir, arena, mut rt) = compile("(defn small? [x] (< x 3)) (take-while small? [1 2 5])");
+    let cs = callees(&hir, &arena, &mut rt);
     assert!(
         !cs.iter().any(|n| n == "take-while"),
         "the dispatch must be gone for a named predicate; callees were {cs:?}",

--- a/src/hir/typeinfer/guard.rs
+++ b/src/hir/typeinfer/guard.rs
@@ -15,6 +15,7 @@
 //! disjunctions the flat fact sets cannot express, so they stay empty).
 
 use super::*;
+use crate::value::SymbolId;
 
 /// One thing a condition proves about one binding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,16 +75,32 @@ fn intrinsic_predicate_type(op: IntrinsicOp) -> Option<TyId> {
 /// The type a *stdlib-named* predicate call proves when truthy. Recognition is
 /// by callee name, the same authority the `match (type-of x)` narrowing uses:
 /// these names are the language's stable predicate vocabulary.
-fn named_predicate_type(name: &str) -> Option<TyId> {
-    match name {
-        "int?" | "integer?" => Some(TypeInterner::INT),
-        "float?" => Some(TypeInterner::FLOAT),
-        "number?" => Some(TypeInterner::NUMBER),
-        "keyword?" => Some(TypeInterner::KEYWORD),
-        "symbol?" => Some(TypeInterner::SYMBOL),
-        "bool?" | "boolean?" => Some(TypeInterner::BOOL),
-        "nil?" => Some(TypeInterner::NIL),
-        "pair?" => Some(TypeInterner::PAIR),
+fn named_predicate_type(sym: SymbolId) -> Option<TyId> {
+    // Const patterns, not `symbols.name(sym)`: the question is identity, and
+    // `SymbolId::of` is a `const fn` over the name's hash, so these compile to
+    // integer compares against constants with no table in scope
+    // (docs/impl/symbol.md § "Reading a name, and not reading one"). Several of
+    // these predicates are defined in the stdlib rather than the primitive
+    // tables, so nothing build-time could hand back their spelling anyway.
+    const INT_P: SymbolId = SymbolId::of("int?");
+    const INTEGER_P: SymbolId = SymbolId::of("integer?");
+    const FLOAT_P: SymbolId = SymbolId::of("float?");
+    const NUMBER_P: SymbolId = SymbolId::of("number?");
+    const KEYWORD_P: SymbolId = SymbolId::of("keyword?");
+    const SYMBOL_P: SymbolId = SymbolId::of("symbol?");
+    const BOOL_P: SymbolId = SymbolId::of("bool?");
+    const BOOLEAN_P: SymbolId = SymbolId::of("boolean?");
+    const NIL_P: SymbolId = SymbolId::of("nil?");
+    const PAIR_P: SymbolId = SymbolId::of("pair?");
+    match sym {
+        INT_P | INTEGER_P => Some(TypeInterner::INT),
+        FLOAT_P => Some(TypeInterner::FLOAT),
+        NUMBER_P => Some(TypeInterner::NUMBER),
+        KEYWORD_P => Some(TypeInterner::KEYWORD),
+        SYMBOL_P => Some(TypeInterner::SYMBOL),
+        BOOL_P | BOOLEAN_P => Some(TypeInterner::BOOL),
+        NIL_P => Some(TypeInterner::NIL),
+        PAIR_P => Some(TypeInterner::PAIR),
         _ => None,
     }
 }
@@ -113,17 +130,11 @@ fn zero_comparison_subject(args: &[Hir]) -> Option<Binding> {
 }
 
 /// Extract the facts `cond` proves, by truth value.
-pub(super) fn cond_facts(
-    cond: &Hir,
-    arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
-) -> CondFacts {
+pub(super) fn cond_facts(cond: &Hir, arena: &BindingArena) -> CondFacts {
     let cond = unwrap_anf_let(cond);
     match &cond.kind {
         HirKind::Intrinsic { op, args } => match op {
-            IntrinsicOp::Not if args.len() == 1 => {
-                cond_facts(&args[0], arena, symbol_names).negate()
-            }
+            IntrinsicOp::Not if args.len() == 1 => cond_facts(&args[0], arena).negate(),
             // (%eq x 0): falsy ⇒ x ≠ 0. (%ne x 0): truthy ⇒ x ≠ 0.
             IntrinsicOp::Eq => match zero_comparison_subject(args) {
                 Some(b) => CondFacts {
@@ -171,19 +182,20 @@ pub(super) fn cond_facts(
             let Some(callee) = unwrap_callee_binding(func) else {
                 return CondFacts::none();
             };
-            let Some(name) = symbol_names.get(&arena.get(callee).name.0) else {
-                return CondFacts::none();
-            };
-            match (name.as_str(), args.len()) {
-                ("not", 1) => cond_facts(&args[0].expr, arena, symbol_names).negate(),
-                ("zero?", 1) => match subject(&args[0].expr) {
+            const NOT: SymbolId = SymbolId::of("not");
+            const ZERO_P: SymbolId = SymbolId::of("zero?");
+            const EQ: SymbolId = SymbolId::of("=");
+            let callee_sym = arena.get(callee).name;
+            match (callee_sym, args.len()) {
+                (NOT, 1) => cond_facts(&args[0].expr, arena).negate(),
+                (ZERO_P, 1) => match subject(&args[0].expr) {
                     Some(b) => CondFacts {
                         when_true: vec![],
                         when_false: vec![Fact::Nonzero(b)],
                     },
                     None => CondFacts::none(),
                 },
-                ("=", 2) => {
+                (EQ, 2) => {
                     let b = if literal_zero(&args[1].expr) {
                         subject(&args[0].expr)
                     } else if literal_zero(&args[0].expr) {
@@ -199,7 +211,7 @@ pub(super) fn cond_facts(
                         None => CondFacts::none(),
                     }
                 }
-                (_, 1) => match (named_predicate_type(name), subject(&args[0].expr)) {
+                (_, 1) => match (named_predicate_type(callee_sym), subject(&args[0].expr)) {
                     (Some(ty), Some(b)) => CondFacts {
                         when_true: vec![Fact::TypeIs(b, ty)],
                         when_false: vec![],
@@ -214,7 +226,7 @@ pub(super) fn cond_facts(
         HirKind::And(items) => CondFacts {
             when_true: items
                 .iter()
-                .flat_map(|i| cond_facts(i, arena, symbol_names).when_true)
+                .flat_map(|i| cond_facts(i, arena).when_true)
                 .collect(),
             when_false: vec![],
         },
@@ -223,7 +235,7 @@ pub(super) fn cond_facts(
             when_true: vec![],
             when_false: items
                 .iter()
-                .flat_map(|i| cond_facts(i, arena, symbol_names).when_false)
+                .flat_map(|i| cond_facts(i, arena).when_false)
                 .collect(),
         },
         _ => CondFacts::none(),
@@ -258,11 +270,7 @@ pub(super) fn diverges(h: &Hir) -> bool {
 /// The facts that hold for the statements *after* `stmt` in a sequence: a
 /// one-armed `If` whose taken branch diverges leaves the other branch's
 /// entry facts standing on the fall-through.
-pub(super) fn facts_after_statement(
-    stmt: &Hir,
-    arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
-) -> Vec<Fact> {
+pub(super) fn facts_after_statement(stmt: &Hir, arena: &BindingArena) -> Vec<Fact> {
     let HirKind::If {
         cond,
         then_branch,
@@ -273,7 +281,7 @@ pub(super) fn facts_after_statement(
     };
     let then_div = diverges(then_branch);
     let else_div = diverges(else_branch);
-    let facts = cond_facts(cond, arena, symbol_names);
+    let facts = cond_facts(cond, arena);
     match (then_div, else_div) {
         (true, false) => facts.when_false,
         (false, true) => facts.when_true,

--- a/src/hir/typeinfer/infer/collect.rs
+++ b/src/hir/typeinfer/infer/collect.rs
@@ -118,7 +118,6 @@ pub(crate) fn collect_lambda_info(
 pub(crate) fn collect_typeof_aliases(
     hir: &Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     out: &mut HashMap<Binding, Binding>,
 ) {
     let record = |b: Binding, init: &Hir, out: &mut HashMap<Binding, Binding>| {
@@ -127,7 +126,7 @@ pub(crate) fn collect_typeof_aliases(
             return;
         }
         let inner = unwrap_anf_let(unwrap_make_cell(init));
-        if let Some(subj) = typeof_call_subject(inner, arena, symbol_names) {
+        if let Some(subj) = typeof_call_subject(inner, arena) {
             if !arena.get(subj).is_mutated {
                 out.insert(b, subj);
             }
@@ -142,5 +141,5 @@ pub(crate) fn collect_typeof_aliases(
         HirKind::Define { binding, value } => record(*binding, value, out),
         _ => {}
     }
-    hir.for_each_child(|c| collect_typeof_aliases(c, arena, symbol_names, out));
+    hir.for_each_child(|c| collect_typeof_aliases(c, arena, out));
 }

--- a/src/hir/typeinfer/infer/node.rs
+++ b/src/hir/typeinfer/infer/node.rs
@@ -11,7 +11,6 @@ pub(crate) fn infer_types(
     hir_types: &mut HashMap<HirId, TyId>,
     lambda_params: &HashMap<Binding, Vec<Binding>>,
     lambda_body_type: &mut HashMap<Binding, TyId>,
-    symbol_names: &HashMap<u32, String>,
     binding_min_length: &mut HashMap<Binding, usize>,
     value_used: &std::collections::HashSet<Binding>,
     typeof_aliases: &HashMap<Binding, Binding>,
@@ -25,7 +24,6 @@ pub(crate) fn infer_types(
         hir_types,
         lambda_params,
         lambda_body_type,
-        symbol_names,
         binding_min_length,
         &mut Vec::new(),
         value_used,
@@ -46,7 +44,6 @@ pub(crate) fn infer_node(
     hir_types: &mut HashMap<HirId, TyId>,
     lambda_params: &HashMap<Binding, Vec<Binding>>,
     lambda_body_type: &mut HashMap<Binding, TyId>,
-    symbol_names: &HashMap<u32, String>,
     binding_min_length: &mut HashMap<Binding, usize>,
     // The letrec lambdas whose own bodies are currently being inferred. A
     // call to one of these from within its own body contributes BOTTOM to
@@ -80,7 +77,6 @@ pub(crate) fn infer_node(
                 hir_types,
                 lambda_params,
                 lambda_body_type,
-                symbol_names,
                 binding_min_length,
                 selfrec,
                 value_used,
@@ -200,7 +196,7 @@ pub(crate) fn infer_node(
             let _cond_ty = recurse!(cond);
             hir_types.insert(cond.id, _cond_ty);
 
-            let facts = super::super::guard::cond_facts(cond, arena, symbol_names);
+            let facts = super::super::guard::cond_facts(cond, arena);
 
             let saved = apply_type_facts(&facts.when_true, binding_types, interner);
             let then_ty = recurse!(then_branch);
@@ -231,7 +227,7 @@ pub(crate) fn infer_node(
             let val_ty = recurse!(value);
             hir_types.insert(value.id, val_ty);
 
-            let subject = typeof_subject_binding(value, arena, symbol_names, typeof_aliases);
+            let subject = typeof_subject_binding(value, arena, typeof_aliases);
             let mut arm_join = TypeInterner::BOTTOM;
             for (pat, guard, body) in arms {
                 if let Some(g) = guard {
@@ -352,11 +348,9 @@ pub(crate) fn infer_node(
 
                 // Primitive return type inference for unresolved callees
                 let callee_sym = arena.get(callee_binding).name;
-                if let Some(name) = symbol_names.get(&callee_sym.0) {
-                    let prim_ty = primitive_return_type(name, &arg_types, interner);
-                    if prim_ty != TypeInterner::TOP {
-                        return prim_ty;
-                    }
+                let prim_ty = primitive_return_type(callee_sym, &arg_types, interner);
+                if prim_ty != TypeInterner::TOP {
+                    return prim_ty;
                 }
             }
 
@@ -376,7 +370,7 @@ pub(crate) fn infer_node(
             for expr in exprs {
                 ty = recurse!(expr);
                 hir_types.insert(expr.id, ty);
-                let facts = super::super::guard::facts_after_statement(expr, arena, symbol_names);
+                let facts = super::super::guard::facts_after_statement(expr, arena);
                 saved.extend(apply_type_facts(&facts, binding_types, interner));
             }
             restore_type_facts(saved, binding_types);
@@ -388,7 +382,7 @@ pub(crate) fn infer_node(
             for expr in body {
                 ty = recurse!(expr);
                 hir_types.insert(expr.id, ty);
-                let facts = super::super::guard::facts_after_statement(expr, arena, symbol_names);
+                let facts = super::super::guard::facts_after_statement(expr, arena);
                 saved.extend(apply_type_facts(&facts, binding_types, interner));
             }
             restore_type_facts(saved, binding_types);
@@ -407,7 +401,7 @@ pub(crate) fn infer_node(
             for (test, body) in clauses {
                 let test_ty = recurse!(test);
                 hir_types.insert(test.id, test_ty);
-                let facts = super::super::guard::cond_facts(test, arena, symbol_names);
+                let facts = super::super::guard::cond_facts(test, arena);
                 let saved = apply_type_facts(&facts.when_true, binding_types, interner);
                 let body_ty = recurse!(body);
                 hir_types.insert(body.id, body_ty);

--- a/src/hir/typeinfer/infer/subject.rs
+++ b/src/hir/typeinfer/infer/subject.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use crate::hir::pattern::{HirPattern, PatternLiteral};
+use crate::value::SymbolId;
 
 /// The binding a `(type-of <var>)` match scrutinee discriminates, for match-arm
 /// narrowing. Recognizes both the `type-of`/`type` callable and the `%type-of`
@@ -13,11 +14,10 @@ use crate::hir::pattern::{HirPattern, PatternLiteral};
 pub(crate) fn typeof_subject_binding(
     value: &Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     typeof_aliases: &HashMap<Binding, Binding>,
 ) -> Option<Binding> {
     let inner = unwrap_anf_let(value);
-    if let Some(subj) = typeof_call_subject(inner, arena, symbol_names) {
+    if let Some(subj) = typeof_call_subject(inner, arena) {
         return Some(subj);
     }
     // The `(let [ta (type-of a)] (match ta …))` idiom: the scrutinee is a plain
@@ -30,11 +30,7 @@ pub(crate) fn typeof_subject_binding(
 /// The subject binding of a `(type-of x)` / `(%type-of x)` expression — `x` a
 /// `Var` or `DerefCell{Var}` — else `None`. `h` must already be positioned at the
 /// underlying expression (callers unwrap ANF/cell wrappers first).
-pub(crate) fn typeof_call_subject(
-    h: &Hir,
-    arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
-) -> Option<Binding> {
+pub(crate) fn typeof_call_subject(h: &Hir, arena: &BindingArena) -> Option<Binding> {
     let subject = match &h.kind {
         HirKind::Intrinsic {
             op: IntrinsicOp::TypeOf,
@@ -42,8 +38,8 @@ pub(crate) fn typeof_call_subject(
         } if args.len() == 1 => &args[0],
         HirKind::Call { func, args, .. } if args.len() == 1 => {
             let callee = unwrap_callee_binding(func)?;
-            let name = symbol_names.get(&arena.get(callee).name.0)?;
-            if name != "type-of" && name != "type" {
+            let callee_name = arena.get(callee).name;
+            if callee_name != SymbolId::of("type-of") && callee_name != SymbolId::of("type") {
                 return None;
             }
             &args[0].expr

--- a/src/hir/typeinfer/monomorphize.rs
+++ b/src/hir/typeinfer/monomorphize.rs
@@ -134,13 +134,7 @@ impl DispatchWrapperRegistry {
     /// Record a locally-collected wrapper under its name. First definition wins,
     /// so the stdlib's canonical wrapper is never clobbered by a later same-named
     /// user binding, and re-recording across compiles is a cheap no-op.
-    fn record(
-        &mut self,
-        name: SymbolId,
-        w: &Wrapper,
-        arena: &BindingArena,
-        symbol_names: &HashMap<u32, String>,
-    ) {
+    fn record(&mut self, name: SymbolId, w: &Wrapper, arena: &BindingArena) {
         self.by_name.entry(name).or_insert_with(|| RegWrapper {
             arity: w.arity,
             arms: w
@@ -148,8 +142,7 @@ impl DispatchWrapperRegistry {
                 .iter()
                 .map(|a| {
                     let native_name = arena.get(a.native).name;
-                    let is_del = symbol_names
-                        .get(&native_name.0)
+                    let is_del = crate::primitives::registration::static_name(native_name)
                         .is_some_and(|n| n.starts_with("%del"));
                     RegArm {
                         ty: a.ty,
@@ -179,16 +172,15 @@ pub(super) fn monomorphize_dispatch_wrappers(
     hir: &mut Hir,
     hir_types: &HashMap<HirId, TyId>,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     typeof_aliases: &HashMap<Binding, Binding>,
     registry: &mut DispatchWrapperRegistry,
 ) {
     let mut wrappers: HashMap<Binding, Wrapper> = HashMap::new();
-    collect_wrappers(hir, arena, symbol_names, typeof_aliases, &mut wrappers);
+    collect_wrappers(hir, arena, typeof_aliases, &mut wrappers);
     // Persist this unit's wrappers by name so later units can reach them (the
     // stdlib's push/put populate the instance registry on the `<stdlib>` compile).
     for (b, w) in &wrappers {
-        registry.record(arena.get(*b).name, w, arena, symbol_names);
+        registry.record(arena.get(*b).name, w, arena);
     }
     if wrappers.is_empty() && registry.by_name.is_empty() {
         return;
@@ -212,7 +204,6 @@ pub(super) fn monomorphize_dispatch_wrappers(
 fn collect_wrappers(
     hir: &Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     typeof_aliases: &HashMap<Binding, Binding>,
     out: &mut HashMap<Binding, Wrapper>,
 ) {
@@ -228,14 +219,7 @@ fn collect_wrappers(
             ..
         } = &value.kind
         {
-            if let Some(w) = build_wrapper(
-                params,
-                *rest_param,
-                body,
-                arena,
-                symbol_names,
-                typeof_aliases,
-            ) {
+            if let Some(w) = build_wrapper(params, *rest_param, body, arena, typeof_aliases) {
                 out.insert(b, w);
             }
         }
@@ -249,7 +233,7 @@ fn collect_wrappers(
         HirKind::Define { binding, value } => record(*binding, value, out),
         _ => {}
     }
-    hir.for_each_child(|c| collect_wrappers(c, arena, symbol_names, typeof_aliases, out));
+    hir.for_each_child(|c| collect_wrappers(c, arena, typeof_aliases, out));
 }
 
 /// Build a `Wrapper` from a lambda's params/body when the body dispatches on
@@ -260,7 +244,6 @@ fn build_wrapper(
     rest_param: Option<Binding>,
     body: &Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     typeof_aliases: &HashMap<Binding, Binding>,
 ) -> Option<Wrapper> {
     // Functionalize lists the rest binding in BOTH `params` and `rest_param`. The
@@ -274,16 +257,8 @@ fn build_wrapper(
         .filter(|p| Some(*p) != rest_param)
         .collect();
     let param0 = *fixed.first()?;
-    let rest_first = rest_param.and_then(|rp| find_rest_first_local(body, rp, arena, symbol_names));
-    let arms = find_arms(
-        body,
-        param0,
-        &fixed,
-        rest_first,
-        arena,
-        symbol_names,
-        typeof_aliases,
-    )?;
+    let rest_first = rest_param.and_then(|rp| find_rest_first_local(body, rp, arena));
+    let arms = find_arms(body, param0, &fixed, rest_first, arena, typeof_aliases)?;
     if arms.is_empty() {
         return None;
     }
@@ -311,11 +286,10 @@ fn find_arms(
     params: &[Binding],
     rest_first: Option<Binding>,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     typeof_aliases: &HashMap<Binding, Binding>,
 ) -> Option<Vec<Arm>> {
     if let HirKind::Match { value, arms } = &body.kind {
-        if typeof_subject_binding(value, arena, symbol_names, typeof_aliases) == Some(param0) {
+        if typeof_subject_binding(value, arena, typeof_aliases) == Some(param0) {
             let mut out = Vec::new();
             for (pat, _guard, arm_body) in arms {
                 let Some(ty) = pattern_type_keyword(pat) else {
@@ -334,33 +308,15 @@ fn find_arms(
     let mut found = None;
     body.for_each_child(|c| {
         if found.is_none() {
-            found = find_arms(
-                c,
-                param0,
-                params,
-                rest_first,
-                arena,
-                symbol_names,
-                typeof_aliases,
-            );
+            found = find_arms(c, param0, params, rest_first, arena, typeof_aliases);
         }
     });
     found
 }
 
 /// The local binding bound to `(first <rest_param>)` within `body`, if any.
-fn find_rest_first_local(
-    body: &Hir,
-    rest_param: Binding,
-    arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
-) -> Option<Binding> {
-    fn is_first_of(
-        init: &Hir,
-        rest: Binding,
-        arena: &BindingArena,
-        names: &HashMap<u32, String>,
-    ) -> bool {
+fn find_rest_first_local(body: &Hir, rest_param: Binding, arena: &BindingArena) -> Option<Binding> {
+    fn is_first_of(init: &Hir, rest: Binding, arena: &BindingArena) -> bool {
         let inner = unwrap_anf_let(init);
         match &inner.kind {
             HirKind::Intrinsic {
@@ -368,33 +324,25 @@ fn find_rest_first_local(
                 args,
             } => args.len() == 1 && var_of(&args[0]) == Some(rest),
             HirKind::Call { func, args, .. } if args.len() == 1 => {
-                unwrap_callee_binding(func)
-                    .and_then(|b| names.get(&arena.get(b).name.0))
-                    .map(String::as_str)
-                    == Some("first")
+                unwrap_callee_binding(func).map(|b| arena.get(b).name)
+                    == Some(SymbolId::of("first"))
                     && var_of(&args[0].expr) == Some(rest)
             }
             _ => false,
         }
     }
     let mut found: Option<Binding> = None;
-    fn go(
-        h: &Hir,
-        rest: Binding,
-        arena: &BindingArena,
-        names: &HashMap<u32, String>,
-        found: &mut Option<Binding>,
-    ) {
+    fn go(h: &Hir, rest: Binding, arena: &BindingArena, found: &mut Option<Binding>) {
         if let HirKind::Let { bindings, .. } = &h.kind {
             for (b, init) in bindings {
-                if found.is_none() && is_first_of(init, rest, arena, names) {
+                if found.is_none() && is_first_of(init, rest, arena) {
                     *found = Some(*b);
                 }
             }
         }
-        h.for_each_child(|c| go(c, rest, arena, names, found));
+        h.for_each_child(|c| go(c, rest, arena, found));
     }
-    go(body, rest_param, arena, symbol_names, &mut found);
+    go(body, rest_param, arena, &mut found);
     found
 }
 
@@ -558,24 +506,18 @@ fn arg_type_id(arg: &Hir) -> HirId {
 mod tests {
     use crate::hir::arena::BindingArena;
     use crate::hir::expr::{Hir, HirKind};
-    use std::collections::HashMap;
 
     /// Collect the name of every call callee (through the ANF/`Var` wrappers) in
     /// the tree, so a test can assert which ops a source form lowered to.
-    fn callee_names(
-        h: &Hir,
-        arena: &BindingArena,
-        names: &HashMap<u32, String>,
-        out: &mut Vec<String>,
-    ) {
+    fn callee_names(h: &Hir, arena: &BindingArena, out: &mut Vec<String>) {
         if let HirKind::Call { func, .. } = &h.kind {
             if let Some(b) = super::unwrap_callee_binding(func) {
-                if let Some(n) = names.get(&arena.get(b).name.0) {
-                    out.push(n.clone());
+                if let Some(n) = crate::primitives::registration::static_name(arena.get(b).name) {
+                    out.push(n.to_string());
                 }
             }
         }
-        h.for_each_child(|c| callee_names(c, arena, names, out));
+        h.for_each_child(|c| callee_names(c, arena, out));
     }
 
     /// Cross-unit dispatch-wrapper monomorphization: a user call to the stdlib
@@ -590,11 +532,11 @@ mod tests {
     fn cross_unit_put_on_proven_struct_monomorphizes() {
         let mut rt = crate::runtime::Runtime::new(); // stdlib loaded
         let (_vm, symbols, cctx) = rt.parts();
-        let (hir, arena, names) =
+        let (hir, arena) =
             crate::pipeline::compile_file_to_fhir("(put {:a 1} :b 2)", symbols, cctx, "<test>")
                 .expect("compile");
         let mut callees = Vec::new();
-        callee_names(&hir, &arena, &names, &mut callees);
+        callee_names(&hir, &arena, &mut callees);
         assert!(
             callees.iter().any(|n| n == "%put-struct"),
             "a `put` on a proven :struct must collapse to %put-struct; callees were {:?}",
@@ -622,11 +564,10 @@ mod tests {
         for (src, want_op, wrapper) in cases {
             let mut rt = crate::runtime::Runtime::new();
             let (_vm, symbols, cctx) = rt.parts();
-            let (hir, arena, names) =
-                crate::pipeline::compile_file_to_fhir(src, symbols, cctx, "<test>")
-                    .expect("compile");
+            let (hir, arena) = crate::pipeline::compile_file_to_fhir(src, symbols, cctx, "<test>")
+                .expect("compile");
             let mut callees = Vec::new();
-            callee_names(&hir, &arena, &names, &mut callees);
+            callee_names(&hir, &arena, &mut callees);
             assert!(
                 callees.iter().any(|n| n == want_op),
                 "{src} must collapse to {want_op}; callees were {callees:?}",

--- a/src/hir/typeinfer/prune.rs
+++ b/src/hir/typeinfer/prune.rs
@@ -69,7 +69,6 @@ use crate::hir::binding::Binding;
 use crate::hir::expr::{Hir, HirKind};
 use crate::hir::pattern::{HirPattern, PatternLiteral};
 use crate::primitives::def::RetType;
-use crate::symbol::SymbolTable;
 
 /// The keyword `type-of` returns for a value of this declared return type, or
 /// `None` when the type is not a single concrete `type-of` category (`Unknown`,
@@ -119,11 +118,10 @@ enum InitKw {
 pub(super) fn concrete_init_keywords(
     hir: &Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
 ) -> FxHashMap<Binding, &'static str> {
     let mut init: FxHashMap<Binding, InitKw> = FxHashMap::default();
     let mut seen: FxHashSet<Binding> = FxHashSet::default();
-    collect_inits(hir, arena, symbol_names, &mut init, &mut seen);
+    collect_inits(hir, arena, &mut init, &mut seen);
 
     // Resolve alias chains to a concrete keyword (depth-bounded; the alias graph
     // is over distinct binding ids, so a small cap both terminates any accidental
@@ -139,11 +137,9 @@ pub(super) fn concrete_init_keywords(
 
 /// Prune provably-dead arms of every `(match (type-of x) …)` whose scrutinee `x`
 /// has a statically-known concrete type. See the module doc.
-pub(crate) fn prune_typeof_match_arms(hir: &mut Hir, arena: &BindingArena, symbols: &SymbolTable) {
-    let symbol_names = symbols.all_names();
-
+pub(crate) fn prune_typeof_match_arms(hir: &mut Hir, arena: &BindingArena) {
     // Phase 1 (read-only): the sound binding→keyword proof.
-    let concrete = concrete_init_keywords(hir, arena, &symbol_names);
+    let concrete = concrete_init_keywords(hir, arena);
     if concrete.is_empty() {
         return;
     }
@@ -151,10 +147,10 @@ pub(crate) fn prune_typeof_match_arms(hir: &mut Hir, arena: &BindingArena, symbo
     // A `(let [ta (type-of x)] (match ta …))` scrutinee resolves through this map
     // to `x`, so the aliased dispatch prunes like the inline `(match (type-of x)`.
     let mut typeof_aliases: HashMap<Binding, Binding> = HashMap::new();
-    collect_typeof_aliases(hir, arena, &symbol_names, &mut typeof_aliases);
+    collect_typeof_aliases(hir, arena, &mut typeof_aliases);
 
     // Phase 2 (mutating): drop the dead arms.
-    prune_node(hir, arena, &symbol_names, &concrete, &typeof_aliases);
+    prune_node(hir, arena, &concrete, &typeof_aliases);
 }
 
 /// Walk every `Let`/`Letrec`/`Define` binding, recording its initializer keyword
@@ -162,7 +158,6 @@ pub(crate) fn prune_typeof_match_arms(hir: &mut Hir, arena: &BindingArena, symbo
 fn collect_inits(
     hir: &Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     init: &mut FxHashMap<Binding, InitKw>,
     seen: &mut FxHashSet<Binding>,
 ) {
@@ -176,7 +171,7 @@ fn collect_inits(
         if !bi.is_immutable || bi.is_mutated {
             return;
         }
-        if let Some(k) = classify_init(value, arena, symbol_names) {
+        if let Some(k) = classify_init(value, arena) {
             init.insert(b, k);
         }
     };
@@ -189,16 +184,12 @@ fn collect_inits(
         HirKind::Define { binding, value } => record(*binding, value, init),
         _ => {}
     }
-    hir.for_each_child(|c| collect_inits(c, arena, symbol_names, init, seen));
+    hir.for_each_child(|c| collect_inits(c, arena, init, seen));
 }
 
 /// The `type-of` keyword an initializer expression evaluates to (or an alias to
 /// the binding it forwards), when soundly determinable. `None` ⇒ unknown.
-fn classify_init(
-    h: &Hir,
-    arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
-) -> Option<InitKw> {
+fn classify_init(h: &Hir, arena: &BindingArena) -> Option<InitKw> {
     match &h.kind {
         HirKind::Int(_) => Some(InitKw::Concrete("integer")),
         HirKind::Float(_) => Some(InitKw::Concrete("float")),
@@ -210,9 +201,7 @@ fn classify_init(
         // Aliases: a bare var, or the ANF/region-transparent wrappers whose value
         // is their inner expression.
         HirKind::Var(b) => Some(InitKw::Alias(*b)),
-        HirKind::MakeCell { value } | HirKind::Return { value } => {
-            classify_init(value, arena, symbol_names)
-        }
+        HirKind::MakeCell { value } | HirKind::Return { value } => classify_init(value, arena),
         // A call to a genuine primitive with a concrete declared return type. The
         // `is_primitive` gate is what makes reading the name's `RetType` sound — a
         // user binding shadowing the name is excluded (its `RetType` would be a
@@ -225,8 +214,7 @@ fn classify_init(
             if !bi.is_primitive || !bi.is_immutable || bi.is_mutated {
                 return None;
             }
-            let name = symbol_names.get(&bi.name.0)?;
-            let def = crate::primitives::registration::def_by_name(name)?;
+            let def = crate::primitives::registration::def_by_symbol(bi.name)?;
             keyword_of_rettype(def.ret).map(InitKw::Concrete)
         }
         _ => None,
@@ -249,12 +237,11 @@ fn resolve(b: Binding, init: &FxHashMap<Binding, InitKw>, depth: u32) -> Option<
 fn prune_node(
     hir: &mut Hir,
     arena: &BindingArena,
-    symbol_names: &HashMap<u32, String>,
     concrete: &FxHashMap<Binding, &'static str>,
     typeof_aliases: &HashMap<Binding, Binding>,
 ) {
     if let HirKind::Match { value, arms } = &mut hir.kind {
-        if let Some(subj) = typeof_subject_binding(value, arena, symbol_names, typeof_aliases) {
+        if let Some(subj) = typeof_subject_binding(value, arena, typeof_aliases) {
             if let Some(&k) = concrete.get(&subj) {
                 let dead = arms.iter().filter(|(p, _, _)| arm_is_dead(p, k)).count();
                 // Prune only when it removes some — but not all — arms: an
@@ -266,7 +253,7 @@ fn prune_node(
             }
         }
     }
-    hir.for_each_child_mut(|c| prune_node(c, arena, symbol_names, concrete, typeof_aliases));
+    hir.for_each_child_mut(|c| prune_node(c, arena, concrete, typeof_aliases));
 }
 
 /// Is this arm a *type-keyword* arm whose keyword set excludes `k`? Such an arm

--- a/src/hir/typeinfer/tests.rs
+++ b/src/hir/typeinfer/tests.rs
@@ -9,7 +9,7 @@ use crate::symbol::SymbolTable;
 /// compile (driven from `hir::regularize`).
 fn compile_fhir(src: &str, symbols: &mut SymbolTable) -> (Hir, BindingArena) {
     let mut cctx = crate::pipeline::CompileCtx::new();
-    let (hir, arena, _names) =
+    let (hir, arena) =
         crate::pipeline::compile_file_to_fhir(src, symbols, &mut cctx, "<test>").expect("compile");
     (hir, arena)
 }
@@ -18,8 +18,7 @@ fn compile_fhir(src: &str, symbols: &mut SymbolTable) -> (Hir, BindingArena) {
 fn inferred_types(src: &str) -> Vec<TyId> {
     let mut symbols = SymbolTable::new();
     let (mut hir, arena) = compile_fhir(src, &mut symbols);
-    let info =
-        infer_and_rewrite(&mut hir, &arena, &symbols, &mut Default::default()).expect("infer");
+    let info = infer_and_rewrite(&mut hir, &arena, &mut Default::default()).expect("infer");
     info.hir_types.values().copied().collect()
 }
 
@@ -560,26 +559,19 @@ fn has_intrinsic_named(hir: &Hir, name: &str) -> bool {
 }
 
 /// Does the tree contain a `Call` whose callee is a `Var` binding named `name`?
-fn has_call_to(hir: &Hir, arena: &BindingArena, symbols: &SymbolTable, name: &str) -> bool {
-    let names = symbols.all_names();
+fn has_call_to(hir: &Hir, arena: &BindingArena, name: &str) -> bool {
     let mut found = false;
-    fn walk(
-        h: &Hir,
-        arena: &BindingArena,
-        names: &std::collections::HashMap<u32, String>,
-        name: &str,
-        found: &mut bool,
-    ) {
+    fn walk(h: &Hir, arena: &BindingArena, name: &str, found: &mut bool) {
         if let HirKind::Call { func, .. } = &h.kind {
             if let HirKind::Var(b) = &func.kind {
-                if names.get(&arena.get(*b).name.0).map(String::as_str) == Some(name) {
+                if arena.get(*b).name == crate::value::SymbolId::of(name) {
                     *found = true;
                 }
             }
         }
-        h.for_each_child(|c| walk(c, arena, names, name, found));
+        h.for_each_child(|c| walk(c, arena, name, found));
     }
-    walk(hir, arena, &names, name, &mut found);
+    walk(hir, arena, name, &mut found);
     found
 }
 
@@ -738,7 +730,7 @@ fn storing_intrinsic_routes_to_the_native_funnel_call() {
         "%array-push must not lower to an inline opcode"
     );
     assert!(
-        has_call_to(&hir, &arena, &symbols, "%array-push"),
+        has_call_to(&hir, &arena, "%array-push"),
         "%array-push lowers to a Call to its registered NativeFn"
     );
 }
@@ -754,7 +746,7 @@ fn pop_routes_to_the_native_funnel_call() {
         "%pop must not lower to an inline opcode"
     );
     assert!(
-        has_call_to(&hir, &arena, &symbols, "%pop"),
+        has_call_to(&hir, &arena, "%pop"),
         "%pop lowers to a Call to its registered NativeFn"
     );
 }
@@ -769,7 +761,7 @@ fn freeze_routes_to_the_native_funnel_call() {
         "%freeze must not lower to an inline opcode"
     );
     assert!(
-        has_call_to(&hir, &arena, &symbols, "%freeze"),
+        has_call_to(&hir, &arena, "%freeze"),
         "%freeze lowers to a Call to its registered NativeFn"
     );
 }
@@ -854,21 +846,16 @@ fn unknown_typed_caller_defeats_param_join_proofs() {
 // path never reaches). An UNPROVEN container leaves the dispatch intact.
 
 /// Count Call nodes whose callee resolves to a binding named `name`.
-fn count_calls_to(
-    hir: &Hir,
-    arena: &BindingArena,
-    names: &std::collections::HashMap<u32, String>,
-    name: &str,
-) -> usize {
+fn count_calls_to(hir: &Hir, arena: &BindingArena, name: &str) -> usize {
     let mut n = 0;
     if let HirKind::Call { func, .. } = &hir.kind {
         if let Some(b) = super::unwrap_callee_binding(func) {
-            if names.get(&arena.get(b).name.0).map(String::as_str) == Some(name) {
+            if arena.get(b).name == crate::value::SymbolId::of(name) {
                 n += 1;
             }
         }
     }
-    hir.for_each_child(|c| n += count_calls_to(c, arena, names, name));
+    hir.for_each_child(|c| n += count_calls_to(c, arena, name));
     n
 }
 
@@ -884,10 +871,9 @@ fn container_dispatch_wrapper_monomorphizes_on_proven_container() {
                (let [s @{:x 0}] (myp s :x 9))";
     let mut symbols = SymbolTable::new();
     let (mut hir, arena) = compile_fhir(src, &mut symbols);
-    let names = symbols.all_names();
-    infer_and_rewrite(&mut hir, &arena, &symbols, &mut Default::default()).expect("infer");
+    infer_and_rewrite(&mut hir, &arena, &mut Default::default()).expect("infer");
     assert_eq!(
-        count_calls_to(&hir, &arena, &names, "myp"),
+        count_calls_to(&hir, &arena, "myp"),
         0,
         "a proven-@struct container collapses the dispatch-wrapper call to its arm"
     );
@@ -905,10 +891,9 @@ fn container_dispatch_wrapper_stays_dynamic_on_unproven_container() {
                (defn g [c] (myp c :x 9)) (g @{:x 0}) (g @[1])";
     let mut symbols = SymbolTable::new();
     let (mut hir, arena) = compile_fhir(src, &mut symbols);
-    let names = symbols.all_names();
-    infer_and_rewrite(&mut hir, &arena, &symbols, &mut Default::default()).expect("infer");
+    infer_and_rewrite(&mut hir, &arena, &mut Default::default()).expect("infer");
     assert!(
-        count_calls_to(&hir, &arena, &names, "myp") >= 1,
+        count_calls_to(&hir, &arena, "myp") >= 1,
         "an unproven container leaves the dispatch-wrapper call intact"
     );
 }

--- a/src/io/aio/tests/backend.rs
+++ b/src/io/aio/tests/backend.rs
@@ -167,16 +167,14 @@ fn test_completion_to_value_success() {
         );
         let fields = v.as_struct().unwrap();
         assert_eq!(
-            sorted_struct_get(fields, &TableKey::Keyword("id".into()))
+            sorted_struct_get(fields, &TableKey::keyword("id"))
                 .unwrap()
                 .as_int(),
             Some(42)
         );
-        assert!(
-            sorted_struct_get(fields, &TableKey::Keyword("error".into()))
-                .unwrap()
-                .is_nil()
-        );
+        assert!(sorted_struct_get(fields, &TableKey::keyword("error"))
+            .unwrap()
+            .is_nil());
     });
 }
 
@@ -194,21 +192,17 @@ fn test_completion_to_value_error() {
         let v = c.to_value(&ctx);
         let fields = v.as_struct().unwrap();
         assert_eq!(
-            sorted_struct_get(fields, &TableKey::Keyword("id".into()))
+            sorted_struct_get(fields, &TableKey::keyword("id"))
                 .unwrap()
                 .as_int(),
             Some(7)
         );
-        assert!(
-            sorted_struct_get(fields, &TableKey::Keyword("value".into()))
-                .unwrap()
-                .is_nil()
-        );
-        assert!(
-            !sorted_struct_get(fields, &TableKey::Keyword("error".into()))
-                .unwrap()
-                .is_nil()
-        );
+        assert!(sorted_struct_get(fields, &TableKey::keyword("value"))
+            .unwrap()
+            .is_nil());
+        assert!(!sorted_struct_get(fields, &TableKey::keyword("error"))
+            .unwrap()
+            .is_nil());
     });
 }
 

--- a/src/io/aio/tests/fileops.rs
+++ b/src/io/aio/tests/fileops.rs
@@ -109,7 +109,7 @@ fn test_async_submit_spawn_echo() {
         let val = completions[0].result.as_ref().expect("spawn failed");
         let fields = val.as_struct().expect("expected struct");
         assert!(
-            sorted_struct_get(fields, &TableKey::Keyword("pid".into()))
+            sorted_struct_get(fields, &TableKey::keyword("pid"))
                 .unwrap()
                 .as_int()
                 .unwrap()
@@ -214,7 +214,7 @@ fn a_failed_pool_process_wait_names_waitpid() {
             .as_ref()
             .expect_err("a wait for a child that is gone must fail");
         let fields = err.as_struct().expect("an io error is a struct");
-        let msg = sorted_struct_get(fields, &TableKey::Keyword("message".into()))
+        let msg = sorted_struct_get(fields, &TableKey::keyword("message"))
             .and_then(|v| v.with_string(|s| s.to_string()))
             .expect("an io error carries a :message");
         assert!(

--- a/src/io/aio/tests/net.rs
+++ b/src/io/aio/tests/net.rs
@@ -959,11 +959,8 @@ fn a_pool_connect_reports_its_own_deadline_as_a_timeout() {
             .expect_err("a connect to a full accept queue must not succeed");
         let fields = err.as_struct().expect("an io error is a struct");
         assert_eq!(
-            crate::value::sorted_struct_get(fields, &TableKey::Keyword("error".into()))
-                .unwrap()
-                .as_keyword_name()
-                .as_deref(),
-            Some("timeout"),
+            crate::value::sorted_struct_get(fields, &TableKey::keyword("error")).copied(),
+            Some(crate::value::Value::keyword("timeout")),
             "a connect that ran out its deadline must report :timeout, not a \
              generic :io-error — `ev/timeout` and `timed-out?` match on the kind",
         );

--- a/src/io/aio/tests/submit.rs
+++ b/src/io/aio/tests/submit.rs
@@ -248,11 +248,8 @@ fn a_process_wait_completes_under_the_id_it_was_submitted_with() {
             .submit(&spawn, crate::io::pending::Submitter::for_test())
             .unwrap();
         let spawned = backend.poll().pop().unwrap().result.unwrap();
-        let handle = sorted_struct_get(
-            spawned.as_struct().unwrap(),
-            &TableKey::Keyword("process".into()),
-        )
-        .expect("spawn result carries a :process handle");
+        let handle = sorted_struct_get(spawned.as_struct().unwrap(), &TableKey::keyword("process"))
+            .expect("spawn result carries a :process handle");
 
         let req = IoRequest {
             op: IoOp::ProcessWait,

--- a/src/io/completion.rs
+++ b/src/io/completion.rs
@@ -249,11 +249,11 @@ pub(super) fn process_raw_completion(
                 .map(|ev| {
                     let mut fields = std::collections::BTreeMap::new();
                     fields.insert(
-                        crate::value::heap::TableKey::Keyword("kind".into()),
+                        crate::value::heap::TableKey::keyword("kind"),
                         Value::keyword(ev.kind.as_keyword()),
                     );
                     let path = ctx.string(ev.path.to_string_lossy().as_ref());
-                    fields.insert(crate::value::heap::TableKey::Keyword("path".into()), path);
+                    fields.insert(crate::value::heap::TableKey::keyword("path"), path);
                     ctx.struct_from(fields)
                 })
                 .collect();
@@ -306,29 +306,29 @@ pub(super) fn process_raw_completion(
                     let name = crate::io::sigmap::signum_to_keyword(ev.signum).unwrap_or("unknown");
                     let mut fields = std::collections::BTreeMap::new();
                     fields.insert(
-                        crate::value::heap::TableKey::Keyword("signal".into()),
+                        crate::value::heap::TableKey::keyword("signal"),
                         Value::keyword(name),
                     );
                     fields.insert(
-                        crate::value::heap::TableKey::Keyword("sender-pid".into()),
+                        crate::value::heap::TableKey::keyword("sender-pid"),
                         match ev.sender_pid {
                             Some(p) => Value::int(p as i64),
                             None => Value::NIL,
                         },
                     );
                     fields.insert(
-                        crate::value::heap::TableKey::Keyword("sender-uid".into()),
+                        crate::value::heap::TableKey::keyword("sender-uid"),
                         match ev.sender_uid {
                             Some(u) => Value::int(u as i64),
                             None => Value::NIL,
                         },
                     );
                     fields.insert(
-                        crate::value::heap::TableKey::Keyword("code".into()),
+                        crate::value::heap::TableKey::keyword("code"),
                         Value::int(ev.code as i64),
                     );
                     fields.insert(
-                        crate::value::heap::TableKey::Keyword("count".into()),
+                        crate::value::heap::TableKey::keyword("count"),
                         Value::int(ev.count as i64),
                     );
                     ctx.struct_from(fields)

--- a/src/io/completion/port.rs
+++ b/src/io/completion/port.rs
@@ -243,18 +243,14 @@ pub(super) fn complete_port_op(
                     let (addr_str, port_num) = crate::io::sockaddr::parse(&addr_storage, addr_len);
 
                     let struct_ref = result.as_struct().expect("recv result must be a struct");
-                    let data_buf = crate::value::sorted_struct_get(
-                        struct_ref,
-                        &TableKey::Keyword("data".into()),
-                    )
-                    .copied()
-                    .expect("recv result must have :data");
-                    let addr_buf = crate::value::sorted_struct_get(
-                        struct_ref,
-                        &TableKey::Keyword("addr".into()),
-                    )
-                    .copied()
-                    .expect("recv result must have :addr");
+                    let data_buf =
+                        crate::value::sorted_struct_get(struct_ref, &TableKey::keyword("data"))
+                            .copied()
+                            .expect("recv result must have :data");
+                    let addr_buf =
+                        crate::value::sorted_struct_get(struct_ref, &TableKey::keyword("addr"))
+                            .copied()
+                            .expect("recv result must have :addr");
 
                     unsafe {
                         // :data — payload already in the buffer on the io_uring
@@ -280,16 +276,12 @@ pub(super) fn complete_port_op(
                         truncate_buffer(&addr_buf, n);
                         let addr_val =
                             bytes_to_string_in_place(addr_buf, origin_heap).unwrap_or(addr_buf);
-                        set_struct_field_in_place(
-                            result,
-                            &TableKey::Keyword("addr".into()),
-                            addr_val,
-                        );
+                        set_struct_field_in_place(result, &TableKey::keyword("addr"), addr_val);
 
                         // :port — stamp the sender port int into the slot.
                         set_struct_field_in_place(
                             result,
-                            &TableKey::Keyword("port".into()),
+                            &TableKey::keyword("port"),
                             Value::int(port_num as i64),
                         );
                     }

--- a/src/io/mock.rs
+++ b/src/io/mock.rs
@@ -215,13 +215,13 @@ impl crate::io::IoBackend for MockBackend {
                                 result.as_struct().expect("recv result must be a struct");
                             let data_buf = crate::value::sorted_struct_get(
                                 struct_ref,
-                                &TableKey::Keyword("data".into()),
+                                &TableKey::keyword("data"),
                             )
                             .copied()
                             .expect("recv result must have :data");
                             let addr_buf = crate::value::sorted_struct_get(
                                 struct_ref,
-                                &TableKey::Keyword("addr".into()),
+                                &TableKey::keyword("addr"),
                             )
                             .copied()
                             .expect("recv result must have :addr");
@@ -240,7 +240,7 @@ impl crate::io::IoBackend for MockBackend {
                                     .unwrap_or(addr_buf);
                                 set_struct_field_in_place(
                                     result,
-                                    &TableKey::Keyword("addr".into()),
+                                    &TableKey::keyword("addr"),
                                     addr_val,
                                 );
                                 // :port stays 0 (mock).

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -208,18 +208,15 @@ impl Completion {
     /// carries it past this array's demise.
     pub(crate) fn to_value(&self, ctx: &crate::primitives::ctx::Alloc<'_>) -> Value {
         let mut fields = BTreeMap::new();
-        fields.insert(
-            TableKey::Keyword("id".into()),
-            Value::int(self.id.as_u64() as i64),
-        );
+        fields.insert(TableKey::keyword("id"), Value::int(self.id.as_u64() as i64));
         match &self.result {
             Ok(v) => {
-                fields.insert(TableKey::Keyword("value".into()), *v);
-                fields.insert(TableKey::Keyword("error".into()), Value::NIL);
+                fields.insert(TableKey::keyword("value"), *v);
+                fields.insert(TableKey::keyword("error"), Value::NIL);
             }
             Err(e) => {
-                fields.insert(TableKey::Keyword("value".into()), Value::NIL);
-                fields.insert(TableKey::Keyword("error".into()), *e);
+                fields.insert(TableKey::keyword("value"), Value::NIL);
+                fields.insert(TableKey::keyword("error"), *e);
             }
         }
         ctx.struct_from(fields)

--- a/src/io/request/spawn.rs
+++ b/src/io/request/spawn.rs
@@ -146,11 +146,11 @@ impl SpawnRequest {
         let handle_val = ctx.external("process", handle);
 
         let mut fields = std::collections::BTreeMap::new();
-        fields.insert(TableKey::Keyword("pid".into()), Value::int(pid as i64));
-        fields.insert(TableKey::Keyword("stdin".into()), stdin_val);
-        fields.insert(TableKey::Keyword("stdout".into()), stdout_val);
-        fields.insert(TableKey::Keyword("stderr".into()), stderr_val);
-        fields.insert(TableKey::Keyword("process".into()), handle_val);
+        fields.insert(TableKey::keyword("pid"), Value::int(pid as i64));
+        fields.insert(TableKey::keyword("stdin"), stdin_val);
+        fields.insert(TableKey::keyword("stdout"), stdout_val);
+        fields.insert(TableKey::keyword("stderr"), stderr_val);
+        fields.insert(TableKey::keyword("process"), handle_val);
         Ok(ctx.struct_from(fields))
     }
 }

--- a/src/io/sigmap.rs
+++ b/src/io/sigmap.rs
@@ -74,11 +74,19 @@ pub fn resolve(val: &crate::value::Value, context: &str) -> Result<libc::c_int, 
             None => Err(ResolveError::UnknownSignum(n)),
         };
     }
-    if let Some(name) = val.as_keyword_name() {
-        return match keyword_to_signum(&name) {
-            Some(s) => Ok(s),
-            None => Err(ResolveError::UnknownKeyword(name.to_string())),
-        };
+    if let Some(hash) = val.keyword_hash() {
+        // Match by hash — the recognised set is fixed, so no spelling is
+        // needed to resolve. A miss recovers a spelling for the error
+        // message through the static vocabulary, or shows the raw hash.
+        for (k, v) in SIGNALS {
+            if crate::value::keyword::keyword_hash(k) == hash {
+                return Ok(*v);
+            }
+        }
+        let spelling = crate::value::keyword::resolve_keyword_name(None, hash)
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("#<keyword:{:#x}>", hash));
+        return Err(ResolveError::UnknownKeyword(spelling));
     }
     let _ = context;
     Err(ResolveError::WrongType(val.type_name()))

--- a/src/io/uring/stream.rs
+++ b/src/io/uring/stream.rs
@@ -295,7 +295,7 @@ pub(crate) fn submit_uring_recvfrom(
     // Writeable pointer into the pre-allocated `:data` buffer (`count` bytes).
     let data_buf = crate::value::sorted_struct_get(
         result.as_struct().expect("recv result must be a struct"),
-        &crate::value::heap::TableKey::Keyword("data".into()),
+        &crate::value::heap::TableKey::keyword("data"),
     )
     .copied()
     .expect("recv result must have :data");

--- a/src/jit/calls.rs
+++ b/src/jit/calls.rs
@@ -266,7 +266,7 @@ pub(crate) fn incref_owned_call_args(
                 let min = closure.template.arity.fixed_params();
                 let mut count = args.len().min(min);
                 while count < fixed_slots && count < args.len() {
-                    if args[count].as_keyword_name().is_some() {
+                    if args[count].is_keyword() {
                         break;
                     }
                     count += 1;

--- a/src/jit/compiler.rs
+++ b/src/jit/compiler.rs
@@ -105,7 +105,6 @@ impl JitCompiler {
         mut self,
         lir: &LirFunction,
         self_sym: Option<SymbolId>,
-        symbol_names: HashMap<u32, String>,
         module_closures: Vec<LirFunction>,
     ) -> Result<JitCode, JitError> {
         // Polymorphic and yielding functions are supported via side-exit.
@@ -166,7 +165,6 @@ impl JitCompiler {
             &mut ctx.func,
             scc_peers.as_ref(),
             self_sym,
-            symbol_names,
             module_closures,
         )?;
 
@@ -243,14 +241,7 @@ impl JitCompiler {
         ctx.func.signature = sig;
         ctx.func.name = UserFuncName::user(0, func_id.as_u32());
 
-        self.translate_function(
-            lir,
-            &mut ctx.func,
-            scc_peers.as_ref(),
-            self_sym,
-            HashMap::new(),
-            Vec::new(),
-        )?;
+        self.translate_function(lir, &mut ctx.func, scc_peers.as_ref(), self_sym, Vec::new())?;
         // closure_constants from clif_text are discarded — diagnostic only
 
         let text = format!("{}", ctx.func);
@@ -265,7 +256,6 @@ impl JitCompiler {
     pub fn compile_batch(
         mut self,
         members: &[BatchMember],
-        symbol_names: HashMap<u32, String>,
     ) -> Result<Vec<(SymbolId, JitCode)>, JitError> {
         // Validate all members are non-polymorphic and non-yielding.
         // Yielding functions require per-function YieldPointMeta in JitCode,
@@ -325,7 +315,6 @@ impl JitCompiler {
                 &mut ctx.func,
                 Some(&scc_peers),
                 Some(member.sym),
-                symbol_names.clone(),
                 Vec::new(),
             )?;
             all_closure_protos.push((member.sym, closure_protos));

--- a/src/jit/compiler/tests.rs
+++ b/src/jit/compiler/tests.rs
@@ -56,7 +56,7 @@ fn test_compile_identity() {
     let lir = make_simple_lir();
     let compiler = JitCompiler::new().expect("Failed to create compiler");
     let code = compiler
-        .compile(&lir, None, HashMap::new(), Vec::new())
+        .compile(&lir, None, Vec::new())
         .expect("Failed to compile");
 
     // Call the compiled function with self_tag=0, self_payload=0 (no self-tail-call).
@@ -83,7 +83,7 @@ fn test_compile_add() {
     let lir = make_add_lir();
     let compiler = JitCompiler::new().expect("Failed to create compiler");
     let code = compiler
-        .compile(&lir, None, HashMap::new(), Vec::new())
+        .compile(&lir, None, Vec::new())
         .expect("Failed to compile");
 
     // Call the compiled function with self_tag=0, self_payload=0
@@ -144,7 +144,7 @@ fn adopt_into_activation_frees_member_at_compiled_return() {
     let lir = make_adopt_into_activation_lir();
     let compiler = JitCompiler::new().expect("Failed to create compiler");
     let code = compiler
-        .compile(&lir, None, HashMap::new(), Vec::new())
+        .compile(&lir, None, Vec::new())
         .expect("Failed to compile");
 
     let mut vm = crate::vm::VM::new();
@@ -198,7 +198,7 @@ fn test_accept_polymorphic() {
     lir.signal = Signal::polymorphic(0);
 
     let compiler = JitCompiler::new().expect("Failed to create compiler");
-    let result = compiler.compile(&lir, None, HashMap::new(), Vec::new());
+    let result = compiler.compile(&lir, None, Vec::new());
     assert!(
         result.is_ok(),
         "JIT should accept polymorphic functions (runtime dispatch handles callables): {:?}",
@@ -213,7 +213,7 @@ fn test_accept_yielding() {
 
     let compiler = JitCompiler::new().expect("Failed to create compiler");
     // Should compile (no Yield terminators in this simple LIR)
-    let result = compiler.compile(&lir, None, HashMap::new(), Vec::new());
+    let result = compiler.compile(&lir, None, Vec::new());
     assert!(result.is_ok());
 }
 
@@ -227,7 +227,7 @@ fn test_compile_batch_single_function() {
         lir: &lir,
     }];
     let results = compiler
-        .compile_batch(&members, HashMap::new())
+        .compile_batch(&members)
         .expect("Failed to compile batch");
 
     assert_eq!(results.len(), 1);
@@ -368,7 +368,7 @@ fn test_compile_batch_mutual_calls() {
         },
     ];
     let results = compiler
-        .compile_batch(&members, HashMap::new())
+        .compile_batch(&members)
         .expect("Failed to compile batch");
     assert_eq!(results.len(), 2);
     assert_eq!(results[0].0, sym_f);
@@ -385,7 +385,7 @@ fn test_compile_batch_rejects_polymorphic() {
         sym: SymbolId(0),
         lir: &lir,
     }];
-    let result = compiler.compile_batch(&members, HashMap::new());
+    let result = compiler.compile_batch(&members);
     assert!(matches!(result, Err(JitError::Polymorphic)));
 }
 
@@ -420,7 +420,7 @@ fn test_compile_yielding_function() {
         .build();
 
     let compiler = JitCompiler::new().expect("Failed to create compiler");
-    let result = compiler.compile(&func, None, HashMap::new(), Vec::new());
+    let result = compiler.compile(&func, None, Vec::new());
     assert!(
         result.is_ok(),
         "Yielding function should compile: {:?}",
@@ -436,7 +436,7 @@ fn test_reject_struct_variadic() {
     lir.vararg_kind = crate::hir::VarargKind::Struct;
 
     let compiler = JitCompiler::new().expect("Failed to create compiler");
-    let result = compiler.compile(&lir, None, HashMap::new(), Vec::new());
+    let result = compiler.compile(&lir, None, Vec::new());
     assert!(
         matches!(result, Err(JitError::UnsupportedInstruction(_))),
         "Struct variadic functions should be rejected: {:?}",
@@ -451,7 +451,7 @@ fn test_reject_strict_struct_variadic() {
     lir.vararg_kind = crate::hir::VarargKind::StrictStruct(vec!["key".to_string()]);
 
     let compiler = JitCompiler::new().expect("Failed to create compiler");
-    let result = compiler.compile(&lir, None, HashMap::new(), Vec::new());
+    let result = compiler.compile(&lir, None, Vec::new());
     assert!(
         matches!(result, Err(JitError::UnsupportedInstruction(_))),
         "StrictStruct variadic functions should be rejected: {:?}",
@@ -469,7 +469,7 @@ fn test_compile_list_variadic() {
     lir.num_params = 2; // x + rest
 
     let compiler = JitCompiler::new().expect("Failed to create compiler");
-    let result = compiler.compile(&lir, None, HashMap::new(), Vec::new());
+    let result = compiler.compile(&lir, None, Vec::new());
     assert!(
         result.is_ok(),
         "List variadic functions should compile: {:?}",
@@ -488,7 +488,7 @@ fn test_compile_batch_rejects_struct_variadic() {
         sym: SymbolId(0),
         lir: &lir,
     }];
-    let result = compiler.compile_batch(&members, HashMap::new());
+    let result = compiler.compile_batch(&members);
     assert!(
         matches!(result, Err(JitError::UnsupportedInstruction(_))),
         "Struct variadic functions should be rejected from batch: {:?}",
@@ -508,7 +508,7 @@ fn test_compile_batch_accepts_list_variadic() {
         sym: SymbolId(0),
         lir: &lir,
     }];
-    let result = compiler.compile_batch(&members, HashMap::new());
+    let result = compiler.compile_batch(&members);
     assert!(
         result.is_ok(),
         "List variadic functions should compile in batch: {:?}",
@@ -522,7 +522,7 @@ fn compile_records_entry_in_code_address_registry() {
     lir.name = Some("registry-probe-solo".to_string());
     let compiler = JitCompiler::new().expect("Failed to create compiler");
     let code = compiler
-        .compile(&lir, None, HashMap::new(), Vec::new())
+        .compile(&lir, None, Vec::new())
         .expect("Failed to compile");
     let entry = code.fn_ptr() as usize;
     let name = crate::jit::registry::snapshot()
@@ -542,7 +542,7 @@ fn compile_batch_records_each_member_in_code_address_registry() {
         lir: &lir,
     }];
     let results = compiler
-        .compile_batch(&members, HashMap::new())
+        .compile_batch(&members)
         .expect("Failed to compile batch");
     let entry = results[0].1.fn_ptr() as usize;
     let name = crate::jit::registry::snapshot()

--- a/src/jit/compiler/translate.rs
+++ b/src/jit/compiler/translate.rs
@@ -13,7 +13,6 @@ impl JitCompiler {
         func: &mut Function,
         scc_peers: Option<&HashMap<SymbolId, FuncId>>,
         self_sym: Option<SymbolId>,
-        symbol_names: HashMap<u32, String>,
         module_closures: Vec<LirFunction>,
     ) -> Result<TranslatedConsts, JitError> {
         let mut builder_ctx = FunctionBuilderContext::new();
@@ -21,7 +20,6 @@ impl JitCompiler {
 
         // Create translator context
         let mut translator = FunctionTranslator::new(&mut self.module, &self.helpers, lir);
-        translator.symbol_names = symbol_names;
         translator.module_closures = module_closures;
 
         translator.self_sym = self_sym;

--- a/src/jit/group.rs
+++ b/src/jit/group.rs
@@ -33,7 +33,7 @@ const MAX_DISCOVERY_DEPTH: usize = 4;
 /// (num_captures == 0) since direct SCC calls pass null env.
 pub(crate) fn discover_compilation_group(
     hot_lir: &LirFunction,
-    globals: &[Value],
+    globals: &HashMap<SymbolId, Value>,
 ) -> Vec<(SymbolId, Rc<LirFunction>)> {
     let mut visited: HashSet<SymbolId> = HashSet::new();
     let mut group: Vec<(SymbolId, Rc<LirFunction>)> = Vec::new();
@@ -52,11 +52,12 @@ pub(crate) fn discover_compilation_group(
             continue;
         }
 
-        let idx = sym.0 as usize;
-        if idx >= globals.len() {
-            continue;
-        }
-        let val = &globals[idx];
+        // Keyed by symbol, not indexed by it: a `SymbolId` is a name hash
+        // (docs/impl/symbol.md), so it addresses nothing densely.
+        let val = match globals.get(&sym) {
+            Some(v) => v,
+            None => continue,
+        };
 
         let closure = match val.as_closure() {
             Some(c) => c,

--- a/src/jit/group/tests.rs
+++ b/src/jit/group/tests.rs
@@ -96,7 +96,7 @@ fn test_find_global_call_targets_no_calls() {
 fn test_discover_empty_when_no_peers() {
     crate::value::arena::with_test_region(|| {
         let leaf = make_leaf();
-        let globals: Vec<Value> = vec![];
+        let globals: HashMap<SymbolId, Value> = HashMap::new();
         let group = discover_compilation_group(&leaf, &globals);
         assert!(group.is_empty());
     });
@@ -112,8 +112,8 @@ fn test_discover_finds_callee() {
         let caller = make_caller("f", sym_g);
         let callee = make_leaf();
 
-        let mut globals = vec![Value::NIL; 10];
-        globals[5] = make_closure_value(callee);
+        let mut globals: HashMap<SymbolId, Value> = HashMap::new();
+        globals.insert(SymbolId(5), make_closure_value(callee));
 
         let group = discover_compilation_group(&caller, &globals);
         assert!(group.is_empty());
@@ -129,8 +129,8 @@ fn test_discover_skips_suspending() {
         let mut callee = make_leaf();
         callee.signal = Signal::yields();
 
-        let mut globals = vec![Value::NIL; 10];
-        globals[5] = make_closure_value(callee);
+        let mut globals: HashMap<SymbolId, Value> = HashMap::new();
+        globals.insert(SymbolId(5), make_closure_value(callee));
 
         let group = discover_compilation_group(&caller, &globals);
         assert!(group.is_empty());
@@ -146,8 +146,8 @@ fn test_discover_skips_captures() {
         let mut callee = make_leaf();
         callee.num_captures = 1;
 
-        let mut globals = vec![Value::NIL; 10];
-        globals[5] = make_closure_value(callee);
+        let mut globals: HashMap<SymbolId, Value> = HashMap::new();
+        globals.insert(SymbolId(5), make_closure_value(callee));
 
         let group = discover_compilation_group(&caller, &globals);
         assert!(group.is_empty());
@@ -182,8 +182,8 @@ fn test_discover_skips_unsupported_instructions() {
             )
             .build();
 
-        let mut globals = vec![Value::NIL; 10];
-        globals[5] = make_closure_value(callee);
+        let mut globals: HashMap<SymbolId, Value> = HashMap::new();
+        globals.insert(SymbolId(5), make_closure_value(callee));
 
         let group = discover_compilation_group(&caller, &globals);
         assert!(group.is_empty());
@@ -202,9 +202,9 @@ fn test_discover_transitive() {
         let g = make_caller("g", sym_h);
         let h = make_leaf();
 
-        let mut globals = vec![Value::NIL; 10];
-        globals[5] = make_closure_value(g);
-        globals[6] = make_closure_value(h);
+        let mut globals: HashMap<SymbolId, Value> = HashMap::new();
+        globals.insert(SymbolId(5), make_closure_value(g));
+        globals.insert(SymbolId(6), make_closure_value(h));
 
         let group = discover_compilation_group(&caller, &globals);
         assert!(group.is_empty());
@@ -224,9 +224,9 @@ fn test_discover_no_duplicates_in_cycle() {
 
         let f_for_global = make_caller("f", sym_g);
 
-        let mut globals = vec![Value::NIL; 10];
-        globals[4] = make_closure_value(f_for_global);
-        globals[5] = make_closure_value(g);
+        let mut globals: HashMap<SymbolId, Value> = HashMap::new();
+        globals.insert(SymbolId(4), make_closure_value(f_for_global));
+        globals.insert(SymbolId(5), make_closure_value(g));
 
         let group = discover_compilation_group(&hot, &globals);
         assert!(group.is_empty());
@@ -234,11 +234,11 @@ fn test_discover_no_duplicates_in_cycle() {
 }
 
 #[test]
-fn test_discover_out_of_bounds_sym() {
+fn test_discover_unknown_sym() {
     crate::value::arena::with_test_region(|| {
         let sym_g = SymbolId(999);
         let caller = make_caller("f", sym_g);
-        let globals = vec![Value::NIL; 10]; // Only 10 globals
+        let globals: HashMap<SymbolId, Value> = HashMap::new();
 
         let group = discover_compilation_group(&caller, &globals);
         assert!(group.is_empty());
@@ -251,8 +251,8 @@ fn test_discover_non_closure_global() {
         let sym_g = SymbolId(5);
         let caller = make_caller("f", sym_g);
 
-        let mut globals = vec![Value::NIL; 10];
-        globals[5] = Value::int(42); // Not a closure
+        let mut globals: HashMap<SymbolId, Value> = HashMap::new();
+        globals.insert(SymbolId(5), Value::int(42)); // Not a closure
 
         let group = discover_compilation_group(&caller, &globals);
         assert!(group.is_empty());
@@ -281,8 +281,8 @@ fn test_discover_closure_without_lir() {
             squelch_mask: SignalBits::EMPTY,
         };
 
-        let mut globals = vec![Value::NIL; 10];
-        globals[5] = h.ctx().closure(closure);
+        let mut globals: HashMap<SymbolId, Value> = HashMap::new();
+        globals.insert(SymbolId(5), h.ctx().closure(closure));
 
         let group = discover_compilation_group(&caller, &globals);
         assert!(group.is_empty());
@@ -334,16 +334,16 @@ fn test_discover_respects_size_bound() {
         // Create a chain of functions f0 -> f1 -> f2 -> ... -> f(N)
         // Verify that discovery stops at MAX_GROUP_SIZE.
         let n = MAX_GROUP_SIZE + 5; // more than the limit
-        let syms: Vec<SymbolId> = (0..n).map(|i| SymbolId(i as u32)).collect();
+        let syms: Vec<SymbolId> = (0..n).map(|i| SymbolId(i as u64)).collect();
 
         // Build chain: f_i calls f_{i+1}
-        let mut globals = vec![Value::NIL; n];
+        let mut globals: HashMap<SymbolId, Value> = HashMap::new();
         for i in 0..n - 1 {
             let caller = make_caller(&format!("f{}", i), syms[i + 1]);
-            globals[i] = make_closure_value(caller);
+            globals.insert(syms[i], make_closure_value(caller));
         }
         // Last function is a leaf
-        globals[n - 1] = make_closure_value(make_leaf());
+        globals.insert(syms[n - 1], make_closure_value(make_leaf()));
 
         // Hot function calls f0
         let hot = make_caller("hot", syms[0]);
@@ -365,14 +365,14 @@ fn test_discover_respects_depth_bound() {
         // Create a chain longer than MAX_DISCOVERY_DEPTH.
         // Even though all functions are valid, depth limiting should cap discovery.
         let n = MAX_DISCOVERY_DEPTH + 3;
-        let syms: Vec<SymbolId> = (0..n).map(|i| SymbolId(i as u32)).collect();
+        let syms: Vec<SymbolId> = (0..n).map(|i| SymbolId(i as u64)).collect();
 
-        let mut globals = vec![Value::NIL; n];
+        let mut globals: HashMap<SymbolId, Value> = HashMap::new();
         for i in 0..n - 1 {
             let caller = make_caller(&format!("f{}", i), syms[i + 1]);
-            globals[i] = make_closure_value(caller);
+            globals.insert(syms[i], make_closure_value(caller));
         }
-        globals[n - 1] = make_closure_value(make_leaf());
+        globals.insert(syms[n - 1], make_closure_value(make_leaf()));
 
         let hot = make_caller("hot", syms[0]);
         let group = discover_compilation_group(&hot, &globals);

--- a/src/jit/helpers.rs
+++ b/src/jit/helpers.rs
@@ -66,15 +66,14 @@ impl<'a> FunctionTranslator<'a> {
                 unreachable!("LirConst::String should be pre-resolved to ValueConst")
             }
             LirConst::Symbol(id) => {
-                let v = crate::value::Value::symbol(id.0);
+                let v = crate::value::Value::symbol(*id);
                 let t = builder.ins().iconst(I64, TAG_SYMBOL as i64);
                 let p = builder.ins().iconst(I64, v.payload as i64);
                 (t, p)
             }
-            LirConst::Keyword(name) => {
-                let v = crate::value::Value::keyword(name);
+            LirConst::Keyword(hash) => {
                 let t = builder.ins().iconst(I64, TAG_KEYWORD as i64);
-                let p = builder.ins().iconst(I64, v.payload as i64);
+                let p = builder.ins().iconst(I64, *hash as i64);
                 (t, p)
             }
             LirConst::ClosureRef(_) => {

--- a/src/jit/runtime/tests.rs
+++ b/src/jit/runtime/tests.rs
@@ -187,8 +187,15 @@ fn test_ge_strings() {
 
 #[test]
 fn test_lt_keywords() {
-    let a = Value::keyword("apple");
-    let b = Value::keyword("banana");
+    // Keyword order is hash order (the portable order sorted containers use),
+    // so the smaller operand is whichever spelling hashes lower.
+    let x = Value::keyword("apple");
+    let y = Value::keyword("banana");
+    let (a, b) = if x.payload < y.payload {
+        (x, y)
+    } else {
+        (y, x)
+    };
     assert_eq!(
         elle_jit_lt(a.tag, a.payload, b.tag, b.payload),
         JitValue::bool_val(true)

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -98,7 +98,6 @@ pub(crate) struct FunctionTranslator<'a> {
     #[allow(clippy::vec_box)] // the Box stable-address is the point (see above)
     pub(crate) templates: Vec<Box<crate::value::ConstTemplate>>,
     /// Symbol name map for nested emitters (MakeClosure).
-    pub(crate) symbol_names: HashMap<u32, String>,
     /// Module's closure list for MakeClosure → ClosureId lookup.
     pub(crate) module_closures: Vec<crate::lir::LirFunction>,
     /// Whether this function's LIR carries an `AdoptIntoActivation` — computed
@@ -162,7 +161,6 @@ impl<'a> FunctionTranslator<'a> {
             abandoned_locals_spill: None,
             closure_protos: Vec::new(),
             templates: Vec::new(),
-            symbol_names: HashMap::new(),
             module_closures: Vec::new(),
             uses_activation_owner_node,
         }

--- a/src/jit/translate/instr/calls.rs
+++ b/src/jit/translate/instr/calls.rs
@@ -246,7 +246,7 @@ impl<'a> FunctionTranslator<'a> {
                     })?
                     .clone();
 
-                let mut emitter = crate::lir::Emitter::new_with_symbols(self.symbol_names.clone());
+                let mut emitter = crate::lir::Emitter::new();
 
                 let lir_module = crate::lir::LirModule {
                     entry: func.clone(),
@@ -260,7 +260,7 @@ impl<'a> FunctionTranslator<'a> {
                 drop(nested_bytecode);
                 drop(nested_yield_points);
                 drop(nested_call_sites);
-                let mut emitter2 = crate::lir::Emitter::new_with_symbols(self.symbol_names.clone());
+                let mut emitter2 = crate::lir::Emitter::new();
                 let all_compiled = emitter2.emit_module_closures(&lir_module);
                 let (nested_bytecode, nested_yield_points, nested_call_sites) =
                     all_compiled.into_iter().nth(closure_id.0 as usize).unwrap();
@@ -282,7 +282,6 @@ impl<'a> FunctionTranslator<'a> {
                     signal: func.signal,
                     capture_params_mask: func.capture_params_mask,
                     capture_locals_mask: func.capture_locals_mask.clone(),
-                    symbol_names: std::rc::Rc::new(nested_bytecode.symbol_names),
                     location_map: std::rc::Rc::new(nested_bytecode.location_map),
                     lir_function: Some(std::rc::Rc::new(nested_lir)),
                     doc: func.doc.clone(),

--- a/src/jit/worker.rs
+++ b/src/jit/worker.rs
@@ -7,8 +7,6 @@
 //!
 //! Modeled on `StdinThread` in `src/io/threadpool.rs`.
 
-use std::collections::HashMap;
-
 use crate::jit::{JitCode, JitCompiler, JitError};
 use crate::lir::LirFunction;
 use crate::value::SymbolId;
@@ -20,7 +18,6 @@ pub(crate) struct JitTask {
     /// dereferencing heap pointers during compilation.
     pub lir: LirFunction,
     pub self_sym: Option<SymbolId>,
-    pub symbol_names: HashMap<u32, String>,
     /// Cache key — the bytecode pointer address, cast to usize.
     pub bytecode_key: usize,
 }
@@ -68,12 +65,7 @@ impl JitWorker {
                 while let Ok(task) = task_rx.recv() {
                     let key = task.bytecode_key;
                     let result = match JitCompiler::new() {
-                        Ok(compiler) => compiler.compile(
-                            &task.lir,
-                            task.self_sym,
-                            task.symbol_names,
-                            Vec::new(),
-                        ),
+                        Ok(compiler) => compiler.compile(&task.lir, task.self_sym, Vec::new()),
                         Err(e) => Err(e),
                     };
                     let _ = result_tx.send(JitResult {
@@ -122,7 +114,6 @@ impl JitWorker {
 pub(crate) fn prepare_task(
     lir: &LirFunction,
     self_sym: Option<SymbolId>,
-    symbol_names: HashMap<u32, String>,
     bytecode_key: usize,
     display_name: Option<&str>,
 ) -> JitTask {
@@ -135,7 +126,6 @@ pub(crate) fn prepare_task(
     JitTask {
         lir,
         self_sym,
-        symbol_names,
         bytecode_key,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub mod lir;
 pub mod lsp;
 #[cfg(feature = "mlir")]
 pub mod mlir;
+pub mod namehash;
 pub mod path;
 pub mod pipeline;
 pub mod plugin;

--- a/src/lir/display.rs
+++ b/src/lir/display.rs
@@ -77,7 +77,7 @@ impl fmt::Display for LirConst {
             LirConst::Float(n) => write!(f, "{}", n),
             LirConst::String(s) => write!(f, "\"{}\"", s),
             LirConst::Symbol(sid) => write!(f, "sym({})", sid.0),
-            LirConst::Keyword(k) => write!(f, ":{}", k),
+            LirConst::Keyword(hash) => write!(f, "kw({:#x})", hash),
             LirConst::ClosureRef(idx) => write!(f, "closure-ref({})", idx),
             LirConst::ValueRef(idx) => write!(f, "value-ref({})", idx),
         }

--- a/src/lir/display/tests.rs
+++ b/src/lir/display/tests.rs
@@ -30,7 +30,13 @@ fn test_cmpop_display() {
 fn test_const_display() {
     assert_eq!(format!("{}", LirConst::Nil), "nil");
     assert_eq!(format!("{}", LirConst::Int(42)), "42");
-    assert_eq!(format!("{}", LirConst::Keyword("lit".into())), ":lit");
+    assert_eq!(
+        format!(
+            "{}",
+            LirConst::Keyword(crate::value::keyword::keyword_hash("lit"))
+        ),
+        format!("kw({:#x})", crate::value::keyword::keyword_hash("lit"))
+    );
     assert_eq!(format!("{}", LirConst::String("hello".into())), "\"hello\"");
 }
 
@@ -132,10 +138,13 @@ fn test_instr_destructuring() {
             LirInstr::StructGetOrNil {
                 dst: Reg(3),
                 src: Reg(0),
-                key: LirConst::Keyword("name".into())
+                key: LirConst::Keyword(crate::value::keyword::keyword_hash("name"))
             }
         ),
-        "r3 ← r0.:name?"
+        format!(
+            "r3 ← r0.kw({:#x})?",
+            crate::value::keyword::keyword_hash("name")
+        )
     );
     assert_eq!(
         format!(
@@ -143,10 +152,13 @@ fn test_instr_destructuring() {
             LirInstr::StructGetDestructure {
                 dst: Reg(3),
                 src: Reg(0),
-                key: LirConst::Keyword("name".into())
+                key: LirConst::Keyword(crate::value::keyword::keyword_hash("name"))
             }
         ),
-        "r3 ← r0.:name!"
+        format!(
+            "r3 ← r0.kw({:#x})!",
+            crate::value::keyword::keyword_hash("name")
+        )
     );
 }
 

--- a/src/lir/emit/instr.rs
+++ b/src/lir/emit/instr.rs
@@ -172,7 +172,6 @@ impl Emitter {
                     signal: func.signal,
                     capture_params_mask: func.capture_params_mask,
                     capture_locals_mask: func.capture_locals_mask.clone(),
-                    symbol_names: Rc::new(nested_bytecode.symbol_names),
                     location_map: Rc::new(nested_bytecode.location_map),
                     lir_function: Some(Rc::new(nested_lir)),
                     doc: func.doc.clone(),
@@ -443,7 +442,7 @@ impl Emitter {
             LirInstr::StructGetOrNil { dst, src, key } => {
                 self.ensure_on_top(*src);
                 let key_value = match key {
-                    LirConst::Keyword(name) => Value::keyword(name),
+                    LirConst::Keyword(hash) => Value::keyword_from_hash(*hash),
                     // Struct/table keys are only keyword or symbol (the pattern
                     // and access-path lowerers never build a string key), so a
                     // string key never reaches the emitter.
@@ -451,7 +450,7 @@ impl Emitter {
                         unreachable!("struct keys are keyword or symbol, never string")
                     }
                     LirConst::Int(n) => Value::int(*n),
-                    LirConst::Symbol(sym) => Value::symbol(sym.0),
+                    LirConst::Symbol(sym) => Value::symbol(*sym),
                     LirConst::Bool(b) => Value::bool(*b),
                     LirConst::Nil => Value::NIL,
                     _ => panic!("StructGetOrNil: unsupported key type"),
@@ -466,7 +465,7 @@ impl Emitter {
             LirInstr::StructGetDestructure { dst, src, key } => {
                 self.ensure_on_top(*src);
                 let key_value = match key {
-                    LirConst::Keyword(name) => Value::keyword(name),
+                    LirConst::Keyword(hash) => Value::keyword_from_hash(*hash),
                     // Struct/table keys are only keyword or symbol (the pattern
                     // and access-path lowerers never build a string key), so a
                     // string key never reaches the emitter.
@@ -474,7 +473,7 @@ impl Emitter {
                         unreachable!("struct keys are keyword or symbol, never string")
                     }
                     LirConst::Int(n) => Value::int(*n),
-                    LirConst::Symbol(sym) => Value::symbol(sym.0),
+                    LirConst::Symbol(sym) => Value::symbol(*sym),
                     LirConst::Bool(b) => Value::bool(*b),
                     LirConst::Nil => Value::NIL,
                     _ => panic!("StructGetDestructure: unsupported key type"),
@@ -496,8 +495,8 @@ impl Emitter {
                 self.bytecode.emit_u16(exclude_keys.len() as u16);
                 for key in exclude_keys {
                     let key_value = match key {
-                        LirConst::Keyword(name) => Value::keyword(name),
-                        LirConst::Symbol(sid) => Value::symbol(sid.0),
+                        LirConst::Keyword(hash) => Value::keyword_from_hash(*hash),
+                        LirConst::Symbol(sid) => Value::symbol(*sid),
                         _ => panic!("StructRest: unsupported key type {:?}", key),
                     };
                     let const_idx = self.bytecode.add_constant(key_value);

--- a/src/lir/emit/mod.rs
+++ b/src/lir/emit/mod.rs
@@ -44,8 +44,6 @@ pub struct Emitter {
     stack: Vec<Reg>,
     /// Register to stack position mapping (for finding values)
     reg_to_stack: HashMap<Reg, usize>,
-    /// Symbol ID → name mapping for cross-thread portability
-    symbol_names: HashMap<u32, String>,
     /// Saved stack state from yield terminators, keyed by resume label.
     /// When a block ends with Terminator::Yield, the stack state is saved here
     /// so the resume block can start with the correct simulation state.
@@ -83,27 +81,6 @@ impl Emitter {
             pending_jumps: Vec::new(),
             stack: Vec::new(),
             reg_to_stack: HashMap::new(),
-            symbol_names: HashMap::new(),
-            yield_stack_state: HashMap::new(),
-            block_entry_depth: HashMap::new(),
-            yield_points: Vec::new(),
-            call_sites: Vec::new(),
-            current_func_may_suspend: false,
-            current_func_num_locals: 0,
-            compiled_closures: None,
-            closure_lir_funcs: None,
-        }
-    }
-
-    /// Create an emitter with symbol name mappings for cross-thread portability.
-    pub fn new_with_symbols(symbol_names: HashMap<u32, String>) -> Self {
-        Emitter {
-            bytecode: Bytecode::new(),
-            label_offsets: HashMap::new(),
-            pending_jumps: Vec::new(),
-            stack: Vec::new(),
-            reg_to_stack: HashMap::new(),
-            symbol_names,
             yield_stack_state: HashMap::new(),
             block_entry_depth: HashMap::new(),
             yield_points: Vec::new(),
@@ -192,10 +169,7 @@ impl Emitter {
 
     /// Emit bytecode from a single LIR function.
     pub fn emit(&mut self, func: &LirFunction) -> ClosureCompiled {
-        let mut bytecode = Bytecode::new();
-        // Copy symbol names to the new bytecode for cross-thread portability
-        bytecode.symbol_names = self.symbol_names.clone();
-        self.bytecode = bytecode;
+        self.bytecode = Bytecode::new();
         self.label_offsets.clear();
         self.pending_jumps.clear();
         self.stack.clear();
@@ -510,13 +484,12 @@ impl Emitter {
                 unreachable!("string literals lower to MaterializeConst, not Const")
             }
             LirConst::Symbol(sym) => {
-                let name = self.symbol_names.get(&sym.0).cloned().unwrap_or_default();
-                let idx = self.bytecode.add_symbol(sym.0, &name);
+                let idx = self.bytecode.add_constant(Value::symbol(*sym));
                 self.bytecode.emit(Instruction::LoadConst);
                 self.bytecode.emit_u16(idx);
             }
-            LirConst::Keyword(name) => {
-                let idx = self.bytecode.add_constant(Value::keyword(name));
+            LirConst::Keyword(hash) => {
+                let idx = self.bytecode.add_constant(Value::keyword_from_hash(*hash));
                 self.bytecode.emit(Instruction::LoadConst);
                 self.bytecode.emit_u16(idx);
             }

--- a/src/lir/intrinsics.rs
+++ b/src/lir/intrinsics.rs
@@ -6,7 +6,6 @@
 
 use super::types::ConvOp;
 use crate::primitives::def::PrimitiveMeta;
-use crate::symbol::SymbolTable;
 use crate::value::SymbolId;
 use rustc_hash::FxHashMap;
 
@@ -17,13 +16,11 @@ pub enum IntrinsicOp {
 }
 
 /// Build the intrinsics map from a symbol table.
-pub(crate) fn build_intrinsics(symbols: &SymbolTable) -> FxHashMap<SymbolId, IntrinsicOp> {
+pub(crate) fn build_intrinsics() -> FxHashMap<SymbolId, IntrinsicOp> {
     let mut map = FxHashMap::default();
 
     let mut add = |name: &str, op: IntrinsicOp| {
-        if let Some(id) = symbols.get(name) {
-            map.insert(id, op);
-        }
+        map.insert(SymbolId::of(name), op);
     };
 
     add("float", IntrinsicOp::Conversion(ConvOp::IntToFloat));
@@ -40,8 +37,8 @@ pub struct PrimitiveClassification {
 }
 
 impl PrimitiveClassification {
-    pub fn new(symbols: &SymbolTable, meta: &PrimitiveMeta) -> Self {
-        let intrinsics = build_intrinsics(symbols);
+    pub fn new(meta: &PrimitiveMeta) -> Self {
+        let intrinsics = build_intrinsics();
 
         // The value-retaining store funnels — the `Funnel` ops whose runtime body
         // increfs the stored heap value (the put/push/add family). NOT the
@@ -61,7 +58,7 @@ impl PrimitiveClassification {
             "%add-set-mut",
         ]
         .iter()
-        .filter_map(|name| symbols.get(name))
+        .map(|name| SymbolId::of(name))
         .collect();
 
         // The BYTE-COPY store funnels — `Funnel` ops that COPY the pushed value's
@@ -76,7 +73,7 @@ impl PrimitiveClassification {
         // excludes does NOT apply). See `CallClassification::bytecopy_store_funnels`.
         let bytecopy_store_funnels = ["%string-push", "%string-push-mut", "%bytes-push"]
             .iter()
-            .filter_map(|name| symbols.get(name))
+            .map(|name| SymbolId::of(name))
             .collect();
 
         // The moves-out ∩ PassThrough natives (`%pop`/`%pop-array*`): a non-fresh
@@ -124,7 +121,7 @@ impl PrimitiveClassification {
             "%pop-bytes",
         ]
         .iter()
-        .filter_map(|name| symbols.get(name))
+        .map(|name| SymbolId::of(name))
         .collect();
 
         let call_classification = crate::hir::CallClassification {
@@ -139,15 +136,15 @@ impl PrimitiveClassification {
             moves_out,
             // The two natives the transferred-returned-subtree cut recognizes
             // structurally: a fiber-body producer and its resume consumer.
-            fiber_new: symbols.get("fiber/new"),
-            fiber_resume: symbols.get("fiber/resume"),
+            fiber_new: Some(SymbolId::of("fiber/new")),
+            fiber_resume: Some(SymbolId::of("fiber/resume")),
             // The emit primitive under each name it answers to: a dynamic `emit`
             // compiles to a call on it, and that call parks and yields exactly as
             // the `Emit` terminator does (`CallClassification::emit_natives`).
             // Ordinary code reaches it through the alias, so both belong here.
             emit_natives: ["fiber/emit", "emit"]
                 .iter()
-                .filter_map(|name| symbols.get(name))
+                .map(|name| SymbolId::of(name))
                 .collect(),
             ..Default::default()
         };

--- a/src/lir/lower/access.rs
+++ b/src/lir/lower/access.rs
@@ -62,7 +62,9 @@ impl<'a> Lowerer<'a> {
                 let parent = self.load_access_path(inner, scrutinee_slot)?;
                 let dst = self.fresh_reg();
                 let lir_key = match key {
-                    PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
+                    PatternKey::Keyword(k) => {
+                        LirConst::Keyword(crate::value::keyword::keyword_hash(k))
+                    }
                     PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                 };
                 self.emit(LirInstr::StructGetOrNil {
@@ -78,7 +80,9 @@ impl<'a> Lowerer<'a> {
                 let lir_exclude: Vec<LirConst> = exclude_keys
                     .iter()
                     .map(|k| match k {
-                        PatternKey::Keyword(s) => LirConst::Keyword(s.clone()),
+                        PatternKey::Keyword(s) => {
+                            LirConst::Keyword(crate::value::keyword::keyword_hash(s))
+                        }
                         PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                     })
                     .collect();

--- a/src/lir/lower/binding/destructure.rs
+++ b/src/lir/lower/binding/destructure.rs
@@ -215,7 +215,9 @@ impl<'a> Lowerer<'a> {
                     });
                     let elem = self.fresh_reg();
                     let lir_key = match key {
-                        PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
+                        PatternKey::Keyword(k) => {
+                            LirConst::Keyword(crate::value::keyword::keyword_hash(k))
+                        }
                         PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                     };
                     self.emit(LirInstr::StructGetOrNil {
@@ -244,7 +246,9 @@ impl<'a> Lowerer<'a> {
                     });
                     let elem = self.fresh_reg();
                     let lir_key = match key {
-                        PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
+                        PatternKey::Keyword(k) => {
+                            LirConst::Keyword(crate::value::keyword::keyword_hash(k))
+                        }
                         PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                     };
                     if strict {
@@ -273,7 +277,9 @@ impl<'a> Lowerer<'a> {
                     let exclude: Vec<LirConst> = entries
                         .iter()
                         .map(|(key, _)| match key {
-                            PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
+                            PatternKey::Keyword(k) => {
+                                LirConst::Keyword(crate::value::keyword::keyword_hash(k))
+                            }
                             PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                         })
                         .collect();
@@ -303,7 +309,9 @@ impl<'a> Lowerer<'a> {
                     });
                     let elem = self.fresh_reg();
                     let lir_key = match key {
-                        PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
+                        PatternKey::Keyword(k) => {
+                            LirConst::Keyword(crate::value::keyword::keyword_hash(k))
+                        }
                         PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                     };
                     if strict {
@@ -332,7 +340,9 @@ impl<'a> Lowerer<'a> {
                     let exclude: Vec<LirConst> = entries
                         .iter()
                         .map(|(key, _)| match key {
-                            PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
+                            PatternKey::Keyword(k) => {
+                                LirConst::Keyword(crate::value::keyword::keyword_hash(k))
+                            }
                             PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                         })
                         .collect();

--- a/src/lir/lower/expr.rs
+++ b/src/lir/lower/expr.rs
@@ -44,7 +44,9 @@ impl<'a> Lowerer<'a> {
                 });
                 Ok(dst)
             }
-            HirKind::Keyword(name) => self.emit_const(LirConst::Keyword(name.clone())),
+            HirKind::Keyword(name) => {
+                self.emit_const(LirConst::Keyword(crate::value::keyword::keyword_hash(name)))
+            }
 
             HirKind::Var(binding) => self.lower_var(binding, &hir.span),
             HirKind::Let { bindings, body } => self.lower_let(bindings, body, hir.id),

--- a/src/lir/lower/expr/var.rs
+++ b/src/lir/lower/expr/var.rs
@@ -70,10 +70,10 @@ impl<'a> Lowerer<'a> {
             // creates a dangling binding for an undefined variable.
             let sym_id = self.arena.get(*binding).name;
             let name = self
-                .symbol_names
-                .get(&sym_id.0)
-                .cloned()
-                .unwrap_or_else(|| format!("symbol #{}", sym_id.0));
+                .symbols
+                .and_then(|s| s.name(sym_id))
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| format!("symbol #{:#x}", sym_id.0));
             Err(format!("{}: undefined variable: {}", span, name))
         }
     }

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -184,6 +184,12 @@ impl ValueSlot {
 /// Lowers HIR to LIR
 pub struct Lowerer<'a> {
     arena: &'a BindingArena,
+    /// The owning instance's display memo, for naming a binding in an error.
+    /// Lowering never resolves a name to decide anything — the only reader is
+    /// the `undefined variable` message, which is a user's own spelling and so
+    /// is not in the static vocabulary (docs/impl/symbol.md). `None` degrades
+    /// that one message to the hash.
+    symbols: Option<&'a crate::symbol::SymbolTable>,
     /// Current function being built
     current_func: LirFunction,
     /// Current block being built
@@ -247,8 +253,6 @@ pub struct Lowerer<'a> {
     /// Lazily allocated on first use. Reused across all discards
     /// within the same function, so only one extra local slot.
     discard_slot: Option<u16>,
-    /// Symbol ID → name mapping for error messages.
-    symbol_names: HashMap<u32, String>,
     /// Flat list of closure bodies. `MakeClosure` instructions reference
     /// closures by `ClosureId` (index into this list). Built depth-first
     /// during lowering.
@@ -451,6 +455,7 @@ impl<'a> Lowerer<'a> {
     pub fn new(arena: &'a BindingArena) -> Self {
         Lowerer {
             arena,
+            symbols: None,
             current_func: LirFunction::new(Arity::Exact(0)),
             current_block: BasicBlock::new(Label(0)),
             next_reg: 0,
@@ -469,7 +474,6 @@ impl<'a> Lowerer<'a> {
             block_lower_contexts: Vec::new(),
             pending_free_regions: Vec::new(),
             discard_slot: None,
-            symbol_names: HashMap::new(),
             closures: Vec::new(),
             current_function_binding: None,
             current_self_binding: None,
@@ -507,12 +511,6 @@ impl<'a> Lowerer<'a> {
         self
     }
 
-    /// Set symbol names for error messages.
-    pub fn with_symbol_names(mut self, names: HashMap<u32, String>) -> Self {
-        self.symbol_names = names;
-        self
-    }
-
     /// Seed `immutable_values` with primitive binding→value pairs.
     ///
     /// Primitive bindings are `BindingScope::Local` with `mark_immutable()`.
@@ -521,6 +519,13 @@ impl<'a> Lowerer<'a> {
     /// binding with a known constant value.
     pub fn with_primitive_values(mut self, values: HashMap<Binding, Value>) -> Self {
         self.immutable_values.extend(values);
+        self
+    }
+
+    /// Give lowering the instance's display memo, so an `undefined variable`
+    /// error names the variable the user wrote.
+    pub fn with_symbols(mut self, symbols: &'a crate::symbol::SymbolTable) -> Self {
+        self.symbols = Some(symbols);
         self
     }
 

--- a/src/lir/lower/pattern.rs
+++ b/src/lir/lower/pattern.rs
@@ -338,7 +338,9 @@ impl<'a> Lowerer<'a> {
                     PatternLiteral::Bool(b) => self.emit_const(LirConst::Bool(*b))?,
                     PatternLiteral::Int(n) => self.emit_const(LirConst::Int(*n))?,
                     PatternLiteral::Float(f) => self.emit_const(LirConst::Float(*f))?,
-                    PatternLiteral::Keyword(k) => self.emit_const(LirConst::Keyword(k.clone()))?,
+                    PatternLiteral::Keyword(k) => {
+                        self.emit_const(LirConst::Keyword(crate::value::keyword::keyword_hash(k)))?
+                    }
                     PatternLiteral::String(_) => unreachable!("string handled above"),
                 };
                 let dst = self.fresh_reg();

--- a/src/lir/lower/pattern/keyed.rs
+++ b/src/lir/lower/pattern/keyed.rs
@@ -52,7 +52,9 @@ impl<'a> Lowerer<'a> {
 
                     let elem_reg = self.fresh_reg();
                     let lir_key = match key {
-                        PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
+                        PatternKey::Keyword(k) => {
+                            LirConst::Keyword(crate::value::keyword::keyword_hash(k))
+                        }
                         PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                     };
                     self.emit(LirInstr::StructGetOrNil {
@@ -74,7 +76,9 @@ impl<'a> Lowerer<'a> {
                     let exclude: Vec<LirConst> = entries
                         .iter()
                         .map(|(key, _)| match key {
-                            PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
+                            PatternKey::Keyword(k) => {
+                                LirConst::Keyword(crate::value::keyword::keyword_hash(k))
+                            }
                             PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                         })
                         .collect();
@@ -130,7 +134,9 @@ impl<'a> Lowerer<'a> {
 
                     let elem_reg = self.fresh_reg();
                     let lir_key = match key {
-                        PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
+                        PatternKey::Keyword(k) => {
+                            LirConst::Keyword(crate::value::keyword::keyword_hash(k))
+                        }
                         PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                     };
                     self.emit(LirInstr::StructGetOrNil {
@@ -152,7 +158,9 @@ impl<'a> Lowerer<'a> {
                     let exclude: Vec<LirConst> = entries
                         .iter()
                         .map(|(key, _)| match key {
-                            PatternKey::Keyword(k) => LirConst::Keyword(k.clone()),
+                            PatternKey::Keyword(k) => {
+                                LirConst::Keyword(crate::value::keyword::keyword_hash(k))
+                            }
                             PatternKey::Symbol(sid) => LirConst::Symbol(*sid),
                         })
                         .collect();

--- a/src/lir/lower/pattern/matching.rs
+++ b/src/lir/lower/pattern/matching.rs
@@ -44,9 +44,8 @@ impl<'a> Lowerer<'a> {
                     PatternLiteral::Int(n) => self.emit_const(LirConst::Int(*n))?,
                     PatternLiteral::Float(f) => self.emit_const(LirConst::Float(*f))?,
                     PatternLiteral::String(s) => self.emit_const(LirConst::String(s.clone()))?,
-                    PatternLiteral::Keyword(name) => {
-                        self.emit_const(LirConst::Keyword(name.clone()))?
-                    }
+                    PatternLiteral::Keyword(name) => self
+                        .emit_const(LirConst::Keyword(crate::value::keyword::keyword_hash(name)))?,
                 };
 
                 let eq_reg = self.fresh_reg();

--- a/src/lir/lower/tests/mod.rs
+++ b/src/lir/lower/tests/mod.rs
@@ -37,14 +37,13 @@ fn make_lowerer_with(
             .stubs(STUBS_RETURNING_ARGS)
             .build_into(source, arena, &mut symbols);
 
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&symbols, &built.meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&built.meta);
     let mut region_info =
         crate::hir::analyze_regions_with(&built.hir, arena, pc.call_classification.clone());
     mutate(&mut region_info, &built.hir);
     let lowerer = Lowerer::new(arena)
         .with_primitive_classification(pc)
         .with_primitive_values(built.primitive_values)
-        .with_symbol_names(symbols.all_names())
         .with_region_info(region_info);
     (lowerer, built.hir)
 }

--- a/src/lir/types/mod.rs
+++ b/src/lir/types/mod.rs
@@ -197,7 +197,7 @@ pub enum LirConst {
     Float(f64),
     String(String),
     Symbol(SymbolId),
-    Keyword(String),
+    Keyword(u64),
     /// Placeholder for a closure during cross-thread LIR transfer.
     /// The usize is the index into `SendBundle::closures`.
     /// Patched back to `ValueConst` during reconstruction.
@@ -224,9 +224,9 @@ pub fn value_to_lir_const(v: Value) -> Option<LirConst> {
     } else if let Some(f) = v.as_float() {
         Some(LirConst::Float(f))
     } else if let Some(id) = v.as_symbol() {
-        Some(LirConst::Symbol(SymbolId(id)))
-    } else if let Some(name) = v.as_keyword_name() {
-        Some(LirConst::Keyword(name))
+        Some(LirConst::Symbol(id))
+    } else if let Some(hash) = v.keyword_hash() {
+        Some(LirConst::Keyword(hash))
     } else {
         v.with_string(|s| s.to_string()).map(LirConst::String)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,19 +72,22 @@ fn run_dump(
     // FHIR — functionalized HIR (s-expression dump before lowering)
     if cfg.dump.contains("fhir") {
         println!(";; ── fhir (functionalized HIR) ──────────────────────────────");
-        let (hir, arena, names) =
+        let (hir, arena) =
             elle::pipeline::compile_file_to_fhir(contents, symbols, cctx, source_name).map_err(
                 |e| {
                     eprintln!("{}", e);
                     e
                 },
             )?;
-        println!("{}", elle::hir::display::display_hir(&hir, &arena, &names));
+        println!(
+            "{}",
+            elle::hir::display::display_hir(&hir, &arena, Some(symbols))
+        );
     }
 
     if cfg.dump.contains("defuse") {
         println!(";; ── defuse (HIR dataflow) ──────────────────────────────────");
-        let (hir, arena, names) =
+        let (hir, arena) =
             elle::pipeline::compile_file_to_fhir(contents, symbols, cctx, source_name).map_err(
                 |e| {
                     eprintln!("{}", e);
@@ -92,12 +95,15 @@ fn run_dump(
                 },
             )?;
         let info = elle::hir::analyze_dataflow(&hir);
-        print!("{}", elle::hir::format_dataflow(&info, &arena, &names));
+        print!(
+            "{}",
+            elle::hir::format_dataflow(&info, &arena, Some(symbols))
+        );
     }
 
     if cfg.dump.contains("regions") {
         println!(";; ── regions (Tofte-Talpin region inference) ─────────────────");
-        let (hir, arena, names) =
+        let (hir, arena) =
             elle::pipeline::compile_file_to_fhir(contents, symbols, cctx, source_name).map_err(
                 |e| {
                     eprintln!("{}", e);
@@ -105,7 +111,10 @@ fn run_dump(
                 },
             )?;
         let info = elle::hir::analyze_regions(&hir, &arena);
-        print!("{}", elle::hir::format_regions(&info, &arena, &names));
+        print!(
+            "{}",
+            elle::hir::format_regions(&info, &arena, Some(symbols))
+        );
     }
 
     let needs_pipeline = cfg.dump.iter().any(|k| {
@@ -159,20 +168,19 @@ fn run_dump(
         // Re-derive the front-end artifacts (run_dump compiles per kind) plus the
         // classification-aware region info — same inputs `render_all` feeds
         // `escape_module`, so the CLI and `compile/dumps :escape` agree.
-        let (hir, arena, names) =
+        let (hir, arena) =
             elle::pipeline::compile_file_to_fhir(contents, symbols, cctx, source_name).map_err(
                 |e| {
                     eprintln!("{}", e);
                     e
                 },
             )?;
-        let pc =
-            elle::lir::intrinsics::PrimitiveClassification::new(symbols, cctx.primitive_meta());
+        let pc = elle::lir::intrinsics::PrimitiveClassification::new(cctx.primitive_meta());
         let rinfo = elle::hir::analyze_regions_with(&hir, &arena, pc.call_classification.clone());
         let escape = elle::hir::analyze_escape(&hir, &arena, &pc.call_classification);
         print!(
             "{}",
-            elle::dump::escape_module(&hir, &arena, &names, &escape, &rinfo, &module)
+            elle::dump::escape_module(&hir, &arena, &escape, &rinfo, &module, Some(symbols))
         );
     }
 
@@ -336,7 +344,7 @@ fn run_source(
         );
     }
 
-    match vm.execute_scheduled(&result.bytecode, symbols, cctx) {
+    match vm.execute_scheduled(&result.bytecode, cctx) {
         Ok(_) => {
             // Script mode is silent except for explicit output (display, etc.)
             Ok(())

--- a/src/mlir/tests/bench.rs
+++ b/src/mlir/tests/bench.rs
@@ -103,9 +103,7 @@ fn bench_mlir() {
     let cranelift_init = start.elapsed();
 
     let start = Instant::now();
-    let _jit_code = compiler
-        .compile(&func, None, std::collections::HashMap::new(), vec![])
-        .unwrap();
+    let _jit_code = compiler.compile(&func, None, vec![]).unwrap();
     let cranelift_compile = start.elapsed();
 
     eprintln!();

--- a/src/namehash.rs
+++ b/src/namehash.rs
@@ -1,0 +1,30 @@
+//! The 64-bit name hash that gives symbols and keywords their identity.
+//!
+//! Both are immediates in the 16-byte `Value`: the payload holds this hash, so
+//! equality is `u64 == u64` — no string compare, no heap deref — and the same
+//! name yields the same payload in every table, thread, process, and build.
+//! Symbols reach it through [`crate::symbol`], keywords through
+//! [`crate::value::keyword`].
+//!
+//! Two different names on one hash is a fatal, unrecoverable condition: both
+//! registries panic rather than merge the names. See
+//! [docs/impl/symbol.md](../../docs/impl/symbol.md) § "Collisions are fatal".
+
+/// FNV-1a over the name's UTF-8 bytes.
+///
+/// `const fn` so a well-known name's hash can be a constant. Uses `while`
+/// rather than `for`: `for` desugars to `IntoIterator::into_iter`, which is not
+/// const-compatible.
+pub const fn name_hash(name: &str) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000000000001b;
+    let bytes = name.as_bytes();
+    let mut hash = FNV_OFFSET;
+    let mut i = 0;
+    while i < bytes.len() {
+        hash ^= bytes[i] as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+    hash
+}

--- a/src/pipeline/analyze.rs
+++ b/src/pipeline/analyze.rs
@@ -3,7 +3,6 @@
 use super::AnalyzeResult;
 use super::CompileCtx;
 use crate::hir::{classify_form, Analyzer, BindingArena};
-use crate::primitives::intern_primitive_names;
 use crate::reader::{read_syntax, read_syntax_all};
 use crate::symbol::SymbolTable;
 use crate::syntax::Span;
@@ -51,8 +50,6 @@ pub fn analyze_file(
     cctx: &mut CompileCtx,
     source_name: &str,
 ) -> Result<AnalyzeResult, String> {
-    intern_primitive_names(symbols);
-
     let syntaxes = read_syntax_all(source, source_name)?;
 
     let (mut expander, meta) = cctx.expander_and_meta();

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -264,18 +264,10 @@ impl CompileCtx {
 
     /// Look up or compute the signal projection for an imported file.
     ///
-    /// On a miss, compiles the file in the caller's `SymbolTable` and this
-    /// instance's context, then caches the projection from the resulting
-    /// bytecode. Returns `None` if the file's return value is not a projectable
-    /// struct (cached as `None` to avoid recompiling).
-    ///
-    /// The table is the caller's, not a fresh one, because this compile expands
-    /// macros: a transformer compiles lazily on its first expansion and caches
-    /// on the shared expander, and its quoted literals bind to whichever table
-    /// compiled it. A throwaway table here would cache transformers carrying ids
-    /// no later expansion can read (pinned by
-    /// `import_projection_probe_interns_into_the_callers_symbol_table` and
-    /// `each_keeps_its_collection_when_an_import_probe_expanded_the_macro_first`).
+    /// On a miss, compiles the file in this instance's context and caches the
+    /// projection from the resulting bytecode. Returns `None` if the file's
+    /// return value is not a projectable struct (cached as `None` to avoid
+    /// recompiling).
     pub fn get_or_compile_projection(
         &mut self,
         resolved_path: &str,
@@ -286,6 +278,12 @@ impl CompileCtx {
         }
 
         let source = std::fs::read_to_string(resolved_path).ok()?;
+        // The probe compiles in the CALLER's memo: the memo is per-instance
+        // (docs/impl/symbol.md § "The display memo"), so a throwaway table
+        // here would drop every name the module's quoted data carries, and a
+        // transformer cached on the shared expander during this compile would
+        // outlive the table it learned into. The `each` and probe tests in
+        // tests/integration/projection.rs pin both halves.
         let projection = super::compile::compile_file(&source, symbols, self, resolved_path)
             .ok()
             .and_then(|result| result.bytecode.signal_projection);
@@ -316,12 +314,9 @@ fn compile_core(
 ) {
     use crate::hir::{Analyzer, BindingArena, FileForm};
     use crate::lir::{Emitter, Lowerer};
-    use crate::primitives::intern_primitive_names;
     use crate::reader::read_syntax_all;
     use crate::syntax::Span;
     use std::rc::Rc;
-
-    intern_primitive_names(symbols);
 
     let syntaxes = read_syntax_all(CORE, "<core>").expect("core.lisp parsing must succeed");
 
@@ -382,27 +377,25 @@ fn compile_core(
     )
     .expect("core.lisp uses no monomorphic container ops, so the proof obligation holds");
 
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols, meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(meta);
     let region_info =
         crate::hir::analyze_regions_with(&hir, &arena, pc.call_classification.clone());
     if crate::config::get().trace_bits() & crate::config::trace_bits::REGIONS != 0 {
-        let names = symbols.all_names();
         eprintln!(
             "[trace:regions] cache (core.lisp):\n{}",
-            crate::hir::format_regions(&region_info, &arena, &names)
+            crate::hir::format_regions(&region_info, &arena, Some(symbols))
         );
     }
-    let symbol_names = symbols.all_names();
     let mut lowerer = Lowerer::new(&arena)
+        .with_symbols(symbols)
         .with_primitive_classification(pc)
         .with_primitive_values(prim_values)
-        .with_symbol_names(symbol_names.clone())
         .with_region_info(region_info);
     let lir_module = lowerer
         .lower(&hir)
         .expect("core.lisp lowering must succeed");
 
-    let mut emitter = Emitter::new_with_symbols(symbol_names);
+    let mut emitter = Emitter::new();
     let (bytecode, _yield_points, _call_sites) = emitter.emit_module(&lir_module);
 
     let closure_val = vm
@@ -449,11 +442,17 @@ fn compile_core(
         .as_struct()
         .expect("core.lisp must return a struct");
     for (key, value) in exports_struct.iter() {
-        if let crate::value::types::TableKey::Keyword(name) = key {
+        if let crate::value::types::TableKey::Keyword(hash) = key {
+            // The export struct was read from module source, so its key
+            // spellings are in the memo; a miss is a missed learning site.
+            let name = symbols
+                .keyword_name(*hash)
+                .map(str::to_string)
+                .unwrap_or_else(|| panic!("module export key {:#x} has no learned spelling", hash));
             // core_env: name-keyed, used by eval_syntax for macro bodies
-            expander.core_env.insert(name.to_string(), *value);
+            expander.core_env.insert(name.clone(), *value);
             // meta: SymbolId-keyed, used by compile_file for user code
-            let sym_id = symbols.intern(name);
+            let sym_id = symbols.intern(&name);
             let signal = if let Some(c) = value.as_closure() {
                 c.template.signal
             } else {

--- a/src/pipeline/compile.rs
+++ b/src/pipeline/compile.rs
@@ -4,7 +4,6 @@ use super::CompileCtx;
 use super::CompileResult;
 use crate::hir::{classify_form, Analyzer, BindingArena, FileForm};
 use crate::lir::{Emitter, Lowerer};
-use crate::primitives::intern_primitive_names;
 use crate::reader::{read_syntax, read_syntax_all_for};
 use crate::symbol::SymbolTable;
 use crate::syntax::{Span, Syntax, SyntaxKind};
@@ -59,7 +58,6 @@ fn compile_inner(
 ) -> Result<CompileResult, String> {
     // Ensure caller's SymbolTable has primitive names interned so that
     // SymbolIds match the compile context's PrimitiveMeta.
-    intern_primitive_names(symbols);
 
     // Phase 1: Parse to Syntax
     let syntax = read_syntax(source, source_name)?;
@@ -99,26 +97,24 @@ fn compile_inner(
     )?;
 
     // Phase 4: Lower to LIR with intrinsic specialization
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let region_info =
         crate::hir::analyze_regions_with(&analysis.hir, &arena, pc.call_classification.clone());
     if crate::config::get().trace_bits() & crate::config::trace_bits::REGIONS != 0 {
-        let names = symbols.all_names();
         eprintln!(
             "[trace:regions] compile:\n{}",
-            crate::hir::format_regions(&region_info, &arena, &names)
+            crate::hir::format_regions(&region_info, &arena, Some(symbols))
         );
     }
-    let symbol_names = symbols.all_names();
     let mut lowerer = Lowerer::new(&arena)
+        .with_symbols(symbols)
         .with_primitive_classification(pc)
         .with_primitive_values(prim_values)
-        .with_symbol_names(symbol_names.clone())
         .with_region_info(region_info);
     let lir_module = lowerer.lower(&analysis.hir)?;
 
     // Phase 5: Emit bytecode with symbol names for cross-thread portability
-    let mut emitter = Emitter::new_with_symbols(symbol_names);
+    let mut emitter = Emitter::new();
     let (bytecode, _yield_points, _call_sites) = emitter.emit_module(&lir_module);
 
     Ok(CompileResult { bytecode })
@@ -148,8 +144,6 @@ fn compile_file_to_lir_inner(
     source_name: &str,
     epoch_skip: usize,
 ) -> Result<crate::lir::LirModule, String> {
-    intern_primitive_names(symbols);
-
     let mut syntaxes = read_syntax_all_for(source, source_name)?;
 
     let source_epoch = crate::epoch::extract_epoch(&mut syntaxes)?;
@@ -229,46 +223,36 @@ fn compile_file_to_lir_inner(
     let (dispatch_wrappers, fn_inline) = cctx.compile_registries_mut();
     crate::hir::regularize(&mut hir, &mut arena, symbols, dispatch_wrappers, fn_inline)?;
 
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols, cctx.primitive_meta());
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(cctx.primitive_meta());
     let region_info =
         crate::hir::analyze_regions_with(&hir, &arena, pc.call_classification.clone());
     if crate::config::get().trace_bits() & crate::config::trace_bits::REGIONS != 0 {
-        let names = symbols.all_names();
         eprintln!(
             "[trace:regions] compile_file_to_lir:\n{}",
-            crate::hir::format_regions(&region_info, &arena, &names)
+            crate::hir::format_regions(&region_info, &arena, Some(symbols))
         );
     }
-    let symbol_names = symbols.all_names();
     let mut lowerer = Lowerer::new(&arena)
+        .with_symbols(symbols)
         .with_primitive_classification(pc)
         .with_primitive_values(prim_values)
-        .with_symbol_names(symbol_names)
         .with_region_info(region_info);
     lowerer.lower(&hir)
 }
 
 /// Compile a file as a single synthetic letrec.
 ///
-/// Compile to functionalized HIR (for `--dump=fhir`). Returns the HIR tree,
-/// the binding arena, and the symbol name map.
+/// Compile to functionalized HIR (for `--dump=fhir`). Returns the HIR tree
+/// and the binding arena.
 pub fn compile_file_to_fhir(
     source: &str,
     symbols: &mut SymbolTable,
     cctx: &mut CompileCtx,
     source_name: &str,
-) -> Result<
-    (
-        crate::hir::Hir,
-        BindingArena,
-        std::collections::HashMap<u32, String>,
-    ),
-    String,
-> {
+) -> Result<(crate::hir::Hir, BindingArena), String> {
     let (hir, arena, _expander, _prim_values, _signal_projection) =
         compile_file_frontend(source, symbols, cctx, source_name)?;
-    let names = symbols.all_names();
-    Ok((hir, arena, names))
+    Ok((hir, arena))
 }
 
 /// All top-level forms are analyzed together, enabling mutual recursion.
@@ -306,23 +290,21 @@ fn compile_file_inner(
 
     // Lower to LIR
     let t = std::time::Instant::now();
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols, cctx.primitive_meta());
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(cctx.primitive_meta());
     let region_info =
         crate::hir::analyze_regions_with(&hir, &arena, pc.call_classification.clone());
     crate::trace::phase(ct, "compile", &format!("{} regions", source_name), t);
     if crate::config::get().trace_bits() & crate::config::trace_bits::REGIONS != 0 {
-        let names = symbols.all_names();
         eprintln!(
             "[trace:regions] compile_file:\n{}",
-            crate::hir::format_regions(&region_info, &arena, &names)
+            crate::hir::format_regions(&region_info, &arena, Some(symbols))
         );
     }
     let t = std::time::Instant::now();
-    let symbol_names = symbols.all_names();
     let mut lowerer = Lowerer::new(&arena)
+        .with_symbols(symbols)
         .with_primitive_classification(pc)
         .with_primitive_values(prim_values)
-        .with_symbol_names(symbol_names.clone())
         .with_region_info(region_info);
 
     let lir_module = lowerer.lower(&hir)?;
@@ -331,7 +313,7 @@ fn compile_file_inner(
     // Emit bytecode
     let t = std::time::Instant::now();
     let signal = lir_module.entry.signal;
-    let mut emitter = Emitter::new_with_symbols(symbol_names);
+    let mut emitter = Emitter::new();
     let (mut bytecode, _, _) = emitter.emit_module(&lir_module);
     crate::trace::phase(ct, "compile", &format!("{} emit", source_name), t);
     bytecode.signal = signal;
@@ -396,24 +378,23 @@ fn compile_syntaxes_with_transform(
 /// and syntax entry points so they differ only in how the front end is fed.
 fn lower_test_frontend(
     frontend: Frontend,
-    symbols: &mut SymbolTable,
+    symbols: &SymbolTable,
     cctx: &mut CompileCtx,
 ) -> Result<CompileResult, String> {
     let (hir, arena, _expander, prim_values, signal_projection) = frontend;
 
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols, cctx.primitive_meta());
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(cctx.primitive_meta());
     let region_info =
         crate::hir::analyze_regions_with(&hir, &arena, pc.call_classification.clone());
-    let symbol_names = symbols.all_names();
     let mut lowerer = Lowerer::new(&arena)
+        .with_symbols(symbols)
         .with_primitive_classification(pc)
         .with_primitive_values(prim_values)
-        .with_symbol_names(symbol_names.clone())
         .with_region_info(region_info);
     let lir_module = lowerer.lower(&hir)?;
 
     let signal = lir_module.entry.signal;
-    let mut emitter = Emitter::new_with_symbols(symbol_names);
+    let mut emitter = Emitter::new();
     let (mut bytecode, _, _) = emitter.emit_module(&lir_module);
     bytecode.signal = signal;
     bytecode.signal_projection = signal_projection;

--- a/src/pipeline/compile/frontend.rs
+++ b/src/pipeline/compile/frontend.rs
@@ -92,7 +92,6 @@ fn compile_syntaxes_frontend_xform_inner(
     source_name: &str,
     xform: impl FnOnce(Vec<Syntax>, crate::syntax::ScopeId) -> Vec<Syntax>,
 ) -> FrontendResult {
-    intern_primitive_names(symbols);
     let ct = crate::trace::compile();
     let t = std::time::Instant::now();
 

--- a/src/pipeline/eval.rs
+++ b/src/pipeline/eval.rs
@@ -52,25 +52,22 @@ pub fn eval_syntax(
     drop(analyzer);
     functionalize(&mut analysis.hir, &mut arena);
     crate::hir::anf::anf_lift(&mut analysis.hir, &mut arena);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let region_info =
         crate::hir::analyze_regions_with(&analysis.hir, &arena, pc.call_classification.clone());
     if crate::config::get().trace_bits() & crate::config::trace_bits::REGIONS != 0 {
-        let names = symbols.all_names();
         eprintln!(
             "[trace:regions] eval_syntax:\n{}",
-            crate::hir::format_regions(&region_info, &arena, &names)
+            crate::hir::format_regions(&region_info, &arena, Some(symbols))
         );
     }
-    let symbol_names = symbols.all_names();
     let mut lowerer = Lowerer::new(&arena)
         .with_primitive_classification(pc)
         .with_primitive_values(prim_values)
-        .with_symbol_names(symbol_names.clone())
         .with_region_info(region_info);
     let lir_module = lowerer.lower(&analysis.hir)?;
 
-    let mut emitter = Emitter::new_with_symbols(symbol_names);
+    let mut emitter = Emitter::new();
     let (bytecode, _yield_points, _call_sites) = emitter.emit_module(&lir_module);
 
     vm.execute(&bytecode).map_err(|e| e.to_string())
@@ -119,25 +116,22 @@ pub fn eval(
     drop(analyzer);
     functionalize(&mut analysis.hir, &mut arena);
     crate::hir::anf::anf_lift(&mut analysis.hir, &mut arena);
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let region_info =
         crate::hir::analyze_regions_with(&analysis.hir, &arena, pc.call_classification.clone());
     if crate::config::get().trace_bits() & crate::config::trace_bits::REGIONS != 0 {
-        let names = symbols.all_names();
         eprintln!(
             "[trace:regions] eval:\n{}",
-            crate::hir::format_regions(&region_info, &arena, &names)
+            crate::hir::format_regions(&region_info, &arena, Some(symbols))
         );
     }
-    let symbol_names = symbols.all_names();
     let mut lowerer = Lowerer::new(&arena)
         .with_primitive_classification(pc)
         .with_primitive_values(prim_values)
-        .with_symbol_names(symbol_names.clone())
         .with_region_info(region_info);
     let lir_module = lowerer.lower(&analysis.hir)?;
 
-    let mut emitter = Emitter::new_with_symbols(symbol_names);
+    let mut emitter = Emitter::new();
     let (bytecode, _yield_points, _call_sites) = emitter.emit_module(&lir_module);
 
     vm.execute(&bytecode).map_err(|e| e.to_string())
@@ -162,7 +156,7 @@ pub fn eval_all(
     // `chan/select`) work in the test harness. `execute_scheduled` falls back
     // to a plain `execute` when `ev/run` is absent (no stdlib loaded), so
     // bare-VM callers are unaffected.
-    vm.execute_scheduled(&result.bytecode, symbols, cctx)
+    vm.execute_scheduled(&result.bytecode, cctx)
         .map_err(|e| e.to_string())
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -111,7 +111,10 @@ pub fn load_plugin(path: &str, vm: &mut VM, symbols: &mut SymbolTable) -> LResul
     let mut fields = BTreeMap::new();
     for def in &collected {
         let short_name = def.name.strip_prefix(prefix).unwrap_or(def.name);
-        fields.insert(TableKey::Keyword(short_name.into()), Value::native_fn(def));
+        fields.insert(
+            TableKey::Keyword(symbols.keyword(short_name)),
+            Value::native_fn(def),
+        );
     }
 
     // Register docs

--- a/src/plugin_api.rs
+++ b/src/plugin_api.rs
@@ -107,9 +107,11 @@ pub(crate) fn call_plugin(
     // (docs/impl/region/ctx.md "Plugins"). The capability lives on this stack
     // frame for exactly the synchronous plugin call — no ambient slot to install
     // or clear, and no way for a (future) nested plugin call to clobber it.
+    let symbols = ctx.vm().symbols_ptr;
     let mut call_ctx = CallCtx {
         region,
         heap: ctx.heap_mut(),
+        symbols,
     };
     let result = unsafe { func(&mut call_ctx, args.as_ptr(), args.len()) };
     (SignalBits::new(result.signal as u64), result.value)

--- a/src/plugin_api/capi.rs
+++ b/src/plugin_api/capi.rs
@@ -17,6 +17,10 @@ use super::*;
 pub struct CallCtx {
     pub(crate) region: crate::hir::region::RuntimeRegion,
     pub(crate) heap: *mut crate::value::fiberheap::FiberHeap,
+    /// The dispatching instance's display memo, so a plugin-minted keyword is
+    /// learned by the instance the call belongs to and a spelling accessor
+    /// reads back through the same memo. Null for a bare test ctx.
+    pub(crate) symbols: *mut crate::symbol::SymbolTable,
 }
 
 /// Run `f` with the call's heap and region, taken from the `CallCtx` the plugin
@@ -108,17 +112,25 @@ pub(super) extern "C" fn make_poll_fd(ctx: *mut CallCtx, fd: i32, events: u32) -
     })
 }
 
-// ── Keyword interning ─────────────────────────────────────────────────
+// ── Keyword identity and spelling ─────────────────────────────────────
 
+/// Pure hash — identity needs no instance, so this ABI function takes no ctx.
 pub(super) extern "C" fn intern_keyword(name_ptr: *const u8, name_len: usize) -> u64 {
     let name =
         unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(name_ptr, name_len)) };
-    crate::value::keyword::intern_keyword(name)
+    crate::value::keyword::keyword_hash(name)
 }
 
-pub(super) extern "C" fn keyword_name(hash: u64, out_len: *mut usize) -> *const u8 {
-    if let Some(name) = crate::value::keyword::keyword_name(hash) {
-        let interned = intern_str(name);
+/// Spelling recovery reads the calling instance's memo (then the static
+/// vocabulary), so it takes the per-call ctx like the constructors do.
+pub(super) extern "C" fn keyword_name(
+    ctx: *mut CallCtx,
+    hash: u64,
+    out_len: *mut usize,
+) -> *const u8 {
+    let symbols = unsafe { ctx.as_ref().and_then(|c| c.symbols.as_ref()) };
+    if let Some(name) = crate::value::keyword::resolve_keyword_name(symbols, hash) {
+        let interned = intern_str(name.to_string());
         unsafe { *out_len = interned.len() };
         interned.as_ptr()
     } else {

--- a/src/plugin_api/capi/accessors.rs
+++ b/src/plugin_api/capi/accessors.rs
@@ -122,12 +122,17 @@ pub(in crate::plugin_api) extern "C" fn is_external(val: [u64; 2]) -> bool {
 // ── Keyword access ────────────────────────────────────────────────────
 
 pub(in crate::plugin_api) extern "C" fn as_keyword_name(
+    ctx: *mut super::CallCtx,
     val: [u64; 2],
     out_len: *mut usize,
 ) -> *const u8 {
     let v = unsafe { to_value(val) };
-    if let Some(name) = v.as_keyword_name() {
-        let interned = intern_str(name);
+    let symbols = unsafe { ctx.as_ref().and_then(|c| c.symbols.as_ref()) };
+    if let Some(name) = v
+        .keyword_hash()
+        .and_then(|h| crate::value::keyword::resolve_keyword_name(symbols, h))
+    {
+        let interned = intern_str(name.to_string());
         unsafe { *out_len = interned.len() };
         interned.as_ptr()
     } else {

--- a/src/plugin_api/capi/collections.rs
+++ b/src/plugin_api/capi/collections.rs
@@ -18,7 +18,7 @@ pub(in crate::plugin_api) extern "C" fn struct_get(
     let v = unsafe { to_value(val) };
     let key_str =
         unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(key_ptr, key_len)) };
-    let key = TableKey::Keyword(key_str.into());
+    let key = TableKey::keyword(key_str);
 
     if !v.is_struct() {
         return from_value(Value::NIL);
@@ -48,6 +48,7 @@ pub(in crate::plugin_api) extern "C" fn struct_len(val: [u64; 2]) -> isize {
 }
 
 pub(in crate::plugin_api) extern "C" fn struct_key(
+    ctx: *mut super::CallCtx,
     val: [u64; 2],
     idx: usize,
     out_len: *mut usize,
@@ -65,7 +66,14 @@ pub(in crate::plugin_api) extern "C" fn struct_key(
                 }
                 let key = &data[idx].0;
                 let s = match key {
-                    TableKey::Keyword(s) | TableKey::String(s) => intern_str(s.clone()),
+                    TableKey::Keyword(hash) => {
+                        let symbols = ctx.as_ref().and_then(|c| c.symbols.as_ref());
+                        match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
+                            Some(name) => intern_str(name.to_string()),
+                            None => return std::ptr::null(),
+                        }
+                    }
+                    TableKey::String(s) => intern_str(s.clone()),
                     _ => return std::ptr::null(),
                 };
                 *out_len = s.len();

--- a/src/plugin_api/capi/constructors.rs
+++ b/src/plugin_api/capi/constructors.rs
@@ -49,8 +49,17 @@ pub(in crate::plugin_api) extern "C" fn make_bytes(
     })
 }
 
-pub(in crate::plugin_api) extern "C" fn make_keyword(ptr: *const u8, len: usize) -> [u64; 2] {
+pub(in crate::plugin_api) extern "C" fn make_keyword(
+    ctx: *mut CallCtx,
+    ptr: *const u8,
+    len: usize,
+) -> [u64; 2] {
     let name = unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(ptr, len)) };
+    // A learning site: the dispatching instance's memo records the spelling,
+    // so a plugin-minted keyword prints in the instance the call belongs to.
+    if let Some(symbols) = unsafe { ctx.as_ref().and_then(|c| c.symbols.as_mut()) } {
+        symbols.keyword(name);
+    }
     from_value(Value::keyword(name))
 }
 
@@ -89,7 +98,10 @@ pub(in crate::plugin_api) extern "C" fn make_struct(
                 std::str::from_utf8_unchecked(std::slice::from_raw_parts(kv.key, kv.key_len))
             };
             let value = unsafe { to_value(kv.value) };
-            fields.insert(TableKey::Keyword(key_str.into()), value);
+            if let Some(symbols) = unsafe { ctx.as_ref().and_then(|c| c.symbols.as_mut()) } {
+                symbols.keyword(key_str);
+            }
+            fields.insert(TableKey::keyword(key_str), value);
         }
     }
     from_value(unsafe {

--- a/src/plugin_api/capi/tests.rs
+++ b/src/plugin_api/capi/tests.rs
@@ -18,6 +18,7 @@ fn ctx_over(heap: &mut FiberHeap, region: crate::hir::region::RuntimeRegion) -> 
     CallCtx {
         region,
         heap: heap as *mut FiberHeap,
+        symbols: std::ptr::null_mut(),
     }
 }
 

--- a/src/primitives/arena.rs
+++ b/src/primitives/arena.rs
@@ -201,12 +201,9 @@ pub(crate) fn prim_arena_region_info(
             use crate::value::heap::TableKey;
             use std::collections::BTreeMap;
             let mut fields = BTreeMap::new();
-            fields.insert(TableKey::Keyword("id".to_string()), Value::int(id as i64));
-            fields.insert(TableKey::Keyword("rc".to_string()), Value::int(rc as i64));
-            fields.insert(
-                TableKey::Keyword("objects".to_string()),
-                Value::int(objects as i64),
-            );
+            fields.insert(TableKey::keyword("id"), Value::int(id as i64));
+            fields.insert(TableKey::keyword("rc"), Value::int(rc as i64));
+            fields.insert(TableKey::keyword("objects"), Value::int(objects as i64));
             ctx.struct_from(fields)
         })
         .collect();

--- a/src/primitives/bytes.rs
+++ b/src/primitives/bytes.rs
@@ -37,7 +37,7 @@ pub(crate) fn prim_bytes(
         if let Some(data) = args[0].with_string(|s| s.as_bytes().to_vec()) {
             return (SIG_OK, ctx.bytes(data));
         }
-        if let Some(name) = args[0].as_keyword_name() {
+        if let Some(name) = ctx.keyword_spelling(args[0]) {
             return (SIG_OK, ctx.bytes(name.as_bytes().to_vec()));
         }
     }
@@ -101,7 +101,7 @@ pub(crate) fn prim_bytes_mut(
         if let Some(data) = args[0].with_string(|s| s.as_bytes().to_vec()) {
             return (SIG_OK, ctx.bytes_mut(data));
         }
-        if let Some(name) = args[0].as_keyword_name() {
+        if let Some(name) = ctx.keyword_spelling(args[0]) {
             return (SIG_OK, ctx.bytes_mut(name.as_bytes().to_vec()));
         }
     }

--- a/src/primitives/collection.rs
+++ b/src/primitives/collection.rs
@@ -117,19 +117,15 @@ pub fn coll_len(val: &Value, ctx: &mut NativeCtx) -> Result<usize, Value> {
         return Ok(t.borrow().len());
     }
     if let Some(sid) = val.as_symbol() {
-        let name = ctx
-            .vm()
-            .symbols()
-            .and_then(|s| s.name(crate::value::SymbolId(sid)).map(|n| n.to_string()));
-        if let Some(name) = name {
-            return Ok(crate::segment::grapheme_count(&name, gen));
+        if let Some(name) = ctx.vm().symbols().and_then(|s| s.name(sid)) {
+            return Ok(crate::segment::grapheme_count(name, gen));
         }
         return Err(ctx.error(
             "internal-error",
             format!("unable to resolve symbol name for id {:?}", sid),
         ));
     }
-    if let Some(name) = val.as_keyword_name() {
+    if let Some(name) = ctx.keyword_spelling(*val) {
         return Ok(crate::segment::grapheme_count(&name, gen));
     }
     if let Some(syntax) = val.as_syntax() {

--- a/src/primitives/compile/mod.rs
+++ b/src/primitives/compile/mod.rs
@@ -59,7 +59,7 @@ pub(crate) use callgraph::*;
 // ── Helper ─────────────────────────────────────────────────────────────
 
 pub(super) fn kw(name: &str) -> TableKey {
-    TableKey::Keyword(name.to_string())
+    TableKey::keyword(name)
 }
 
 // ── Analysis handle ────────────────────────────────────────────────────
@@ -147,7 +147,7 @@ pub(super) fn resolve_name(
     ctx: &mut NativeCtx,
 ) -> Result<String, (SignalBits, Value)> {
     // Accept keyword or string.
-    if let Some(name) = args[idx].as_keyword_name() {
+    if let Some(name) = ctx.keyword_spelling(args[idx]) {
         return Ok(name.to_string());
     }
     if let Some(name) = args[idx].with_string(|s| s.to_string()) {

--- a/src/primitives/compile/transform.rs
+++ b/src/primitives/compile/transform.rs
@@ -232,7 +232,7 @@ pub(super) fn prim_compile_run_on(
     args: &[Value],
 ) -> (SignalBits, Value) {
     // Cheap front-end validation — full type checks happen in the dispatch handler.
-    if args[0].as_keyword_name().is_none() {
+    if !args[0].is_keyword() {
         return (
             SIG_ERROR,
             ctx.error(

--- a/src/primitives/compile/transform/rewrite.rs
+++ b/src/primitives/compile/transform/rewrite.rs
@@ -23,7 +23,7 @@ pub(crate) fn prim_compile_extract(
     };
 
     let from_name = match sorted_struct_get(opts, &kw("from")).and_then(|v| {
-        v.as_keyword_name()
+        ctx.keyword_spelling(*v)
             .map(|s| s.to_string())
             .or_else(|| v.with_string(|s| s.to_string()))
     }) {
@@ -52,7 +52,7 @@ pub(crate) fn prim_compile_extract(
         };
 
     let new_fn_name = match sorted_struct_get(opts, &kw("name")).and_then(|v| {
-        v.as_keyword_name()
+        ctx.keyword_spelling(*v)
             .map(|s| s.to_string())
             .or_else(|| v.with_string(|s| s.to_string()))
     }) {
@@ -192,9 +192,8 @@ pub(crate) fn prim_compile_parallelize(
         Some(arr) => {
             let mut names = Vec::new();
             for v in arr {
-                match v
-                    .as_keyword_name()
-                    .map(|s| s.to_string())
+                match ctx
+                    .keyword_spelling(*v)
                     .or_else(|| v.with_string(|s| s.to_string()))
                 {
                     Some(n) => names.push(n),

--- a/src/primitives/concurrency.rs
+++ b/src/primitives/concurrency.rs
@@ -90,17 +90,14 @@ fn spawn_closure_impl(
 
     // Serialize the closure (validates sendability recursively). The temporary
     // closure Value is born in the caller's region; `from_value` deep-copies it
-    // (resolving symbol ids to names via the sender's table) and the temporary is
-    // dropped.
+    // and the temporary is dropped. The spawning instance's memo names the
+    // symbols in the bundle so the worker can print them.
     let closure_val = ctx.closure(closure.clone());
-    let bundle = {
-        let symbols = match ctx.vm().symbols() {
-            Some(s) => s,
-            None => return Err(LError::generic("spawn: no symbol table".to_string())),
-        };
-        SendBundle::from_value(closure_val, ctx.heap_mut(), symbols)
-            .map_err(|e| LError::generic(format!("spawn: {}", e)))?
-    };
+    let sender_symbols = ctx.vm().symbols_ptr;
+    let bundle = SendBundle::from_value(closure_val, ctx.heap_mut(), unsafe {
+        sender_symbols.as_ref()
+    })
+    .map_err(|e| LError::generic(format!("spawn: {}", e)))?;
 
     let result_holder: Arc<Mutex<Option<Result<SendBundle, String>>>> = Arc::new(Mutex::new(None));
     let result_clone = result_holder.clone();
@@ -253,7 +250,7 @@ fn spawn_closure_impl(
                 let closure_val = {
                     let mut recv_ctx =
                         crate::primitives::ctx::Alloc::with_region(recv_region, vm.heap());
-                    bundle.into_value(&mut recv_ctx, &mut symbols)
+                    bundle.into_value(&mut recv_ctx, Some(&mut symbols))
                 };
                 let closure = closure_val
                     .as_closure()
@@ -315,7 +312,7 @@ fn spawn_closure_impl(
                 let result = vm.execute_code(closure.template.code(), Some(&env_rc));
 
                 let send_result = match result {
-                    Ok(val) => SendBundle::from_value(val, vm.heap(), &symbols)
+                    Ok(val) => SendBundle::from_value(val, vm.heap(), Some(&symbols))
                         .map_err(|e| format!("Failed to serialize result: {}", e)),
                     Err(e) => Err(e.to_string()),
                 };
@@ -445,21 +442,13 @@ pub(crate) fn prim_thread_state(
             if let Some(result) = holder.as_ref() {
                 return match result {
                     Ok(bundle) => {
-                        // Reconstruct into the caller's region (`ctx`), re-interning
-                        // symbol names into this instance's table (raw deref so the
-                        // table borrow is independent of the `&mut Alloc` borrow).
-                        let symbols_ptr = ctx.vm().symbols_ptr;
-                        if symbols_ptr.is_null() {
-                            return (
-                                SIG_ERROR,
-                                ctx.error("internal-error", "thread-state: no symbol table"),
-                            );
-                        }
-                        let value = {
-                            let symbols = unsafe { &mut *symbols_ptr };
-                            // `ctx` deref-coerces `&mut NativeCtx` → `&mut Alloc`.
-                            bundle.clone().into_value(ctx, symbols)
-                        };
+                        // Reconstruct into the caller's region (`ctx`).
+                        // `ctx` deref-coerces `&mut NativeCtx` → `&mut Alloc`.
+                        // The joiner's memo learns the worker's symbol names.
+                        let joiner_symbols = ctx.vm().symbols_ptr;
+                        let value = bundle
+                            .clone()
+                            .into_value(ctx, unsafe { joiner_symbols.as_mut() });
                         (SIG_OK, ctx.array(vec![Value::keyword("ready"), value]))
                     }
                     Err(e) => {
@@ -482,6 +471,25 @@ pub(crate) fn prim_thread_state(
             ),
         )
     }
+}
+
+/// The counter behind `sys/unique`. Process-global on purpose: uniqueness must
+/// hold across every instance and module in the process, because consumers key
+/// process-global tables with it (the scheduler's futex park queues).
+static UNIQUE_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// `(sys/unique)` — a fresh integer, unique across the whole process.
+///
+/// The identity-only alternative to `gensym`: a coordination key (a futex key,
+/// a correlation id) needs uniqueness and hashability, not a name, and an
+/// integer interns nothing into the symbol table.
+/// `tests/elle/sync-keys.lisp` pins that property for the sync constructors.
+pub(crate) fn prim_unique(
+    _ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
+    _args: &[Value],
+) -> (SignalBits, Value) {
+    let n = UNIQUE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    (SIG_OK, Value::int(n as i64))
 }
 
 /// Returns the ID of the current thread
@@ -540,6 +548,15 @@ primitive! {
         category: "sys",
         example: "(sys/thread-id)",
         aliases: &["current-thread-id", "os/thread-id"],
+        effect: RegionEffect::Immediate,
+    }
+    "sys/unique" => prim_unique {
+        signal: Signal::silent(),
+        arity: Arity::Exact(0),
+        doc: "Return a fresh integer, unique across the whole process. A coordination key (futex key, correlation id) that, unlike a gensym, interns nothing.",
+        category: "sys",
+        example: "(sys/unique)",
+        aliases: &[],
         effect: RegionEffect::Immediate,
     }
 }

--- a/src/primitives/config.rs
+++ b/src/primitives/config.rs
@@ -70,10 +70,7 @@ pub(crate) fn prim_backend_q(
     args: &[Value],
 ) -> (SignalBits, Value) {
     let active = ctx.vm().active_tier;
-    let matches = match args[0].as_keyword_name() {
-        Some(k) => k == active,
-        None => false,
-    };
+    let matches = args[0].is_keyword_named(active);
     (SIG_OK, Value::bool(matches))
 }
 

--- a/src/primitives/convert/numeric.rs
+++ b/src/primitives/convert/numeric.rs
@@ -52,7 +52,7 @@ pub(crate) fn prim_parse_int(
     if let Some(result) = args[0].with_string(|s| parse_int(ctx, s, radix)) {
         return result;
     }
-    if let Some(name) = args[0].as_keyword_name() {
+    if let Some(name) = ctx.keyword_spelling(args[0]) {
         return parse_int(ctx, &name, radix);
     }
     type_error!(ctx, args[0], "parse-int", "string or keyword")
@@ -98,7 +98,7 @@ pub(crate) fn prim_parse_float(
     if let Some(result) = args[0].with_string(|s| parse_float(ctx, s)) {
         return result;
     }
-    if let Some(name) = args[0].as_keyword_name() {
+    if let Some(name) = ctx.keyword_spelling(args[0]) {
         return parse_float(ctx, &name);
     }
     type_error!(ctx, args[0], "parse-float", "string or keyword")

--- a/src/primitives/convert/tostring.rs
+++ b/src/primitives/convert/tostring.rs
@@ -72,15 +72,19 @@ fn write_value_to_string(
         out.push_str("nil");
         return Ok(());
     }
-    if let Some(name) = val.as_keyword_name() {
+    if let Some(name) = ctx.keyword_spelling(val) {
         out.push_str(&name);
         return Ok(());
     }
     if let Some(sym_id) = val.as_symbol() {
-        let name = ctx.vm().symbols().and_then(|s| {
-            s.name(crate::value::SymbolId(sym_id))
-                .map(|n| n.to_string())
-        });
+        // Copied out of the memo before `ctx` is touched again: `symbols()`
+        // hands back a borrow into the instance's map, and `ctx.error` below
+        // reborrows the same ctx.
+        let name = ctx
+            .vm()
+            .symbols()
+            .and_then(|s| s.name(sym_id))
+            .map(str::to_string);
         match name {
             Some(name) => out.push_str(&name),
             None => {
@@ -88,7 +92,7 @@ fn write_value_to_string(
                     SIG_ERROR,
                     ctx.error(
                         "internal-error",
-                        format!("to-string: symbol ID {} not found in symbol table", sym_id),
+                        format!("to-string: symbol ID {} has no recorded name", sym_id),
                     ),
                 ))
             }
@@ -196,23 +200,24 @@ fn prim_to_string_single(
     }
 
     if let Some(sym_id) = val.as_symbol() {
-        let name = ctx.vm().symbols().and_then(|s| {
-            s.name(crate::value::SymbolId(sym_id))
-                .map(|n| n.to_string())
-        });
+        let name = ctx
+            .vm()
+            .symbols()
+            .and_then(|s| s.name(sym_id))
+            .map(str::to_string);
         return match name {
-            Some(name) => (SIG_OK, ctx.string(name)),
+            Some(name) => (SIG_OK, ctx.string(&name)),
             None => (
                 SIG_ERROR,
                 ctx.error(
                     "internal-error",
-                    format!("to-string: symbol ID {} not found in symbol table", sym_id),
+                    format!("to-string: symbol ID {} has no recorded name", sym_id),
                 ),
             ),
         };
     }
 
-    if let Some(name) = val.as_keyword_name() {
+    if let Some(name) = ctx.keyword_spelling(val) {
         return (SIG_OK, ctx.string(name));
     }
 
@@ -305,8 +310,12 @@ fn prim_to_string_single(
         return (SIG_OK, ctx.string(vec_str));
     }
 
-    // For other types, use a reasonable debug representation — through this
-    // instance's symbol table so nested symbols still resolve to names.
-    let repr = format!("{}", val.debug_with(ctx.vm().symbols().as_deref()));
+    // For other types, render Debug-style through the instance memo, so
+    // nested symbol and keyword spellings resolve (docs/impl/symbol.md
+    // § "Reading a name, and not reading one").
+    let repr = {
+        let symbols = unsafe { ctx.vm().symbols_ptr.as_ref() };
+        format!("{}", val.debug_with(symbols))
+    };
     (SIG_OK, ctx.string(repr))
 }

--- a/src/primitives/ctx.rs
+++ b/src/primitives/ctx.rs
@@ -210,6 +210,25 @@ impl<'h> NativeCtx<'h> {
         unsafe { &mut *self.vm }
     }
 
+    /// The spelling of a keyword value, through this instance's memo and the
+    /// static vocabulary. `None` if `v` is not a keyword or the spelling was
+    /// never learned (docs/impl/symbol.md § "The display memo").
+    pub fn keyword_spelling(&self, v: crate::value::Value) -> Option<String> {
+        let hash = v.keyword_hash()?;
+        let symbols = unsafe { self.vm().symbols_ptr.as_ref() };
+        crate::value::keyword::resolve_keyword_name(symbols, hash).map(str::to_string)
+    }
+
+    /// Learn `name` into this instance's memo and build the keyword value —
+    /// the mint path for a spelling that exists only at run time (a string
+    /// conversion, a parsed JSON key).
+    pub fn keyword(&mut self, name: &str) -> crate::value::Value {
+        if let Some(symbols) = unsafe { self.vm().symbols_ptr.as_mut() } {
+            symbols.keyword(name);
+        }
+        crate::value::Value::keyword(name)
+    }
+
     /// The VM's Unicode segmentation generation, for grapheme operations.
     #[inline]
     pub fn unicode_generation(&self) -> crate::segment::Generation {

--- a/src/primitives/ctx/tests.rs
+++ b/src/primitives/ctx/tests.rs
@@ -58,7 +58,7 @@ fn rich_error_string_field_shares_the_error_region() {
         let fields = err.as_struct().expect("error is a struct");
         let path_val = crate::value::types::sorted_struct_get(
             fields,
-            &crate::value::heap::TableKey::Keyword("path".into()),
+            &crate::value::heap::TableKey::keyword("path"),
         )
         .copied()
         .expect(":path field present");

--- a/src/primitives/debug.rs
+++ b/src/primitives/debug.rs
@@ -37,11 +37,9 @@ pub(crate) fn prim_trace(
         let name = ctx
             .vm()
             .symbols()
-            .and_then(|s| {
-                s.name(crate::value::SymbolId(sym_id))
-                    .map(|n| n.to_string())
-            })
-            .unwrap_or_else(|| format!("#<sym:{}>", sym_id));
+            .and_then(|s| s.name(sym_id))
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| format!("#<symbol:{:#x}>", sym_id.0));
         eprintln!("[TRACE] {}: {:?}", name, args[1]);
         (SIG_OK, args[1])
     } else {
@@ -178,25 +176,15 @@ fn get_memory_usage() -> (u64, u64) {
     (0, 0)
 }
 
-/// Returns the number of interned symbols in the VM's symbol table
-/// (via `ctx.vm().symbols()`).
+/// Returns the number of distinct spellings this instance's memo has
+/// recorded, across both vocabularies (docs/impl/symbol.md).
 /// (debug/symbol-count)
 pub(crate) fn prim_symbol_count(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     _args: &[Value],
 ) -> (SignalBits, Value) {
-    let count = ctx.vm().symbols().map_or(0, |s| s.len());
-    (SIG_OK, Value::int(count as i64))
-}
-
-/// Returns the number of registered keywords in the global name table.
-/// (debug/keyword-count)
-pub(crate) fn prim_keyword_count(
-    _ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
-    _args: &[Value],
-) -> (SignalBits, Value) {
-    let count = crate::value::keyword::keyword_count();
-    (SIG_OK, Value::int(count as i64))
+    let n = ctx.vm().symbols().map_or(0, |s| s.len());
+    (SIG_OK, Value::int(n as i64))
 }
 
 // Declarative primitive definitions for debug operations.
@@ -232,12 +220,6 @@ primitive! {
         doc: "Returns the number of interned symbols in the symbol table",
         category: "debug",
         example: "(debug/symbol-count)",
-        effect: RegionEffect::Immediate,
-    }
-    "debug/keyword-count" => prim_keyword_count {
-        doc: "Returns the number of registered keywords in the global name table",
-        category: "debug",
-        example: "(debug/keyword-count)",
         effect: RegionEffect::Immediate,
     }
 }

--- a/src/primitives/disassembly.rs
+++ b/src/primitives/disassembly.rs
@@ -116,7 +116,7 @@ fn flow_from_closure(
 
     // :name
     fields.insert(
-        TableKey::Keyword("name".to_string()),
+        TableKey::keyword("name"),
         match &lir.name {
             Some(n) => ctx.string(n.as_str()),
             None => Value::NIL,
@@ -125,7 +125,7 @@ fn flow_from_closure(
 
     // :doc
     fields.insert(
-        TableKey::Keyword("doc".to_string()),
+        TableKey::keyword("doc"),
         closure
             .template
             .doc
@@ -136,27 +136,21 @@ fn flow_from_closure(
 
     // :arity — use Display impl: "2", "1+", "2-4"
     fields.insert(
-        TableKey::Keyword("arity".to_string()),
+        TableKey::keyword("arity"),
         ctx.string(format!("{}", lir.arity)),
     );
 
     // :regs
-    fields.insert(
-        TableKey::Keyword("regs".to_string()),
-        Value::int(lir.num_regs as i64),
-    );
+    fields.insert(TableKey::keyword("regs"), Value::int(lir.num_regs as i64));
 
     // :locals
     fields.insert(
-        TableKey::Keyword("locals".to_string()),
+        TableKey::keyword("locals"),
         Value::int(lir.num_locals as i64),
     );
 
     // :entry
-    fields.insert(
-        TableKey::Keyword("entry".to_string()),
-        Value::int(lir.entry.0 as i64),
-    );
+    fields.insert(TableKey::keyword("entry"), Value::int(lir.entry.0 as i64));
 
     // :blocks — array of block structs
     let blocks: Vec<Value> = lir
@@ -166,10 +160,7 @@ fn flow_from_closure(
             let mut block_fields = BTreeMap::new();
 
             // :label
-            block_fields.insert(
-                TableKey::Keyword("label".to_string()),
-                Value::int(block.label.0 as i64),
-            );
+            block_fields.insert(TableKey::keyword("label"), Value::int(block.label.0 as i64));
 
             // :instrs — array of Debug-formatted instruction strings
             let instrs: Vec<Value> = block
@@ -177,7 +168,7 @@ fn flow_from_closure(
                 .iter()
                 .map(|si| ctx.string(format!("{:?}", si.instr)))
                 .collect();
-            block_fields.insert(TableKey::Keyword("instrs".to_string()), ctx.array(instrs));
+            block_fields.insert(TableKey::keyword("instrs"), ctx.array(instrs));
 
             // :display — array of compact human-readable instruction strings
             let display: Vec<Value> = block
@@ -185,7 +176,7 @@ fn flow_from_closure(
                 .iter()
                 .map(|si| ctx.string(format!("{}", si.instr)))
                 .collect();
-            block_fields.insert(TableKey::Keyword("display".to_string()), ctx.array(display));
+            block_fields.insert(TableKey::keyword("display"), ctx.array(display));
 
             // :spans — array of "line:col" strings (nil for synthetic spans)
             let spans: Vec<Value> = block
@@ -199,7 +190,7 @@ fn flow_from_closure(
                     }
                 })
                 .collect();
-            block_fields.insert(TableKey::Keyword("spans".to_string()), ctx.array(spans));
+            block_fields.insert(TableKey::keyword("spans"), ctx.array(spans));
 
             // :annotated — display strings with span annotations for CFG rendering
             let annotated: Vec<Value> = block
@@ -214,20 +205,17 @@ fn flow_from_closure(
                     }
                 })
                 .collect();
-            block_fields.insert(
-                TableKey::Keyword("annotated".to_string()),
-                ctx.array(annotated),
-            );
+            block_fields.insert(TableKey::keyword("annotated"), ctx.array(annotated));
 
             // :term — Debug-formatted terminator string
             block_fields.insert(
-                TableKey::Keyword("term".to_string()),
+                TableKey::keyword("term"),
                 ctx.string(format!("{:?}", block.terminator.terminator)),
             );
 
             // :term-display — compact terminator string
             block_fields.insert(
-                TableKey::Keyword("term-display".to_string()),
+                TableKey::keyword("term-display"),
                 ctx.string(format!("{}", block.terminator.terminator)),
             );
 
@@ -240,11 +228,11 @@ fn flow_from_closure(
                     block.terminator.span.line, block.terminator.span.col
                 ))
             };
-            block_fields.insert(TableKey::Keyword("term-span".to_string()), term_span);
+            block_fields.insert(TableKey::keyword("term-span"), term_span);
 
             // :term-kind — keyword identifying the terminator type
             block_fields.insert(
-                TableKey::Keyword("term-kind".to_string()),
+                TableKey::keyword("term-kind"),
                 Value::keyword(terminator_kind(&block.terminator.terminator)),
             );
 
@@ -266,13 +254,13 @@ fn flow_from_closure(
                     vec![Value::int(resume_label.0 as i64)]
                 }
             };
-            block_fields.insert(TableKey::Keyword("edges".to_string()), ctx.array(edges));
+            block_fields.insert(TableKey::keyword("edges"), ctx.array(edges));
 
             ctx.struct_from(block_fields)
         })
         .collect();
 
-    fields.insert(TableKey::Keyword("blocks".to_string()), ctx.array(blocks));
+    fields.insert(TableKey::keyword("blocks"), ctx.array(blocks));
 
     (SIG_OK, ctx.struct_from(fields))
 }

--- a/src/primitives/display.rs
+++ b/src/primitives/display.rs
@@ -4,7 +4,7 @@ use crate::value::types::Arity;
 use crate::value::Value;
 
 /// Generate a flat single-line representation of a value
-fn flat_repr(val: Value, depth: usize) -> String {
+fn flat_repr(val: Value, symbols: Option<&crate::symbol::SymbolTable>, depth: usize) -> String {
     // Depth limit to prevent infinite recursion on circular structures
     if depth > 10 {
         return "...".to_string();
@@ -42,12 +42,9 @@ fn flat_repr(val: Value, depth: usize) -> String {
         return r;
     }
 
-    if let Some(_id) = val.as_symbol() {
-        return val.to_string();
-    }
-
-    if val.as_keyword_name().is_some() {
-        return val.to_string();
+    if val.as_symbol().is_some() || val.is_keyword() {
+        // Render through the memo so spellings resolve.
+        return format!("{}", val.display_with(symbols));
     }
 
     // Lists
@@ -55,11 +52,11 @@ fn flat_repr(val: Value, depth: usize) -> String {
         let mut parts = Vec::new();
         let mut current = val;
         while let Some(pair) = current.as_pair() {
-            parts.push(flat_repr(pair.first, depth + 1));
+            parts.push(flat_repr(pair.first, symbols, depth + 1));
             current = pair.rest;
         }
         if !current.is_empty_list() && !current.is_nil() {
-            parts.push(format!(". {}", flat_repr(current, depth + 1)));
+            parts.push(format!(". {}", flat_repr(current, symbols, depth + 1)));
         }
         return format!("({})", parts.join(" "));
     }
@@ -67,7 +64,10 @@ fn flat_repr(val: Value, depth: usize) -> String {
     // @array (mutable)
     if let Some(vec_ref) = val.as_array_mut() {
         let vec = vec_ref.borrow();
-        let parts: Vec<String> = vec.iter().map(|v| flat_repr(*v, depth + 1)).collect();
+        let parts: Vec<String> = vec
+            .iter()
+            .map(|v| flat_repr(*v, symbols, depth + 1))
+            .collect();
         return format!("@[{}]", parts.join(" "));
     }
 
@@ -76,7 +76,11 @@ fn flat_repr(val: Value, depth: usize) -> String {
         let table = table_ref.borrow();
         let mut parts = Vec::new();
         for (k, v) in table.iter() {
-            parts.push(format!("{:?} {}", k, flat_repr(*v, depth + 1)));
+            parts.push(format!(
+                "{} {}",
+                crate::value::types::TableKeyDisplay(k, symbols),
+                flat_repr(*v, symbols, depth + 1)
+            ));
         }
         return format!("@{{{}}}", parts.join(" "));
     }
@@ -85,7 +89,11 @@ fn flat_repr(val: Value, depth: usize) -> String {
     if let Some(struct_map) = val.as_struct() {
         let mut parts = Vec::new();
         for (k, v) in struct_map.iter() {
-            parts.push(format!("{:?} {}", k, flat_repr(*v, depth + 1)));
+            parts.push(format!(
+                "{} {}",
+                crate::value::types::TableKeyDisplay(k, symbols),
+                flat_repr(*v, symbols, depth + 1)
+            ));
         }
         return format!("{{{}}}", parts.join(" "));
     }
@@ -110,7 +118,13 @@ fn flat_repr(val: Value, depth: usize) -> String {
 }
 
 /// Pretty-print a value with width-aware line breaking
-fn pretty_print_impl(val: Value, indent: usize, remaining_width: usize, depth: usize) -> String {
+fn pretty_print_impl(
+    val: Value,
+    symbols: Option<&crate::symbol::SymbolTable>,
+    indent: usize,
+    remaining_width: usize,
+    depth: usize,
+) -> String {
     const DEFAULT_WIDTH: usize = 80;
 
     // Depth limit
@@ -119,7 +133,7 @@ fn pretty_print_impl(val: Value, indent: usize, remaining_width: usize, depth: u
     }
 
     // Get flat representation
-    let flat = flat_repr(val, depth);
+    let flat = flat_repr(val, symbols, depth);
 
     // If it fits on one line, use it
     if flat.len() <= remaining_width {
@@ -137,7 +151,7 @@ fn pretty_print_impl(val: Value, indent: usize, remaining_width: usize, depth: u
         || val.as_int().is_some()
         || val.as_float().is_some()
         || val.as_symbol().is_some()
-        || val.as_keyword_name().is_some()
+        || val.is_keyword()
         || val.is_closure()
         || val.as_fiber().is_some()
         || val.as_native_fn().is_some()
@@ -159,6 +173,7 @@ fn pretty_print_impl(val: Value, indent: usize, remaining_width: usize, depth: u
         while let Some(pair) = current.as_pair() {
             let part = pretty_print_impl(
                 pair.first,
+                symbols,
                 next_indent,
                 DEFAULT_WIDTH - next_indent,
                 depth + 1,
@@ -173,8 +188,13 @@ fn pretty_print_impl(val: Value, indent: usize, remaining_width: usize, depth: u
         }
 
         if !current.is_empty_list() && !current.is_nil() {
-            let tail =
-                pretty_print_impl(current, next_indent, DEFAULT_WIDTH - next_indent, depth + 1);
+            let tail = pretty_print_impl(
+                current,
+                symbols,
+                next_indent,
+                DEFAULT_WIDTH - next_indent,
+                depth + 1,
+            );
             parts.push(format!("{}. {}", next_indent_str, tail));
         }
 
@@ -189,7 +209,13 @@ fn pretty_print_impl(val: Value, indent: usize, remaining_width: usize, depth: u
         }
         let mut parts = Vec::new();
         for v in vec.iter() {
-            let part = pretty_print_impl(*v, next_indent, DEFAULT_WIDTH - next_indent, depth + 1);
+            let part = pretty_print_impl(
+                *v,
+                symbols,
+                next_indent,
+                DEFAULT_WIDTH - next_indent,
+                depth + 1,
+            );
             parts.push(format!("{}{}", next_indent_str, part));
         }
         return format!("@[\n{}]", parts.join("\n"));
@@ -203,8 +229,19 @@ fn pretty_print_impl(val: Value, indent: usize, remaining_width: usize, depth: u
         }
         let mut parts = Vec::new();
         for (k, v) in table.iter() {
-            let v_str = pretty_print_impl(*v, next_indent, DEFAULT_WIDTH - next_indent, depth + 1);
-            parts.push(format!("{}{:?} {}", next_indent_str, k, v_str));
+            let v_str = pretty_print_impl(
+                *v,
+                symbols,
+                next_indent,
+                DEFAULT_WIDTH - next_indent,
+                depth + 1,
+            );
+            parts.push(format!(
+                "{}{} {}",
+                next_indent_str,
+                crate::value::types::TableKeyDisplay(k, symbols),
+                v_str
+            ));
         }
         return format!("@{{\n{}}}", parts.join("\n"));
     }
@@ -216,8 +253,19 @@ fn pretty_print_impl(val: Value, indent: usize, remaining_width: usize, depth: u
         }
         let mut parts = Vec::new();
         for (k, v) in struct_map.iter() {
-            let v_str = pretty_print_impl(*v, next_indent, DEFAULT_WIDTH - next_indent, depth + 1);
-            parts.push(format!("{}{:?} {}", next_indent_str, k, v_str));
+            let v_str = pretty_print_impl(
+                *v,
+                symbols,
+                next_indent,
+                DEFAULT_WIDTH - next_indent,
+                depth + 1,
+            );
+            parts.push(format!(
+                "{}{} {}",
+                next_indent_str,
+                crate::value::types::TableKeyDisplay(k, symbols),
+                v_str
+            ));
         }
         return format!("{{\n{}}}", parts.join("\n"));
     }
@@ -228,13 +276,14 @@ fn pretty_print_impl(val: Value, indent: usize, remaining_width: usize, depth: u
 
 /// (pp value) — Pretty-print a value with indentation, returns the value
 pub(crate) fn prim_pp(
-    _ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
+    ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
 ) -> (SignalBits, Value) {
     let val = args[0];
 
     const DEFAULT_WIDTH: usize = 80;
-    let output = pretty_print_impl(val, 0, DEFAULT_WIDTH, 0);
+    let symbols = unsafe { ctx.vm().symbols_ptr.as_ref() };
+    let output = pretty_print_impl(val, symbols, 0, DEFAULT_WIDTH, 0);
     println!("{}", output);
 
     (SIG_OK, val)
@@ -293,11 +342,15 @@ pub(crate) fn prim_describe(
         );
     }
 
-    if let Some(_id) = val.as_symbol() {
-        return (SIG_OK, ctx.string(format!("<symbol {}>", val)));
+    if val.as_symbol().is_some() {
+        let symbols = unsafe { ctx.vm().symbols_ptr.as_ref() };
+        return (
+            SIG_OK,
+            ctx.string(format!("<symbol {}>", val.display_with(symbols))),
+        );
     }
 
-    if let Some(name) = val.as_keyword_name() {
+    if let Some(name) = ctx.keyword_spelling(val) {
         return (SIG_OK, ctx.string(format!("<keyword :{}>", name)));
     }
 

--- a/src/primitives/ffi.rs
+++ b/src/primitives/ffi.rs
@@ -17,7 +17,7 @@ pub(crate) fn resolve_type_desc(
     ctx: &mut NativeCtx,
 ) -> Result<TypeDesc, (SignalBits, Value)> {
     // First try keyword
-    if let Some(name) = value.as_keyword_name() {
+    if let Some(name) = ctx.keyword_spelling(*value) {
         return TypeDesc::from_keyword(&name).ok_or_else(|| {
             (
                 SIG_ERROR,

--- a/src/primitives/fibers.rs
+++ b/src/primitives/fibers.rs
@@ -53,7 +53,7 @@ pub(crate) fn prim_fiber_new(
     let mut deny_bits = SignalBits::EMPTY;
     let mut i = 2;
     while i < args.len() {
-        if args[i].as_keyword_name().as_deref() == Some("deny") {
+        if args[i].is_keyword_named("deny") {
             if i + 1 >= args.len() {
                 return (
                     SIG_ERROR,
@@ -72,8 +72,7 @@ pub(crate) fn prim_fiber_new(
                     "argument-error",
                     format!(
                         "fiber/new: unexpected keyword argument :{}",
-                        args[i]
-                            .as_keyword_name()
+                        ctx.keyword_spelling(args[i])
                             .unwrap_or_else(|| args[i].type_name().to_string())
                     ),
                 ),

--- a/src/primitives/fibers/resolve.rs
+++ b/src/primitives/fibers/resolve.rs
@@ -23,7 +23,7 @@ fn resolve_keyword_slice(
     let reg = crate::signals::registry::global_registry().lock().unwrap();
     let mut bits = SignalBits::EMPTY;
     for elem in elems {
-        let name = elem.as_keyword_name().ok_or_else(|| {
+        let name = ctx.keyword_spelling(*elem).ok_or_else(|| {
             (
                 SIG_ERROR,
                 ctx.error(
@@ -69,7 +69,7 @@ pub(crate) fn resolve_signal_bits(
     }
 
     // 2. Single keyword
-    if let Some(name) = val.as_keyword_name() {
+    if let Some(name) = ctx.keyword_spelling(*val) {
         let reg = crate::signals::registry::global_registry().lock().unwrap();
         return match reg.to_signal_bits(&name) {
             Some(bits) => Ok(bits),
@@ -88,7 +88,7 @@ pub(crate) fn resolve_signal_bits(
         let reg = crate::signals::registry::global_registry().lock().unwrap();
         let mut bits = SignalBits::EMPTY;
         for elem in set.iter() {
-            let name = elem.as_keyword_name().ok_or_else(|| {
+            let name = ctx.keyword_spelling(*elem).ok_or_else(|| {
                 (
                     SIG_ERROR,
                     ctx.error(
@@ -132,7 +132,7 @@ pub(crate) fn resolve_signal_bits(
         let mut bits = SignalBits::EMPTY;
         let mut current = *val;
         while let Some(pair) = current.as_pair() {
-            let name = pair.first.as_keyword_name().ok_or_else(|| {
+            let name = ctx.keyword_spelling(pair.first).ok_or_else(|| {
                 (
                     SIG_ERROR,
                     ctx.error(

--- a/src/primitives/fileio/manage.rs
+++ b/src/primitives/fileio/manage.rs
@@ -252,7 +252,7 @@ pub(crate) fn prim_file_size(
 }
 
 pub(super) fn kw(name: &str) -> TableKey {
-    TableKey::Keyword(name.to_string())
+    TableKey::keyword(name)
 }
 
 pub(super) fn system_time_to_value(result: std::io::Result<SystemTime>) -> Value {

--- a/src/primitives/format/dispatch.rs
+++ b/src/primitives/format/dispatch.rs
@@ -59,7 +59,7 @@ pub(super) fn format_named(
     let mut kwargs: HashMap<String, Value> = HashMap::new();
     let mut provided_keys: Vec<String> = Vec::new();
     for i in (0..args.len()).step_by(2) {
-        let key = match args[i].as_keyword_name() {
+        let key = match ctx.keyword_spelling(args[i]) {
             Some(name) => name,
             None => {
                 return type_error!(ctx, args[i], "string/format", "keyword");

--- a/src/primitives/introspection.rs
+++ b/src/primitives/introspection.rs
@@ -172,7 +172,7 @@ pub(crate) fn prim_vm_query(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
 ) -> (SignalBits, Value) {
-    if !args[0].is_string() && args[0].as_keyword_name().is_none() {
+    if !args[0].is_string() && !args[0].is_keyword() {
         return (
             SIG_ERROR,
             ctx.error(
@@ -208,8 +208,10 @@ pub(crate) fn prim_keyword(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
 ) -> (SignalBits, Value) {
-    if let Some(kw) = args[0].with_string(Value::keyword) {
-        (SIG_OK, kw)
+    // A learning site: the spelling exists only at run time, so the instance
+    // memo records it here (docs/impl/symbol.md § "The display memo").
+    if let Some(name) = args[0].with_string(str::to_string) {
+        (SIG_OK, ctx.keyword(&name))
     } else {
         type_error!(ctx, args[0], "keyword", "string")
     }

--- a/src/primitives/io.rs
+++ b/src/primitives/io.rs
@@ -76,7 +76,7 @@ fn prim_io_backend(
             Err((kind, msg)) => return (SIG_ERROR, ctx.error(kind, msg)),
         },
     };
-    match args[0].as_keyword_name().as_deref() {
+    match ctx.keyword_spelling(args[0]).as_deref() {
         Some("async") => {
             match AsyncBackend::new_with_unicode(ctx.unicode_generation(), keepalive) {
                 Ok(backend) => {
@@ -298,7 +298,7 @@ fn prim_ev_poll_fd(
         }
     };
 
-    let events: u32 = if let Some(kw) = args[1].as_keyword_name() {
+    let events: u32 = if let Some(kw) = ctx.keyword_spelling(args[1]) {
         match kw.as_str() {
             "read" => libc::POLLIN as u32,
             "write" => libc::POLLOUT as u32,

--- a/src/primitives/json/mod.rs
+++ b/src/primitives/json/mod.rs
@@ -45,8 +45,8 @@ pub(crate) fn prim_json_parse(
     };
 
     let use_keyword_keys = if args.len() == 3 {
-        let opt_key_ok = args[1].as_keyword_name().as_deref() == Some("keys");
-        let opt_val_ok = args[2].as_keyword_name().as_deref() == Some("keyword");
+        let opt_key_ok = args[1].is_keyword_named("keys");
+        let opt_val_ok = args[2].is_keyword_named("keyword");
         if opt_key_ok && opt_val_ok {
             true
         } else {
@@ -77,7 +77,7 @@ pub(crate) fn prim_json_serialize(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
 ) -> (SignalBits, Value) {
-    let json_str = match serialize_value(&args[0]) {
+    let json_str = match serialize_value(&args[0], ctx.vm().symbols().map(|s| &*s)) {
         Ok(s) => s,
         Err(e) => return (SIG_ERROR, ctx.error("serde-error", e)),
     };
@@ -89,7 +89,7 @@ pub(crate) fn prim_json_serialize_pretty(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
 ) -> (SignalBits, Value) {
-    let json_str = match serialize_value_pretty(&args[0], 0) {
+    let json_str = match serialize_value_pretty(&args[0], ctx.vm().symbols().map(|s| &*s), 0) {
         Ok(s) => s,
         Err(e) => return (SIG_ERROR, ctx.error("serde-error", e)),
     };

--- a/src/primitives/json/parser.rs
+++ b/src/primitives/json/parser.rs
@@ -385,7 +385,10 @@ impl<'a, 'h> JsonParser<'a, 'h> {
             let key = match key_value.with_string(|s| s.to_string()) {
                 Some(s) => {
                     if self.use_keyword_keys {
-                        TableKey::Keyword(s)
+                        // A JSON key is a spelling that exists only at run
+                        // time — learn it so the struct's keys can print.
+                        self.ctx.keyword(&s);
+                        TableKey::keyword(&s)
                     } else {
                         TableKey::String(s)
                     }

--- a/src/primitives/json/serializer.rs
+++ b/src/primitives/json/serializer.rs
@@ -23,7 +23,10 @@ pub fn escape_json_string(s: &str) -> String {
 }
 
 /// Serialize a value to compact JSON
-pub fn serialize_value(value: &Value) -> Result<String, String> {
+pub fn serialize_value(
+    value: &Value,
+    symbols: Option<&crate::symbol::SymbolTable>,
+) -> Result<String, String> {
     if value.is_nil() {
         Ok("null".to_string())
     } else if let Some(b) = value.as_bool() {
@@ -49,18 +52,30 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
     } else if value.is_pair() {
         // Convert list to array
         let vec = value.list_to_vec()?;
-        let elements: Result<Vec<String>, String> = vec.iter().map(serialize_value).collect();
+        let elements: Result<Vec<String>, String> =
+            vec.iter().map(|v| serialize_value(v, symbols)).collect();
         Ok(format!("[{}]", elements?.join(",")))
     } else if let Some(v) = value.as_array_mut() {
         let borrowed = v.borrow();
-        let elements: Result<Vec<String>, String> = borrowed.iter().map(serialize_value).collect();
+        let elements: Result<Vec<String>, String> = borrowed
+            .iter()
+            .map(|v| serialize_value(v, symbols))
+            .collect();
         Ok(format!("[{}]", elements?.join(",")))
     } else if let Some(t) = value.as_struct_mut() {
         let mstruct = t.borrow();
         let mut pairs = Vec::new();
         for (k, v) in mstruct.iter() {
             let key_str = match k {
-                TableKey::String(s) | TableKey::Keyword(s) => escape_json_string(s),
+                TableKey::String(s) => escape_json_string(s),
+                TableKey::Keyword(hash) => {
+                    match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
+                        Some(name) => escape_json_string(name),
+                        None => {
+                            return Err("keyword struct key has no learned spelling".to_string())
+                        }
+                    }
+                }
                 _ => {
                     return Err(
                         "@struct keys must be strings or keywords for JSON serialization"
@@ -68,7 +83,7 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
                     )
                 }
             };
-            let val_str = serialize_value(v)?;
+            let val_str = serialize_value(v, symbols)?;
             pairs.push(format!("{}:{}", key_str, val_str));
         }
         Ok(format!("{{{}}}", pairs.join(",")))
@@ -76,7 +91,15 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
         let mut pairs = Vec::new();
         for (k, v) in s.iter() {
             let key_str = match k {
-                TableKey::String(s) | TableKey::Keyword(s) => escape_json_string(s),
+                TableKey::String(s) => escape_json_string(s),
+                TableKey::Keyword(hash) => {
+                    match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
+                        Some(name) => escape_json_string(name),
+                        None => {
+                            return Err("keyword struct key has no learned spelling".to_string())
+                        }
+                    }
+                }
                 _ => {
                     return Err(
                         "Struct keys must be strings or keywords for JSON serialization"
@@ -84,12 +107,14 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
                     )
                 }
             };
-            let val_str = serialize_value(v)?;
+            let val_str = serialize_value(v, symbols)?;
             pairs.push(format!("{}:{}", key_str, val_str));
         }
         Ok(format!("{{{}}}", pairs.join(",")))
-    } else if let Some(name) = value.as_keyword_name() {
-        Ok(escape_json_string(&name))
+    } else if let Some(hash) = value.keyword_hash() {
+        let name = crate::value::keyword::resolve_keyword_name(symbols, hash)
+            .ok_or_else(|| "keyword has no learned spelling".to_string())?;
+        Ok(escape_json_string(name))
     } else if value.is_closure() {
         Err("Cannot serialize closures to JSON".to_string())
     } else if value.is_symbol() {
@@ -97,7 +122,7 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
     } else if let Some(cell) = value.as_lbox() {
         // Dereference the cell and serialize the inner value
         let inner = cell.borrow();
-        serialize_value(&inner)
+        serialize_value(&inner, symbols)
     } else if let Some(tag) = value.heap_tag() {
         use crate::value::heap::HeapTag;
         match tag {
@@ -110,7 +135,7 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
             HeapTag::LArray => {
                 if let Some(elems) = value.as_array() {
                     let items: Result<Vec<String>, String> =
-                        elems.iter().map(serialize_value).collect();
+                        elems.iter().map(|v| serialize_value(v, symbols)).collect();
                     Ok(format!("[{}]", items?.join(",")))
                 } else {
                     Err("Tuple should have been accessible".to_string())
@@ -138,7 +163,7 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
             HeapTag::LSet => {
                 if let Some(s) = value.as_set() {
                     let items: Result<Vec<String>, String> =
-                        s.iter().map(serialize_value).collect();
+                        s.iter().map(|v| serialize_value(v, symbols)).collect();
                     Ok(format!("[{}]", items?.join(",")))
                 } else {
                     Err("Set should have been accessible".to_string())
@@ -148,7 +173,7 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
                 if let Some(s_ref) = value.as_set_mut() {
                     let s = s_ref.borrow();
                     let items: Result<Vec<String>, String> =
-                        s.iter().map(serialize_value).collect();
+                        s.iter().map(|v| serialize_value(v, symbols)).collect();
                     Ok(format!("[{}]", items?.join(",")))
                 } else {
                     Err("Mutable set should have been accessible".to_string())
@@ -164,7 +189,11 @@ pub fn serialize_value(value: &Value) -> Result<String, String> {
 }
 
 /// Serialize a value to pretty-printed JSON with indentation
-pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<String, String> {
+pub fn serialize_value_pretty(
+    value: &Value,
+    symbols: Option<&crate::symbol::SymbolTable>,
+    indent_level: usize,
+) -> Result<String, String> {
     let indent = "  ".repeat(indent_level);
     let next_indent = "  ".repeat(indent_level + 1);
 
@@ -196,7 +225,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
         }
         let elements: Result<Vec<String>, String> = vec
             .iter()
-            .map(|v| serialize_value_pretty(v, indent_level + 1))
+            .map(|v| serialize_value_pretty(v, symbols, indent_level + 1))
             .collect();
         Ok(format!(
             "[\n{}{}\n{}]",
@@ -211,7 +240,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
         }
         let elements: Result<Vec<String>, String> = borrowed
             .iter()
-            .map(|val| serialize_value_pretty(val, indent_level + 1))
+            .map(|val| serialize_value_pretty(val, symbols, indent_level + 1))
             .collect();
         Ok(format!(
             "[\n{}{}\n{}]",
@@ -227,7 +256,15 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
         let mut pairs = Vec::new();
         for (k, v) in mstruct.iter() {
             let key_str = match k {
-                TableKey::String(s) | TableKey::Keyword(s) => escape_json_string(s),
+                TableKey::String(s) => escape_json_string(s),
+                TableKey::Keyword(hash) => {
+                    match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
+                        Some(name) => escape_json_string(name),
+                        None => {
+                            return Err("keyword struct key has no learned spelling".to_string())
+                        }
+                    }
+                }
                 _ => {
                     return Err(
                         "@struct keys must be strings or keywords for JSON serialization"
@@ -235,7 +272,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
                     )
                 }
             };
-            let val_str = serialize_value_pretty(v, indent_level + 1)?;
+            let val_str = serialize_value_pretty(v, symbols, indent_level + 1)?;
             pairs.push(format!("{}: {}", key_str, val_str));
         }
         Ok(format!(
@@ -251,7 +288,15 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
         let mut pairs = Vec::new();
         for (k, v) in s.iter() {
             let key_str = match k {
-                TableKey::String(s) | TableKey::Keyword(s) => escape_json_string(s),
+                TableKey::String(s) => escape_json_string(s),
+                TableKey::Keyword(hash) => {
+                    match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
+                        Some(name) => escape_json_string(name),
+                        None => {
+                            return Err("keyword struct key has no learned spelling".to_string())
+                        }
+                    }
+                }
                 _ => {
                     return Err(
                         "Struct keys must be strings or keywords for JSON serialization"
@@ -259,7 +304,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
                     )
                 }
             };
-            let val_str = serialize_value_pretty(v, indent_level + 1)?;
+            let val_str = serialize_value_pretty(v, symbols, indent_level + 1)?;
             pairs.push(format!("{}: {}", key_str, val_str));
         }
         Ok(format!(
@@ -268,8 +313,10 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
             pairs.join(&format!(",\n{}", next_indent)),
             indent
         ))
-    } else if let Some(name) = value.as_keyword_name() {
-        Ok(escape_json_string(&name))
+    } else if let Some(hash) = value.keyword_hash() {
+        let name = crate::value::keyword::resolve_keyword_name(symbols, hash)
+            .ok_or_else(|| "keyword has no learned spelling".to_string())?;
+        Ok(escape_json_string(name))
     } else if value.is_closure() {
         Err("Cannot serialize closures to JSON".to_string())
     } else if value.is_symbol() {
@@ -277,7 +324,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
     } else if let Some(cell) = value.as_lbox() {
         // Dereference the cell and serialize the inner value
         let inner = cell.borrow();
-        serialize_value_pretty(&inner, indent_level)
+        serialize_value_pretty(&inner, symbols, indent_level)
     } else if let Some(tag) = value.heap_tag() {
         use crate::value::heap::HeapTag;
         match tag {
@@ -291,7 +338,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
                 if let Some(elems) = value.as_array() {
                     let items: Result<Vec<String>, String> = elems
                         .iter()
-                        .map(|v| serialize_value_pretty(v, indent_level + 1))
+                        .map(|v| serialize_value_pretty(v, symbols, indent_level + 1))
                         .collect();
                     Ok(format!(
                         "[\n{}{}\n{}]",
@@ -326,7 +373,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
                 if let Some(s) = value.as_set() {
                     let items: Result<Vec<String>, String> = s
                         .iter()
-                        .map(|v| serialize_value_pretty(v, indent_level + 1))
+                        .map(|v| serialize_value_pretty(v, symbols, indent_level + 1))
                         .collect();
                     Ok(format!(
                         "[\n{}{}\n{}]",
@@ -343,7 +390,7 @@ pub fn serialize_value_pretty(value: &Value, indent_level: usize) -> Result<Stri
                     let s = s_ref.borrow();
                     let items: Result<Vec<String>, String> = s
                         .iter()
-                        .map(|v| serialize_value_pretty(v, indent_level + 1))
+                        .map(|v| serialize_value_pretty(v, symbols, indent_level + 1))
                         .collect();
                     Ok(format!(
                         "[\n{}{}\n{}]",

--- a/src/primitives/kwarg.rs
+++ b/src/primitives/kwarg.rs
@@ -56,7 +56,7 @@ pub(crate) fn extract_keyword_timeout(
         let key = &remaining[i];
         let val = &remaining[i + 1];
 
-        match key.as_keyword_name().as_deref() {
+        match ctx.keyword_spelling(*key).as_deref() {
             Some("timeout") => match val.as_int() {
                 Some(ms) if ms >= 0 => {
                     timeout = Some(Duration::from_millis(ms as u64));
@@ -147,7 +147,7 @@ pub(crate) fn extract_connect_kwargs(
         let key = &remaining[i];
         let val = &remaining[i + 1];
 
-        match key.as_keyword_name().as_deref() {
+        match ctx.keyword_spelling(*key).as_deref() {
             Some("timeout") => match val.as_int() {
                 Some(ms) if ms >= 0 => {
                     result.timeout = Some(Duration::from_millis(ms as u64));
@@ -188,7 +188,7 @@ pub(crate) fn extract_connect_kwargs(
                 result.options.keepalive = Some(extract_bool(val, "keepalive", prim_name, ctx)?);
             }
             Some("encoding") => {
-                let enc = match val.as_keyword_name().as_deref() {
+                let enc = match ctx.keyword_spelling(*val).as_deref() {
                     Some("text") => Encoding::Text,
                     Some("binary") => Encoding::Binary,
                     Some(other) => {

--- a/src/primitives/list/mod.rs
+++ b/src/primitives/list/mod.rs
@@ -122,7 +122,7 @@ pub(crate) fn prim_length(
     // Types without traitsets that still support length
     if args[0].is_nil()
         || args[0].is_symbol()
-        || args[0].as_keyword_name().is_some()
+        || args[0].is_keyword()
         || args[0].as_syntax().is_some()
         || args[0].is_empty_list()
     {

--- a/src/primitives/meta.rs
+++ b/src/primitives/meta.rs
@@ -55,7 +55,7 @@ pub(crate) fn prim_gensym(
         );
     }
     let id = unsafe { (*symbols_ptr).intern(&sym_name) };
-    (SIG_OK, Value::symbol(id.0))
+    (SIG_OK, Value::symbol(id))
 }
 
 /// Create a syntax object with the lexical context of another syntax object.

--- a/src/primitives/meta/syntaxops.rs
+++ b/src/primitives/meta/syntaxops.rs
@@ -109,7 +109,7 @@ pub(crate) fn prim_syntax_e(
                 );
             }
             let id = unsafe { (*symbols_ptr).intern(name) };
-            (SIG_OK, Value::symbol(id.0))
+            (SIG_OK, Value::symbol(id))
         }
         // Compounds: return the syntax object unchanged.
         _ => (SIG_OK, args[0]),
@@ -238,15 +238,12 @@ pub(crate) fn prim_meta_origin(
         None => return (SIG_OK, Value::NIL),
     };
     let mut fields = std::collections::BTreeMap::new();
-    fields.insert(TableKey::Keyword("file".to_string()), ctx.string(&*file));
+    fields.insert(TableKey::keyword("file"), ctx.string(&*file));
     fields.insert(
-        TableKey::Keyword("line".to_string()),
+        TableKey::keyword("line"),
         Value::int(syntax.span.line as i64),
     );
-    fields.insert(
-        TableKey::Keyword("col".to_string()),
-        Value::int(syntax.span.col as i64),
-    );
+    fields.insert(TableKey::keyword("col"), Value::int(syntax.span.col as i64));
     (SIG_OK, ctx.struct_from(fields))
 }
 

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -69,6 +69,5 @@ pub use def::{PrimitiveDef, PrimitiveMeta};
 pub use docs::help_text;
 pub use module_init::init_stdlib;
 pub use registration::{
-    build_primitive_meta, intern_primitive_names, prim_def, prim_id_of, prim_table_snapshot,
-    register_primitives,
+    build_primitive_meta, prim_def, prim_id_of, prim_table_snapshot, register_primitives,
 };

--- a/src/primitives/module_init.rs
+++ b/src/primitives/module_init.rs
@@ -109,8 +109,14 @@ fn extract_exports(
     });
     let mut result = HashMap::new();
     for (key, value) in exports_struct.iter() {
-        if let crate::value::types::TableKey::Keyword(name) = key {
-            let sym_id = symbols.intern(name);
+        if let crate::value::types::TableKey::Keyword(hash) = key {
+            // The export struct was read from stdlib source, so its key
+            // spellings are in the memo; a miss is a missed learning site.
+            let name = symbols
+                .keyword_name(*hash)
+                .map(str::to_string)
+                .unwrap_or_else(|| panic!("stdlib export key {:#x} has no learned spelling", hash));
+            let sym_id = symbols.intern(&name);
             let signal = if let Some(closure) = value.as_closure() {
                 closure.template.signal
             } else if value.is_parameter() {

--- a/src/primitives/net.rs
+++ b/src/primitives/net.rs
@@ -109,7 +109,7 @@ pub(crate) fn parse_shutdown_how(
     prim_name: &str,
     ctx: &mut NativeCtx,
 ) -> Result<i32, (SignalBits, Value)> {
-    match value.as_keyword_name().as_deref() {
+    match ctx.keyword_spelling(*value).as_deref() {
         Some("read") => Ok(libc::SHUT_RD),
         Some("write") => Ok(libc::SHUT_WR),
         Some("read-write") => Ok(libc::SHUT_RDWR),

--- a/src/primitives/net/udp.rs
+++ b/src/primitives/net/udp.rs
@@ -102,14 +102,11 @@ pub(super) fn prim_udp_recv_from(
     let result = {
         use crate::value::heap::TableKey;
         let mut fields = std::collections::BTreeMap::new();
-        fields.insert(
-            TableKey::Keyword("data".into()),
-            ctx.bytes(vec![0u8; count]),
-        );
+        fields.insert(TableKey::keyword("data"), ctx.bytes(vec![0u8; count]));
         // INET6_ADDRSTRLEN is 46; 64 gives slack and the completion truncates to
         // the real length before transmuting the buffer to a string.
-        fields.insert(TableKey::Keyword("addr".into()), ctx.bytes(vec![0u8; 64]));
-        fields.insert(TableKey::Keyword("port".into()), Value::int(0));
+        fields.insert(TableKey::keyword("addr"), ctx.bytes(vec![0u8; 64]));
+        fields.insert(TableKey::keyword("port"), Value::int(0));
         ctx.struct_from(fields)
     };
     (

--- a/src/primitives/ports/lifecycle.rs
+++ b/src/primitives/ports/lifecycle.rs
@@ -51,7 +51,7 @@ fn open_file(
         }
     };
 
-    let mode_name_owned = match args[1].as_keyword_name() {
+    let mode_name_owned = match ctx.keyword_spelling(args[1]) {
         Some(name) => name,
         None => {
             return (

--- a/src/primitives/ports/query.rs
+++ b/src/primitives/ports/query.rs
@@ -29,7 +29,7 @@ pub(super) fn prim_port_set_options(
         let key = &remaining[i];
         let val = &remaining[i + 1];
 
-        match key.as_keyword_name().as_deref() {
+        match ctx.keyword_spelling(*key).as_deref() {
             Some("timeout") => {
                 if val.is_nil() {
                     port.set_timeout_ms(None);
@@ -179,7 +179,7 @@ pub(super) fn prim_port_seek(
 
     // Parse optional :from keyword-value pair (args[2] and args[3]).
     let whence = if args.len() == 4 {
-        match args[2].as_keyword_name().as_deref() {
+        match ctx.keyword_spelling(args[2]).as_deref() {
             Some("from") => {}
             Some(other) => {
                 return (
@@ -192,7 +192,7 @@ pub(super) fn prim_port_seek(
             }
             None => return type_error!(ctx, args[2], "port/seek", "keyword for third argument"),
         }
-        match args[3].as_keyword_name().as_deref() {
+        match ctx.keyword_spelling(args[3]).as_deref() {
             Some("start") => libc::SEEK_SET,
             Some("current") => libc::SEEK_CUR,
             Some("end") => libc::SEEK_END,

--- a/src/primitives/posix.rs
+++ b/src/primitives/posix.rs
@@ -55,7 +55,7 @@ fn resolve_signal_set(
         };
 
     // Single keyword.
-    if let Some(name) = val.as_keyword_name() {
+    if let Some(name) = ctx.keyword_spelling(*val) {
         process_keyword(&name, &mut out)?;
         return Ok(out);
     }
@@ -63,7 +63,7 @@ fn resolve_signal_set(
     // Set of keywords.
     if let Some(set) = val.as_set() {
         for elem in set.iter() {
-            let name = elem.as_keyword_name().ok_or_else(|| {
+            let name = ctx.keyword_spelling(*elem).ok_or_else(|| {
                 (
                     SIG_ERROR,
                     ctx.error(
@@ -84,7 +84,7 @@ fn resolve_signal_set(
     // Array / mutable array of keywords.
     if let Some(elems) = val.as_array() {
         for elem in elems.iter() {
-            let name = elem.as_keyword_name().ok_or_else(|| {
+            let name = ctx.keyword_spelling(*elem).ok_or_else(|| {
                 (
                     SIG_ERROR,
                     ctx.error(
@@ -103,7 +103,7 @@ fn resolve_signal_set(
     }
     if let Some(arr) = val.as_array_mut() {
         for elem in arr.borrow().iter() {
-            let name = elem.as_keyword_name().ok_or_else(|| {
+            let name = ctx.keyword_spelling(*elem).ok_or_else(|| {
                 (
                     SIG_ERROR,
                     ctx.error(
@@ -125,7 +125,7 @@ fn resolve_signal_set(
     if val.as_pair().is_some() {
         let mut current = *val;
         while let Some(pair) = current.as_pair() {
-            let name = pair.first.as_keyword_name().ok_or_else(|| {
+            let name = ctx.keyword_spelling(pair.first).ok_or_else(|| {
                 (
                     SIG_ERROR,
                     ctx.error(

--- a/src/primitives/registration.rs
+++ b/src/primitives/registration.rs
@@ -106,6 +106,45 @@ pub(crate) fn def_by_name(name: &str) -> Option<&'static PrimitiveDef> {
     INDEX.get(name).copied()
 }
 
+/// Hash→(spelling, def) index over the same tables `def_by_name` walks.
+///
+/// The built-in vocabulary is fixed at build time, so its spellings need no
+/// instance memo: a compiler pass holding a primitive binding's `SymbolId` can
+/// recover the name it was written with, wherever it runs and with no table in
+/// scope. That is what keeps type inference, narrowing and fusion off the
+/// display path (docs/impl/symbol.md § "Reading a name, and not reading one").
+///
+/// `static_vocabulary_is_collision_free` asserts the spellings are distinct, so
+/// a build whose own names collide fails before this index can hide one.
+fn static_index() -> &'static std::collections::HashMap<u64, (&'static str, &'static PrimitiveDef)>
+{
+    use std::collections::HashMap;
+    use std::sync::LazyLock;
+    static INDEX: LazyLock<HashMap<u64, (&'static str, &'static PrimitiveDef)>> =
+        LazyLock::new(|| {
+            let mut index = HashMap::new();
+            for table in ALL_TABLES.iter().chain(ffi_tables().iter()) {
+                for def in *table {
+                    for name in std::iter::once(&def.name).chain(def.aliases) {
+                        index.insert(crate::namehash::name_hash(name), (*name, def));
+                    }
+                }
+            }
+            index
+        });
+    &INDEX
+}
+
+/// The spelling of a built-in name, or `None` if `id` names nothing built in.
+pub(crate) fn static_name(id: crate::value::SymbolId) -> Option<&'static str> {
+    static_index().get(&id.0).map(|(name, _)| *name)
+}
+
+/// The def a built-in name resolves to, by id rather than by spelling.
+pub(crate) fn def_by_symbol(id: crate::value::SymbolId) -> Option<&'static PrimitiveDef> {
+    static_index().get(&id.0).map(|(_, def)| *def)
+}
+
 /// The process-global registry owning the `prim_id` ↔ `&'static PrimitiveDef`
 /// correspondence. A native-fn is the IMMEDIATE `Value{TAG_NATIVE_FN, prim_id}`
 /// (no `HeapObject`, no region), so the id is its whole identity: dense (a
@@ -263,23 +302,6 @@ pub fn build_primitive_meta(symbols: &mut SymbolTable) -> PrimitiveMeta {
     }
 
     meta
-}
-
-/// Intern all primitive names (and aliases) into a SymbolTable.
-///
-/// This ensures the SymbolTable has the same SymbolId assignments as
-/// the cached PrimitiveMeta. Must be called before using cached meta
-/// with a SymbolTable that hasn't had `register_primitives` called on it.
-/// Idempotent — safe to call multiple times.
-pub fn intern_primitive_names(symbols: &mut SymbolTable) {
-    for table in ALL_TABLES.iter().chain(ffi_tables().iter()) {
-        for def in *table {
-            symbols.intern(def.name);
-            for alias in def.aliases {
-                symbols.intern(alias);
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/primitives/subprocess/exec.rs
+++ b/src/primitives/subprocess/exec.rs
@@ -24,7 +24,7 @@ pub(super) fn parse_exec_opts(
     };
 
     // :env — struct of string → string, or nil for inherit
-    let env = match sorted_struct_get(fields, &TableKey::Keyword("env".into())) {
+    let env = match sorted_struct_get(fields, &TableKey::keyword("env")) {
         Some(v) if v.is_nil() => None,
         Some(v) => {
             let env_fields = match v.as_struct() {
@@ -38,19 +38,31 @@ pub(super) fn parse_exec_opts(
             };
             let mut pairs = Vec::new();
             for (k, val) in env_fields {
-                let key_str = match k {
-                    TableKey::Keyword(s) => s.clone(),
-                    TableKey::String(s) => s.clone(),
-                    _ => {
-                        return Err((
-                            SIG_ERROR,
-                            ctx.error(
-                                "type-error",
-                                "subprocess/exec: :env keys must be keywords or strings",
-                            ),
-                        ))
-                    }
-                };
+                let key_str =
+                    match k {
+                        TableKey::Keyword(hash) => {
+                            match ctx.keyword_spelling(Value::keyword_from_hash(*hash)) {
+                                Some(s) => s,
+                                None => return Err((
+                                    SIG_ERROR,
+                                    ctx.error(
+                                        "type-error",
+                                        "subprocess/exec: :env keyword key has no learned spelling",
+                                    ),
+                                )),
+                            }
+                        }
+                        TableKey::String(s) => s.clone(),
+                        _ => {
+                            return Err((
+                                SIG_ERROR,
+                                ctx.error(
+                                    "type-error",
+                                    "subprocess/exec: :env keys must be keywords or strings",
+                                ),
+                            ))
+                        }
+                    };
                 let val_str = match val.with_string(|s| s.to_string()) {
                     Some(s) => s,
                     None => {
@@ -68,7 +80,7 @@ pub(super) fn parse_exec_opts(
     };
 
     // :cwd — string or nil
-    let cwd = match sorted_struct_get(fields, &TableKey::Keyword("cwd".into())) {
+    let cwd = match sorted_struct_get(fields, &TableKey::keyword("cwd")) {
         Some(v) if v.is_nil() => None,
         Some(v) => Some(match v.with_string(|s| s.to_string()) {
             Some(s) => s,
@@ -88,7 +100,7 @@ pub(super) fn parse_exec_opts(
         field: &str,
         ctx: &mut NativeCtx,
     ) -> Result<StdioDisposition, (SignalBits, Value)> {
-        match v.as_keyword_name().as_deref() {
+        match ctx.keyword_spelling(*v).as_deref() {
             Some("pipe") => Ok(StdioDisposition::Pipe),
             Some("inherit") => Ok(StdioDisposition::Inherit),
             Some("null") => Ok(StdioDisposition::Null),
@@ -105,15 +117,15 @@ pub(super) fn parse_exec_opts(
         }
     }
 
-    let stdin_disp = match sorted_struct_get(fields, &TableKey::Keyword("stdin".into())) {
+    let stdin_disp = match sorted_struct_get(fields, &TableKey::keyword("stdin")) {
         Some(v) => parse_disp(v, ":stdin", ctx)?,
         None => StdioDisposition::Pipe,
     };
-    let stdout_disp = match sorted_struct_get(fields, &TableKey::Keyword("stdout".into())) {
+    let stdout_disp = match sorted_struct_get(fields, &TableKey::keyword("stdout")) {
         Some(v) => parse_disp(v, ":stdout", ctx)?,
         None => StdioDisposition::Pipe,
     };
-    let stderr_disp = match sorted_struct_get(fields, &TableKey::Keyword("stderr".into())) {
+    let stderr_disp = match sorted_struct_get(fields, &TableKey::keyword("stderr")) {
         Some(v) => parse_disp(v, ":stderr", ctx)?,
         None => StdioDisposition::Pipe,
     };
@@ -133,7 +145,7 @@ pub(super) fn extract_process_handle(
         return Ok(*val);
     }
     if let Some(fields) = val.as_struct() {
-        match sorted_struct_get(fields, &TableKey::Keyword("process".into())) {
+        match sorted_struct_get(fields, &TableKey::keyword("process")) {
             Some(v) => return Ok(*v),
             None => {
                 return Err((

--- a/src/primitives/traitregistry.rs
+++ b/src/primitives/traitregistry.rs
@@ -215,15 +215,16 @@ fn call_method_fn(
 
 /// Look up a keyword key in a struct without allocating a TableKey.
 ///
-/// Trait tables are small (2–5 entries), so linear scan on the keyword
-/// discriminant + string comparison avoids the String allocation that
-/// `TableKey::Keyword(key.into())` would require on every dispatch.
+/// Trait tables are small (2–5 entries), so a linear scan comparing the
+/// keyword hash — one integer compare per entry, no allocation — beats a
+/// sorted probe.
 fn lookup_keyword(val: &Value, key: &str) -> Value {
+    let key_hash = crate::value::keyword::keyword_hash(key);
     // Immutable struct — linear scan (small tables)
     if let Some(entries) = val.as_struct() {
         for (k, v) in entries.iter() {
-            if let TableKey::Keyword(ref s) = k {
-                if s == key {
+            if let TableKey::Keyword(hash) = k {
+                if *hash == key_hash {
                     return *v;
                 }
             }
@@ -235,8 +236,8 @@ fn lookup_keyword(val: &Value, key: &str) -> Value {
     if let Some(map_ref) = val.as_struct_mut() {
         let borrowed = map_ref.borrow();
         for (k, v) in borrowed.iter() {
-            if let TableKey::Keyword(ref s) = k {
-                if s == key {
+            if let TableKey::Keyword(hash) = k {
+                if *hash == key_hash {
                     return *v;
                 }
             }

--- a/src/primitives/traitregistry/methods.rs
+++ b/src/primitives/traitregistry/methods.rs
@@ -37,23 +37,11 @@ pub(super) fn build_sequence_methods(heap: &mut FiberHeap) -> Value {
     });
 
     let mut entries = BTreeMap::new();
-    entries.insert(
-        TableKey::Keyword("first".into()),
-        Value::native_fn(&SEQ_FIRST),
-    );
-    entries.insert(
-        TableKey::Keyword("rest".into()),
-        Value::native_fn(&SEQ_REST),
-    );
-    entries.insert(
-        TableKey::Keyword("last".into()),
-        Value::native_fn(&SEQ_LAST),
-    );
-    entries.insert(TableKey::Keyword("nth".into()), Value::native_fn(&SEQ_NTH));
-    entries.insert(
-        TableKey::Keyword("iter".into()),
-        Value::native_fn(&SEQ_ITER),
-    );
+    entries.insert(TableKey::keyword("first"), Value::native_fn(&SEQ_FIRST));
+    entries.insert(TableKey::keyword("rest"), Value::native_fn(&SEQ_REST));
+    entries.insert(TableKey::keyword("last"), Value::native_fn(&SEQ_LAST));
+    entries.insert(TableKey::keyword("nth"), Value::native_fn(&SEQ_NTH));
+    entries.insert(TableKey::keyword("iter"), Value::native_fn(&SEQ_ITER));
     alloc_trait_table(heap, entries)
 }
 
@@ -94,24 +82,12 @@ pub(super) fn build_collection_methods(heap: &mut FiberHeap) -> Value {
     });
 
     let mut entries = BTreeMap::new();
+    entries.insert(TableKey::keyword("length"), Value::native_fn(&COLL_LENGTH));
+    entries.insert(TableKey::keyword("empty?"), Value::native_fn(&COLL_EMPTY));
+    entries.insert(TableKey::keyword("has?"), Value::native_fn(&COLL_HAS));
+    entries.insert(TableKey::keyword("conj"), Value::native_fn(&COLL_CONJ));
     entries.insert(
-        TableKey::Keyword("length".into()),
-        Value::native_fn(&COLL_LENGTH),
-    );
-    entries.insert(
-        TableKey::Keyword("empty?".into()),
-        Value::native_fn(&COLL_EMPTY),
-    );
-    entries.insert(
-        TableKey::Keyword("has?".into()),
-        Value::native_fn(&COLL_HAS),
-    );
-    entries.insert(
-        TableKey::Keyword("conj".into()),
-        Value::native_fn(&COLL_CONJ),
-    );
-    entries.insert(
-        TableKey::Keyword("empty".into()),
+        TableKey::keyword("empty"),
         Value::native_fn(&COLL_EMPTY_NEW),
     );
     alloc_trait_table(heap, entries)
@@ -162,10 +138,10 @@ pub(super) fn make_traitset(
 ) -> Value {
     let mut entries = BTreeMap::new();
     if let Some(seq) = sequence {
-        entries.insert(TableKey::Keyword("Sequence".into()), seq);
+        entries.insert(TableKey::keyword("Sequence"), seq);
     }
     if let Some(coll) = collection {
-        entries.insert(TableKey::Keyword("Collection".into()), coll);
+        entries.insert(TableKey::keyword("Collection"), coll);
     }
     alloc_trait_table_mut(heap, entries)
 }

--- a/src/primitives/watch.rs
+++ b/src/primitives/watch.rs
@@ -50,11 +50,8 @@ fn prim_watch_add(
         args[2]
             .as_struct()
             .and_then(|s| {
-                sorted_struct_get(
-                    s,
-                    &crate::value::heap::TableKey::Keyword("recursive".into()),
-                )
-                .map(|v| v.is_truthy())
+                sorted_struct_get(s, &crate::value::heap::TableKey::keyword("recursive"))
+                    .map(|v| v.is_truthy())
             })
             .unwrap_or(true)
     } else {

--- a/src/reader/parser.rs
+++ b/src/reader/parser.rs
@@ -105,7 +105,7 @@ impl Reader {
                             Some(OwnedToken::RightBracket) => {
                                 self.advance();
                                 // Build (list e1 e2 e3 ...)
-                                let list_sym = Value::symbol(symbols.intern("list").0);
+                                let list_sym = Value::symbol(symbols.intern("list"));
                                 let result = elements
                                     .into_iter()
                                     .rev()
@@ -125,7 +125,7 @@ impl Reader {
                 } else if let Some(OwnedToken::String(s)) = self.current().cloned() {
                     // @"..." is sugar for (thaw "...")
                     self.advance();
-                    let sb_sym = Value::symbol(symbols.intern("thaw").0);
+                    let sb_sym = Value::symbol(symbols.intern("thaw"));
                     let str_val = ctx.string(s.as_str());
                     let inner = ctx.pair(str_val, Value::EMPTY_LIST);
                     Ok(ctx.pair(sb_sym, inner))
@@ -141,35 +141,35 @@ impl Reader {
             OwnedToken::Quote => {
                 self.advance();
                 let val = self.read(ctx, symbols)?;
-                let quote_sym = Value::symbol(symbols.intern("quote").0);
+                let quote_sym = Value::symbol(symbols.intern("quote"));
                 let inner = ctx.pair(val, Value::EMPTY_LIST);
                 Ok(ctx.pair(quote_sym, inner))
             }
             OwnedToken::Quasiquote => {
                 self.advance();
                 let val = self.read(ctx, symbols)?;
-                let qq_sym = Value::symbol(symbols.intern("quasiquote").0);
+                let qq_sym = Value::symbol(symbols.intern("quasiquote"));
                 let inner = ctx.pair(val, Value::EMPTY_LIST);
                 Ok(ctx.pair(qq_sym, inner))
             }
             OwnedToken::Unquote => {
                 self.advance();
                 let val = self.read(ctx, symbols)?;
-                let uq_sym = Value::symbol(symbols.intern("unquote").0);
+                let uq_sym = Value::symbol(symbols.intern("unquote"));
                 let inner = ctx.pair(val, Value::EMPTY_LIST);
                 Ok(ctx.pair(uq_sym, inner))
             }
             OwnedToken::UnquoteSplicing => {
                 self.advance();
                 let val = self.read(ctx, symbols)?;
-                let uqs_sym = Value::symbol(symbols.intern("unquote-splicing").0);
+                let uqs_sym = Value::symbol(symbols.intern("unquote-splicing"));
                 let inner = ctx.pair(val, Value::EMPTY_LIST);
                 Ok(ctx.pair(uqs_sym, inner))
             }
             OwnedToken::Splice => {
                 self.advance();
                 let val = self.read(ctx, symbols)?;
-                let splice_sym = Value::symbol(symbols.intern("splice").0);
+                let splice_sym = Value::symbol(symbols.intern("splice"));
                 let inner = ctx.pair(val, Value::EMPTY_LIST);
                 Ok(ctx.pair(splice_sym, inner))
             }
@@ -198,12 +198,14 @@ impl Reader {
                 Ok(Value::NIL)
             }
             OwnedToken::Symbol(s) => {
-                let id = symbols.intern(s).0;
+                let id = symbols.intern(s);
                 self.advance();
                 Ok(Value::symbol(id))
             }
             OwnedToken::Keyword(s) => {
-                // Keywords are self-evaluating values (interned strings)
+                // Keywords are self-evaluating; the spelling is learned here —
+                // the value-reader is a learning site like the analyzer.
+                symbols.keyword(s);
                 self.advance();
                 Ok(Value::keyword(s))
             }
@@ -334,7 +336,7 @@ impl Reader {
                 Some(OwnedToken::RightBrace) => {
                     self.advance();
                     // Build (struct k1 v1 k2 v2 ...)
-                    let struct_sym = Value::symbol(symbols.intern("struct").0);
+                    let struct_sym = Value::symbol(symbols.intern("struct"));
                     let result = elements
                         .into_iter()
                         .rev()
@@ -360,7 +362,7 @@ impl Reader {
                 Some(OwnedToken::RightBrace) => {
                     self.advance();
                     // Build (table k1 v1 k2 v2 ...)
-                    let table_sym = Value::symbol(symbols.intern("table").0);
+                    let table_sym = Value::symbol(symbols.intern("table"));
                     let result = elements
                         .into_iter()
                         .rev()

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -194,7 +194,9 @@ fn try_eval_accumulated(
                 match eval_form(form, vm, symbols, cctx) {
                     Ok(value) => {
                         if !value.is_nil() {
-                            println!("⟹ {:?}", value);
+                            // Debug render through the instance memo, so symbol
+                            // and keyword spellings resolve.
+                            println!("⟹ {}", value.debug_with(Some(symbols)));
                         }
                     }
                     Err(e) => {
@@ -324,7 +326,7 @@ fn try_resolve_single(
         return false;
     };
     cctx.register_repl_macros(expander.macros());
-    let Ok(value) = vm.execute_scheduled(&result.bytecode, symbols, cctx) else {
+    let Ok(value) = vm.execute_scheduled(&result.bytecode, cctx) else {
         return false;
     };
     let sym_id = symbols.intern(&form.name);
@@ -358,7 +360,7 @@ fn try_batch_resolve(
         return false;
     };
     cctx.register_repl_macros(expander.macros());
-    let Ok(tuple_val) = vm.execute_scheduled(&result.bytecode, symbols, cctx) else {
+    let Ok(tuple_val) = vm.execute_scheduled(&result.bytecode, cctx) else {
         return false;
     };
 
@@ -516,7 +518,7 @@ fn eval_form(
         // return value IS the bound value.
         let (result, expander) = compile_file_repl(&form.source, symbols, cctx, "<repl>")?;
         cctx.register_repl_macros(expander.macros());
-        let value = vm.execute_scheduled(&result.bytecode, symbols, cctx)?;
+        let value = vm.execute_scheduled(&result.bytecode, cctx)?;
 
         if let Some(binding) = form.bindings.first() {
             let sym_id = symbols.intern(&binding.name);
@@ -536,7 +538,7 @@ fn eval_form(
 
         let (result, expander) = compile_file_repl(&combined, symbols, cctx, "<repl>")?;
         cctx.register_repl_macros(expander.macros());
-        let tuple_val = vm.execute_scheduled(&result.bytecode, symbols, cctx)?;
+        let tuple_val = vm.execute_scheduled(&result.bytecode, cctx)?;
 
         // Register each leaf binding from the tuple.
         if let Some(items) = tuple_val.as_array() {

--- a/src/runtime/tests/lifecycle.rs
+++ b/src/runtime/tests/lifecycle.rs
@@ -76,7 +76,7 @@ fn two_instances_interleaved_defs_are_isolated() {
             compile_file_repl(src, symbols, cctx, "<embed>").expect("def compiles");
         // A simple `(def x V)` returns V (the letrec body is the bound name).
         let value = vm
-            .execute_scheduled(&result.bytecode, symbols, cctx)
+            .execute_scheduled(&result.bytecode, cctx)
             .expect("def runs");
         let sym_id = symbols.intern(name);
         cctx.register_repl_binding(
@@ -92,7 +92,7 @@ fn two_instances_interleaved_defs_are_isolated() {
         let (vm, symbols, cctx) = rt.parts();
         let (result, _expander) =
             compile_file_repl(src, symbols, cctx, "<embed>").expect("read compiles");
-        vm.execute_scheduled(&result.bytecode, symbols, cctx)
+        vm.execute_scheduled(&result.bytecode, cctx)
             .expect("read runs")
             .as_int()
             .expect("read yields an int")
@@ -131,7 +131,7 @@ fn two_instances_read_their_own_vm_args() {
         let (vm, symbols, cctx) = rt.parts();
         let (result, _expander) =
             compile_file_repl(src, symbols, cctx, "<embed>").expect("compiles");
-        vm.execute_scheduled(&result.bytecode, symbols, cctx)
+        vm.execute_scheduled(&result.bytecode, cctx)
             .expect("runs")
             .with_string(|s| s.to_string())
     }
@@ -156,25 +156,23 @@ fn two_instances_read_their_own_vm_args() {
     );
 }
 
-/// Counterfactual for the symbol axis: two embedded instances on one thread must
-/// each resolve symbol NAMES through their OWN symbol table.
+/// The symbol axis: two embedded instances on one thread agree on every name,
+/// and each still resolves a name only it ever mentioned.
 ///
-/// `(string 'sym)` interns `sym` into the COMPILING instance's table (at a fresh
-/// id past the shared stdlib), then at runtime resolves that id back to a name. If
-/// runtime resolution read a single per-thread table shared by both instances, it
-/// would read whichever `Runtime` was built last (`b`), so instance `a`'s fresh
-/// id — valid only in `a`'s table — is out of range in `b`'s table and
-/// `(string …)` fails. Reaching the call's own driving VM's table via
-/// `ctx.vm().symbols()` makes each instance resolve its own: a site is correct iff
-/// it behaves correctly with two instances interleaved on one thread.
+/// Names are the one thing instances may share. A symbol id is the name's hash
+/// (docs/impl/symbol.md), so it means the same symbol in both instances by
+/// construction — nothing an instance can do makes its own id mean something
+/// else. That is what lets `a` read a symbol `b` compiled, and the discriminator
+/// below: under mint-order ids, `a`'s fresh id was a dense index valid only in
+/// `a`'s table, so `b` resolved it to a different name or to none.
 #[test]
-fn two_instances_resolve_their_own_symbols() {
+fn two_instances_agree_on_every_symbol_name() {
     use crate::pipeline::compile_file_repl;
 
     fn to_string(rt: &mut Runtime, src: &str) -> Option<String> {
         let (vm, symbols, cctx) = rt.parts();
         let (result, _expander) = compile_file_repl(src, symbols, cctx, "<embed>").ok()?;
-        vm.execute_scheduled(&result.bytecode, symbols, cctx)
+        vm.execute_scheduled(&result.bytecode, cctx)
             .ok()?
             .with_string(|s| s.to_string())
     }
@@ -182,18 +180,20 @@ fn two_instances_resolve_their_own_symbols() {
     let mut a = Runtime::new();
     let mut b = Runtime::new();
 
-    // `a`'s fresh symbol id is the discriminator: a single shared table
-    // (resolving against `b`, built last) cannot resolve it.
     assert_eq!(
-        to_string(&mut a, "(string 'alpha_only_in_a)").as_deref(),
-        Some("alpha_only_in_a"),
-        "instance a must resolve its own symbol via its own table, not b's \
-         (the symbol table must not be shared between instances)"
+        to_string(&mut a, "(string 'alpha_first_seen_in_a)").as_deref(),
+        Some("alpha_first_seen_in_a"),
+        "an instance resolves a name only it has mentioned"
+    );
+    // The same spelling, compiled by the OTHER instance, is the same symbol.
+    assert_eq!(
+        to_string(&mut b, "(string 'alpha_first_seen_in_a)").as_deref(),
+        Some("alpha_first_seen_in_a"),
+        "and the other instance reads that name as the same symbol"
     );
     assert_eq!(
-        to_string(&mut b, "(string 'beta_only_in_b)").as_deref(),
-        Some("beta_only_in_b"),
-        "instance b must resolve its own symbol via its own table"
+        to_string(&mut b, "(string 'beta_first_seen_in_b)").as_deref(),
+        Some("beta_first_seen_in_b"),
     );
 }
 

--- a/src/runtime/tests/ownership/jit.rs
+++ b/src/runtime/tests/ownership/jit.rs
@@ -41,9 +41,9 @@ pub(super) fn jit_region_growth(body: &str) -> (i64, bool) {
     // First run builds the lambda and calls it, submitting it for background JIT
     // compilation; drain blocks until that finishes (or the worker dies).
     {
-        let (vm, symbols, cctx) = rt.parts();
+        let (vm, _symbols, cctx) = rt.parts();
         let v = vm
-            .execute_scheduled(&prog.bytecode, symbols, cctx)
+            .execute_scheduled(&prog.bytecode, cctx)
             .expect("runs (submits the JIT task)");
         assert!(v.is_nil(), "the discarded-shape lambda returns nil");
     }
@@ -52,18 +52,14 @@ pub(super) fn jit_region_growth(body: &str) -> (i64, bool) {
 
     // Warmup (the lambda body now dispatches to cached native code), then measure.
     {
-        let (vm, symbols, cctx) = rt.parts();
-        let v = vm
-            .execute_scheduled(&prog.bytecode, symbols, cctx)
-            .expect("runs");
+        let (vm, _symbols, cctx) = rt.parts();
+        let v = vm.execute_scheduled(&prog.bytecode, cctx).expect("runs");
         assert!(v.is_nil());
     }
     let baseline = rt.heap().active_region_count() as i64;
     for _ in 0..50 {
-        let (vm, symbols, cctx) = rt.parts();
-        let v = vm
-            .execute_scheduled(&prog.bytecode, symbols, cctx)
-            .expect("runs");
+        let (vm, _symbols, cctx) = rt.parts();
+        let v = vm.execute_scheduled(&prog.bytecode, cctx).expect("runs");
         assert!(v.is_nil());
     }
     let delta = rt.heap().active_region_count() as i64 - baseline;

--- a/src/runtime/tests/ownership/mod.rs
+++ b/src/runtime/tests/ownership/mod.rs
@@ -61,18 +61,14 @@ pub(super) fn steady_region_growth(src: &str) -> i64 {
             .0
     };
     {
-        let (vm, symbols, cctx) = rt.parts();
-        let v = vm
-            .execute_scheduled(&result.bytecode, symbols, cctx)
-            .expect("runs");
+        let (vm, _symbols, cctx) = rt.parts();
+        let v = vm.execute_scheduled(&result.bytecode, cctx).expect("runs");
         assert!(v.is_nil(), "the discarded-shape program returns nil");
     }
     let baseline = rt.heap().active_region_count() as i64;
     for _ in 0..50 {
-        let (vm, symbols, cctx) = rt.parts();
-        let v = vm
-            .execute_scheduled(&result.bytecode, symbols, cctx)
-            .expect("runs");
+        let (vm, _symbols, cctx) = rt.parts();
+        let v = vm.execute_scheduled(&result.bytecode, cctx).expect("runs");
         assert!(v.is_nil());
     }
     rt.heap().active_region_count() as i64 - baseline
@@ -115,8 +111,8 @@ pub(super) fn mid_run_growth(mut rt: Runtime, prelude: &str, body: &str, gauge: 
             .expect("compiles")
             .0
     };
-    let (vm, symbols, cctx) = rt.parts();
-    vm.execute_scheduled(&result.bytecode, symbols, cctx)
+    let (vm, _symbols, cctx) = rt.parts();
+    vm.execute_scheduled(&result.bytecode, cctx)
         .expect("runs")
         .as_int()
         .expect("program returns the gauge delta as an int")

--- a/src/runtime/tests/ownership/owner.rs
+++ b/src/runtime/tests/ownership/owner.rs
@@ -237,27 +237,23 @@ fn region_ownership_reclaims_returned_cycle_under_jit() {
                 .0
         };
         {
-            let (vm, symbols, cctx) = rt.parts();
+            let (vm, _symbols, cctx) = rt.parts();
             let v = vm
-                .execute_scheduled(&prog.bytecode, symbols, cctx)
+                .execute_scheduled(&prog.bytecode, cctx)
                 .expect("runs (submits the JIT task)");
             assert!(v.is_nil());
         }
         rt.vm().drain_jit_pending();
         let jit_compiled = !rt.vm().jit_cache.is_empty();
         {
-            let (vm, symbols, cctx) = rt.parts();
-            let v = vm
-                .execute_scheduled(&prog.bytecode, symbols, cctx)
-                .expect("runs");
+            let (vm, _symbols, cctx) = rt.parts();
+            let v = vm.execute_scheduled(&prog.bytecode, cctx).expect("runs");
             assert!(v.is_nil());
         }
         let baseline = rt.heap().active_region_count() as i64;
         for _ in 0..50 {
-            let (vm, symbols, cctx) = rt.parts();
-            let v = vm
-                .execute_scheduled(&prog.bytecode, symbols, cctx)
-                .expect("runs");
+            let (vm, _symbols, cctx) = rt.parts();
+            let v = vm.execute_scheduled(&prog.bytecode, cctx).expect("runs");
             assert!(v.is_nil());
         }
         (
@@ -421,8 +417,8 @@ fn reassign_toplevel_prior_release_is_bounded() {
                 .expect("compiles")
                 .0
         };
-        let (vm, symbols, cctx) = rt.parts();
-        vm.execute_scheduled(&result.bytecode, symbols, cctx)
+        let (vm, _symbols, cctx) = rt.parts();
+        vm.execute_scheduled(&result.bytecode, cctx)
             .expect("runs")
             .as_int()
             .expect("program returns the region-count delta as an int")

--- a/src/runtime/tests/ownership/selfrec.rs
+++ b/src/runtime/tests/ownership/selfrec.rs
@@ -93,8 +93,8 @@ fn closure_cycle_discarded_release_is_prompt() {
                 .expect("compiles")
                 .0
         };
-        let (vm, symbols, cctx) = rt.parts();
-        vm.execute_scheduled(&result.bytecode, symbols, cctx)
+        let (vm, _symbols, cctx) = rt.parts();
+        vm.execute_scheduled(&result.bytecode, cctx)
             .expect("runs")
             .as_int()
             .expect("program returns the region-count delta as an int")
@@ -335,9 +335,9 @@ fn self_recursive_loop_reclaims_per_call_no_stdlib() {
             .expect("compiles")
             .0
     };
-    let (vm, symbols, cctx) = rt.parts();
+    let (vm, _symbols, cctx) = rt.parts();
     let delta = vm
-        .execute_scheduled(&res.bytecode, symbols, cctx)
+        .execute_scheduled(&res.bytecode, cctx)
         .expect("runs")
         .as_int()
         .expect("program returns the region-count delta as an int");
@@ -389,9 +389,9 @@ fn self_recursive_loop_under_a_branch_tail_reclaims_per_call() {
             .expect("compiles")
             .0
     };
-    let (vm, symbols, cctx) = rt.parts();
+    let (vm, _symbols, cctx) = rt.parts();
     let delta = vm
-        .execute_scheduled(&res.bytecode, symbols, cctx)
+        .execute_scheduled(&res.bytecode, cctx)
         .expect("runs")
         .as_int()
         .expect("program returns the region-count delta as an int");
@@ -664,9 +664,9 @@ fn tail_or_short_circuit_returns_owned_param_no_uaf() {
             .expect("compiles")
             .0
     };
-    let (vm, symbols, cctx) = rt.parts();
+    let (vm, _symbols, cctx) = rt.parts();
     let v = vm
-        .execute_scheduled(&res.bytecode, symbols, cctx)
+        .execute_scheduled(&res.bytecode, cctx)
         .expect("a tail `(or param …)` returning an owned heap param must not double-free it");
     assert!(
         v.is_string(),
@@ -842,9 +842,9 @@ fn self_recursive_define_in_lambda_no_double_free() {
             .expect("compiles")
             .0
     };
-    let (vm, symbols, cctx) = rt.parts();
+    let (vm, _symbols, cctx) = rt.parts();
     let v = vm
-        .execute_scheduled(&res.bytecode, symbols, cctx)
+        .execute_scheduled(&res.bytecode, cctx)
         .expect("a cell-free self-recursive `def` must not double-free its closure region");
     assert!(
         v.is_keyword(),
@@ -877,9 +877,9 @@ fn self_recursive_and_sibling_captured_no_double_free() {
             .expect("compiles")
             .0
     };
-    let (vm, symbols, cctx) = rt.parts();
+    let (vm, _symbols, cctx) = rt.parts();
     let v = vm
-        .execute_scheduled(&res.bytecode, symbols, cctx)
+        .execute_scheduled(&res.bytecode, cctx)
         .expect("a sibling-captured self-recursive `def` must not double-free its closure region");
     assert!(
         v.is_keyword(),

--- a/src/runtime/tests/ownership/subtree.rs
+++ b/src/runtime/tests/ownership/subtree.rs
@@ -28,19 +28,15 @@ fn region_ownership_adopt_subtree_drop_reclaims_in_a_real_run() {
 
     // Warm-up run, then measure the steady-state live region count.
     {
-        let (vm, symbols, cctx) = rt.parts();
-        let v = vm
-            .execute_scheduled(&result.bytecode, symbols, cctx)
-            .expect("runs");
+        let (vm, _symbols, cctx) = rt.parts();
+        let v = vm.execute_scheduled(&result.bytecode, cctx).expect("runs");
         assert!(v.is_nil(), "the discarded-container program returns nil");
     }
     let baseline = rt.heap().active_region_count();
 
     for _ in 0..50 {
-        let (vm, symbols, cctx) = rt.parts();
-        let v = vm
-            .execute_scheduled(&result.bytecode, symbols, cctx)
-            .expect("runs");
+        let (vm, _symbols, cctx) = rt.parts();
+        let v = vm.execute_scheduled(&result.bytecode, cctx).expect("runs");
         assert!(v.is_nil());
     }
     let after = rt.heap().active_region_count();
@@ -122,10 +118,8 @@ fn region_ownership_capture_adopt_reclaims_in_a_real_run() {
             .0
     };
     {
-        let (vm, symbols, cctx) = rt.parts();
-        let v = vm
-            .execute_scheduled(&result.bytecode, symbols, cctx)
-            .expect("runs");
+        let (vm, _symbols, cctx) = rt.parts();
+        let v = vm.execute_scheduled(&result.bytecode, cctx).expect("runs");
         assert!(
             v.is_nil(),
             "the discarded captured-value program returns nil"
@@ -133,10 +127,8 @@ fn region_ownership_capture_adopt_reclaims_in_a_real_run() {
     }
     let baseline = rt.heap().active_region_count();
     for _ in 0..50 {
-        let (vm, symbols, cctx) = rt.parts();
-        let v = vm
-            .execute_scheduled(&result.bytecode, symbols, cctx)
-            .expect("runs");
+        let (vm, _symbols, cctx) = rt.parts();
+        let v = vm.execute_scheduled(&result.bytecode, cctx).expect("runs");
         assert!(v.is_nil());
     }
     let after = rt.heap().active_region_count();
@@ -258,10 +250,8 @@ fn region_ownership_store_then_capture_chain_reclaims_in_a_real_run() {
             .0
     };
     {
-        let (vm, symbols, cctx) = rt.parts();
-        let v = vm
-            .execute_scheduled(&result.bytecode, symbols, cctx)
-            .expect("runs");
+        let (vm, _symbols, cctx) = rt.parts();
+        let v = vm.execute_scheduled(&result.bytecode, cctx).expect("runs");
         assert!(
             v.is_nil(),
             "the discarded container+closure program returns nil"
@@ -269,10 +259,8 @@ fn region_ownership_store_then_capture_chain_reclaims_in_a_real_run() {
     }
     let baseline = rt.heap().active_region_count();
     for _ in 0..50 {
-        let (vm, symbols, cctx) = rt.parts();
-        let v = vm
-            .execute_scheduled(&result.bytecode, symbols, cctx)
-            .expect("runs");
+        let (vm, _symbols, cctx) = rt.parts();
+        let v = vm.execute_scheduled(&result.bytecode, cctx).expect("runs");
         assert!(v.is_nil());
     }
     let after = rt.heap().active_region_count();

--- a/src/runtime/tests/selfrec.rs
+++ b/src/runtime/tests/selfrec.rs
@@ -43,8 +43,8 @@ fn run_int(src: &str) -> i64 {
             .expect("compiles")
             .0
     };
-    let (vm, symbols, cctx) = rt.parts();
-    vm.execute_scheduled(&result.bytecode, symbols, cctx)
+    let (vm, _symbols, cctx) = rt.parts();
+    vm.execute_scheduled(&result.bytecode, cctx)
         .expect("runs")
         .as_int()
         .expect("program returns its result as an int")

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,77 +1,121 @@
+//! Symbol identity and the per-instance name memo.
+//!
+//! A `SymbolId` is the name's hash ([`crate::namehash`]), so identity needs no
+//! table: `SymbolId::of(n)` answers it anywhere, for free. What does need a
+//! table is *display*, because a hash cannot be printed as a name. This module
+//! is that table — one per instance, and the only thing a symbol table is for.
+//!
+//! See [docs/impl/symbol.md](../../docs/impl/symbol.md) for the model and what
+//! it buys.
+
 use crate::value::SymbolId;
 use rustc_hash::FxHashMap;
-use std::rc::Rc;
 
-/// Symbol interning table for fast symbol comparison
+/// One instance's hash → spelling memo, for display.
 ///
-/// Uses `Rc<str>` for symbol names to avoid duplication:
-/// - Single allocation via `Rc::from(name)`
-/// - Shared reference counting between map and names vector
-/// - Reduces memory fragmentation
-#[derive(Debug)]
+/// One map serves both vocabularies: a symbol and a keyword with the same
+/// spelling share one entry, because the map's domain is spellings and the tag
+/// that separates `map` from `:map` lives in the `Value`. Not shared, so it
+/// takes no lock, and it is dropped with the instance that owns it — a name
+/// lives exactly as long as the run that learned it. That is why
+/// [`name`](Self::name) hands out a borrow tied to `&self` rather than a
+/// `&'static str`.
+///
+/// A memo answers only for names its own instance met, at the learning sites
+/// docs/impl/symbol.md § "The display memo" enumerates. A value whose name was
+/// never recorded is still a valid value and still compares correctly; it
+/// simply has no spelling to print.
+///
+/// `FxHashMap`, not the default hasher: the reader interns once per identifier
+/// token, so this is on the compile path, and the key is already a
+/// well-distributed hash — SipHash would buy nothing over it.
+#[derive(Debug, Default)]
 pub struct SymbolTable {
-    map: FxHashMap<Rc<str>, SymbolId>,
-    names: Vec<Rc<str>>,
+    names: FxHashMap<u64, Box<str>>,
 }
 
 impl SymbolTable {
     pub fn new() -> Self {
         SymbolTable {
-            map: FxHashMap::default(),
-            names: Vec::new(),
+            names: FxHashMap::default(),
         }
     }
 
-    /// Intern a symbol, returning its ID
+    /// Intern `name`: return its id and record the name for display.
     ///
-    /// Uses `Rc::from()` for a single allocation that's shared between
-    /// the map and names vector, avoiding the previous double-allocation.
+    /// Every symbol that reaches a `Value` through this instance comes here, so
+    /// every symbol the instance can print has a recoverable name.
     pub fn intern(&mut self, name: &str) -> SymbolId {
-        if let Some(&id) = self.map.get(name) {
-            return id;
-        }
-
-        let id = SymbolId(self.names.len() as u32);
-        let shared_name: Rc<str> = Rc::from(name); // Single allocation
-        self.names.push(shared_name.clone());
-        self.map.insert(shared_name, id);
+        let id = SymbolId::of(name);
+        assert!(
+            id != SymbolId::SYNTHETIC,
+            "symbol {:?} hashes onto the reserved SYNTHETIC id",
+            name
+        );
+        self.record(id, name);
         id
     }
 
-    /// Get the name of a symbol by ID
-    pub fn name(&self, id: SymbolId) -> Option<&str> {
-        self.names.get(id.0 as usize).map(|s| s.as_ref())
+    /// The keyword entry point onto the same map: record `name` and return its
+    /// hash — the payload of the keyword value it names. Keyed by raw hash
+    /// because a keyword payload is not a `SymbolId`.
+    pub fn keyword(&mut self, name: &str) -> u64 {
+        let hash = crate::value::keyword::keyword_hash(name);
+        self.record_raw(hash, name);
+        hash
     }
 
-    /// Return the number of interned symbols.
+    /// Record `name` under `id`, panicking if a different name is already there.
+    ///
+    /// Split out from [`intern`](Self::intern) so a name that arrives already
+    /// hashed — from a dump's name table, or beside a symbol that crossed a
+    /// thread — is checked by the same code that checks a freshly read
+    /// identifier.
+    pub(crate) fn record(&mut self, id: SymbolId, name: &str) {
+        self.record_raw(id.0, name);
+    }
+
+    /// A spelling arriving already hashed from either vocabulary — a bundle's
+    /// name table, an image's name table.
+    pub(crate) fn record_spelling(&mut self, hash: u64, name: &str) {
+        self.record_raw(hash, name);
+    }
+
+    /// The one collision guard, shared by both vocabularies: recording a hash
+    /// the memo already maps to a different spelling panics.
+    fn record_raw(&mut self, hash: u64, name: &str) {
+        match self.names.get(&hash) {
+            Some(existing) => assert!(
+                &**existing == name,
+                "name hash collision: {:?} and {:?} both hash to {:#x}",
+                existing,
+                name,
+                hash
+            ),
+            None => {
+                self.names.insert(hash, name.into());
+            }
+        }
+    }
+
+    /// The name recorded for `id`, or `None` if this instance never met it.
+    pub fn name(&self, id: SymbolId) -> Option<&str> {
+        self.names.get(&id.0).map(|n| &**n)
+    }
+
+    /// The spelling recorded for a keyword payload, or `None` if this instance
+    /// never met it.
+    pub fn keyword_name(&self, hash: u64) -> Option<&str> {
+        self.names.get(&hash).map(|n| &**n)
+    }
+
+    /// How many distinct symbol names this instance has recorded.
     pub fn len(&self) -> usize {
         self.names.len()
     }
 
-    /// Return true if no symbols have been interned.
     pub fn is_empty(&self) -> bool {
         self.names.is_empty()
-    }
-
-    /// Check if a symbol exists
-    pub fn get(&self, name: &str) -> Option<SymbolId> {
-        self.map.get(name).copied()
-    }
-
-    /// Extract all symbol ID → name mappings.
-    /// Used for cross-thread symbol portability.
-    pub fn all_names(&self) -> std::collections::HashMap<u32, String> {
-        self.names
-            .iter()
-            .enumerate()
-            .map(|(i, name)| (i as u32, name.to_string()))
-            .collect()
-    }
-}
-
-impl Default for SymbolTable {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/src/symbol/tests.rs
+++ b/src/symbol/tests.rs
@@ -1,9 +1,10 @@
 //! Unit tests (`super` is the parent impl module).
 
 use super::*;
+use crate::value::SymbolId;
 
 #[test]
-fn test_symbol_interning() {
+fn interning_the_same_name_twice_gives_one_id() {
     let mut table = SymbolTable::new();
     let id1 = table.intern("foo");
     let id2 = table.intern("bar");
@@ -13,4 +14,204 @@ fn test_symbol_interning() {
     assert_ne!(id1, id2);
     assert_eq!(table.name(id1), Some("foo"));
     assert_eq!(table.name(id2), Some("bar"));
+}
+
+// The property the whole identity model exists for. Two tables built by
+// different histories agree on every name — so a symbol value copied from one
+// compilation to another still names the same symbol.
+//
+// Counter-factual: under mint-order ids, `first` assigns 0/1/2 and `second`
+// assigns 2/1/0 to the same three names, and every assertion below fails.
+#[test]
+fn two_tables_built_in_opposite_orders_agree_on_every_name() {
+    let mut first = SymbolTable::new();
+    let mut second = SymbolTable::new();
+    let names = ["zeta-xt", "mu-xt", "alpha-xt"];
+
+    let forward: Vec<_> = names.iter().map(|n| first.intern(n)).collect();
+    let backward: Vec<_> = names.iter().rev().map(|n| second.intern(n)).collect();
+
+    for (i, id) in forward.iter().enumerate() {
+        assert_eq!(*id, backward[names.len() - 1 - i]);
+        assert_eq!(second.name(*id), Some(names[i]));
+    }
+}
+
+// What separates a display memo from a registry, and the reason `send`,
+// hydration and `ConstTemplate` decode all carry names: identity crosses on its
+// own, a spelling does not. An instance answers for the symbols it has met.
+//
+// Counter-factual: back the names with one process-wide table and `b.name(id)`
+// answers `Some` here, because `a` recorded it. Then nothing forces a name onto
+// the wire, and a receiver that never met the symbol prints it wrong instead of
+// admitting it does not know.
+#[test]
+fn a_name_learned_by_one_memo_is_unknown_to_another() {
+    let mut a = SymbolTable::new();
+    let b = SymbolTable::new();
+
+    let id = a.intern("memo-local-xt");
+
+    assert_eq!(a.name(id), Some("memo-local-xt"));
+    assert_eq!(
+        b.name(id),
+        None,
+        "a memo holds only the names its own instance learned; one that answers \
+         for another instance's names is a registry"
+    );
+    assert_eq!(
+        SymbolId::of("memo-local-xt"),
+        id,
+        "identity is the name's hash, so it needs no memo and crosses anyway"
+    );
+}
+
+// Identity is a pure function of the name — the same one keywords use, so a
+// symbol payload and a keyword payload are the same kind of number.
+// `src/value/keyword/tests.rs` holds the independent digest oracle; this test
+// pins that symbols share it rather than repeating the values.
+#[test]
+fn id_is_the_shared_name_hash() {
+    for n in ["foo", "map", "+", "list?", "λ", ""] {
+        assert_eq!(SymbolId::of(n).0, crate::value::keyword::keyword_hash(n));
+    }
+    assert_eq!(SymbolId::of("foo").0, 0x7eb4_f5db_4cbe_5ae7);
+}
+
+// `of` answers identity without recording anything; `intern` also records the
+// name. A name nobody interned has an id but no recoverable spelling.
+#[test]
+fn of_computes_identity_without_recording_a_name() {
+    let mut table = SymbolTable::new();
+    let unrecorded = SymbolId::of("never-interned-anywhere-xt");
+    assert_eq!(table.name(unrecorded), None);
+
+    assert_eq!(table.intern("never-interned-anywhere-xt"), unrecorded);
+    assert_eq!(table.name(unrecorded), Some("never-interned-anywhere-xt"));
+}
+
+#[test]
+fn names_survive_later_interning() {
+    let mut table = SymbolTable::new();
+    let id = table.intern("persistent-xt");
+    for i in 0..100 {
+        table.intern(&format!("sym-xt-{}", i));
+    }
+    assert_eq!(table.name(id), Some("persistent-xt"));
+    assert_eq!(table.intern("persistent-xt"), id);
+}
+
+#[test]
+fn distinct_names_get_distinct_ids() {
+    let mut table = SymbolTable::new();
+    let ids: Vec<_> = (0..1000)
+        .map(|i| table.intern(&format!("distinct-xt-{}", i)))
+        .collect();
+    let unique: std::collections::HashSet<_> = ids.iter().collect();
+    assert_eq!(unique.len(), ids.len());
+}
+
+#[test]
+fn special_characters_and_unicode_round_trip() {
+    let mut table = SymbolTable::new();
+    for sym in [
+        "+",
+        "-",
+        "*",
+        "/",
+        "=",
+        "<",
+        ">",
+        "<=",
+        ">=",
+        "!=",
+        "list?",
+        "nil?",
+        "some-func-name",
+        "CamelCase",
+        "with_underscores",
+        "λ",
+        "こんにちは",
+    ] {
+        let id = table.intern(sym);
+        assert_eq!(table.name(id), Some(sym));
+    }
+    let long = "a".repeat(1000);
+    let id = table.intern(&long);
+    assert_eq!(table.name(id), Some(long.as_str()));
+}
+
+// The sentinel is reserved: no real name may occupy it, so a compiler
+// temporary can never be confused with a symbol somebody wrote.
+#[test]
+fn synthetic_is_outside_the_name_space() {
+    let table = SymbolTable::new();
+    assert_eq!(SymbolId::SYNTHETIC.0, u64::MAX);
+    assert_eq!(table.name(SymbolId::SYNTHETIC), None);
+}
+
+// Two names on one hash would silently become one symbol everywhere at once.
+// The memo refuses instead. Real FNV-1a collisions are not constructible at
+// this scale, so the test drives the guard directly.
+#[test]
+#[should_panic(expected = "name hash collision")]
+fn a_second_name_on_one_hash_panics() {
+    let mut table = SymbolTable::new();
+    let forged = SymbolId::of("collision-probe-xt");
+    table.record(forged, "collision-probe-xt");
+    table.record(forged, "a-different-name-entirely");
+}
+
+// The check lives at the learning site, not in one table, so it still fires for
+// a name that arrives from somewhere else — a dump replayed into this instance,
+// or a symbol sent from another thread. A memo that had never met the name is
+// exactly the case a process-wide table cannot check, because it would have
+// recorded the first spelling itself.
+#[test]
+#[should_panic(expected = "name hash collision")]
+fn a_name_arriving_from_elsewhere_is_checked_against_this_memo() {
+    let mut receiver = SymbolTable::new();
+    let forged = SymbolId::of("hydrated-name-xt");
+    receiver.intern("hydrated-name-xt");
+    receiver.record(forged, "what-the-dump-called-it");
+}
+
+// ── keywords share the map ───────────────────────────────────────────
+
+// The memo's domain is spellings, not values: `map` and `:map` differ by tag
+// in the Value, so one entry serves both. Two maps would double the collision
+// guard and let the two vocabularies drift.
+#[test]
+fn a_keyword_and_a_symbol_with_one_spelling_share_one_entry() {
+    let mut table = SymbolTable::new();
+    let sym = table.intern("shared-spelling-xt");
+    let kw = table.keyword("shared-spelling-xt");
+
+    assert_eq!(sym.0, kw, "one spelling, one hash, both vocabularies");
+    assert_eq!(table.len(), 1, "one entry serves both vocabularies");
+    assert_eq!(table.name(sym), Some("shared-spelling-xt"));
+    assert_eq!(table.keyword_name(kw), Some("shared-spelling-xt"));
+}
+
+// The keyword analogue of `of_computes_identity_without_recording_a_name`:
+// identity is pure, display is learned.
+#[test]
+fn keyword_name_answers_only_after_learning() {
+    let mut table = SymbolTable::new();
+    let hash = crate::value::keyword::keyword_hash("kw-unlearned-xt");
+
+    assert_eq!(table.keyword_name(hash), None);
+    assert_eq!(table.keyword("kw-unlearned-xt"), hash);
+    assert_eq!(table.keyword_name(hash), Some("kw-unlearned-xt"));
+}
+
+// One map means one guard: a keyword spelling that collides with a symbol
+// spelling is caught the moment the second one is learned, whichever
+// vocabulary met the hash first.
+#[test]
+#[should_panic(expected = "name hash collision")]
+fn the_collision_guard_spans_both_vocabularies() {
+    let mut table = SymbolTable::new();
+    table.intern("cross-vocab-xt");
+    table.record_spelling(SymbolId::of("cross-vocab-xt").0, "some-other-spelling");
 }

--- a/src/syntax/convert.rs
+++ b/src/syntax/convert.rs
@@ -32,6 +32,40 @@ pub(crate) fn contains_syntax_literal(s: &Syntax) -> bool {
     }
 }
 
+/// Record every keyword spelling in `syntax` into the instance memo — the
+/// keyword analogue of interning identifiers. Called by the expander on each
+/// tree it enters (macro arguments and quasiquote templates round-trip
+/// keywords as bare hashes, so their spellings must be learned before the
+/// round-trip) and by the analyzer as a pre-pass
+/// (docs/impl/symbol.md § "The display memo"). Idempotent; the memo dedups.
+pub(crate) fn learn_keywords(syntax: &Syntax, symbols: &mut SymbolTable) {
+    match &syntax.kind {
+        SyntaxKind::Keyword(name) => {
+            symbols.keyword(name);
+        }
+        SyntaxKind::List(items)
+        | SyntaxKind::Array(items)
+        | SyntaxKind::ArrayMut(items)
+        | SyntaxKind::Struct(items)
+        | SyntaxKind::StructMut(items)
+        | SyntaxKind::Set(items)
+        | SyntaxKind::SetMut(items)
+        | SyntaxKind::Bytes(items)
+        | SyntaxKind::BytesMut(items) => {
+            for item in items {
+                learn_keywords(item, symbols);
+            }
+        }
+        SyntaxKind::Quote(inner)
+        | SyntaxKind::Quasiquote(inner)
+        | SyntaxKind::Unquote(inner)
+        | SyntaxKind::UnquoteSplicing(inner)
+        | SyntaxKind::Splice(inner) => learn_keywords(inner, symbols),
+        SyntaxKind::SyntaxLiteral(inner) => learn_keywords(inner, symbols),
+        _ => {}
+    }
+}
+
 /// Convert a TableKey back to a Syntax node.
 fn table_key_to_syntax(
     key: &TableKey,
@@ -47,7 +81,11 @@ fn table_key_to_syntax(
             SyntaxKind::Symbol(name.to_string())
         }
         TableKey::String(s) => SyntaxKind::String(s.clone()),
-        TableKey::Keyword(s) => SyntaxKind::Keyword(s.clone()),
+        TableKey::Keyword(hash) => {
+            let name = crate::value::keyword::resolve_keyword_name(Some(symbols), *hash)
+                .ok_or_else(|| format!("Unknown keyword {:#x} in table key", hash))?;
+            SyntaxKind::Keyword(name.to_string())
+        }
         TableKey::EmptyList => SyntaxKind::List(vec![]),
         TableKey::Array(keys) => {
             let elements: Result<Vec<_>, _> = keys
@@ -89,9 +127,15 @@ impl Syntax {
             SyntaxKind::Float(n) => Value::float(*n),
             SyntaxKind::Symbol(s) => {
                 let id = symbols.intern(s);
-                Value::symbol(id.0)
+                Value::symbol(id)
             }
-            SyntaxKind::Keyword(s) => Value::keyword(s),
+            SyntaxKind::Keyword(s) => {
+                // A learning site: read-time keyword data (`read`, `read-all`,
+                // `syntax->datum`) records its spelling like the analyzer does
+                // for compiled source.
+                symbols.keyword(s);
+                Value::keyword(s)
+            }
             SyntaxKind::String(s) => ctx.string(s),
             SyntaxKind::StringMut(s) => ctx.string_mut(s.as_bytes().to_vec()),
             SyntaxKind::List(items) => {
@@ -118,69 +162,69 @@ impl Syntax {
             SyntaxKind::Bytes(items) => {
                 // Convert to (bytes e1 e2 ...) list
                 let bytes_sym = symbols.intern("bytes");
-                let mut values = vec![Value::symbol(bytes_sym.0)];
+                let mut values = vec![Value::symbol(bytes_sym)];
                 values.extend(items.iter().map(|item| item.to_value_in(symbols, ctx)));
                 ctx.list(values)
             }
             SyntaxKind::BytesMut(items) => {
                 // Convert to (@bytes e1 e2 ...) list
                 let bytes_mut_sym = symbols.intern("@bytes");
-                let mut values = vec![Value::symbol(bytes_mut_sym.0)];
+                let mut values = vec![Value::symbol(bytes_mut_sym)];
                 values.extend(items.iter().map(|item| item.to_value_in(symbols, ctx)));
                 ctx.list(values)
             }
             SyntaxKind::Struct(items) => {
                 // Convert to (struct k1 v1 k2 v2 ...) list
                 let struct_sym = symbols.intern("struct");
-                let mut values = vec![Value::symbol(struct_sym.0)];
+                let mut values = vec![Value::symbol(struct_sym)];
                 values.extend(items.iter().map(|item| item.to_value_in(symbols, ctx)));
                 ctx.list(values)
             }
             SyntaxKind::StructMut(items) => {
                 // Convert to (@struct k1 v1 k2 v2 ...) list
                 let struct_mut_sym = symbols.intern("@struct");
-                let mut values = vec![Value::symbol(struct_mut_sym.0)];
+                let mut values = vec![Value::symbol(struct_mut_sym)];
                 values.extend(items.iter().map(|item| item.to_value_in(symbols, ctx)));
                 ctx.list(values)
             }
             SyntaxKind::Set(items) => {
                 // Convert to (set e1 e2 ...) list
                 let set_sym = symbols.intern("set");
-                let mut values = vec![Value::symbol(set_sym.0)];
+                let mut values = vec![Value::symbol(set_sym)];
                 values.extend(items.iter().map(|item| item.to_value_in(symbols, ctx)));
                 ctx.list(values)
             }
             SyntaxKind::SetMut(items) => {
                 // Convert to (@set e1 e2 ...) list
                 let set_mut_sym = symbols.intern("@set");
-                let mut values = vec![Value::symbol(set_mut_sym.0)];
+                let mut values = vec![Value::symbol(set_mut_sym)];
                 values.extend(items.iter().map(|item| item.to_value_in(symbols, ctx)));
                 ctx.list(values)
             }
             SyntaxKind::Quote(inner) => {
                 let quote_sym = symbols.intern("quote");
                 let inner_val = inner.to_value_in(symbols, ctx);
-                ctx.list(vec![Value::symbol(quote_sym.0), inner_val])
+                ctx.list(vec![Value::symbol(quote_sym), inner_val])
             }
             SyntaxKind::Quasiquote(inner) => {
                 let sym = symbols.intern("quasiquote");
                 let inner_val = inner.to_value_in(symbols, ctx);
-                ctx.list(vec![Value::symbol(sym.0), inner_val])
+                ctx.list(vec![Value::symbol(sym), inner_val])
             }
             SyntaxKind::Unquote(inner) => {
                 let sym = symbols.intern("unquote");
                 let inner_val = inner.to_value_in(symbols, ctx);
-                ctx.list(vec![Value::symbol(sym.0), inner_val])
+                ctx.list(vec![Value::symbol(sym), inner_val])
             }
             SyntaxKind::UnquoteSplicing(inner) => {
                 let sym = symbols.intern("unquote-splicing");
                 let inner_val = inner.to_value_in(symbols, ctx);
-                ctx.list(vec![Value::symbol(sym.0), inner_val])
+                ctx.list(vec![Value::symbol(sym), inner_val])
             }
             SyntaxKind::Splice(inner) => {
                 let sym = symbols.intern("splice");
                 let inner_val = inner.to_value_in(symbols, ctx);
-                ctx.list(vec![Value::symbol(sym.0), inner_val])
+                ctx.list(vec![Value::symbol(sym), inner_val])
             }
             // A hygiene-bearing template symbol. Materialize a fresh syntax object
             // (ordinary allocation into the ctx's region) wrapping the carried
@@ -322,11 +366,11 @@ impl Syntax {
         } else if let Some(n) = value.as_float() {
             SyntaxKind::Float(n)
         } else if let Some(id) = value.as_symbol() {
-            let name = symbols
-                .name(crate::value::SymbolId(id))
-                .ok_or("Unknown symbol")?;
+            let name = symbols.name(id).ok_or("Unknown symbol")?;
             SyntaxKind::Symbol(name.to_string())
-        } else if let Some(name) = value.as_keyword_name() {
+        } else if let Some(hash) = value.keyword_hash() {
+            let name = crate::value::keyword::resolve_keyword_name(Some(symbols), hash)
+                .ok_or_else(|| format!("Unknown keyword {:#x}", hash))?;
             SyntaxKind::Keyword(name.to_string())
         } else if let Some(s) = value.with_string(|s| s.to_string()) {
             SyntaxKind::String(s)

--- a/src/syntax/expand/mod.rs
+++ b/src/syntax/expand/mod.rs
@@ -236,6 +236,10 @@ impl Expander {
         // recursion; the table is reborrowed per transformer call, never touched
         // simultaneously (docs/impl/region/ctx.md § "Symbols").
         vm.set_symbols(symbols as *mut SymbolTable);
+        // Keyword spellings must be learned BEFORE expansion: a macro argument
+        // or quasiquote template round-trips a keyword as a bare hash, and the
+        // value → syntax conversion on the way back needs the spelling.
+        crate::syntax::convert::learn_keywords(&syntax, symbols);
         match &syntax.kind {
             SyntaxKind::Symbol(_) => Ok(syntax),
             SyntaxKind::List(items) if !items.is_empty() => {

--- a/src/value/AGENTS.md
+++ b/src/value/AGENTS.md
@@ -27,7 +27,7 @@ Runtime value representation using a tagged union.
 | `heap.rs` | `HeapObject` enum, `HeapTag`, `Pair`, `ThreadHandle`, `LSet`, `LSetMut` (re-exports `Closure`, `Arity`, `NativeFn`, `TableKey`) |
 | `send/` | `SendValue`/`SendBundle` wrappers for thread-safe transfer |
 | `display.rs` | `Display` implementation for values |
-| `keyword.rs` | Hash-based keyword identity: FNV-1a hash (full 64-bit), global name table, DSO routing |
+| `keyword.rs` | Keyword identity (name hash) and the static keyword vocabulary for display |
 
 ## Key types
 
@@ -62,7 +62,7 @@ These are set during the swap protocol in `vm/fiber.rs::with_child_fiber`.
 | `FiberStatus` | `fiber.rs` | Fiber lifecycle: New, Alive, Paused, Dead, Error |
 | `SignalBits` | `fiber/signalbits.rs` | Newtype over `u64` (re-exported from `fiber.rs`). The `SIG_*` constants are defined in `crate::signals`: SIG_OK(0), SIG_ERROR(1<<0), SIG_YIELD(1<<1), SIG_DEBUG(1<<2), SIG_RESUME(1<<3), SIG_FFI(1<<4), SIG_PROPAGATE(1<<5), SIG_HALT(1<<8) (among others) |
 | `Arity` | `types.rs` | Function arity (Exact, AtLeast, Range) |
-| `SymbolId` | `types.rs` | Interned symbol identifier |
+| `SymbolId` | `types.rs` | Symbol identity: the FNV-1a hash of the name |
 | `SendValue` | `send/` | Thread-safe value wrapper |
 
 ## Invariants

--- a/src/value/build.rs
+++ b/src/value/build.rs
@@ -330,10 +330,10 @@ pub(crate) fn error_extra(
 ) -> Value {
     let msg_val = string(heap, msg.into(), region);
     let mut fields = BTreeMap::new();
-    fields.insert(TableKey::Keyword("error".into()), Value::keyword(kind));
-    fields.insert(TableKey::Keyword("message".into()), msg_val);
+    fields.insert(TableKey::keyword("error"), Value::keyword(kind));
+    fields.insert(TableKey::keyword("message"), msg_val);
     for (key, val) in extra {
-        fields.insert(TableKey::Keyword((*key).into()), *val);
+        fields.insert(TableKey::keyword(key), *val);
     }
     struct_from(heap, fields, region)
 }

--- a/src/value/closure.rs
+++ b/src/value/closure.rs
@@ -14,7 +14,6 @@ use crate::value::region_slice::RegionSlice;
 use crate::value::types::Arity;
 use crate::value::CaptureMask;
 use crate::value::Value;
-use std::collections::HashMap;
 use std::rc::Rc;
 
 /// Per-definition closure data shared across all instances of the same lambda.
@@ -42,8 +41,6 @@ pub struct ClosureTemplate {
     /// in width (see `CaptureMask`) — an uncaptured local at any index gets a
     /// bare-NIL env slot, never a leaked dead cell.
     pub capture_locals_mask: CaptureMask,
-    /// Symbol ID → name mapping for cross-thread portability.
-    pub symbol_names: Rc<HashMap<u32, String>>,
     /// Bytecode offset → source location mapping for error reporting.
     pub location_map: Rc<LocationMap>,
     /// LIR function for deferred JIT compilation.
@@ -112,7 +109,6 @@ impl ClosureTemplate {
             signal: Signal::silent(),
             capture_params_mask: 0,
             capture_locals_mask: CaptureMask::empty(),
-            symbol_names: Rc::new(HashMap::new()),
             location_map: Rc::new(LocationMap::new()),
             lir_function: None,
             doc: None,
@@ -350,7 +346,6 @@ impl PartialEq for Closure {
             && self.template.signal == other.template.signal
             && self.template.capture_params_mask == other.template.capture_params_mask
             && self.template.capture_locals_mask == other.template.capture_locals_mask
-            && self.template.symbol_names == other.template.symbol_names
             && self.template.location_map == other.template.location_map
             && self.template.doc == other.template.doc
             && self.template.vararg_kind == other.template.vararg_kind

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -2,8 +2,8 @@
 //!
 //! The tagged-union `Value` renders through one body, `fmt_value`, parameterized
 //! by a `debug` flag and an optional `&SymbolTable`. Symbol-name resolution is
-//! per-instance (docs/impl/region/ctx.md § "Symbols through the ctx"): a bare
-//! `Display`/`Debug` carries no table and renders a symbol as `#<sym:id>`, while
+//! per-instance (docs/impl/symbol.md § "Reading a name, and not reading one"): a bare
+//! `Display`/`Debug` carries no table and renders a symbol as `#<symbol:hash>`, while
 //! [`Value::display_with`] / [`Value::debug_with`] thread an instance's table so
 //! names resolve all the way down.
 
@@ -79,9 +79,9 @@ fn write_float(f: &mut fmt::Formatter<'_>, n: f64) -> fmt::Result {
 /// rendering body for both `Display` (`debug == false`) and `Debug`
 /// (`debug == true`); it recurses by calling itself, so a threaded table reaches
 /// every nested symbol. `symbols` is `None` for a bare trait render — a symbol
-/// then prints `#<sym:id>` — and `Some` when a caller threads its instance's
+/// then prints `#<symbol:hash>` — and `Some` when a caller threads its instance's
 /// table via [`Value::display_with`] / [`Value::debug_with`]
-/// (docs/impl/region/ctx.md § "Symbols through the ctx").
+/// (docs/impl/symbol.md § "Reading a name, and not reading one").
 ///
 /// Where the two renderings diverge they branch on `debug`: strings (Debug quotes
 /// and escapes), and the element/key recursion of cons/array/set/struct. A struct
@@ -115,7 +115,7 @@ pub(crate) fn fmt_value(
     }
     if let Some(id) = v.as_symbol() {
         // Identical in Display and Debug: the bare name if the threaded table
-        // resolves it, else `#<sym:id>`. The name carries no leading `'` —
+        // resolves it, else `#<symbol:hash>`. The name carries no leading `'` —
         // Scheme/CL print a symbol as its bare name (`'` is reader syntax for
         // `quote`, not part of a symbol's printed form), and this matches the
         // `string`/`println` path (`src/primitives/convert.rs`), so a list of
@@ -123,13 +123,20 @@ pub(crate) fn fmt_value(
         // `Display`, a struct field, an error's `:syntax` form). A symbol stays
         // distinguishable from a `"string"` in Debug mode (strings quote) and
         // from a `:keyword` always.
-        return match symbols.and_then(|s| s.name(crate::value::SymbolId(id))) {
+        return match symbols.and_then(|s| s.name(id)) {
             Some(name) => write!(f, "{}", name),
-            None => write!(f, "#<sym:{}>", id),
+            None => write!(f, "#<symbol:{:#x}>", id.0),
         };
     }
-    if let Some(name) = v.as_keyword_name() {
-        return write!(f, ":{}", name);
+    // Keywords resolve their spelling through the threaded memo, exactly as
+    // symbols do; without one (or for a spelling this instance never learned)
+    // the unreadable form keeps the identity visible without fabricating a
+    // keyword literal that would denote a different keyword.
+    if let Some(hash) = v.keyword_hash() {
+        return match crate::value::keyword::resolve_keyword_name(symbols, hash) {
+            Some(name) => write!(f, ":{}", name),
+            None => write!(f, "#<keyword:{:#x}>", hash),
+        };
     }
     if let Some(addr) = v.as_pointer() {
         return write!(f, "<pointer 0x{:x}>", addr);
@@ -405,7 +412,7 @@ impl fmt::Debug for Value {
 /// A `Value` paired with a symbol table for name-resolving rendering. Returned by
 /// [`Value::display_with`]; its `Display` resolves symbol names (the bare `name`)
 /// through the table, where a bare `Display`/`Debug` (no table) would print
-/// `#<sym:id>`.
+/// `#<symbol:hash>`.
 pub struct DisplayWith<'a> {
     value: Value,
     symbols: Option<&'a SymbolTable>,
@@ -433,8 +440,8 @@ impl fmt::Display for DebugWith<'_> {
 
 impl Value {
     /// Render through `symbols`, resolving symbol names (`'name`); pass `None` to
-    /// render `#<sym:id>`. The threaded-table alternative to a bare `Display`
-    /// (docs/impl/region/ctx.md § "Symbols through the ctx").
+    /// render `#<symbol:hash>`. The threaded-table alternative to a bare `Display`
+    /// (docs/impl/symbol.md § "Reading a name, and not reading one").
     pub fn display_with<'a>(&self, symbols: Option<&'a SymbolTable>) -> DisplayWith<'a> {
         DisplayWith {
             value: *self,

--- a/src/value/display/tests.rs
+++ b/src/value/display/tests.rs
@@ -2,6 +2,7 @@
 
 use crate::value::arena::with_test_region;
 use crate::value::error::error_val_in;
+use crate::value::Value;
 
 /// Debug repr of a string containing a double-quote must escape it.
 #[test]
@@ -55,4 +56,33 @@ fn test_display_struct_quotes_string_values() {
         // :message → "expected \"integer\"" (string, quoted and escaped)
         assert!(repr.contains(r#""expected \"integer\"""#), "got: {}", repr);
     })
+}
+
+// ── keyword display resolves memo → vocabulary → unreadable form ─────
+
+// A vocabulary spelling ("ok") needs no memo; a run-time spelling resolves
+// only through the memo that learned it; an unlearned spelling renders the
+// unreadable form. The form is deliberately not a keyword literal: any
+// `:something` rendering would denote a real — and different — keyword.
+#[test]
+fn keyword_display_resolves_memo_then_vocabulary_then_unreadable() {
+    let mut memo = crate::symbol::SymbolTable::new();
+    memo.keyword("kw-display-learned-xt");
+
+    let learned = Value::keyword("kw-display-learned-xt");
+    let vocab = Value::keyword("ok");
+    let unlearned = Value::keyword("kw-display-unlearned-xt");
+
+    assert_eq!(
+        format!("{}", learned.display_with(Some(&memo))),
+        ":kw-display-learned-xt"
+    );
+    assert_eq!(format!("{}", vocab), ":ok");
+    assert_eq!(
+        format!("{}", unlearned.display_with(Some(&memo))),
+        format!(
+            "#<keyword:{:#x}>",
+            crate::value::keyword::keyword_hash("kw-display-unlearned-xt")
+        )
+    );
 }

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -72,11 +72,14 @@ pub fn match_fail_error_in(heap: &mut FiberHeap, val: Value, region: RuntimeRegi
 pub fn format_error(value: Value) -> String {
     // Struct error: {:error :keyword :message "string"}
     if let Some(fields) = value.as_struct() {
-        let error = sorted_struct_get(fields, &TableKey::Keyword("error".into()));
-        let msg = sorted_struct_get(fields, &TableKey::Keyword("message".into()));
+        let error = sorted_struct_get(fields, &TableKey::keyword("error"));
+        let msg = sorted_struct_get(fields, &TableKey::keyword("message"));
         if let (Some(error_val), Some(msg_val)) = (error, msg) {
             if let (Some(name), Some(text)) = (
-                error_val.as_keyword_name(),
+                error_val
+                    .keyword_hash()
+                    .and_then(|h| crate::value::keyword::resolve_keyword_name(None, h))
+                    .map(str::to_string),
                 msg_val.with_string(|s| s.to_string()),
             ) {
                 return format!("{}: {}", name, text);
@@ -88,7 +91,10 @@ pub fn format_error(value: Value) -> String {
     if let Some(elems) = value.as_array() {
         if elems.len() == 2 {
             if let Some(msg) = elems[1].with_string(|s| s.to_string()) {
-                if let Some(name) = elems[0].as_keyword_name() {
+                if let Some(name) = elems[0]
+                    .keyword_hash()
+                    .and_then(|h| crate::value::keyword::resolve_keyword_name(None, h))
+                {
                     return format!("{}: {}", name, msg);
                 }
                 return msg;

--- a/src/value/error/tests.rs
+++ b/src/value/error/tests.rs
@@ -45,20 +45,17 @@ fn test_error_val_creates_struct() {
 
         // Should have :error and :message keys
         let fields = err.as_struct().unwrap();
+        assert!(sorted_struct_contains(fields, &TableKey::keyword("error")));
         assert!(sorted_struct_contains(
             fields,
-            &TableKey::Keyword("error".into())
-        ));
-        assert!(sorted_struct_contains(
-            fields,
-            &TableKey::Keyword("message".into())
+            &TableKey::keyword("message")
         ));
 
         // Values should be correct
-        let error_key = sorted_struct_get(fields, &TableKey::Keyword("error".into())).unwrap();
-        assert_eq!(error_key.as_keyword_name().as_deref(), Some("type-error"));
+        let error_key = sorted_struct_get(fields, &TableKey::keyword("error")).unwrap();
+        assert!(error_key.is_keyword_named("type-error"));
 
-        let msg_key = sorted_struct_get(fields, &TableKey::Keyword("message".into())).unwrap();
+        let msg_key = sorted_struct_get(fields, &TableKey::keyword("message")).unwrap();
         assert_eq!(
             msg_key.with_string(|s| s.to_string()),
             Some("expected integer".to_string())
@@ -130,19 +127,16 @@ fn test_error_val_extra_creates_struct() {
         let fields = err.as_struct().unwrap();
         // :error keyword correct
         assert_eq!(
-            sorted_struct_get(fields, &TableKey::Keyword("error".into()))
-                .unwrap()
-                .as_keyword_name()
-                .as_deref(),
-            Some("io-error"),
+            sorted_struct_get(fields, &TableKey::keyword("error")).copied(),
+            Some(Value::keyword("io-error")),
         );
         // :message correct
         assert!(sorted_struct_contains(
             fields,
-            &TableKey::Keyword("message".into())
+            &TableKey::keyword("message")
         ));
         // :path extra field present
-        let path_val = sorted_struct_get(fields, &TableKey::Keyword("path".into())).unwrap();
+        let path_val = sorted_struct_get(fields, &TableKey::keyword("path")).unwrap();
         assert_eq!(
             path_val.with_string(|s| s.to_string()),
             Some("/no/such".to_string()),

--- a/src/value/fiberheap/census.rs
+++ b/src/value/fiberheap/census.rs
@@ -267,7 +267,7 @@ fn slice_stat<T: 'static>(sl: &RegionSlice<T>, seen: &mut FxHashSet<usize>, stat
 
 fn key_bytes(k: &TableKey) -> usize {
     match k {
-        TableKey::String(s) | TableKey::Keyword(s) => s.len(),
+        TableKey::String(s) => s.len(),
         TableKey::Array(ks) => ks.iter().map(key_bytes).sum(),
         _ => 0,
     }

--- a/src/value/keyword.rs
+++ b/src/value/keyword.rs
@@ -1,116 +1,363 @@
-//! Hash-based keyword identity with global name recovery.
+//! Keyword identity and the static keyword vocabulary.
 //!
-//! Keywords are stored as tagged-union values where the payload holds an FNV-1a
-//! hash of the keyword name. The hash is deterministic across runs, threads, and
-//! DSO boundaries. Equality is `u64 == u64` — no string comparison, no heap
-//! dereference.
+//! A keyword's payload is the 64-bit FNV-1a hash of its name — the same
+//! function symbol identity uses ([`crate::namehash`]), so equality is
+//! `u64 == u64` with no string comparison and no heap dereference, and the
+//! same name yields the same payload in every thread, process, and build.
 //!
-//! The global name table (`KEYWORD_NAMES`) maps hashes back to names for display
-//! and pattern matching. Every keyword ever created via `Value::keyword()` has
-//! its name in the table.
-//!
-//! ## Plugin keyword routing
-//!
-//! Plugins using the stable ABI (`elle-plugin` crate) do not link against
-//! `elle` and never access `KEYWORD_NAMES` directly. Instead, they call
-//! `api().keyword("name")` which routes through the named-function ABI to
-//! `make_keyword` in `plugin_api.rs`, which calls `Value::keyword()` in the
-//! host — automatically using the host's keyword table.
-//!
-//! ## Collision handling
-//!
-//! Hash collisions panic immediately — different names that produce the same
-//! 64-bit hash are a fatal, unrecoverable condition. The payload is a full
-//! `u64` (the keyword tag occupies the separate tag word of the 16-byte
-//! `Value`), so the hash uses all 64 bits. At realistic keyword set sizes
-//! (≤ 10,000), the birthday-bound collision probability is below
-//! 0.0000000003% (~1 in 3·10^11).
+//! Construction is identity only: [`Value::keyword`](crate::value::Value)
+//! records nothing. Display resolves a spelling through the per-instance
+//! memo first (`SymbolTable::keyword_name`), then through `VOCABULARY` —
+//! the build-fixed list of every spelling the Rust runtime itself mints.
+//! The vocabulary is the keyword analogue of the primitive-name index in
+//! `primitives::registration::static_name`: fixed at build time, immutable,
+//! and needing no instance. A spelling in neither renders as
+//! `#<keyword:hash>` (docs/impl/symbol.md § "Reading a name, and not
+//! reading one").
 
+use crate::symbol::SymbolTable;
 use std::collections::HashMap;
-use std::sync::{LazyLock, RwLock};
+use std::sync::LazyLock;
 
-/// Global keyword name table. Maps 64-bit FNV-1a hash to keyword name.
-///
-/// This is the authoritative table in the host binary. Stable-ABI plugins
-/// never access it directly — they call through the named-function API
-/// (`intern_keyword`, `keyword_name` in `plugin_api.rs`), which operates
-/// on this table in the host process.
-static KEYWORD_NAMES: LazyLock<RwLock<HashMap<u64, Box<str>>>> =
-    LazyLock::new(|| RwLock::new(HashMap::new()));
-
-/// Full 64-bit FNV-1a hash of a keyword name.
-///
-/// No truncation: the keyword payload is a full `u64` in the 16-byte
-/// `Value`, so the hash spans the entire 64-bit space for maximum
-/// collision resistance.
-///
-/// `const fn` to enable precomputed keyword hash constants in the future.
-/// Uses `while` loop (not `for`) because `for` desugars to
-/// `IntoIterator::into_iter()` which is not const-compatible.
+/// The 64-bit name hash of a keyword name — [`crate::namehash::name_hash`],
+/// the same function symbol identity uses.
 pub const fn keyword_hash(name: &str) -> u64 {
-    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
-    const FNV_PRIME: u64 = 0x100000000000001b;
-    let bytes = name.as_bytes();
-    let mut hash = FNV_OFFSET;
-    let mut i = 0;
-    while i < bytes.len() {
-        hash ^= bytes[i] as u64;
-        hash = hash.wrapping_mul(FNV_PRIME);
-        i += 1;
-    }
-    hash
+    crate::namehash::name_hash(name)
 }
 
-/// Register a keyword name and return its 64-bit hash.
+/// Every keyword spelling the Rust runtime mints from a fixed string —
+/// result-struct keys, error kinds, type names, config and event keywords.
+/// Display-only: identity never consults this list. Spellings that reach a
+/// keyword dynamically (read from source, converted from a string, minted by
+/// a plugin, parsed from JSON) are learned by the instance memo instead.
 ///
-/// Panics on hash collision (different name maps to same hash).
-/// RwLock poisoning on collision panic is intentional — a collision
-/// is fatal and the process should abort.
-pub fn intern_keyword(name: &str) -> u64 {
-    let hash = keyword_hash(name);
-    {
-        let table = KEYWORD_NAMES.read().unwrap();
-        if let Some(existing) = table.get(&hash) {
-            assert!(
-                &**existing == name,
-                "keyword hash collision: {:?} and {:?} both hash to {:#x}",
-                existing,
-                name,
-                hash
-            );
-            return hash;
+/// `vocabulary_is_collision_free` proves the list injective under the hash;
+/// a missing entry is not an error — the keyword prints as `#<keyword:hash>`
+/// until the spelling is added here or learned at run time.
+static VOCABULARY: &[&str] = &[
+    // Result-struct keys and general fields
+    "a",
+    "active-allocator",
+    "addr",
+    "aliases",
+    "allocated-bytes",
+    "annotated",
+    "args",
+    "arity",
+    "attempts",
+    "blocks",
+    "calls",
+    "category",
+    "code",
+    "col",
+    "count",
+    "cwd",
+    "data",
+    "doc",
+    "edges",
+    "entry",
+    "env",
+    "example",
+    "file",
+    "first",
+    "func",
+    "id",
+    "instrs",
+    "k",
+    "kind",
+    "label",
+    "last",
+    "length",
+    "line",
+    "locals",
+    "message",
+    "name",
+    "params",
+    "path",
+    "peak-count",
+    "pid",
+    "port",
+    "process",
+    "rc",
+    "reason",
+    "region",
+    "regs",
+    "rest",
+    "scope-depth",
+    "scope-dtor-count",
+    "scope-enter-count",
+    "sender-pid",
+    "sender-uid",
+    "signal",
+    "spans",
+    "stats",
+    "term",
+    "term-display",
+    "term-kind",
+    "term-span",
+    "value",
+    "x",
+    // Status and outcome keywords
+    "denied",
+    "disconnected",
+    "empty",
+    "error",
+    "failed",
+    "flip",
+    "full",
+    "ineligible",
+    "missing",
+    "ok",
+    "pending",
+    "ready",
+    "recursive",
+    "gated",
+    // Capability / feature gating
+    "capability-denied",
+    "feature-disabled",
+    "fiber/caps",
+    // Error kinds (`ctx.error(kind, …)` becomes the `:error` field's keyword)
+    "argument-error",
+    "arity-error",
+    "compile-error",
+    "division-by-zero",
+    "double-free",
+    "encoding-error",
+    "exec-error",
+    "ffi-error",
+    "fiber-error",
+    "format-error",
+    "internal-error",
+    "io-error",
+    "match-error",
+    "mlir-error",
+    "os-signal-error",
+    "overflow-error",
+    "range-error",
+    "read-error",
+    "rewrite-error",
+    "runtime-error",
+    "serde-error",
+    "state-error",
+    "thread-error",
+    "trait-error",
+    "type-error",
+    "unknown-tier",
+    "allocation-error",
+    "analysis-error",
+    "barrier-error",
+    "eval-error",
+    "lookup-error",
+    "parse-error",
+    "signal-error",
+    "syntax-error",
+    "value-error",
+    "stack-overflow",
+    "out-of-fuel",
+    "halt",
+    "double-resume",
+    "failed-assertion",
+    "not-implemented",
+    "timed-out",
+    // Type names (`type-of` and type errors mint `Value::keyword(type_name())`)
+    "boolean",
+    "float",
+    "integer",
+    "keyword",
+    "list",
+    "native-fn",
+    "nil",
+    "ptr",
+    "symbol",
+    "unknown",
+    "array",
+    "@array",
+    "box",
+    "bytes",
+    "@bytes",
+    "capture-cell",
+    "closure",
+    "closure-template",
+    "external",
+    "ffi",
+    "ffi-signature",
+    "ffi-type",
+    "fiber",
+    "library-handle",
+    "parameter",
+    "set",
+    "@set",
+    "string",
+    "@string",
+    "struct",
+    "@struct",
+    "syntax",
+    "thread-handle",
+    // Trait protocol keys
+    "Collection",
+    "Sequence",
+    "conj",
+    "display",
+    "empty?",
+    "has?",
+    "iter",
+    "nth",
+    // Compile / VM / config keywords
+    "compile/barrier-module",
+    "compile/dumps",
+    "compile/run-on",
+    "compile/whole-module",
+    "compile/whole-module-syntax",
+    "debug-bytecode",
+    "list-primitives",
+    "primitive",
+    "primitive-meta",
+    "vm/config",
+    "vm/config-set",
+    "trace",
+    "unicode",
+    "adaptive",
+    "custom",
+    "eager",
+    "lazy",
+    "off",
+    "on",
+    // Execution tiers
+    "git",
+    "gpu",
+    "jit",
+    "jit?",
+    "jit/rejections",
+    "mlir",
+    "mlir-cpu",
+    "mlir/compile-spirv",
+    "vm",
+    "wasm",
+    // Arena / memory gauges
+    "arena/allocs",
+    "arena/stats",
+    "object-count",
+    "object-limit",
+    "objects",
+    // I/O and process keywords
+    "read-write",
+    "timeout",
+    "read",
+    "write",
+    "inherit",
+    "null",
+    "pipe",
+    "async",
+    "keys",
+    "deny",
+    "from",
+    "start",
+    "current",
+    "end",
+    "text",
+    "binary",
+    "keepalive",
+    "encoding",
+    "sigterm",
+    "sigkill",
+    "sighup",
+    "sigint",
+    "sigquit",
+    "sigpipe",
+    "sigalrm",
+    "sigusr1",
+    "sigusr2",
+    "sigchld",
+    "sigcont",
+    "sigstop",
+    "sigtstp",
+    "sigttin",
+    "sigttou",
+    "sigwinch",
+    "stderr",
+    "stdin",
+    "stdout",
+    // File-watch event kinds
+    "create",
+    "modify",
+    "remove",
+    "rename",
+    // FFI type keywords (`TypeDesc::from_keyword`; "float"/"string" appear
+    // above)
+    "bool",
+    "char",
+    "default",
+    "double",
+    "i16",
+    "i32",
+    "i64",
+    "i8",
+    "int",
+    "long",
+    "short",
+    "size",
+    "ssize",
+    "u16",
+    "u32",
+    "u64",
+    "u8",
+    "uchar",
+    "uint",
+    "ulong",
+    "ushort",
+    "void",
+    // Fiber statuses
+    "alive",
+    "dead",
+    "new",
+    "paused",
+    // Introspection enums: binding scope, capture kind, diagnostic severity,
+    // symbol kind, LIR terminator kind, compile-dump kind ("parameter",
+    // "error", "jit" already appear above)
+    "local",
+    "lbox",
+    "transitive",
+    "info",
+    "warning",
+    "function",
+    "variable",
+    "builtin",
+    "macro",
+    "branch",
+    "emit",
+    "jump",
+    "return",
+    "unreachable",
+    "ast",
+    "cfg",
+    "defuse",
+    "dfa",
+    "escape",
+    "fhir",
+    "hir",
+    "lir",
+    "regions",
+];
+
+/// The spelling of a vocabulary keyword, or `None` if `hash` names nothing
+/// the runtime spells itself.
+pub(crate) fn static_keyword_name(hash: u64) -> Option<&'static str> {
+    static INDEX: LazyLock<HashMap<u64, &'static str>> = LazyLock::new(|| {
+        let mut index = HashMap::new();
+        for name in VOCABULARY {
+            index.insert(keyword_hash(name), *name);
         }
-    }
-    let mut table = KEYWORD_NAMES.write().unwrap();
-    if let Some(existing) = table.get(&hash) {
-        assert!(
-            &**existing == name,
-            "keyword hash collision: {:?} and {:?} both hash to {:#x}",
-            existing,
-            name,
-            hash
-        );
-    } else {
-        table.insert(hash, name.into());
-    }
-    hash
+        index
+    });
+    INDEX.get(&hash).copied()
 }
 
-/// Return the number of registered keywords in the global name table.
-pub fn keyword_count() -> usize {
-    KEYWORD_NAMES.read().unwrap().len()
-}
-
-/// Look up a keyword name by its 64-bit hash.
-///
-/// Returns None only if the hash was never registered — should not happen
-/// for any keyword created through Value::keyword().
-pub fn keyword_name(hash: u64) -> Option<String> {
-    KEYWORD_NAMES
-        .read()
-        .unwrap()
-        .get(&hash)
-        .map(|s| s.to_string())
+/// Resolve a keyword payload to its spelling: the instance memo first, then
+/// the static vocabulary. The one lookup order every display and
+/// name-recovering site uses.
+pub(crate) fn resolve_keyword_name(memo: Option<&SymbolTable>, hash: u64) -> Option<&str> {
+    memo.and_then(|m| m.keyword_name(hash))
+        .or_else(|| static_keyword_name(hash))
 }
 
 #[cfg(test)]

--- a/src/value/keyword/tests.rs
+++ b/src/value/keyword/tests.rs
@@ -84,15 +84,79 @@ fn known_keywords_no_collision() {
     }
 }
 
+// The vocabulary is injective under the hash — the static half of the
+// collision guard the memo enforces at run time.
 #[test]
-fn intern_and_lookup() {
-    let h = intern_keyword("test-intern-lookup");
-    assert_eq!(keyword_name(h).as_deref(), Some("test-intern-lookup"));
+fn vocabulary_is_collision_free() {
+    let mut seen = std::collections::HashMap::new();
+    for name in VOCABULARY {
+        if let Some(prev) = seen.insert(keyword_hash(name), name) {
+            panic!("vocabulary collision: {:?} and {:?}", prev, name);
+        }
+    }
 }
 
+// Resolution order: the memo answers first, then the static vocabulary, then
+// nothing. "error" is in the vocabulary; a fresh spelling is not.
 #[test]
-fn intern_idempotent() {
-    let h1 = intern_keyword("test-idempotent");
-    let h2 = intern_keyword("test-idempotent");
-    assert_eq!(h1, h2);
+fn resolution_reads_memo_then_vocabulary() {
+    let mut memo = crate::symbol::SymbolTable::new();
+    let dynamic = memo.keyword("kw-resolve-order-xt");
+
+    assert_eq!(
+        resolve_keyword_name(Some(&memo), dynamic),
+        Some("kw-resolve-order-xt"),
+        "a learned spelling resolves through the memo"
+    );
+    assert_eq!(
+        resolve_keyword_name(None, dynamic),
+        None,
+        "a run-time spelling is invisible without the memo that learned it"
+    );
+    assert_eq!(
+        resolve_keyword_name(None, keyword_hash("error")),
+        Some("error"),
+        "a vocabulary spelling needs no memo"
+    );
+}
+
+// Every fixed spelling the runtime mints must be in VOCABULARY, or the value
+// it names prints as #<keyword:hash>. The scan covers the literal mint forms;
+// spellings reaching keywords through enum accessors are covered by the
+// corpus, which prints them.
+//
+// Counter-factual: remove "ok" from VOCABULARY and this fails on the
+// `Value::keyword("ok")` sites.
+#[test]
+fn vocabulary_covers_literal_mint_sites() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut missing = std::collections::BTreeSet::new();
+    let mut stack = vec![root];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("readable source dir") {
+            let path = entry.expect("readable dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs")
+                // Test-only literals never reach a user's display path.
+                && !path.to_string_lossy().contains("tests")
+            {
+                let text = std::fs::read_to_string(&path).expect("readable source file");
+                for pat in ["Value::keyword(\"", "TableKey::keyword(\"", "ctx.error(\""] {
+                    for (i, _) in text.match_indices(pat) {
+                        let rest = &text[i + pat.len()..];
+                        let name = &rest[..rest.find('"').expect("terminated literal")];
+                        if static_keyword_name(keyword_hash(name)).is_none() {
+                            missing.insert(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "keyword spellings minted from literals but absent from VOCABULARY: {:?}",
+        missing
+    );
 }

--- a/src/value/repr/AGENTS.md
+++ b/src/value/repr/AGENTS.md
@@ -33,7 +33,7 @@ Does NOT:
 | TAG_FALSE | 0 | False (falsy) |
 | TAG_TRUE | 0 | True (truthy) |
 | TAG_EMPTY_LIST | 0 | Empty list (truthy) |
-| TAG_SYMBOL | u32 symbol ID | Symbol |
+| TAG_SYMBOL | FNV-1a hash of name | Symbol |
 | TAG_KEYWORD | FNV-1a hash of name | Keyword |
 | TAG_PTR | heap pointer | Cons, Array, Table, Closure, Fiber, etc. |
 ## Constructors
@@ -44,7 +44,7 @@ Does NOT:
 | `Value::float(f)` | Float | Handles NaN/Infinity specially |
 | `Value::bool(b)` | Bool | True or False |
 | `Value::symbol(id)` | Symbol | From SymbolId |
-| `Value::keyword(name)` | Keyword | FNV-1a hash of name; registers in global name table |
+| `Value::keyword(name)` | Keyword | FNV-1a hash of name; identity only, records nothing |
 | `Value::nil()` | Nil | Falsy, represents absence |
 | `Value::EMPTY_LIST` | EmptyList | Truthy, represents empty list |
 | `Value::TRUE` | True | Truthy singleton |
@@ -80,8 +80,8 @@ Does NOT:
 | `is_symbol()` | bool | Type check |
 | `as_symbol()` | Option<SymbolId> | Extract symbol ID |
 | `is_keyword()` | bool | Type check |
-| `keyword_hash()` | Option<u64> | Extract 64-bit keyword hash (fast path — no lock) |
-| `as_keyword_name()` | Option<String> | Extract keyword name (acquires RwLock + allocates) |
+| `keyword_hash()` | Option<u64> | Extract 64-bit keyword hash |
+| `is_keyword_named(name)` | bool | One hash compare against a spelling; spelling recovery goes through the memo |
 | `is_nil()` | bool | Type check (only matches nil, not empty list) |
 | `is_empty_list()` | bool | Type check (only matches empty list, not nil) |
 | `is_cons()` | bool | Type check |

--- a/src/value/repr/accessors.rs
+++ b/src/value/repr/accessors.rs
@@ -74,10 +74,11 @@ impl Value {
             .flatten()
     }
 
-    /// Compare two keyword values lexicographically by name.
+    /// Compare two keyword values by hash — the portable order sorted
+    /// containers rely on, deterministic in every instance and build.
     /// Returns None if either value is not a keyword.
     pub fn compare_keyword(&self, other: &Value) -> Option<std::cmp::Ordering> {
-        match (self.as_keyword_name(), other.as_keyword_name()) {
+        match (self.keyword_hash(), other.keyword_hash()) {
             (Some(a), Some(b)) => Some(a.cmp(&b)),
             _ => None,
         }

--- a/src/value/repr/accessors/conversions.rs
+++ b/src/value/repr/accessors/conversions.rs
@@ -53,11 +53,11 @@ impl Value {
             self.as_float()
         }
     }
-    /// Extract symbol ID if this is a symbol.
+    /// Extract symbol identity if this is a symbol.
     #[inline]
-    pub fn as_symbol(&self) -> Option<u32> {
+    pub fn as_symbol(&self) -> Option<crate::value::SymbolId> {
         if self.is_symbol() {
-            Some(self.payload as u32)
+            Some(crate::value::SymbolId(self.payload))
         } else {
             None
         }
@@ -71,16 +71,13 @@ impl Value {
             None
         }
     }
-    /// Extract keyword name if this is a keyword.
-    /// Acquires RwLock read lock and allocates a String.
-    /// Use `keyword_hash()` when only comparing, not displaying.
+    /// Whether this value is the keyword spelled `name` — one hash compare,
+    /// no table, no allocation (docs/impl/symbol.md § "Reading a name, and
+    /// not reading one"). Spelling recovery goes through
+    /// `keyword::resolve_keyword_name` with a memo instead.
     #[inline]
-    pub fn as_keyword_name(&self) -> Option<String> {
-        if self.is_keyword() {
-            crate::value::keyword::keyword_name(self.payload)
-        } else {
-            None
-        }
+    pub fn is_keyword_named(&self, name: &str) -> bool {
+        self.keyword_hash() == Some(crate::value::keyword::keyword_hash(name))
     }
     /// Extract heap pointer if this is a heap value.
     #[inline]

--- a/src/value/repr/constructors.rs
+++ b/src/value/repr/constructors.rs
@@ -41,21 +41,38 @@ impl Value {
         }
     }
 
-    /// Create a symbol value from a SymbolId.
+    /// Create a symbol value from a `SymbolId`.
+    ///
+    /// Takes the newtype, not a bare `u64`: a keyword hash is also a `u64`, and
+    /// the two payloads would otherwise be swappable at a call site with no
+    /// compile error.
     #[inline]
-    pub fn symbol(id: u32) -> Self {
+    pub fn symbol(id: crate::value::SymbolId) -> Self {
         Value {
             tag: TAG_SYMBOL,
-            payload: id as u64,
+            payload: id.0,
         }
     }
 
-    /// Create a keyword value from a name string.
-    /// The name is hashed and registered in the global keyword table.
-    /// Equality is O(1) hash comparison; name recovery via `as_keyword_name()`.
+    /// Create a keyword value from a name string. Identity only — the
+    /// spelling is recorded nowhere; display resolves it through the
+    /// per-instance memo and the static vocabulary
+    /// (docs/impl/symbol.md § "The display memo"). `const`, so a well-known
+    /// keyword can be a constant.
     #[inline]
-    pub fn keyword(name: &str) -> Self {
-        let hash = crate::value::keyword::intern_keyword(name);
+    pub const fn keyword(name: &str) -> Self {
+        Value {
+            tag: TAG_KEYWORD,
+            payload: crate::value::keyword::keyword_hash(name),
+        }
+    }
+
+    /// Rebuild a keyword from its payload — a hash that came off an existing
+    /// keyword (`keyword_hash()`), a `TableKey::Keyword`, or a decoded
+    /// constant. Not for arbitrary integers: a payload that never came from
+    /// [`keyword_hash`](crate::value::keyword::keyword_hash) names nothing.
+    #[inline]
+    pub(crate) fn keyword_from_hash(hash: u64) -> Self {
         Value {
             tag: TAG_KEYWORD,
             payload: hash,

--- a/src/value/repr/traits/ord.rs
+++ b/src/value/repr/traits/ord.rs
@@ -122,12 +122,9 @@ fn cmp_same_rank(a: &Value, b: &Value, rank: u8) -> std::cmp::Ordering {
             a_id.cmp(&b_id)
         }
 
-        // Keyword — lexicographic by name
-        4 => {
-            let a_name = a.as_keyword_name().unwrap();
-            let b_name = b.as_keyword_name().unwrap();
-            a_name.cmp(&b_name)
-        }
+        // Keyword — by hash, the portable order sorted containers rely on
+        // (deterministic in every instance, no spelling lookup on compare).
+        4 => a.payload.cmp(&b.payload),
 
         // C pointer — by address (payload)
         5 => a.payload.cmp(&b.payload),

--- a/src/value/send/de.rs
+++ b/src/value/send/de.rs
@@ -14,13 +14,6 @@ pub(super) fn recv_traits(
     }
 }
 
-/// Reconstruct a symbol value on the receiving thread by re-interning its name
-/// into the receiver's symbol table (`symbols`, threaded explicitly). A symbol
-/// crosses the boundary by name because ids are per-table.
-pub(super) fn recv_symbol(name: &str, symbols: &mut crate::symbol::SymbolTable) -> Value {
-    Value::symbol(symbols.intern(name).0)
-}
-
 /// Reconstruct a standard-stream port value of the given kind. Only the three
 /// stdio kinds are ever serialized (see the `"port"` arm in `from_value_inner`);
 /// any other kind falls back to stdout defensively (unreachable in practice).
@@ -50,7 +43,7 @@ pub(super) enum ReconState {
 /// reconstructed heap object is born explicitly in the call's region on the
 /// call's heap. Region coherence is safety-critical here — a cross-thread message
 /// tree must land entirely in one region (docs/impl/region/ctx.md).
-pub(super) struct DeserContext<'a, 'h, 's> {
+pub(super) struct DeserContext<'a, 'h> {
     /// Owned closure data. Entries are `take`n as they are reconstructed.
     closures: Vec<Option<SendableClosure>>,
     /// Reconstruction state per intern table index.
@@ -62,17 +55,12 @@ pub(super) struct DeserContext<'a, 'h, 's> {
     /// The allocation capability every reconstructed heap object is born
     /// through — the receiving thread's per-call ctx.
     pub(super) ctx: &'a mut crate::primitives::ctx::Alloc<'h>,
-    /// The RECEIVER's symbol table — a symbol value re-interns its name here on
-    /// arrival (ids are per-table). Threaded explicitly
-    /// (docs/impl/region/ctx.md § "Symbols through the ctx").
-    pub(super) symbols: &'s mut crate::symbol::SymbolTable,
 }
 
-impl<'a, 'h, 's> DeserContext<'a, 'h, 's> {
+impl<'a, 'h> DeserContext<'a, 'h> {
     pub(super) fn new(
         closures: Vec<SendableClosure>,
         ctx: &'a mut crate::primitives::ctx::Alloc<'h>,
-        symbols: &'s mut crate::symbol::SymbolTable,
     ) -> Self {
         let n = closures.len();
         DeserContext {
@@ -80,7 +68,6 @@ impl<'a, 'h, 's> DeserContext<'a, 'h, 's> {
             states: (0..n).map(|_| ReconState::NotStarted).collect(),
             fixups: Vec::new(),
             ctx,
-            symbols,
         }
     }
 
@@ -107,7 +94,7 @@ impl<'a, 'h, 's> DeserContext<'a, 'h, 's> {
 /// resolves by index.
 fn template_from_sendable(
     sc: SendableClosure,
-    ctx: &mut DeserContext<'_, '_, '_>,
+    ctx: &mut DeserContext<'_, '_>,
 ) -> std::rc::Rc<crate::value::ClosureTemplate> {
     use std::rc::Rc;
     let constants: Vec<Value> = sc
@@ -138,7 +125,6 @@ fn template_from_sendable(
         signal: sc.signal,
         capture_params_mask: sc.capture_params_mask,
         capture_locals_mask: sc.capture_locals_mask,
-        symbol_names: Rc::new(sc.symbol_names),
         location_map: Rc::new(sc.location_map),
         lir_function,
         doc,
@@ -152,7 +138,7 @@ fn template_from_sendable(
     })
 }
 
-pub(super) fn into_value_inner(sv: SendValue, ctx: &mut DeserContext<'_, '_, '_>) -> Value {
+pub(super) fn into_value_inner(sv: SendValue, ctx: &mut DeserContext<'_, '_>) -> Value {
     use crate::value::closure::{Closure, ClosureTemplate};
     use crate::value::heap::{HeapObject, Pair};
     use std::cell::RefCell;
@@ -161,8 +147,7 @@ pub(super) fn into_value_inner(sv: SendValue, ctx: &mut DeserContext<'_, '_, '_>
 
     match sv {
         SendValue::Immediate(v) => v,
-        SendValue::Keyword(name) => Value::keyword(&name),
-        SendValue::Symbol { name, .. } => recv_symbol(&name, ctx.symbols),
+
         SendValue::String(s) => ctx.ctx.string(s),
         SendValue::Syntax(ss) => ctx.ctx.syntax(send_to_syntax(*ss)),
         SendValue::Pair(first, rest, traits) => {
@@ -413,7 +398,6 @@ pub(super) fn into_value_inner(sv: SendValue, ctx: &mut DeserContext<'_, '_, '_>
                 signal: sc.signal,
                 capture_params_mask: sc.capture_params_mask,
                 capture_locals_mask: sc.capture_locals_mask,
-                symbol_names: Rc::new(sc.symbol_names),
                 location_map: Rc::new(sc.location_map),
                 lir_function,
                 doc,
@@ -440,7 +424,7 @@ pub(super) fn into_value_inner(sv: SendValue, ctx: &mut DeserContext<'_, '_, '_>
 
 /// Patch `ClosureRef(idx)` entries in a LIR function back to `ValueConst`.
 /// Forces reconstruction of any referenced closures that haven't been built yet.
-fn patch_lir_closure_refs(lir: &mut crate::lir::LirFunction, ctx: &mut DeserContext<'_, '_, '_>) {
+fn patch_lir_closure_refs(lir: &mut crate::lir::LirFunction, ctx: &mut DeserContext<'_, '_>) {
     use crate::lir::LirConst;
     use crate::lir::LirInstr;
 

--- a/src/value/send/mod.rs
+++ b/src/value/send/mod.rs
@@ -49,7 +49,6 @@ pub struct SendableClosure {
     pub signal: Signal,
     pub capture_params_mask: u64,
     pub capture_locals_mask: crate::value::CaptureMask,
-    pub symbol_names: HashMap<u32, String>,
     pub location_map: LocationMap,
     pub doc: Option<String>,
     pub vararg_kind: VarargKind,
@@ -86,26 +85,14 @@ pub struct SendableClosure {
 
 /// A thread-safe wrapper around Value that deep-copies heap data.
 ///
-/// For immediate values (nil, bool, int, float, symbol), SendValue stores
-/// them directly. Keywords carry their name for cross-thread re-interning.
+/// For immediate values (nil, bool, int, float, symbol, keyword), SendValue
+/// stores them directly; their spellings ride the bundle's name table.
 /// For heap values, SendValue stores owned copies of the heap data, ensuring
 /// the data remains valid even if the original Rc is dropped.
 #[derive(Clone)]
 pub enum SendValue {
     /// Immediate values that don't need copying
     Immediate(Value),
-
-    /// Keyword with name for cross-thread re-interning
-    Keyword(String),
-
-    /// Symbol with name for cross-thread re-interning. Symbol IDs are per-table
-    /// and are NOT comparable across tables, so a symbol that appears as runtime
-    /// *data* (a quoted datum, a channel message) carries its name and is
-    /// re-interned in the receiving thread's table. `id` is the sender-table id,
-    /// kept only as a fallback for the (unexpected) case where the receiving
-    /// thread has no symbol table — then it falls back to the raw id rather than
-    /// losing the value.
-    Symbol { name: String, id: u32 },
 
     /// Owned string copy
     String(String),
@@ -223,6 +210,13 @@ pub struct SendBundle {
     pub root: SendValue,
     /// Intern table of all closures reachable from `root`.
     pub closures: Vec<SendableClosure>,
+    /// Spelling table for every symbol and keyword in the bundle, read from
+    /// the sender's memo (and, for keywords, the static vocabulary). The
+    /// receiving instance replays it into its own memo so the names it now
+    /// holds can be printed (docs/impl/symbol.md § "The display memo"). A
+    /// name the sender never learned is absent — its hash still compares
+    /// correctly on the other side.
+    pub symbols: Vec<(u64, Box<str>)>,
 }
 
 // SAFETY: SendBundle owns all its data — no Rc, no RefCell.
@@ -240,9 +234,8 @@ impl SendValue {
     pub fn from_value(
         value: Value,
         heap: &crate::value::fiberheap::FiberHeap,
-        symbols: &crate::symbol::SymbolTable,
     ) -> Result<Self, String> {
-        let mut ctx = SerContext::new(heap, symbols);
+        let mut ctx = SerContext::new(heap, None);
         let sv = from_value_inner(value, &mut ctx)?;
         if !ctx.closures.is_empty() {
             panic!("SendValue::from_value cannot serialize closures; use SendBundle::from_value instead");
@@ -251,18 +244,13 @@ impl SendValue {
     }
 
     /// Convert SendValue back into a Value by reconstructing heap objects into
-    /// the call's region through `ctx`, re-interning any symbol names into the
-    /// receiver's `symbols` (both threaded explicitly).
-    pub fn into_value(
-        self,
-        ctx: &mut crate::primitives::ctx::Alloc,
-        symbols: &mut crate::symbol::SymbolTable,
-    ) -> Value {
+    /// the call's region through `ctx`.
+    pub fn into_value(self, ctx: &mut crate::primitives::ctx::Alloc) -> Value {
         // A bare `SendValue` carries no closures (`from_value` panics if any are
         // reachable), so reconstruction is the closure-free subset of
         // `into_value_inner` — delegate through an empty `DeserContext` rather
         // than duplicate every heap-object arm.
-        let mut dctx = DeserContext::new(Vec::new(), ctx, symbols);
+        let mut dctx = DeserContext::new(Vec::new(), ctx);
         into_value_inner(self, &mut dctx)
     }
 }
@@ -280,16 +268,23 @@ impl SendBundle {
     ///
     /// Returns `Err` if any value in the reachable graph is not sendable
     /// (e.g., mutable @struct, fiber, FFI handle).
+    ///
+    /// `symbols` is the sender's display memo; every symbol met during
+    /// serialization takes its name from it into the bundle's name table.
+    /// `None` sends ids without names — valid, but the receiver cannot print
+    /// them.
     pub fn from_value(
         value: Value,
         heap: &crate::value::fiberheap::FiberHeap,
-        symbols: &crate::symbol::SymbolTable,
+        symbols: Option<&crate::symbol::SymbolTable>,
     ) -> Result<Self, String> {
         let mut ctx = SerContext::new(heap, symbols);
         let root = from_value_inner(value, &mut ctx)?;
+        let names = ctx.take_names();
         Ok(SendBundle {
             root,
             closures: ctx.closures,
+            symbols: names,
         })
     }
 
@@ -298,12 +293,22 @@ impl SendBundle {
     /// Mutually recursive closures are handled via LBox fixups: if a closure's
     /// env contains an LBox wrapping a not-yet-built closure, the LBox is
     /// allocated with a NIL placeholder and updated after all closures are built.
+    ///
+    /// `symbols` is the receiving instance's display memo; the bundle's name
+    /// table replays into it (a learning site, so a cross-instance hash
+    /// collision is caught here). `None` reconstructs values whose symbols
+    /// print as `#<symbol:hash>`.
     pub fn into_value(
         self,
         ctx: &mut crate::primitives::ctx::Alloc,
-        symbols: &mut crate::symbol::SymbolTable,
+        symbols: Option<&mut crate::symbol::SymbolTable>,
     ) -> Value {
-        let mut dctx = DeserContext::new(self.closures, ctx, symbols);
+        if let Some(memo) = symbols {
+            for (hash, name) in &self.symbols {
+                memo.record_spelling(*hash, name);
+            }
+        }
+        let mut dctx = DeserContext::new(self.closures, ctx);
 
         let result = into_value_inner(self.root, &mut dctx);
 

--- a/src/value/send/ser.rs
+++ b/src/value/send/ser.rs
@@ -42,25 +42,18 @@ pub(super) fn from_value_inner(
     value: Value,
     ctx: &mut SerContext<'_>,
 ) -> Result<SendValue, String> {
-    // Keywords carry their name for cross-thread re-interning
-    if let Some(name) = value.as_keyword_name() {
-        return Ok(SendValue::Keyword(name));
-    }
-
-    // Symbols carry their name for cross-thread re-interning (IDs are
-    // per-table). If the id is not in the sender's table (should not happen),
-    // fall through to Immediate.
+    // Immediate values are always safe. A symbol or keyword is among them: its
+    // payload is the name's hash (docs/impl/symbol.md), which means the same
+    // name in the receiving thread. Its spelling goes into the bundle's name
+    // table so the receiving instance can print it.
     if let Some(id) = value.as_symbol() {
-        if let Some(name) = ctx.symbols.name(crate::value::SymbolId(id)) {
-            return Ok(SendValue::Symbol {
-                name: name.to_string(),
-                id,
-            });
-        }
+        ctx.note_symbol(id);
         return Ok(SendValue::Immediate(value));
     }
-
-    // Immediate values are always safe
+    if let Some(hash) = value.keyword_hash() {
+        ctx.note_keyword(hash);
+        return Ok(SendValue::Immediate(value));
+    }
     if value.is_nil() || value.is_bool() || value.is_int() || value.is_float() {
         return Ok(SendValue::Immediate(value));
     }
@@ -116,6 +109,11 @@ pub(super) fn from_value_inner(
             for (k, v) in s.iter() {
                 if !k.is_sendable() {
                     return Err("Cannot send struct with identity keys".to_string());
+                }
+                match k {
+                    crate::value::heap::TableKey::Symbol(id) => ctx.note_symbol(*id),
+                    crate::value::heap::TableKey::Keyword(hash) => ctx.note_keyword(*hash),
+                    _ => {}
                 }
                 copied.insert(k.clone(), from_value_inner(*v, ctx)?);
             }
@@ -195,6 +193,11 @@ pub(super) fn from_value_inner(
             for (k, v) in borrowed.iter() {
                 if !k.is_sendable() {
                     return Err("Cannot send @struct with identity keys".to_string());
+                }
+                match k {
+                    crate::value::heap::TableKey::Symbol(id) => ctx.note_symbol(*id),
+                    crate::value::heap::TableKey::Keyword(hash) => ctx.note_keyword(*hash),
+                    _ => {}
                 }
                 copied.insert(k.clone(), from_value_inner(*v, ctx)?);
             }

--- a/src/value/send/ser/closure.rs
+++ b/src/value/send/ser/closure.rs
@@ -43,7 +43,6 @@ pub(super) fn send_closure(
         signal: closure_rc.template.signal,
         capture_params_mask: 0,
         capture_locals_mask: crate::value::CaptureMask::empty(),
-        symbol_names: HashMap::new(),
         location_map: LocationMap::new(),
         doc: None,
         vararg_kind: closure_rc.template.vararg_kind.clone(),
@@ -120,8 +119,6 @@ pub(super) fn send_closure(
         signal: closure_rc.template.signal,
         capture_params_mask: closure_rc.template.capture_params_mask,
         capture_locals_mask: closure_rc.template.capture_locals_mask.clone(),
-
-        symbol_names: (*closure_rc.template.symbol_names).clone(),
         location_map: (*closure_rc.template.location_map).clone(),
         doc,
         vararg_kind: closure_rc.template.vararg_kind.clone(),

--- a/src/value/send/ser/ctx.rs
+++ b/src/value/send/ser/ctx.rs
@@ -3,9 +3,11 @@
 //! The context is split out from the serialization logic itself so the big
 //! `match` over heap tags reads as pure "what does each tag serialize to",
 //! with all the mutable bookkeeping (intern table, cycle-detection map,
-//! sender-side symbol/heap tables) collected here.
+//! sender-side heap table, symbol-name table) collected here.
 
 use super::super::*;
+use crate::value::SymbolId;
+use rustc_hash::FxHashMap;
 
 /// Per-call serialization context for `SendBundle::from_value`.
 pub(in crate::value::send) struct SerContext<'s> {
@@ -14,26 +16,60 @@ pub(in crate::value::send) struct SerContext<'s> {
     /// Maps `value.payload` (heap pointer address) → intern table index.
     /// Inserted BEFORE recursing into a closure's fields, so back-references find it.
     pub(super) visited: HashMap<u64, usize>,
-    /// The SENDER's symbol table — used to resolve a symbol value's id to its name
-    /// so it crosses the thread boundary by name (ids are per-table). Threaded
-    /// explicitly (docs/impl/region/ctx.md § "Symbols through the ctx").
-    pub(in crate::value::send) symbols: &'s crate::symbol::SymbolTable,
     /// The SENDER's heap — `send_traits` reads its default-traits table to skip
     /// registry-default traitsets (the receiver rebuilds them). The value being
     /// serialized lives on this heap, so it is the right table to compare against.
     pub(super) heap: &'s crate::value::fiberheap::FiberHeap,
+    /// The SENDER's display memo — [`note_symbol`](Self::note_symbol) reads it
+    /// to name each symbol the serializer meets. `None` when the caller has no
+    /// memo (the receiver then prints those symbols as `#<symbol:hash>`).
+    memo: Option<&'s crate::symbol::SymbolTable>,
+    /// Names collected for the bundle's name table, deduplicated by id.
+    names: FxHashMap<u64, Box<str>>,
 }
 
 impl<'s> SerContext<'s> {
     pub(in crate::value::send) fn new(
         heap: &'s crate::value::fiberheap::FiberHeap,
-        symbols: &'s crate::symbol::SymbolTable,
+        memo: Option<&'s crate::symbol::SymbolTable>,
     ) -> Self {
         SerContext {
             visited: HashMap::new(),
             closures: Vec::new(),
-            symbols,
             heap,
+            memo,
+            names: FxHashMap::default(),
         }
+    }
+
+    /// Record `id`'s name into the bundle's name table, if the sender's memo
+    /// knows one. Called at every serializer site that meets a symbol: the
+    /// immediate-value arm and the struct-key clones (keys are `TableKey`s,
+    /// never routed through `from_value_inner`).
+    pub(super) fn note_symbol(&mut self, id: SymbolId) {
+        self.note(id.0, self.memo.and_then(|m| m.name(id)));
+    }
+
+    /// [`note_symbol`](Self::note_symbol) for a keyword payload — the same
+    /// spelling table, resolved through the memo and the static vocabulary.
+    pub(super) fn note_keyword(&mut self, hash: u64) {
+        self.note(
+            hash,
+            crate::value::keyword::resolve_keyword_name(self.memo, hash),
+        );
+    }
+
+    fn note(&mut self, hash: u64, name: Option<&str>) {
+        if self.names.contains_key(&hash) {
+            return;
+        }
+        if let Some(name) = name {
+            self.names.insert(hash, name.into());
+        }
+    }
+
+    /// The collected name table, in the bundle's `Vec` form.
+    pub(in crate::value::send) fn take_names(&mut self) -> Vec<(u64, Box<str>)> {
+        std::mem::take(&mut self.names).into_iter().collect()
     }
 }

--- a/src/value/send/ser/template.rs
+++ b/src/value/send/ser/template.rs
@@ -55,7 +55,6 @@ pub(super) fn sendable_from_template(
         signal: t.signal,
         capture_params_mask: t.capture_params_mask,
         capture_locals_mask: t.capture_locals_mask.clone(),
-        symbol_names: (*t.symbol_names).clone(),
         location_map: (*t.location_map).clone(),
         doc,
         vararg_kind: t.vararg_kind.clone(),

--- a/src/value/send/tests.rs
+++ b/src/value/send/tests.rs
@@ -11,16 +11,11 @@ use std::rc::Rc;
 /// heap, NOT releasing the region: the result must outlive the call (the test
 /// reads it afterward), so freeing the region would recycle the pages the
 /// returned value points at. The leaked heap keeps it resident for the test.
-fn into_value_in_region(
-    f: impl FnOnce(&mut crate::primitives::ctx::Alloc, &mut crate::symbol::SymbolTable) -> Value,
-) -> Value {
+fn into_value_in_region(f: impl FnOnce(&mut crate::primitives::ctx::Alloc) -> Value) -> Value {
     let heap_ptr = crate::value::arena::leaked_test_heap();
     let region = unsafe { (*heap_ptr).new_runtime_region() };
     let mut ctx = crate::primitives::ctx::Alloc::with_region(region, unsafe { &mut *heap_ptr });
-    // These round-trips carry no symbols; a fresh table suffices. The
-    // symbol-specific round-trip threads its own sender/receiver tables.
-    let mut symbols = crate::symbol::SymbolTable::new();
-    f(&mut ctx, &mut symbols)
+    f(&mut ctx)
 }
 
 /// Build a minimal closure Value with an attached LIR function, on `heap`.
@@ -115,13 +110,9 @@ fn test_send_bundle_patches_closure_value_const_in_lir() {
         );
 
         // 3. Round-trip through SendBundle.
-        let bundle = SendBundle::from_value(
-            outer_val,
-            unsafe { &*heap_ptr },
-            &crate::symbol::SymbolTable::new(),
-        )
-        .expect("should serialize");
-        let restored = into_value_in_region(|ctx, symbols| bundle.into_value(ctx, symbols));
+        let bundle = SendBundle::from_value(outer_val, unsafe { &*heap_ptr }, None)
+            .expect("should serialize");
+        let restored = into_value_in_region(|ctx| bundle.into_value(ctx, None));
 
         // 4. The reconstructed outer closure should still have an LIR.
         let restored_rc = restored
@@ -172,9 +163,9 @@ fn parameter_round_trips_preserving_id_and_default() {
         let p = h.ctx().parameter(Value::int(7));
         let (id0, _) = p.as_parameter().expect("p is a parameter");
 
-        let bundle = SendBundle::from_value(p, h.heap(), &crate::symbol::SymbolTable::new())
+        let bundle = SendBundle::from_value(p, h.heap(), None)
             .expect("a parameter with a sendable default must be sendable");
-        let p2 = into_value_in_region(|ctx, symbols| bundle.into_value(ctx, symbols));
+        let p2 = into_value_in_region(|ctx| bundle.into_value(ctx, None));
 
         let (id1, def1) = p2
             .as_parameter()
@@ -199,69 +190,143 @@ fn stdio_port_round_trips_by_kind() {
             (Port::stdin as fn() -> Port, PortKind::Stdin),
         ] {
             let v = h.ctx().external("port", mk());
-            let bundle = SendBundle::from_value(v, h.heap(), &crate::symbol::SymbolTable::new())
-                .expect("stdio ports are sendable");
-            let v2 = into_value_in_region(|ctx, symbols| bundle.into_value(ctx, symbols));
+            let bundle =
+                SendBundle::from_value(v, h.heap(), None).expect("stdio ports are sendable");
+            let v2 = into_value_in_region(|ctx| bundle.into_value(ctx, None));
             let got = v2.as_external::<Port>().map(|p| p.kind());
             assert_eq!(got, Some(kind), "stdio port must reconstruct with its kind");
         }
     });
 }
 
-// ── symbol values re-intern by name (not by raw id) ─────────────────
+// ── symbol identity survives the boundary verbatim ──────────────────
+//
+// The three tests below cover the three ways a symbol id crosses `send`: as a
+// value, as a struct key, and as a LIR constant. Only the first was ever
+// translated; the other two always crossed raw, so they were correct only when
+// the two tables happened to agree. Hash identity makes all three the same
+// case, and each test asserts a name resolves on the receiving side.
+
+/// A receiver's table whose history differs from the sender's. Under
+/// mint-order ids the four decoys are what made every shared name disagree.
+fn skewed_receiver() -> crate::symbol::SymbolTable {
+    let mut receiver = crate::symbol::SymbolTable::new();
+    for n in ["skew-w", "skew-x", "skew-y", "skew-z"] {
+        let _ = receiver.intern(n);
+    }
+    receiver
+}
 
 #[test]
-fn symbol_round_trips_by_name_not_id() {
+fn a_symbol_value_names_the_same_symbol_on_both_sides() {
     use crate::symbol::SymbolTable;
-    use crate::value::SymbolId;
 
-    // Sender's table: intern a couple of names first so "begin" lands at
-    // some non-zero id that is meaningful only in THIS table.
     let mut sender = SymbolTable::new();
-    let _ = sender.intern("aaa");
-    let _ = sender.intern("bbb");
-    let begin_sender = sender.intern("begin");
+    let _ = sender.intern("send-aaa");
+    let _ = sender.intern("send-bbb");
+    let begin = sender.intern("begin");
 
-    // Serialize a symbol value carrying the sender-table id, resolving the name
-    // against the sender's table (threaded explicitly).
     // A symbol is immediate, so serialization allocates nothing; any heap serves.
     let sv = SendBundle::from_value(
-        Value::symbol(begin_sender.0),
+        Value::symbol(begin),
         unsafe { &*crate::value::arena::leaked_test_heap() },
-        &sender,
+        Some(&sender),
     )
     .expect("symbol is sendable");
 
-    // Receiver's table: a DIFFERENT layout, so "begin" gets a different id.
-    // This is the cross-thread reality the worker faces.
-    let mut receiver = SymbolTable::new();
-    for n in ["w", "x", "y", "z"] {
-        let _ = receiver.intern(n);
-    }
-    let begin_receiver = receiver.intern("begin");
-    assert_ne!(
-        begin_sender.0, begin_receiver.0,
-        "test setup: the two tables must assign 'begin' different ids"
-    );
-
-    // Reconstruct re-interning into the RECEIVER's table (threaded explicitly).
-    // A symbol is an immediate, so reconstruction allocates nothing — any mortal
-    // ctx serves as the target.
+    let mut receiver = skewed_receiver();
     let got = {
         let heap_ptr = crate::value::arena::leaked_test_heap();
         let region = unsafe { (*heap_ptr).new_runtime_region() };
         let mut alloc =
             crate::primitives::ctx::Alloc::with_region(region, unsafe { &mut *heap_ptr });
-        sv.into_value(&mut alloc, &mut receiver)
+        sv.into_value(&mut alloc, Some(&mut receiver))
     };
 
     let got_id = got.as_symbol().expect("reconstructed value is a symbol");
+    assert_eq!(got_id, begin, "the id crosses unchanged");
+    assert_eq!(receiver.name(got_id), Some("begin"));
+}
+
+// `SendValue::Struct` clones each `TableKey` verbatim, so a symbol key crosses
+// as a bare id with no name beside it. The receiver must still read the key the
+// sender wrote.
+//
+// Counter-factual: with mint-order ids this is the defect that made
+// `(get (sys/join (sys/spawn (fn [] {'alpha 1}))) 'alpha)` return the wrong
+// entry — `tests/elle/symbol-identity.lisp` pins the end-to-end shape.
+#[test]
+fn a_symbol_struct_key_names_the_same_symbol_on_both_sides() {
+    use crate::symbol::SymbolTable;
+    use crate::value::heap::TableKey;
+
+    crate::value::arena::with_test_region(|| {
+        let mut sender = SymbolTable::new();
+        let _ = sender.intern("send-aaa");
+        let alpha = sender.intern("key-alpha");
+        let beta = sender.intern("key-beta");
+
+        let h = crate::primitives::ctx::TestHeap::new();
+        let mut entries = vec![
+            (TableKey::Symbol(alpha), Value::int(7)),
+            (TableKey::Symbol(beta), Value::int(8)),
+        ];
+        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        let s = h.ctx().struct_from_sorted(entries);
+        let bundle =
+            SendBundle::from_value(s, h.heap(), Some(&sender)).expect("struct is sendable");
+
+        let mut receiver = skewed_receiver();
+        let probe = TableKey::Symbol(receiver.intern("key-alpha"));
+        let got = {
+            let heap_ptr = crate::value::arena::leaked_test_heap();
+            let region = unsafe { (*heap_ptr).new_runtime_region() };
+            let mut alloc =
+                crate::primitives::ctx::Alloc::with_region(region, unsafe { &mut *heap_ptr });
+            bundle.into_value(&mut alloc, Some(&mut receiver))
+        };
+
+        let entries = got.as_struct().expect("reconstructed value is a struct");
+        assert_eq!(
+            crate::value::types::sorted_struct_get(entries, &probe),
+            Some(&crate::value::Value::int(7)),
+            "the receiver's own key must find the entry the sender stored"
+        );
+        // `key-beta` was never interned on this side: its name reaches the
+        // receiver only through the bundle's name table, from the struct-key
+        // noting site (keys are cloned as `TableKey`, never routed through
+        // `from_value_inner`).
+        assert_eq!(
+            receiver.name(beta),
+            Some("key-beta"),
+            "a struct key's name must cross inside the bundle"
+        );
+    });
+}
+
+// A `LirConst::Symbol` ships inside the live `LirFunction` with no name and no
+// rewrite, so the id the sender lowered is the id the worker re-emits into its
+// own constant pool.
+#[test]
+fn a_lir_symbol_const_names_the_same_symbol_on_both_sides() {
+    use crate::lir::value_to_lir_const;
+    use crate::symbol::SymbolTable;
+
+    let mut sender = SymbolTable::new();
+    let _ = sender.intern("send-aaa");
+    let alpha = sender.intern("lir-alpha");
+
+    let shipped = match value_to_lir_const(Value::symbol(alpha)) {
+        Some(LirConst::Symbol(id)) => id,
+        other => panic!("a symbol lowers to LirConst::Symbol, got {:?}", other),
+    };
+
+    let mut receiver = skewed_receiver();
+    let _ = receiver.intern("lir-alpha");
     assert_eq!(
-        receiver.name(SymbolId(got_id)),
-        Some("begin"),
-        "a symbol must cross the boundary by NAME and re-intern in the \
-             receiver's table — carrying the raw sender id would resolve to the \
-             wrong name (or none)"
+        receiver.name(shipped),
+        Some("lir-alpha"),
+        "the worker re-emits this id verbatim; it must name the sender's symbol"
     );
 }
 
@@ -274,9 +339,9 @@ fn parameter_holding_stdout_port_is_sendable() {
         let p = h
             .ctx()
             .parameter(h.ctx().external("port", crate::port::Port::stdout()));
-        let bundle = SendBundle::from_value(p, h.heap(), &crate::symbol::SymbolTable::new())
+        let bundle = SendBundle::from_value(p, h.heap(), None)
             .expect("a parameter defaulting to a stdio port must be sendable");
-        let p2 = into_value_in_region(|ctx, symbols| bundle.into_value(ctx, symbols));
+        let p2 = into_value_in_region(|ctx| bundle.into_value(ctx, None));
         let (_, def) = p2.as_parameter().expect("reconstructed is a parameter");
         assert_eq!(
             def.as_external::<crate::port::Port>().map(|p| p.kind()),
@@ -323,13 +388,9 @@ fn closure_round_trips_preserving_frame_release_tables() {
             },
         );
 
-        let bundle = SendBundle::from_value(
-            val,
-            unsafe { &*heap_ptr },
-            &crate::symbol::SymbolTable::new(),
-        )
-        .expect("a plain closure is sendable");
-        let restored = into_value_in_region(|ctx, symbols| bundle.into_value(ctx, symbols));
+        let bundle = SendBundle::from_value(val, unsafe { &*heap_ptr }, None)
+            .expect("a plain closure is sendable");
+        let restored = into_value_in_region(|ctx| bundle.into_value(ctx, None));
 
         let closure = restored.as_closure().expect("restored value is a closure");
         assert_eq!(
@@ -352,5 +413,44 @@ fn closure_round_trips_preserving_frame_release_tables() {
              template_from_sendable, not send_closure — its tables must cross too"
         );
         assert_eq!(&child.frame_release_regions[..], &[23u32]);
+    });
+}
+
+// A keyword crosses as an immediate; its spelling rides the bundle's name
+// table with the symbols', so the receiving instance can print both the
+// keyword value and a keyword struct key it never learned itself.
+#[test]
+fn a_keyword_names_the_same_keyword_on_both_sides() {
+    use crate::symbol::SymbolTable;
+    use crate::value::heap::TableKey;
+
+    crate::value::arena::with_test_region(|| {
+        let mut sender = SymbolTable::new();
+        let kw_hash = sender.keyword("kw-send-xt");
+        let key_hash = sender.keyword("kw-send-key-xt");
+
+        let h = crate::primitives::ctx::TestHeap::new();
+        let s = h.ctx().struct_from_sorted(vec![(
+            TableKey::Keyword(key_hash),
+            Value::keyword("kw-send-xt"),
+        )]);
+        let bundle =
+            SendBundle::from_value(s, h.heap(), Some(&sender)).expect("struct is sendable");
+
+        let mut receiver = SymbolTable::new();
+        let got = {
+            let heap_ptr = crate::value::arena::leaked_test_heap();
+            let region = unsafe { (*heap_ptr).new_runtime_region() };
+            let mut alloc =
+                crate::primitives::ctx::Alloc::with_region(region, unsafe { &mut *heap_ptr });
+            bundle.into_value(&mut alloc, Some(&mut receiver))
+        };
+
+        assert_eq!(
+            format!("{}", got.display_with(Some(&receiver))),
+            "{:kw-send-key-xt :kw-send-xt}",
+            "both the key's and the value's spellings crossed in the bundle"
+        );
+        assert_eq!(receiver.keyword_name(kw_hash), Some("kw-send-xt"));
     });
 }

--- a/src/value/template.rs
+++ b/src/value/template.rs
@@ -76,8 +76,11 @@ impl ConstTemplate {
             ConstTemplate::Bool(b) => Some(Value::bool(*b)),
             ConstTemplate::Int(n) => Some(Value::int(*n)),
             ConstTemplate::Float(f) => Some(Value::float(*f)),
-            ConstTemplate::Symbol(name) => Some(Value::symbol(symbols.intern(name).0)),
-            ConstTemplate::Keyword(k) => Some(Value::keyword(k)),
+            ConstTemplate::Symbol(name) => Some(Value::symbol(symbols.intern(name))),
+            ConstTemplate::Keyword(k) => {
+                symbols.keyword(k);
+                Some(Value::keyword(k))
+            }
             ConstTemplate::String(_)
             | ConstTemplate::StringMut(_)
             | ConstTemplate::Pair(_, _)
@@ -117,13 +120,18 @@ impl ConstTemplate {
             ConstTemplate::Bool(b) => Value::bool(*b),
             ConstTemplate::Int(n) => Value::int(*n),
             ConstTemplate::Float(f) => Value::float(*f),
-            ConstTemplate::Keyword(k) => Value::keyword(k),
+            ConstTemplate::Keyword(k) => {
+                if let Some(symbols) = symbols.as_deref_mut() {
+                    symbols.keyword(k);
+                }
+                Value::keyword(k)
+            }
             // Re-intern the symbol's name into the executing instance's table so
             // the id is valid HERE — across a `sys/spawn` boundary the sender's id
             // would name a different symbol (spawn-eval.lisp).
             ConstTemplate::Symbol(name) => {
                 let symbols = symbols.expect("materialize: no symbol table for a quoted symbol");
-                Value::symbol(symbols.intern(name).0)
+                Value::symbol(symbols.intern(name))
             }
 
             ConstTemplate::String(s) => {

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -1,7 +1,7 @@
 //! Core value types for the Elle runtime
 //!
 //! This module contains fundamental types used throughout the value system:
-//! - `SymbolId` - Interned symbol identifier
+//! - `SymbolId` - Symbol identity: the name's hash (`docs/impl/symbol.md`)
 //! - `Arity` - Function arity specification
 //! - `TableKey` - Keys for structs (accepts all immutable non-float types)
 //! - `NativeFn` - Unified primitive function type
@@ -26,17 +26,28 @@ use crate::value::heap::HeapTag;
 use crate::value::Value;
 use std::fmt;
 
-/// Symbol ID for interned symbols.
+/// Symbol identity: the name's 64-bit hash.
 ///
-/// Symbols are interned for fast comparison (O(1) via ID comparison
-/// instead of O(n) string comparison).
+/// The id is a pure function of the name ([`crate::namehash`]), so it is the
+/// same in every symbol table, thread, process, and build — comparison is one
+/// integer compare, and a symbol value is portable by construction. Ordering
+/// follows the hash, which is deterministic but carries no alphabetical
+/// meaning; see [docs/impl/symbol.md](../../docs/impl/symbol.md).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SymbolId(pub u32);
+pub struct SymbolId(pub u64);
 
 impl SymbolId {
-    /// Sentinel value for compiler-generated bindings with no source-level
-    /// symbol name (phi temporaries, etc.). Not a valid interned symbol.
-    pub const SYNTHETIC: Self = Self(u32::MAX);
+    /// The id of `name`, without recording the name for display. Use
+    /// [`SymbolTable::intern`](crate::symbol::SymbolTable::intern) when the
+    /// symbol may need to be printed.
+    pub const fn of(name: &str) -> Self {
+        Self(crate::namehash::name_hash(name))
+    }
+
+    /// Sentinel for compiler-generated bindings with no source-level symbol
+    /// name (phi temporaries, etc.). Reserved: `SymbolTable::intern` refuses a
+    /// name that hashes onto it, so it is never a real symbol.
+    pub const SYNTHETIC: Self = Self(u64::MAX);
 }
 
 impl fmt::Display for SymbolId {
@@ -116,7 +127,13 @@ pub enum TableKey {
     Int(i64),
     Symbol(SymbolId),
     String(String),
-    Keyword(String),
+    /// A keyword key is its 64-bit name hash — the keyword value's payload,
+    /// exactly as `Symbol` is its `SymbolId`. Identity and order are pure
+    /// functions of the hash, so a probe builds a key with no lock and no
+    /// allocation, and a sorted struct probes correctly in every instance.
+    /// Display resolves the spelling through the per-instance memo
+    /// (docs/impl/symbol.md § "The display memo").
+    Keyword(u64),
     EmptyList,
     /// Immutable array key. All elements must themselves be valid TableKeys.
     /// Mutable arrays are rejected — mutation after insertion would break
@@ -135,6 +152,12 @@ pub enum TableKey {
 }
 
 impl TableKey {
+    /// Build a keyword key from its spelling. Identity only — the spelling is
+    /// not recorded anywhere; display resolves through the per-instance memo.
+    pub fn keyword(name: &str) -> TableKey {
+        TableKey::Keyword(crate::value::keyword::keyword_hash(name))
+    }
+
     /// Convert a Value to a TableKey if possible.
     ///
     /// Returns `None` if the value cannot be used as a key.
@@ -147,9 +170,9 @@ impl TableKey {
         } else if let Some(i) = val.as_int() {
             Some(TableKey::Int(i))
         } else if let Some(id) = val.as_symbol() {
-            Some(TableKey::Symbol(SymbolId(id)))
-        } else if let Some(name) = val.as_keyword_name() {
-            Some(TableKey::Keyword(name))
+            Some(TableKey::Symbol(id))
+        } else if let Some(hash) = val.keyword_hash() {
+            Some(TableKey::Keyword(hash))
         } else if let Some(s) = val.with_string(|s| s.to_string()) {
             Some(TableKey::String(s))
         } else if let Some(arr) = val.as_array() {
@@ -195,9 +218,9 @@ impl TableKey {
             TableKey::Nil => Value::NIL,
             TableKey::Bool(b) => Value::bool(*b),
             TableKey::Int(i) => Value::int(*i),
-            TableKey::Symbol(sid) => Value::symbol(sid.0),
+            TableKey::Symbol(sid) => Value::symbol(*sid),
             TableKey::String(s) => ctx.string(s.as_str()),
-            TableKey::Keyword(s) => Value::keyword(s.as_str()),
+            TableKey::Keyword(hash) => Value::keyword_from_hash(*hash),
             TableKey::EmptyList => Value::EMPTY_LIST,
             TableKey::Array(keys) => {
                 let items: Vec<Value> = keys.iter().map(|k| k.to_value(ctx)).collect();
@@ -341,13 +364,12 @@ impl Ord for TableKey {
     }
 }
 
-/// Render a `TableKey`, optionally resolving a symbol key's name through
-/// `symbols` — the shared body for `Display` (`debug == false`) and `Debug`
-/// (`debug == true`), and the entry `Value`'s struct rendering threads its table
-/// through (docs/impl/region/ctx.md § "Symbols through the ctx"). The two modes
-/// diverge only in the symbol arm (Display prints the raw `SymbolId`; Debug
-/// resolves a name, falling back to `'#<sym:id>` with no table) and in the nested
-/// recursion of array/heap keys (which follows the outer mode).
+/// Render a `TableKey` — the shared body for `Display` (`debug == false`) and
+/// `Debug` (`debug == true`). A symbol key's name comes from the process-global
+/// registry (docs/impl/symbol.md), so nothing is threaded. The two modes diverge
+/// only in the symbol arm (Display prints the raw `SymbolId`; Debug prints the
+/// quoted name) and in the nested recursion of array/heap keys, which follows the
+/// outer mode.
 pub(crate) fn fmt_table_key(
     key: &TableKey,
     symbols: Option<&crate::symbol::SymbolTable>,
@@ -362,14 +384,19 @@ pub(crate) fn fmt_table_key(
             if debug {
                 match symbols.and_then(|s| s.name(*id)) {
                     Some(name) => write!(f, "'{}", name),
-                    None => write!(f, "'#<sym:{}>", id.0),
+                    None => write!(f, "'#<symbol:{:#x}>", id.0),
                 }
             } else {
                 write!(f, "{:?}", id)
             }
         }
         TableKey::String(s) => write!(f, "\"{}\"", s),
-        TableKey::Keyword(s) => write!(f, ":{}", s),
+        TableKey::Keyword(hash) => {
+            match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
+                Some(name) => write!(f, ":{}", name),
+                None => write!(f, "#<keyword:{:#x}>", hash),
+            }
+        }
         TableKey::EmptyList => write!(f, "()"),
         TableKey::Array(keys) => {
             write!(f, "[")?;
@@ -391,9 +418,21 @@ impl fmt::Display for TableKey {
     }
 }
 
+/// A `TableKey` paired with a memo for name-resolving Debug-style rendering —
+/// the key analogue of `Value::debug_with`, for formatters that print keys
+/// outside `fmt_value`'s recursion.
+pub(crate) struct TableKeyDisplay<'a>(pub &'a TableKey, pub Option<&'a crate::symbol::SymbolTable>);
+
+impl fmt::Display for TableKeyDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_table_key(self.0, self.1, true, f)
+    }
+}
+
 impl fmt::Debug for TableKey {
     /// Machine-readable representation of table keys.
-    /// Symbols: 'name (with opening quote only); `'#<sym:id>` with no table.
+    /// Symbols: `'#<symbol:hash>` — a bare `Debug` threads no memo, so it has no
+    /// name to print; `fmt_table_key` with a memo renders `'name`.
     /// Strings: "value" (with quotes)
     /// Keywords: :name
     /// Others: same as Display

--- a/src/value/types/tests.rs
+++ b/src/value/types/tests.rs
@@ -30,3 +30,64 @@ fn test_arity_display() {
 fn test_symbol_id_display() {
     assert_eq!(format!("{}", SymbolId(42)), "Symbol(42)");
 }
+
+// An immutable struct and an immutable set are sorted arrays, and symbol keys
+// sort by raw id. Two compilations that met the same names in opposite orders
+// must therefore lay their keys out identically, or a container built by one is
+// misread by the other.
+//
+// Counter-factual: under mint-order ids the two sorts are exact reverses of
+// each other, and `sorted_struct_get` on the second layout finds the wrong
+// entry — which is what a worker returning a symbol-keyed struct used to do.
+#[test]
+fn symbol_keys_sort_the_same_in_every_table() {
+    use crate::symbol::SymbolTable;
+
+    let names = ["zeta-sort", "mu-sort", "alpha-sort"];
+    let mut forward = SymbolTable::new();
+    let mut backward = SymbolTable::new();
+
+    let mut a: Vec<TableKey> = names
+        .iter()
+        .map(|n| TableKey::Symbol(forward.intern(n)))
+        .collect();
+    let mut b: Vec<TableKey> = names
+        .iter()
+        .rev()
+        .map(|n| TableKey::Symbol(backward.intern(n)))
+        .collect();
+    a.sort();
+    b.sort();
+
+    assert_eq!(a, b);
+}
+
+// A sorted struct built against one table is probed correctly through the
+// other — the binary search and the layout share a comparator that depends on
+// nothing but the names.
+#[test]
+fn a_struct_built_in_one_table_is_probed_by_another() {
+    use crate::symbol::SymbolTable;
+
+    let mut builder = SymbolTable::new();
+    let mut prober = SymbolTable::new();
+    let _ = prober.intern("probe-decoy-1");
+    let _ = prober.intern("probe-decoy-2");
+
+    let mut entries: Vec<(TableKey, Value)> = ["probe-zeta", "probe-mu", "probe-alpha"]
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (TableKey::Symbol(builder.intern(n)), Value::int(i as i64)))
+        .collect();
+    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    for (i, n) in ["probe-zeta", "probe-mu", "probe-alpha"].iter().enumerate() {
+        let key = TableKey::Symbol(prober.intern(n));
+        assert_eq!(
+            sorted_struct_get(&entries, &key),
+            Some(&Value::int(i as i64)),
+            "{} must resolve to the value the builder stored",
+            n
+        );
+    }
+}

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -343,6 +343,15 @@ impl VM {
         }
     }
 
+    /// The spelling of a keyword value, through this instance's memo and the
+    /// static vocabulary. `None` if `v` is not a keyword or the spelling was
+    /// never learned.
+    pub(crate) fn keyword_spelling(&self, v: crate::value::Value) -> Option<String> {
+        let hash = v.keyword_hash()?;
+        crate::value::keyword::resolve_keyword_name(self.symbols().map(|s| &*s), hash)
+            .map(str::to_string)
+    }
+
     /// The owning instance's compile context, for the runtime `eval`
     /// instruction. Returns `None` for a bare VM (no `RuntimeCore`), in which
     /// case `(eval …)` of macro-using code is unsupported. The borrow is sound

--- a/src/vm/core/format.rs
+++ b/src/vm/core/format.rs
@@ -47,13 +47,10 @@ impl VM {
             }
         }
 
-        // Error value last. Render through this instance's symbol table so a
-        // symbol-bearing error value shows names (`'name`), not `#<sym:id>` — a
-        // bare `{:?}` has no table (docs/impl/region/ctx.md § "Symbols").
-        result.push_str(&format!(
-            "✗ Runtime error: {}",
-            err_value.debug_with(self.symbols().as_deref())
-        ));
+        // Error value last. `{:?}` resolves symbol names through the global
+        // registry (docs/impl/symbol.md), so a symbol-bearing error value shows
+        // names, not raw ids.
+        result.push_str(&format!("✗ Runtime error: {:?}", err_value));
 
         result
     }

--- a/src/vm/env.rs
+++ b/src/vm/env.rs
@@ -180,7 +180,7 @@ impl VM {
                     // only with non-keyword args
                     let mut count = args.len().min(min);
                     while count < fixed_slots && count < args.len() {
-                        if args[count].as_keyword_name().is_some() {
+                        if args[count].is_keyword() {
                             break;
                         }
                         count += 1;
@@ -506,7 +506,7 @@ impl VM {
         let mut map = BTreeMap::new();
         for i in (0..args.len()).step_by(2) {
             let key = match TableKey::from_value(&args[i]) {
-                Some(TableKey::Keyword(k)) => k,
+                Some(TableKey::Keyword(hash)) => hash,
                 _ => {
                     return Err((
                         "argument-error",
@@ -517,15 +517,26 @@ impl VM {
                     ));
                 }
             };
+            // Error-message spelling: this static path has no memo, so an
+            // off-vocabulary key falls back to the unreadable form.
+            let spell = || {
+                crate::value::keyword::resolve_keyword_name(None, key)
+                    .map(|n| format!(":{}", n))
+                    .unwrap_or_else(|| format!("#<keyword:{:#x}>", key))
+            };
 
-            // Strict validation for &named
+            // Strict validation for &named — parameter spellings are known, so
+            // matching is by hash and the error lists the valid spellings.
             if let Some(valid) = valid_keys {
-                if !valid.iter().any(|v| v == &key) {
+                if !valid
+                    .iter()
+                    .any(|v| crate::value::keyword::keyword_hash(v) == key)
+                {
                     return Err((
                         "argument-error",
                         format!(
-                            "unknown named parameter :{}, valid parameters are: {}",
-                            key,
+                            "unknown named parameter {}, valid parameters are: {}",
+                            spell(),
                             valid
                                 .iter()
                                 .map(|v| format!(":{}", v))
@@ -536,11 +547,11 @@ impl VM {
                 }
             }
 
-            let table_key = TableKey::Keyword(key.clone());
+            let table_key = TableKey::Keyword(key);
             if map.contains_key(&table_key) {
                 return Err((
                     "argument-error",
-                    format!("duplicate keyword argument :{}", key),
+                    format!("duplicate keyword argument {}", spell()),
                 ));
             }
             map.insert(table_key, args[i + 1]);

--- a/src/vm/eval.rs
+++ b/src/vm/eval.rs
@@ -171,21 +171,19 @@ fn eval_inner(
     crate::hir::anf::anf_lift(&mut analysis.hir, &mut arena);
 
     // Lower
-    let pc = crate::lir::intrinsics::PrimitiveClassification::new(symbols, &meta);
+    let pc = crate::lir::intrinsics::PrimitiveClassification::new(&meta);
     let region_info =
         crate::hir::analyze_regions_with(&analysis.hir, &arena, pc.call_classification.clone());
     let mut lowerer = Lowerer::new(&arena)
         .with_primitive_classification(pc)
         .with_primitive_values(prim_values)
-        .with_symbol_names(symbols.all_names())
         .with_region_info(region_info);
     let lir_module = lowerer
         .lower(&analysis.hir)
         .map_err(|e| LError::generic(format!("eval: lowering failed: {}", e)))?;
 
     // Emit
-    let symbol_snapshot = symbols.all_names();
-    let mut emitter = Emitter::new_with_symbols(symbol_snapshot);
+    let mut emitter = Emitter::new();
     let (bytecode, _yield_points, _call_sites) = emitter.emit_module(&lir_module);
 
     // Execute

--- a/src/vm/jit_entry.rs
+++ b/src/vm/jit_entry.rs
@@ -145,13 +145,8 @@ impl VM {
     ) {
         let label = closure.template.display_label();
         let bytecode = closure.template.bytecode.clone();
-        let task = crate::jit::worker::prepare_task(
-            lir_func,
-            None,
-            (*closure.template.symbol_names).clone(),
-            bytecode_ptr as usize,
-            Some(&label),
-        );
+        let task =
+            crate::jit::worker::prepare_task(lir_func, None, bytecode_ptr as usize, Some(&label));
 
         // `--trace=syncjit`: compile here on the VM thread and install
         // immediately; the `elle-jit` worker never spawns. Codegen inputs are
@@ -163,7 +158,7 @@ impl VM {
         // synchronous install like the background path logs its own.
         if crate::config::get().has_trace("syncjit") {
             let res = crate::jit::JitCompiler::new()
-                .and_then(|c| c.compile(&task.lir, task.self_sym, task.symbol_names, Vec::new()));
+                .and_then(|c| c.compile(&task.lir, task.self_sym, Vec::new()));
             match res {
                 Ok(jit_code) => {
                     if self

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -32,7 +32,6 @@ pub use core::VM;
 use crate::compiler::bytecode::{Bytecode, Instruction};
 use crate::error::LocationMap;
 use crate::pipeline::CompileCtx;
-use crate::symbol::SymbolTable;
 use crate::value::{SignalBits, SuspendedFrame, Value, SIG_ERROR, SIG_HALT, SIG_SWITCH};
 use std::rc::Rc;
 
@@ -364,14 +363,9 @@ impl VM {
     pub fn execute_scheduled(
         &mut self,
         bytecode: &Bytecode,
-        symbols: &SymbolTable,
         cctx: &CompileCtx,
     ) -> Result<Value, String> {
-        let ev_run_id = match symbols.get("ev/run") {
-            Some(id) => id,
-            None => return self.execute(bytecode),
-        };
-        let ev_run = match cctx.lookup_stdlib_value(ev_run_id) {
+        let ev_run = match cctx.lookup_stdlib_value(crate::value::SymbolId::of("ev/run")) {
             Some(v) => v,
             None => return self.execute(bytecode),
         };
@@ -469,14 +463,16 @@ pub(crate) fn gated_reason(err_value: Value) -> Option<String> {
     let mut is_gated = false;
     let mut reason = String::new();
     for (key, value) in entries {
-        let crate::value::types::TableKey::Keyword(name) = key else {
+        let crate::value::types::TableKey::Keyword(hash) = key else {
             continue;
         };
-        match name.as_str() {
-            "error" if value.as_keyword_name().as_deref() == Some("gated") => {
+        match *hash {
+            h if h == crate::value::keyword::keyword_hash("error")
+                && value.is_keyword_named("gated") =>
+            {
                 is_gated = true;
             }
-            "reason" => {
+            h if h == crate::value::keyword::keyword_hash("reason") => {
                 if let Some(s) = value.with_string(|s| s.to_string()) {
                     reason = s;
                 }

--- a/src/vm/run_on/jit.rs
+++ b/src/vm/run_on/jit.rs
@@ -55,12 +55,7 @@ impl VM {
                         )
                     }
                 };
-                match compiler.compile(
-                    &lir,
-                    None,
-                    (*closure.template.symbol_names).clone(),
-                    Vec::new(),
-                ) {
+                match compiler.compile(&lir, None, Vec::new()) {
                     Ok(jc) => {
                         let jc = Arc::new(jc);
                         self.install_jit_code(closure.template.bytecode.clone(), jc.clone());

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -371,13 +371,13 @@ impl VM {
 
         let mut fields = BTreeMap::new();
         fields.insert(
-            TableKey::Keyword("error".into()),
+            TableKey::keyword("error"),
             Value::keyword("capability-denied"),
         );
-        fields.insert(TableKey::Keyword("denied".into()), denied);
-        fields.insert(TableKey::Keyword("primitive".into()), primitive);
-        fields.insert(TableKey::Keyword("func".into()), Value::native_fn(def));
-        fields.insert(TableKey::Keyword("args".into()), args_array);
+        fields.insert(TableKey::keyword("denied"), denied);
+        fields.insert(TableKey::keyword("primitive"), primitive);
+        fields.insert(TableKey::keyword("func"), Value::native_fn(def));
+        fields.insert(TableKey::keyword("args"), args_array);
 
         ctx.struct_from(fields)
     }

--- a/src/vm/signal/config.rs
+++ b/src/vm/signal/config.rs
@@ -50,7 +50,7 @@ impl VM {
                 self.unicode_version_value(ctx),
             );
             (SIG_OK, ctx.struct_from(map))
-        } else if let Some(kw) = arg.as_keyword_name() {
+        } else if let Some(kw) = self.keyword_spelling(arg) {
             match kw.as_str() {
                 "jit" => (SIG_OK, Value::keyword(rc.jit.keyword())),
                 "wasm" => (SIG_OK, Value::keyword(rc.wasm.keyword())),
@@ -98,7 +98,7 @@ impl VM {
         let key = pair.first;
         let val = pair.rest;
 
-        let kw = match key.as_keyword_name() {
+        let kw = match self.keyword_spelling(key) {
             Some(k) => k,
             None => {
                 return ctx.error(
@@ -116,7 +116,7 @@ impl VM {
                 if let Some(closure) = val.as_closure() {
                     let _ = closure; // TODO: store for actual dispatch
                     self.runtime_config.jit = crate::config::JitPolicy::Custom;
-                } else if let Some(policy_kw) = val.as_keyword_name() {
+                } else if let Some(policy_kw) = self.keyword_spelling(val) {
                     match crate::config::JitPolicy::from_keyword(&policy_kw) {
                         Some(policy) => {
                             self.runtime_config.jit = policy;
@@ -140,7 +140,7 @@ impl VM {
                 Value::NIL
             }
             "wasm" => {
-                if let Some(policy_kw) = val.as_keyword_name() {
+                if let Some(policy_kw) = self.keyword_spelling(val) {
                     match crate::config::WasmPolicy::from_keyword(&policy_kw) {
                         Some(policy) => {
                             self.runtime_config.wasm = policy;
@@ -164,7 +164,7 @@ impl VM {
                 Value::NIL
             }
             "mlir" => {
-                if let Some(policy_kw) = val.as_keyword_name() {
+                if let Some(policy_kw) = self.keyword_spelling(val) {
                     match crate::config::MlirPolicy::from_keyword(&policy_kw) {
                         Some(policy) => {
                             #[cfg(feature = "mlir")]
@@ -196,7 +196,7 @@ impl VM {
                 if let Some(set) = val.as_set() {
                     let mut keywords = std::collections::HashSet::new();
                     for v in set.iter() {
-                        if let Some(k) = v.as_keyword_name() {
+                        if let Some(k) = self.keyword_spelling(*v) {
                             keywords.insert(k);
                         }
                     }

--- a/src/vm/signal/modules.rs
+++ b/src/vm/signal/modules.rs
@@ -33,7 +33,7 @@ impl VM {
             );
         }
 
-        let tier_kw = match parts[0].as_keyword_name() {
+        let tier_kw = match self.keyword_spelling(parts[0]) {
             Some(k) => k,
             None => {
                 return (

--- a/src/vm/signal/query.rs
+++ b/src/vm/signal/query.rs
@@ -44,7 +44,7 @@ impl VM {
         };
 
         // Accept keyword or string as operation identifier.
-        let op_name: String = if let Some(name) = pair.first.as_keyword_name() {
+        let op_name: String = if let Some(name) = self.keyword_spelling(pair.first) {
             name
         } else if let Some(s) = pair.first.with_string(|s| s.to_string()) {
             s
@@ -76,7 +76,7 @@ impl VM {
             "doc" => {
                 let name = if let Some(s) = arg.with_string(|s| s.to_string()) {
                     s
-                } else if let Some(s) = arg.as_keyword_name() {
+                } else if let Some(s) = self.keyword_spelling(arg) {
                     s
                 } else {
                     return (
@@ -109,7 +109,7 @@ impl VM {
                 // arg is nil (no filter) or a keyword/string category name
                 let category_filter: Option<String> = if arg.is_nil() {
                     None
-                } else if let Some(k) = arg.as_keyword_name() {
+                } else if let Some(k) = self.keyword_spelling(arg) {
                     Some(k)
                 } else {
                     arg.with_string(|s| s.to_string())
@@ -136,7 +136,7 @@ impl VM {
                             ctx.string(n)
                         } else {
                             let id = unsafe { (*symbols_ptr).intern(n) };
-                            Value::symbol(id.0)
+                            Value::symbol(id)
                         }
                     })
                     .collect();
@@ -145,13 +145,14 @@ impl VM {
             "primitive-meta" => {
                 let name = if let Some(s) = arg.with_string(|s| s.to_string()) {
                     s
-                } else if let Some(s) = arg.as_keyword_name() {
+                } else if let Some(s) = self.keyword_spelling(arg) {
                     s
                 } else if let Some(sym_id) = arg.as_symbol() {
-                    match self.symbols().and_then(|s| {
-                        s.name(crate::value::SymbolId(sym_id))
-                            .map(|n| n.to_string())
-                    }) {
+                    match self
+                        .symbols()
+                        .and_then(|s| s.name(sym_id))
+                        .map(|n| n.to_string())
+                    {
                         Some(s) => s,
                         None => {
                             return (
@@ -159,7 +160,7 @@ impl VM {
                                 ctx.error(
                                     "internal-error",
                                     format!(
-                                        "primitive-meta: symbol ID {} not found in symbol table",
+                                        "primitive-meta: symbol ID {} has no recorded name",
                                         sym_id
                                     ),
                                 ),
@@ -179,30 +180,24 @@ impl VM {
                     use crate::value::heap::TableKey;
                     use std::collections::BTreeMap;
                     let mut fields = BTreeMap::new();
-                    fields.insert(TableKey::Keyword("name".to_string()), ctx.string(doc.name));
-                    fields.insert(TableKey::Keyword("doc".to_string()), ctx.string(doc.doc));
+                    fields.insert(TableKey::keyword("name"), ctx.string(doc.name));
+                    fields.insert(TableKey::keyword("doc"), ctx.string(doc.doc));
                     // params as a list of strings
                     let params: Vec<Value> = doc.params.iter().map(|p| ctx.string(*p)).collect();
-                    fields.insert(TableKey::Keyword("params".to_string()), ctx.list(params));
+                    fields.insert(TableKey::keyword("params"), ctx.list(params));
+                    fields.insert(TableKey::keyword("category"), ctx.string(doc.category));
+                    fields.insert(TableKey::keyword("example"), ctx.string(doc.example));
                     fields.insert(
-                        TableKey::Keyword("category".to_string()),
-                        ctx.string(doc.category),
-                    );
-                    fields.insert(
-                        TableKey::Keyword("example".to_string()),
-                        ctx.string(doc.example),
-                    );
-                    fields.insert(
-                        TableKey::Keyword("arity".to_string()),
+                        TableKey::keyword("arity"),
                         ctx.string(format!("{}", doc.arity)),
                     );
                     fields.insert(
-                        TableKey::Keyword("signal".to_string()),
+                        TableKey::keyword("signal"),
                         ctx.string(format!("{}", doc.signal)),
                     );
                     // aliases as a list of strings
                     let aliases: Vec<Value> = doc.aliases.iter().map(|a| ctx.string(*a)).collect();
-                    fields.insert(TableKey::Keyword("aliases".to_string()), ctx.list(aliases));
+                    fields.insert(TableKey::keyword("aliases"), ctx.list(aliases));
                     (SIG_OK, ctx.struct_from(fields))
                 } else {
                     (SIG_OK, Value::NIL)
@@ -221,35 +216,29 @@ impl VM {
                 fn build_stats(heap: &crate::value::FiberHeap) -> BTreeMap<TableKey, Value> {
                     let mut fields = BTreeMap::new();
                     fields.insert(
-                        TableKey::Keyword("object-count".to_string()),
+                        TableKey::keyword("object-count"),
                         Value::int(heap.visible_len() as i64),
                     );
                     fields.insert(
-                        TableKey::Keyword("peak-count".to_string()),
+                        TableKey::keyword("peak-count"),
                         Value::int(heap.peak_alloc_count() as i64),
                     );
                     fields.insert(
-                        TableKey::Keyword("allocated-bytes".to_string()),
+                        TableKey::keyword("allocated-bytes"),
                         Value::int(heap.allocated_bytes() as i64),
                     );
                     let limit_val = match heap.object_limit() {
                         Some(n) => Value::int(n as i64),
                         None => Value::NIL,
                     };
-                    fields.insert(TableKey::Keyword("object-limit".to_string()), limit_val);
-                    fields.insert(TableKey::Keyword("scope-depth".to_string()), Value::int(0));
+                    fields.insert(TableKey::keyword("object-limit"), limit_val);
+                    fields.insert(TableKey::keyword("scope-depth"), Value::int(0));
                     fields.insert(
-                        TableKey::Keyword("active-allocator".to_string()),
+                        TableKey::keyword("active-allocator"),
                         Value::keyword("region"),
                     );
-                    fields.insert(
-                        TableKey::Keyword("scope-enter-count".to_string()),
-                        Value::int(0),
-                    );
-                    fields.insert(
-                        TableKey::Keyword("scope-dtor-count".to_string()),
-                        Value::int(0),
-                    );
+                    fields.insert(TableKey::keyword("scope-enter-count"), Value::int(0));
+                    fields.insert(TableKey::keyword("scope-dtor-count"), Value::int(0));
                     fields
                 }
 
@@ -288,21 +277,15 @@ impl VM {
                     .map(|(ptr, info)| {
                         let mut fields = BTreeMap::new();
                         let name = info.name.as_deref().unwrap_or("<anon>");
-                        fields.insert(TableKey::Keyword("name".to_string()), ctx.string(name));
+                        fields.insert(TableKey::keyword("name"), ctx.string(name));
                         fields.insert(
-                            TableKey::Keyword("reason".to_string()),
+                            TableKey::keyword("reason"),
                             ctx.string(info.reason.to_string()),
                         );
                         let calls = self.closure_call_counts.get(ptr).copied().unwrap_or(0);
-                        fields.insert(
-                            TableKey::Keyword("calls".to_string()),
-                            Value::int(calls as i64),
-                        );
+                        fields.insert(TableKey::keyword("calls"), Value::int(calls as i64));
                         let attempts = self.jit_compile_attempts.get(ptr).copied().unwrap_or(0);
-                        fields.insert(
-                            TableKey::Keyword("attempts".to_string()),
-                            Value::int(attempts as i64),
-                        );
+                        fields.insert(TableKey::keyword("attempts"), Value::int(attempts as i64));
                         ctx.struct_from(fields)
                     })
                     .collect();

--- a/src/vm/types/tests.rs
+++ b/src/vm/types/tests.rs
@@ -35,7 +35,7 @@ fn intr_get_unhashable_key_on_immutable_struct_panics() {
         let h = crate::primitives::ctx::TestHeap::new();
         let mut vm = VM::new();
         let s = h.ctx().struct_from_sorted(vec![(
-            crate::value::heap::TableKey::Keyword("a".to_string()),
+            crate::value::heap::TableKey::keyword("a"),
             Value::int(1),
         )]);
         vm.fiber.stack.push(s);
@@ -51,10 +51,7 @@ fn intr_get_unhashable_key_on_mutable_struct_panics() {
         let h = crate::primitives::ctx::TestHeap::new();
         let mut vm = VM::new();
         let mut entries = std::collections::BTreeMap::new();
-        entries.insert(
-            crate::value::heap::TableKey::Keyword("a".to_string()),
-            Value::int(1),
-        );
+        entries.insert(crate::value::heap::TableKey::keyword("a"), Value::int(1));
         let s = h.ctx().struct_mut_from(entries);
         vm.fiber.stack.push(s);
         vm.fiber.stack.push(Value::float(1.5)); // floats are not hashable keys
@@ -70,7 +67,7 @@ fn intr_get_absent_hashable_key_on_struct_is_nil() {
         let h = crate::primitives::ctx::TestHeap::new();
         let mut vm = VM::new();
         let s = h.ctx().struct_from_sorted(vec![(
-            crate::value::heap::TableKey::Keyword("a".to_string()),
+            crate::value::heap::TableKey::keyword("a"),
             Value::int(1),
         )]);
         vm.fiber.stack.push(s);

--- a/src/wasm/instruction/data.rs
+++ b/src/wasm/instruction/data.rs
@@ -82,8 +82,10 @@ impl WasmEmitter {
     ) {
         self.write_val_to_mem(f, src, 0);
         match key {
-            LirConst::Keyword(name) => self.emit_const_pool_load(f, dst, Value::keyword(name)),
-            LirConst::Symbol(id) => self.emit_const_pool_load(f, dst, Value::symbol(id.0)),
+            LirConst::Keyword(hash) => {
+                self.emit_const_pool_load(f, dst, Value::keyword_from_hash(*hash))
+            }
+            LirConst::Symbol(id) => self.emit_const_pool_load(f, dst, Value::symbol(*id)),
             _ => {
                 f.instruction(&Instruction::I64Const(TAG_NIL as i64));
                 f.instruction(&Instruction::LocalSet(self.tag_local(dst)));

--- a/src/wasm/instruction/dispatch.rs
+++ b/src/wasm/instruction/dispatch.rs
@@ -488,11 +488,11 @@ impl WasmEmitter {
                 self.write_val_to_mem(f, *src, 0);
                 for (i, key) in exclude_keys.iter().enumerate() {
                     match key {
-                        LirConst::Keyword(name) => {
-                            self.emit_const_pool_load(f, *dst, Value::keyword(name));
+                        LirConst::Keyword(hash) => {
+                            self.emit_const_pool_load(f, *dst, Value::keyword_from_hash(*hash));
                         }
                         LirConst::Symbol(id) => {
-                            self.emit_const_pool_load(f, *dst, Value::symbol(id.0));
+                            self.emit_const_pool_load(f, *dst, Value::symbol(*id));
                         }
                         _ => {
                             f.instruction(&Instruction::I64Const(TAG_NIL as i64));

--- a/src/wasm/instruction/mem.rs
+++ b/src/wasm/instruction/mem.rs
@@ -87,10 +87,10 @@ impl WasmEmitter {
                 self.emit_const_pool_load(f, dst, sval);
             }
             LirConst::Symbol(id) => {
-                self.emit_const_pool_load(f, dst, Value::symbol(id.0));
+                self.emit_const_pool_load(f, dst, Value::symbol(*id));
             }
-            LirConst::Keyword(name) => {
-                self.emit_const_pool_load(f, dst, Value::keyword(name));
+            LirConst::Keyword(hash) => {
+                self.emit_const_pool_load(f, dst, Value::keyword_from_hash(*hash));
             }
             _ => {
                 let (tag, payload) = match value {

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -437,7 +437,10 @@ fn eval_wasm_raw(source: &str, source_name: &str, with_stdlib: bool) -> Result<S
     // execution), but test harnesses format it; returning the owned string keeps
     // them sound for heap results, not only immediates. Pinned by the `wasm_smoke`
     // / `wasm_stdlib` heap-result tests (e.g. `[1 2 3]`, `(map … (list 1 2 3))`).
-    let ret = ret.map(|v| format!("{}", v));
+    // Render through this instance's table: a bare `Display` prints a symbol or
+    // keyword as `#<symbol:hash>` (docs/impl/symbol.md § "Reading a name, and
+    // not reading one").
+    let ret = ret.map(|v| format!("{}", v.display_with(Some(&symbols))));
 
     let funcs = 1 + lir_module.closures.len();
     let lir_secs = (t1 - t0).as_secs_f64();

--- a/tests/elle/AGENTS.md
+++ b/tests/elle/AGENTS.md
@@ -67,6 +67,7 @@ Tests are organized by feature area:
 | `regex.lisp` | Regular expressions |
 | `bytes.lisp` | Bytes operations |
 | `string.lisp` | String and @string operations |
+| `symbol-identity.lisp` | Symbol identity across worker symbol tables |
 
 ## Running Elle scripts
 

--- a/tests/elle/comparison.lisp
+++ b/tests/elle/comparison.lisp
@@ -32,23 +32,27 @@
 # ============================================================================
 # Keyword comparison
 # ============================================================================
+# Keywords order by name hash (docs/impl/symbol.md § "What the property
+# buys"): the order is total and identical in every run, thread, process,
+# and tier, but carries no alphabetical meaning. The counter-factual these
+# assertions replace: lexicographic order needed a name lookup on every
+# compare, which a sorted-container probe and the JIT tier cannot afford.
 
-# Keyword less-than
-(assert (< :apple :banana) ":apple < :banana")
-(assert (not (< :banana :apple)) ":banana < :apple is false")
+# Total and irreflexive
 (assert (not (< :apple :apple)) ":apple < :apple is false")
+(assert (or (< :apple :banana) (< :banana :apple)) "keyword order is total")
+(assert (not (and (< :apple :banana) (< :banana :apple)))
+        "keyword order is antisymmetric")
 
-# Keyword greater-than
-(assert (> :banana :apple) ":banana > :apple")
-(assert (not (> :apple :banana)) ":apple > :banana is false")
+# < and > mirror each other
+(assert (= (< :apple :banana) (> :banana :apple)) "< and > agree")
+(assert (= (< :banana :apple) (> :apple :banana)) "< and > agree, reversed")
 
-# Keyword less-than-or-equal
-(assert (<= :apple :banana) ":apple <= :banana")
+# Reflexive bounds
 (assert (<= :apple :apple) ":apple <= :apple")
-
-# Keyword greater-than-or-equal
-(assert (>= :banana :apple) ":banana >= :apple")
 (assert (>= :apple :apple) ":apple >= :apple")
+(assert (= (<= :apple :banana) (not (> :apple :banana))) "<= is not->")
+(assert (= (>= :apple :banana) (not (< :apple :banana))) ">= is not-<")
 
 # ============================================================================
 # Edge cases

--- a/tests/elle/functional.lisp
+++ b/tests/elle/functional.lisp
@@ -23,7 +23,12 @@
 ## ── sort: non-numeric types ─────────────────────────────────────────
 (assert (= (sort (list "banana" "apple" "cherry"))
            (list "apple" "banana" "cherry")) "sort: strings")
-(assert (= (sort (list :b :a :c)) (list :a :b :c)) "sort: keywords")
+# Keyword sort order is hash order — deterministic (the same for any input
+# permutation) but not alphabetical (docs/impl/symbol.md).
+(assert (= (sort (list :b :a :c)) (sort (list :c :a :b)))
+        "sort: keywords is deterministic across permutations")
+(assert (= (length (sort (list :b :a :c))) 3)
+        "sort: keywords keeps all elements")
 # Cross-type ordering: nil < bool < int < ... (Value::Ord rank order)
 (let [result (sort [nil true 1])]
   (assert (= (get result 0) nil) "sort: cross-type nil first")

--- a/tests/elle/spawn-eval.lisp
+++ b/tests/elle/spawn-eval.lisp
@@ -22,10 +22,10 @@
 
 # Special forms (begin/def/quote/if) are recognized by the analyzer by NAME,
 # so they resolve in a light worker too — they are not stdlib. This only works
-# because a quoted symbol crosses the spawn boundary by name and re-interns in
-# the worker's own table; a raw sender-table id would not name `begin`/`def`
-# there. (Regression guard: before symbols carried their name, this was a loud
-# :eval-error "Unknown symbol".)
+# because a quoted symbol crosses the spawn boundary unchanged and still names
+# `begin`/`def` on the far side: the id is the name's hash
+# (docs/impl/symbol.md). A per-table id would name something else there.
+# (Regression guard: it was once a loud :eval-error "Unknown symbol".)
 (assert (= 7
            (sys/join (sys/spawn-vm (fn []
                                      (eval (quote (begin

--- a/tests/elle/symbol-identity.lisp
+++ b/tests/elle/symbol-identity.lisp
@@ -1,0 +1,65 @@
+(elle/epoch 12)
+# ── A symbol means the same thing in every symbol table ───────────────
+#
+# A symbol id is the FNV-1a hash of its name (docs/impl/symbol.md), so a
+# symbol built by an OS-thread worker — which compiles against its OWN table
+# — is the symbol the main thread wrote. These asserts run on the main
+# thread; only the construction happens in the worker.
+#
+# (epoch 12: sys/spawn is the heavy, stdlib-backed worker. At an earlier
+#  epoch the migration would rewrite sys/spawn → sys/spawn-vm.)
+#
+# The names below are deliberately unusual so that nothing else interns them
+# first: the defect these guard against is a table that met the same names in
+# a different order.
+
+# ── A symbol value crosses unchanged ──────────────────────────────────
+
+(assert (= 'sigil-alpha (sys/join (sys/spawn (fn [] 'sigil-alpha))))
+        "a quoted symbol built in a worker equals the main thread's")
+
+# ── A symbol-keyed struct is readable on the other side ───────────────
+#
+# Struct keys cross as bare ids with no name beside them. Counterfactual:
+# with per-table ids the worker's key `sigil-one` arrived as the main
+# thread's `sigil-two` (or as a symbol the file never mentioned), so this
+# lookup returned the neighbouring value or nil.
+
+(def from-worker (sys/join (sys/spawn (fn [] {'sigil-one 1 'sigil-two 2}))))
+
+(assert (= 1 (get from-worker 'sigil-one))
+        "the main thread's key finds the entry the worker stored")
+(assert (= 2 (get from-worker 'sigil-two)) "and so does the second key")
+
+# ── A struct built either side is the same struct ─────────────────────
+#
+# An immutable struct is a SORTED array, and symbol keys sort by id. Equal
+# contents therefore demand equal layouts: the worker's sort and the main
+# thread's sort must agree, key for key.
+
+(def here {'sigil-zeta 1 'sigil-mu 2 'sigil-alpha 3})
+(def there
+  (sys/join (sys/spawn (fn [] {'sigil-zeta 1 'sigil-mu 2 'sigil-alpha 3}))))
+
+(assert (= here there) "the same struct literal is the same struct in a worker")
+(assert (= (string here) (string there))
+        "and prints identically — same key names in the same sorted order")
+
+# ── The same for an immutable set ─────────────────────────────────────
+
+(def set-here (set 'sigil-zeta 'sigil-mu 'sigil-alpha))
+(def set-there
+  (sys/join (sys/spawn (fn [] (set 'sigil-zeta 'sigil-mu 'sigil-alpha)))))
+
+(assert (= set-here set-there)
+        "the same set literal is the same set in a worker")
+(assert (= (string set-here) (string set-there))
+        "and prints identically — same elements in the same sorted order")
+
+# ── A worker's eval agrees with the main thread's reader ──────────────
+#
+# `eval` interns against the worker's table; the quoted datum reaching it was
+# read against the main thread's. Both must name one symbol.
+
+(assert (= 5 (sys/join (sys/spawn (fn [] (eval '(get {'sigil-k 5} 'sigil-k))))))
+        "a worker's eval reads the key the main thread's reader wrote")

--- a/tests/elle/sync-keys.lisp
+++ b/tests/elle/sync-keys.lisp
@@ -1,0 +1,40 @@
+(elle/epoch 12)
+## Synchronisation objects must not grow the symbol table.
+##
+## A futex key only has to be a unique hashable value; it does not have to
+## be a symbol. `sys/unique` mints process-unique integers, and the sync
+## constructors key their futexes with it, so building locks in a loop
+## retains nothing. Keying with `(gensym)` instead would intern one symbol
+## per constructor call, permanently — the assertions below read
+## `debug/symbol-count` across a constructor loop and demand it flat.
+
+(def sync ((import "std/sync")))
+
+# Distinctness: the uniqueness gensym provided, without the interning.
+(assert (not (= (sys/unique) (sys/unique))) "sys/unique mints distinct keys")
+(assert (int? (sys/unique)) "sys/unique mints integers")
+
+# Warm each shape first so one-time interning (module load, first-call
+# paths) settles before the measured window.
+(defn measure [f]
+  (var i 0)
+  (while (< i 20)
+    (f)
+    (assign i (+ i 1)))
+  (let [before (debug/symbol-count)]
+    (var j 0)
+    (while (< j 100)
+      (f)
+      (assign j (+ j 1)))
+    (- (debug/symbol-count) before)))
+
+(assert (= 0 (measure (fn [] (sync:make-futex false))))
+        "make-futex must not intern symbols")
+(assert (= 0 (measure (fn [] (sync:make-lock))))
+        "make-lock must not intern symbols")
+(assert (= 0 (measure (fn [] (sync:make-queue 4))))
+        "make-queue must not intern symbols")
+(assert (= 0 (measure (fn [] (sync:make-monitor))))
+        "make-monitor must not intern symbols")
+
+(println "sync-keys: ok")

--- a/tests/integration/embedding.rs
+++ b/tests/integration/embedding.rs
@@ -68,7 +68,7 @@ fn test_scheduled_execution() {
     )
     .unwrap();
     let value = vm
-        .execute_scheduled(&result.bytecode, symbols, cctx)
+        .execute_scheduled(&result.bytecode, cctx)
         .unwrap();
     assert!(value.is_keyword());
 }

--- a/tests/integration/jit.rs
+++ b/tests/integration/jit.rs
@@ -117,7 +117,7 @@ fn compile_and_call(lir: &LirFunction, args: &[Value]) -> Result<Value, JitError
     let _signals = register_primitives(&mut vm, &mut symbols);
 
     let compiler = JitCompiler::new()?;
-    let code = compiler.compile(lir, None, std::collections::HashMap::new(), Vec::new())?;
+    let code = compiler.compile(lir, None, Vec::new())?;
     // self_tag/self_payload = 0 since we're not testing self-tail-calls in these basic tests
     let result = unsafe {
         code.call(

--- a/tests/integration/jit/control.rs
+++ b/tests/integration/jit/control.rs
@@ -225,7 +225,7 @@ fn test_jit_accepts_yielding() {
     func.entry = Label(0);
 
     let compiler = JitCompiler::new().unwrap();
-    let result = compiler.compile(&func, None, std::collections::HashMap::new(), Vec::new());
+    let result = compiler.compile(&func, None, Vec::new());
     assert!(
         result.is_ok(),
         "JIT should accept yielding functions via side-exit: {:?}",
@@ -258,7 +258,7 @@ fn test_jit_call_compiles() {
     func.entry = Label(0);
 
     let compiler = JitCompiler::new().unwrap();
-    let result = compiler.compile(&func, None, std::collections::HashMap::new(), Vec::new());
+    let result = compiler.compile(&func, None, Vec::new());
     // Call should now compile successfully
     assert!(result.is_ok(), "Call should compile: {:?}", result);
 }
@@ -290,7 +290,7 @@ fn test_jit_rejects_make_closure() {
     func.entry = Label(0);
 
     let compiler = JitCompiler::new().unwrap();
-    let result = compiler.compile(&func, None, std::collections::HashMap::new(), Vec::new());
+    let result = compiler.compile(&func, None, Vec::new());
     assert!(
         matches!(result, Err(elle::jit::JitError::UnsupportedInstruction(_))),
         "MakeClosure should be rejected: {:?}",

--- a/tests/integration/jit/fastpath.rs
+++ b/tests/integration/jit/fastpath.rs
@@ -135,7 +135,7 @@ fn test_jit_accepts_yields_errors_signal() {
     func.entry = Label(0);
 
     let compiler = JitCompiler::new().unwrap();
-    let result = compiler.compile(&func, None, std::collections::HashMap::new(), Vec::new());
+    let result = compiler.compile(&func, None, Vec::new());
     assert!(
         result.is_ok(),
         "JIT should accept yields_errors signal via side-exit: {:?}",
@@ -166,7 +166,7 @@ fn test_jit_accepts_errors_only_signal() {
     func.entry = Label(0);
 
     let compiler = JitCompiler::new().unwrap();
-    let result = compiler.compile(&func, None, std::collections::HashMap::new(), Vec::new());
+    let result = compiler.compile(&func, None, Vec::new());
     assert!(
         result.is_ok(),
         "JIT should accept errors-only signal: {:?}",

--- a/tests/integration/jit/tailcall.rs
+++ b/tests/integration/jit/tailcall.rs
@@ -34,7 +34,7 @@ fn test_jit_tail_call_compiles() {
     func.entry = Label(0);
 
     let compiler = JitCompiler::new().unwrap();
-    let result = compiler.compile(&func, None, std::collections::HashMap::new(), Vec::new());
+    let result = compiler.compile(&func, None, Vec::new());
     // TailCall should now compile successfully
     assert!(result.is_ok(), "TailCall should compile: {:?}", result);
 }

--- a/tests/integration/net.rs
+++ b/tests/integration/net.rs
@@ -21,7 +21,7 @@ fn setup_scheduled() -> Runtime {
 fn run_scheduled(input: &str, rt: &mut Runtime) -> Result<Value, String> {
     let (vm, symbols, cctx) = rt.parts();
     let result = compile_file(input, symbols, cctx, "<test>")?;
-    let value = vm.execute_scheduled(&result.bytecode, symbols, cctx)?;
+    let value = vm.execute_scheduled(&result.bytecode, cctx)?;
     Ok(value)
 }
 
@@ -130,7 +130,7 @@ fn test_udp_roundtrip() {
     let fields = result.as_struct().expect("expected struct result");
     use elle::value::heap::TableKey;
     use elle::value::sorted_struct_get;
-    let data = sorted_struct_get(fields, &TableKey::Keyword("data".into())).unwrap();
+    let data = sorted_struct_get(fields, &TableKey::keyword("data")).unwrap();
     let data_bytes = data.as_bytes().unwrap();
     assert_eq!(data_bytes, b"udp-hello");
 

--- a/tests/integration/projection.rs
+++ b/tests/integration/projection.rs
@@ -10,6 +10,7 @@ use elle::hir::HirKind;
 use elle::primitives::register_primitives;
 use elle::signals::{Signal, SIG_IO, SIG_YIELD};
 use elle::symbol::SymbolTable;
+use elle::value::SymbolId;
 use elle::vm::VM;
 
 fn setup() -> (SymbolTable, VM) {
@@ -244,31 +245,25 @@ fn test_projection_yields_function() {
 }
 
 // ============================================================================
-// 4. THE PROBE COMPILES IN THE CALLER'S SYMBOL TABLE
+// 4. THE IMPORT PROJECTION PROBE
 // ============================================================================
 
 #[test]
-fn import_projection_probe_interns_into_the_callers_symbol_table() {
+fn import_projection_probe_compiles_the_imported_module() {
     // `((import "…"))` makes the analyzer compile the imported file to read its
     // signal projection (src/hir/analyze/call.rs § "Import projection
-    // detection"). Which symbol table that compile runs in is not an internal
-    // detail: macro transformers compile lazily on first expansion and cache on
-    // the shared expander, and a transformer's quoted literals bind to the table
-    // that compiled it. A probe running in a throwaway table therefore caches
-    // transformers whose ids mean nothing in the instance's table, and a later
-    // expansion comparing against an instance-table symbol takes the wrong
-    // branch — `each`'s `(= (syntax->datum iter-or-in) 'in)` is the shape that
-    // bites.
+    // detection"). `compile_file` never executes the import, so the probe is the
+    // only thing that reaches the module's source at all.
     //
-    // The caller's table learning the module's quoted symbol is the observable
-    // form of the invariant: `compile_file` never executes the import, so the
-    // probe is the only thing that could have interned it.
+    // The trap: `SymbolId::of` derives an id without recording anything, so the
+    // name answers here only if some compile interned it. The module's marker is
+    // a quoted symbol — runtime data, which compiling must intern — unlike a
+    // binding name, which analysis resolves into the binding arena instead. The
+    // spelling has to stay unique across this test binary: the registry is
+    // process-global, so any other test interning it would answer here too.
     let tmp = tempfile::tempdir().expect("scratch dir");
     let dir = tmp.path();
     let module = dir.join("probe_module.lisp");
-    // A quoted symbol is runtime data, so compiling this file must intern
-    // `probe-only-marker` — unlike a binding name, which analysis resolves into
-    // the binding arena instead.
     std::fs::write(
         &module,
         "(fn [] (def marker 'probe-only-marker) {:marker marker})\n",
@@ -279,14 +274,11 @@ fn import_projection_probe_interns_into_the_callers_symbol_table() {
     let source = format!("(def m ((import \"{}\")))\nm\n", module.display());
     compile_file(&source, &mut symbols, "<probe-main>").expect("main file compiles");
 
-    let learned = symbols.get("probe-only-marker");
-
     assert!(
-        learned.is_some(),
-        "the import projection probe must compile in the caller's symbol table; \
-         compiling in a throwaway one leaves the instance's table without the \
-         module's symbols and caches transformers bound to a table nothing else \
-         can read"
+        symbols.name(SymbolId::of("probe-only-marker")).is_some(),
+        "compiling a file whose import is probed must compile the module: with \
+         no probe nothing reads the module's source, so its quoted data is never \
+         interned and the import falls back to the conservative projection"
     );
 }
 
@@ -294,25 +286,25 @@ fn import_projection_probe_interns_into_the_callers_symbol_table() {
 fn each_keeps_its_collection_when_an_import_probe_expanded_the_macro_first() {
     // The trap: `each` decides whether it was written in `in` form with
     // `(= (syntax->datum iter-or-in) 'in)` (src/prelude.lisp § each). That `'in`
-    // is a quoted literal in the transformer's own bytecode, so it carries the
-    // `SymbolId` of whichever table compiled the transformer — and a transformer
+    // is a quoted literal in the transformer's own bytecode, and a transformer
     // compiles once, lazily, on its first expansion, then caches on the shared
-    // expander (`ensure_transformer`, src/syntax/expand/macro_expand.rs). The
-    // first expansion in an instance therefore fixes the id every later
-    // expansion compares against.
+    // expander (`ensure_transformer`, src/syntax/expand/macro_expand.rs). So
+    // whichever compile expands `each` first fixes the literal that every later
+    // expansion compares against — including a compile the program never asked
+    // for.
     //
-    // Here the import projection probe expands `each` first: this runtime loads
-    // no stdlib, so nothing has warmed the transformer against the instance's
-    // table, and compiling the main file runs the probe over a module that uses
-    // `each`. The second compile, on the same context, is the one that must
-    // still read its `in`.
+    // Here the import projection probe is that first compile: this runtime loads
+    // no stdlib, so nothing has warmed the transformer, and compiling the main
+    // file runs the probe over a module that uses `each`. The probe compiles in
+    // its own symbol table (`CompileCtx::get_or_compile_projection`), so this is
+    // also what pins that the two tables agree. The second compile, on the same
+    // context, is the one that must still read its `in`.
     //
-    // The counter-factual: with the probe compiling in a throwaway table, the
-    // comparison against the instance table's `in` is false, so `each` takes the
-    // symbol `in` itself as the collection and shifts `'(1 2 3)` into the body —
-    // the second compile then fails with `undefined variable: in`. The assertion
-    // names the elements the loop visited rather than settling for a successful
-    // compile, because the same shift is silent wherever `in` is bound.
+    // The counter-factual: the assertion names the elements the loop visited
+    // rather than settling for a successful compile. When the comparison against
+    // `'in` fails, `each` takes the symbol `in` itself as the collection and
+    // shifts `'(1 2 3)` into the body — which raises `undefined variable: in`
+    // only where `in` is unbound, and is silent everywhere else.
     //
     // Both files define `pair?` themselves: `each`'s `:list` arm calls it, it is
     // the one name in the expansion that is not a primitive, and no stdlib is
@@ -359,8 +351,8 @@ fn each_keeps_its_collection_when_an_import_probe_expanded_the_macro_first() {
         visited.as_ref().map(|v| v.to_string()).as_deref(),
         Ok("(3 2 1)"),
         "`each` must still read its `in` form after the import projection probe \
-         expanded the macro; a probe in a throwaway table caches a transformer \
-         whose quoted `'in` no instance-table expansion can match, and the \
-         collection is dropped from the loop"
+         expanded the macro; when the cached transformer's quoted `'in` stops \
+         matching the one at the use site, the collection is dropped from the \
+         loop and the body iterates over the symbol `in`"
     );
 }

--- a/tests/property/nanboxing/scalars.rs
+++ b/tests/property/nanboxing/scalars.rs
@@ -1,4 +1,5 @@
 use super::*;
+use elle::value::SymbolId;
 
 #[test]
 fn int_roundtrip_min() {
@@ -142,25 +143,25 @@ fn float_is_float_type() {
 
 #[test]
 fn symbol_roundtrip_zero() {
-    let v = Value::symbol(0);
-    assert_eq!(v.as_symbol(), Some(0));
+    let v = Value::symbol(SymbolId(0));
+    assert_eq!(v.as_symbol(), Some(SymbolId(0)));
 }
 
 #[test]
 fn symbol_roundtrip_one() {
-    let v = Value::symbol(1);
-    assert_eq!(v.as_symbol(), Some(1));
+    let v = Value::symbol(SymbolId(1));
+    assert_eq!(v.as_symbol(), Some(SymbolId(1)));
 }
 
 #[test]
-fn symbol_roundtrip_large() {
-    let v = Value::symbol(99999);
-    assert_eq!(v.as_symbol(), Some(99999));
+fn symbol_roundtrip_full_64_bit_payload() {
+    let v = Value::symbol(SymbolId(0xdead_beef_cafe_f00d));
+    assert_eq!(v.as_symbol(), Some(SymbolId(0xdead_beef_cafe_f00d)));
 }
 
 #[test]
 fn symbol_is_symbol_type() {
-    let v = Value::symbol(42);
+    let v = Value::symbol(SymbolId(42));
     assert!(v.is_symbol());
     assert!(!v.is_int());
     assert!(!v.is_float());
@@ -262,7 +263,7 @@ fn exactly_one_type_for_float_zero() {
 
 #[test]
 fn exactly_one_type_for_symbol_zero() {
-    let v = Value::symbol(0);
+    let v = Value::symbol(SymbolId(0));
     let count = v.is_nil() as u8
         + v.is_empty_list() as u8
         + v.is_bool() as u8
@@ -275,8 +276,8 @@ fn exactly_one_type_for_symbol_zero() {
 }
 
 #[test]
-fn exactly_one_type_for_symbol_large() {
-    let v = Value::symbol(99999);
+fn exactly_one_type_for_symbol_full_64_bit_payload() {
+    let v = Value::symbol(SymbolId(0xdead_beef_cafe_f00d));
     let count = v.is_nil() as u8
         + v.is_empty_list() as u8
         + v.is_bool() as u8
@@ -324,7 +325,7 @@ fn float_is_truthy_zero() {
 
 #[test]
 fn symbol_is_truthy() {
-    assert!(Value::symbol(42).is_truthy());
+    assert!(Value::symbol(SymbolId(42)).is_truthy());
 }
 
 #[test]
@@ -381,7 +382,7 @@ fn float_eq_reflexive_zero() {
 
 #[test]
 fn symbol_eq_reflexive() {
-    let v = Value::symbol(42);
+    let v = Value::symbol(SymbolId(42));
     assert_eq!(v, v);
 }
 

--- a/tests/property/strategies.rs
+++ b/tests/property/strategies.rs
@@ -4,6 +4,7 @@
 
 use elle::ffi::types::{StructDesc, TypeDesc};
 use elle::Value;
+use elle::value::SymbolId;
 use proptest::prelude::*;
 
 /// Strategy for arbitrary immediate Values (no heap allocation).
@@ -29,7 +30,7 @@ pub fn arb_immediate() -> impl Strategy<Value = Value> {
         1 => Just(Value::float(f64::NEG_INFINITY)),
         1 => Just(Value::float(f64::NAN)),
         // Symbols
-        3 => (0u32..10000).prop_map(Value::symbol),
+        3 => (0u64..10000).prop_map(|n| Value::symbol(SymbolId(n))),
     ]
 }
 
@@ -57,7 +58,7 @@ fn arb_value_depth(depth: u32) -> BoxedStrategy<Value> {
             10 => prop::num::f64::NORMAL.prop_map(Value::float),
             1 => Just(Value::float(f64::INFINITY)),
             1 => Just(Value::float(f64::NEG_INFINITY)),
-            3 => (0u32..10000).prop_map(Value::symbol),
+            3 => (0u64..10000).prop_map(|n| Value::symbol(SymbolId(n))),
             5 => "[a-zA-Z0-9_ ]{0,20}".prop_map(|s| {
                 let h = elle::primitives::ctx::TestHeap::new();
                 h.ctx().string(s)

--- a/tests/region_parallel_compile.rs
+++ b/tests/region_parallel_compile.rs
@@ -7,7 +7,7 @@
 //! use-after-free: a region freed while a `Bytecode`'s strings/slices still
 //! point into its pages, whose page-reuse window opens far more often under
 //! multi-thread memory pressure. It surfaces as a torn `String` length inside a
-//! `Bytecode::symbol_names` (`HashMap<u32,String>`) clone in `lir::emit`,
+//! `Bytecode` clone in `lir::emit`,
 //! attempting a multi-hundred-GiB allocation that aborts (a garbage length, so
 //! an OOM-abort rather than a clean SIGSEGV). It reproduces with
 //! `--jit=off --mlir=off`, so it is neither the JIT nor the analyzer's HIR logic.
@@ -86,7 +86,7 @@ fn parallel_compile_no_corruption() {
     assert!(
         status.success(),
         "concurrent-compile child exited abnormally ({status:?}): the cumulative \
-         parallel-compile heap corruption reproduced (torn Bytecode::symbol_names \
+         parallel-compile heap corruption reproduced (torn Bytecode string \
          in lir::emit)."
     );
 }

--- a/tests/region_process_teardown.rs
+++ b/tests/region_process_teardown.rs
@@ -34,8 +34,7 @@ fn census_with(mut rt: Runtime, src: Option<&str>) {
         let value = {
             let (vm, symbols, cctx) = rt.parts();
             let result = compile_file(src, symbols, cctx, "<census>").expect("compiles");
-            vm.execute_scheduled(&result.bytecode, symbols, cctx)
-                .expect("runs")
+            vm.execute_scheduled(&result.bytecode, cctx).expect("runs")
         };
         // The program value is handed to the embedding caller with one owning
         // reference ("ownership transfer"). Dropping the `Value` is a no-op (it

--- a/tests/region_process_teardown/census.rs
+++ b/tests/region_process_teardown/census.rs
@@ -14,8 +14,7 @@ fn process_teardown_is_observable_and_idempotent() {
     {
         let (vm, symbols, cctx) = rt.parts();
         let result = compile_file(src, symbols, cctx, "<teardown-test>").expect("compiles");
-        vm.execute_scheduled(&result.bytecode, symbols, cctx)
-            .expect("runs");
+        vm.execute_scheduled(&result.bytecode, cctx).expect("runs");
     }
 
     let report = rt.teardown();

--- a/tests/region_process_teardown/growth.rs
+++ b/tests/region_process_teardown/growth.rs
@@ -186,8 +186,7 @@ fn process_teardown_frees_all_regions() {
     {
         let (vm, symbols, cctx) = rt.parts();
         let result = compile_file("(+ 1 2)", symbols, cctx, "<teardown-target>").expect("compiles");
-        vm.execute_scheduled(&result.bytecode, symbols, cctx)
-            .expect("runs");
+        vm.execute_scheduled(&result.bytecode, cctx).expect("runs");
     }
     let report = rt.teardown();
     assert_eq!(

--- a/tests/unittests/cycle.rs
+++ b/tests/unittests/cycle.rs
@@ -60,7 +60,7 @@ fn display_self_referencing_struct() {
     let mut rt = elle::runtime::Runtime::without_stdlib();
     let h = elle::primitives::ctx::TestHeap::new();
     let t = h.ctx().struct_mut();
-    elle::value::arena::struct_put_with_rebind(rt.heap(), t, TableKey::Keyword("self".to_string()), t);
+    elle::value::arena::struct_put_with_rebind(rt.heap(), t, TableKey::keyword("self"), t);
     let s = format!("{}", t);
     assert!(s.contains("<cycle>"), "expected <cycle>, got: {}", s);
 }
@@ -93,7 +93,7 @@ fn debug_self_referencing_struct() {
     let mut rt = elle::runtime::Runtime::without_stdlib();
     let h = elle::primitives::ctx::TestHeap::new();
     let t = h.ctx().struct_mut();
-    elle::value::arena::struct_put_with_rebind(rt.heap(), t, TableKey::Keyword("self".to_string()), t);
+    elle::value::arena::struct_put_with_rebind(rt.heap(), t, TableKey::keyword("self"), t);
     let s = format!("{:?}", t);
     assert!(s.contains("<cycle>"), "expected <cycle>, got: {}", s);
 }

--- a/tests/unittests/primitives/meta.rs
+++ b/tests/unittests/primitives/meta.rs
@@ -29,7 +29,7 @@ fn test_gensym_with_prefix() {
     assert!(sym.as_symbol().is_some(), "gensym should return a symbol");
     // Verify the interned name starts with VAR
     let sym_id = sym.as_symbol().unwrap();
-    let name = symbols.name(elle::value::SymbolId(sym_id)).unwrap();
+    let name = symbols.name(sym_id).unwrap();
     assert!(
         name.starts_with("VAR"),
         "gensym with prefix should start with VAR, got: {}",
@@ -225,7 +225,7 @@ fn test_trace_primitive() {
 
     // Test with symbol label
     let sym_id = symbols.intern("trace-label");
-    let label = Value::symbol(sym_id.0);
+    let label = Value::symbol(sym_id);
     let result = call_primitive(&trace, &[label, value]);
     assert!(result.is_ok());
 

--- a/tests/unittests/primitives/runtime.rs
+++ b/tests/unittests/primitives/runtime.rs
@@ -133,8 +133,8 @@ fn test_string_to_keyword_returns_keyword() {
     eval_full(r#"(string->keyword "foo")"#, |r| {
         let result = r.unwrap();
         assert!(
-            result.as_keyword_name().is_some(),
-            "string->keyword should return a keyword"
+            result.is_keyword_named("foo"),
+            "string->keyword should return the keyword :foo"
         );
     });
 }

--- a/tests/unittests/symbol.rs
+++ b/tests/unittests/symbol.rs
@@ -1,146 +1,36 @@
-// DEFENSE: Symbol interning must be fast and correct
+// DEFENSE: an embedder sees stable, table-independent symbol identity.
+//
+// The mechanism's own tests live in `src/symbol/tests.rs`. These pin what only
+// a consumer of the public API can see: that `elle::symbol` hands out the same
+// id for a name no matter which handle asks, and that an id computed without a
+// handle is the id interning produces.
 use elle::symbol::SymbolTable;
+use elle::value::SymbolId;
 
 #[test]
-fn test_symbol_interning_basic() {
-    let mut table = SymbolTable::new();
+fn every_handle_agrees_on_a_name() {
+    let mut first = SymbolTable::new();
+    let mut second = SymbolTable::new();
 
-    let id1 = table.intern("foo");
-    let id2 = table.intern("bar");
-    let id3 = table.intern("foo"); // Same as id1
+    let a = first.intern("embedder-alpha");
+    let _ = second.intern("embedder-decoy-1");
+    let _ = second.intern("embedder-decoy-2");
+    let b = second.intern("embedder-alpha");
 
-    assert_eq!(id1, id3);
-    assert_ne!(id1, id2);
+    assert_eq!(a, b);
+    assert_eq!(first.name(b), Some("embedder-alpha"));
+    assert_eq!(second.name(a), Some("embedder-alpha"));
 }
 
 #[test]
-fn test_symbol_names() {
+fn identity_needs_no_handle() {
     let mut table = SymbolTable::new();
-
-    let id = table.intern("hello");
-    assert_eq!(table.name(id), Some("hello"));
+    assert_eq!(table.intern("embedder-beta"), SymbolId::of("embedder-beta"));
 }
 
 #[test]
-fn test_symbol_lookup() {
-    let mut table = SymbolTable::new();
-
-    // Intern first
-    let id1 = table.intern("test");
-
-    // Lookup should return same ID
-    let id2 = table.get("test");
-    assert_eq!(Some(id1), id2);
-
-    // Unknown symbol
-    assert_eq!(None, table.get("unknown"));
-}
-
-#[test]
-fn test_many_symbols() {
-    let mut table = SymbolTable::new();
-
-    // Intern 1000 unique symbols
-    let ids: Vec<_> = (0..1000)
-        .map(|i| table.intern(&format!("symbol-{}", i)))
-        .collect();
-
-    // All should be unique
-    for i in 0..1000 {
-        for j in 0..1000 {
-            if i == j {
-                assert_eq!(ids[i], ids[j]);
-            } else {
-                assert_ne!(ids[i], ids[j]);
-            }
-        }
-    }
-}
-
-#[test]
-fn test_symbol_persistence() {
-    let mut table = SymbolTable::new();
-
-    let id = table.intern("persistent");
-
-    // Add more symbols
-    for i in 0..100 {
-        table.intern(&format!("sym-{}", i));
-    }
-
-    // Original symbol should still be valid
-    assert_eq!(table.name(id), Some("persistent"));
-    assert_eq!(table.intern("persistent"), id);
-}
-
-#[test]
-fn test_special_characters() {
-    let mut table = SymbolTable::new();
-
-    // Lisp allows many special characters in symbols
-    let symbols = vec![
-        "+",
-        "-",
-        "*",
-        "/",
-        "=",
-        "<",
-        ">",
-        "<=",
-        ">=",
-        "!=",
-        "list?",
-        "nil?",
-        "number?",
-        "some-func-name",
-        "CamelCase",
-        "with_underscores",
-    ];
-
-    for sym in symbols {
-        let id = table.intern(sym);
-        assert_eq!(table.name(id), Some(sym));
-    }
-}
-
-#[test]
-fn test_empty_symbol_table() {
+fn an_unrecorded_id_has_no_name() {
     let table = SymbolTable::new();
-
-    // Invalid ID should return None
-    assert_eq!(table.name(elle::value::SymbolId(0)), None);
-    assert_eq!(table.name(elle::value::SymbolId(9999)), None);
-}
-
-#[test]
-fn test_symbol_ordering() {
-    let mut table = SymbolTable::new();
-
-    let id0 = table.intern("first");
-    let id1 = table.intern("second");
-    let id2 = table.intern("third");
-
-    // IDs should be assigned sequentially
-    assert_eq!(id0.0 + 1, id1.0);
-    assert_eq!(id1.0 + 1, id2.0);
-}
-
-#[test]
-fn test_unicode_symbols() {
-    let mut table = SymbolTable::new();
-
-    let id = table.intern("λ");
-    assert_eq!(table.name(id), Some("λ"));
-
-    let id2 = table.intern("こんにちは");
-    assert_eq!(table.name(id2), Some("こんにちは"));
-}
-
-#[test]
-fn test_long_symbol_names() {
-    let mut table = SymbolTable::new();
-
-    let long_name = "a".repeat(1000);
-    let id = table.intern(&long_name);
-    assert_eq!(table.name(id), Some(long_name.as_str()));
+    assert_eq!(table.name(SymbolId::of("embedder-never-interned")), None);
+    assert_eq!(table.name(SymbolId::SYNTHETIC), None);
 }

--- a/tests/unittests/table_key.rs
+++ b/tests/unittests/table_key.rs
@@ -29,9 +29,11 @@ fn test_from_value_int() {
 fn test_from_value_keyword() {
     let val = Value::keyword("foo");
     let key = TableKey::from_value(&val).unwrap();
-    assert!(matches!(key, TableKey::Keyword(ref s) if s == "foo"));
+    assert!(
+        matches!(key, TableKey::Keyword(h) if h == elle::value::keyword::keyword_hash("foo"))
+    );
     // to_value produces an equivalent keyword
-    assert_eq!(with_test_ctx(|ctx| key.to_value(ctx)).as_keyword_name().unwrap(), "foo");
+    assert!(with_test_ctx(|ctx| key.to_value(ctx)).is_keyword_named("foo"));
 }
 
 #[test]
@@ -121,7 +123,7 @@ fn test_is_sendable_value_keys() {
     assert!(TableKey::Bool(true).is_sendable());
     assert!(TableKey::Int(42).is_sendable());
     assert!(TableKey::String("hello".to_string()).is_sendable());
-    assert!(TableKey::Keyword("foo".to_string()).is_sendable());
+    assert!(TableKey::keyword("foo").is_sendable());
     assert!(TableKey::EmptyList.is_sendable());
 }
 


### PR DESCRIPTION
The first foundation from the image design (docs/impl/image.md § "Landing order"), on top of #914.

## What was wrong

`SymbolId` was a dense per-table index minted in first-intern order. Two symbol tables that met the same names in different orders disagreed about every id, so a symbol value meant something only where it was built — and the codebase compensated everywhere: each code object carried a `symbol_names` map, `send` re-interned symbol data by name, `CompileCtx` leaned on a "primitive registration order is deterministic" invariant, and every formatter threaded an `Option<&SymbolTable>` so a name could be resolved at all.

Two paths did not compensate, and were wrong. `SendValue::Struct` clones each `TableKey` verbatim, so a symbol *key* crossed a thread boundary as a raw sender id:

```lisp
(def s (sys/join (sys/spawn (fn [] {'alpha 1 'beta 2}))))
(println s)              # {'__file_expr_1 1 'alpha 2}   ← names the program never wrote
(println (get s 'alpha)) # 2                             ← the neighbouring entry
```

`LirConst::Symbol` ships inside the live `LirFunction`, so worker-side re-emission pooled sender-space ids the same way. Both holes were recorded by #914's symbol-identity scout; both are closed here.

Keywords carried the complementary defect: identity was already the name hash, but every spelling lived in one process-global `RwLock` table (`KEYWORD_NAMES`) that every struct probe locked and allocated through, and that no instance could ever drop (#1000). And `lib/sync` minted every futex key with `(gensym)`, permanently interning one to three symbols per synchronisation object (#1001).

## What the change does

A `SymbolId` is the 64-bit FNV-1a hash of the name, and a keyword's payload is the same hash of the same spelling space, through one shared function (`src/namehash.rs`). Identity is a pure function of the name — the same in every table, thread, process, and build — so `send` crosses symbols and keywords as immediates, sorted containers are portable by construction, and an identity question is one integer compare against a constant.

Display is the only thing a table is still for, and that table is one **per-instance memo** (`src/symbol.rs`) serving both vocabularies: a symbol and a keyword with one spelling share one entry, one collision guard spans both, no lock is taken, and the memo drops with the instance that owns it. It learns spellings only where names travel: the reader and analyzer, the expander (macro arguments and quasiquote templates round-trip keywords as bare hashes), `send` (a bundle carries a hash→spelling table beside its values, replayed into the receiver's memo — a learning site, so cross-instance collisions are caught as names land), `ConstTemplate` decode, the `(keyword str)` primitive and the JSON parser, and the plugin ABI (`CallCtx` carries the memo; `make_keyword`/`make_struct` learn through it, `keyword_name`/`as_keyword_name`/`struct_key` read back through it, `intern_keyword` is a pure hash). Spellings the Rust runtime mints from fixed strings live in a static vocabulary (`src/value/keyword.rs`), the keyword analogue of `registration.rs`'s static primitive-name index; a scan test fails the build when a literal mint site's spelling is missing. A spelling in neither renders as `#<symbol:0x…>`/`#<keyword:0x…>` — deliberately not a readable literal, because any real spelling would denote a different name.

`TableKey::Keyword` and `LirConst::Keyword` carry the raw hash instead of a `String`, so a struct probe builds its key with no lock and no allocation. Ordering — `<`, `sort`, `compare`, and container order — is hash order for both vocabularies: deterministic in every run, thread, process, and tier, with no alphabetical meaning (`docs/structs.md`).

`sys/unique`, a process-global atomic counter primitive, replaces `(gensym)` as the futex-key source in `lib/sync` and `lib/http2`: it preserves the process-wide uniqueness the park queues need and interns nothing.

**Deleted:** `KEYWORD_NAMES` and `Value::as_keyword_name`; the `symbol_names` maps and their `HashMap<u32, String>` threading through type inference, lowering, emission and the JIT; `SymbolTable::all_names`; `SendValue::Symbol`, `SendValue::Keyword` and `send`'s re-interning; `intern_primitive_names` and the `CompileCtx` registration-order invariant; `debug/keyword-count` with the table it counted.

**Seams:** `Value::symbol` takes a `SymbolId` and `as_symbol` returns one, so a keyword hash cannot be passed where a symbol id belongs; `Value::keyword` is a pure `const fn`; `jit::group`'s globals are keyed by symbol instead of indexed by it; `SYNTHETIC` is a reserved `u64::MAX` that `intern` refuses to mint.

Fixed on the way: the import projection probe compiled the imported module into a throwaway symbol table, and `is_primitive_named`/`gated_reason` resolved spellings through the memo only to compare them against literals — both are hash compares now; the REPL, `pp`, `to-string`, and `describe` printers rendered through bare `Display`/`Debug` instead of the instance memo.

## Tests

- `tests/elle/symbol-identity.lisp` — the end-to-end shape: a symbol, a struct and a set built in a `sys/spawn` worker equal and print like the main thread's. The struct-key assertions fail on the parent commit with the output above.
- `src/symbol/tests.rs` — two tables built in opposite orders agree on every name; the id is the shared name hash; a keyword and a symbol with one spelling share one memo entry; the collision guard spans both vocabularies and fires for names arriving from elsewhere; `SYNTHETIC` is outside the name space.
- `src/value/keyword/tests.rs` — the vocabulary is injective under the hash; resolution reads memo, then vocabulary, then nothing; the literal-mint-site scan pins vocabulary completeness.
- `src/value/send/tests.rs` — a symbol value, a symbol struct key, a keyword value and a keyword struct key each name the same thing on both sides of `send`, through the bundle's name table.
- `src/value/display/tests.rs` — keyword display resolves memo → vocabulary → the unreadable form, which is not a keyword literal.
- `src/value/types/tests.rs` — symbol keys sort identically in every table, and a sorted struct built against one table is probed correctly through another.
- `src/runtime/tests/lifecycle.rs` — two embedded instances agree on every symbol name.
- `tests/property/nanboxing/scalars.rs` — a full 64-bit symbol payload round-trips; the old accessor truncated with `as u32`.
- `tests/elle/comparison.lisp`, `tests/elle/functional.lisp` — keyword order is total, antisymmetric, and permutation-stable; it is not alphabetical.
- `tests/elle/sync-keys.lisp` — `debug/symbol-count` stays flat across sync-constructor loops; the same harness reads one intern per call under gensym keys.
- `tests/integration/projection.rs` — the import projection probe interns the module's quoted data into the caller's memo.

## Measured

Green locally against the release binary: the `elle test` corpus (0 fail, 0 diverge, 0 timeout; leak oracle ok), the per-file VM and JIT passes, doctests, both embedding hosts, `cargo test --lib` (2323), `cargo test --test lib` (1246), and `make qa` (rustfmt, workspace clippy, macOS cross-check, rustdoc).
