### PR TITLE
io: a stdin line past its buffer is answered whole

### DIFF
--- a/src/io/aio/convert.rs
+++ b/src/io/aio/convert.rs
@@ -22,7 +22,9 @@ pub(super) fn cook_raw(
         RawCompletion::Pool(pc) => {
             pool_to_completion(pc, pending, fd_states, buffer_pool, origin_heap, gen)
         }
-        RawCompletion::Stdin(sc) => stdin_to_completion(sc, pending, buffer_pool, origin_heap),
+        RawCompletion::Stdin(sc) => {
+            stdin_to_completion(sc, pending, fd_states, buffer_pool, origin_heap, gen)
+        }
     }
 }
 
@@ -52,8 +54,10 @@ fn misrouted(pending_op: &PendingOp, kind: OpKind, id: SubmissionId) -> Option<S
 pub(super) fn stdin_to_completion(
     sc: crate::io::threadpool::StdinCompletion,
     pending: &mut PendingTable,
+    fd_states: &mut HashMap<PortKey, FdState>,
     buffer_pool: &mut BufferPool,
     origin_heap: *mut crate::value::fiberheap::FiberHeap,
+    gen: crate::segment::Generation,
 ) -> Option<Completion> {
     let id = SubmissionId::from_raw(sc.id);
     let pending_op = match pending.take(id) {
@@ -86,74 +90,28 @@ pub(super) fn stdin_to_completion(
     }
     Some(match sc.result {
         Ok(data) if data.is_empty() => Completion::ok(id, Value::NIL),
-        Ok(data) => {
-            // For Read/ReadLine, copy data into the pre-allocated buffer
-            if let PendingOp::Port {
-                op: PortOp::ReadLine { ref buffer } | PortOp::Read { ref buffer, .. },
-                ref port,
-                ..
-            } = &*pending_op
-            {
-                let enc = port
-                    .as_external::<Port>()
-                    .map(|p| p.encoding())
-                    .unwrap_or(Encoding::Binary);
-                unsafe {
-                    let (dst, dst_cap) = crate::io::request::writeable_buffer_ptr(buffer);
-                    let copy_len = data.len().min(dst_cap);
-                    std::ptr::copy_nonoverlapping(data.as_ptr(), dst, copy_len);
-                    // For ReadLine, trim trailing \r\n
-                    let final_len = if matches!(
-                        &*pending_op,
-                        PendingOp::Port {
-                            op: PortOp::ReadLine { .. },
-                            ..
-                        }
-                    ) {
-                        let mut end = copy_len;
-                        if end > 0 && data[end - 1] == b'\n' {
-                            end -= 1;
-                            if end > 0 && data[end - 1] == b'\r' {
-                                end -= 1;
-                            }
-                        }
-                        end
-                    } else {
-                        copy_len
-                    };
-                    crate::io::request::truncate_buffer(buffer, final_len);
-                }
-                if let PendingOp::Port {
-                    op: PortOp::ReadLine { buffer } | PortOp::Read { buffer, .. },
-                    ..
-                } = &*pending_op
-                {
-                    // ReadLine always returns string; Read depends on encoding
-                    let result = if matches!(
-                        &*pending_op,
-                        PendingOp::Port {
-                            op: PortOp::ReadLine { .. },
-                            ..
-                        }
-                    ) || enc == Encoding::Text
-                    {
-                        unsafe {
-                            crate::io::request::bytes_to_string_in_place(*buffer, origin_heap)
-                        }
-                    } else {
-                        Ok(*buffer)
-                    };
-                    Completion::new(id, result)
-                } else {
-                    unreachable!()
-                }
-            } else {
-                // ReadAll or other — construct bytes (legacy path)
-                let heap = unsafe { &mut *crate::io::completion_heap_ptr(origin_heap) };
-                let ctx = crate::primitives::ctx::Alloc::new(heap);
-                Completion::ok(id, ctx.bytes(data))
-            }
-        }
+        // The worker's bytes are cooked where the pool's are, and for the same
+        // reason: a line has no upper bound, so staging them into the fiber's
+        // pre-allocated buffer first would clamp them to its size. `read_result`
+        // answers from the buffer when the bytes fit and from the requesting
+        // instance's heap when they do not, instead of dropping the excess —
+        // bytes the port has already taken from the kernel, which nothing is
+        // left to read again.
+        //
+        // The pool worker reports its byte count as the result code, and this
+        // worker reports its bytes; `data.len()` is the same number. The buffer
+        // handle is released above, so none is passed here.
+        Ok(data) => completion::process_raw_completion(
+            id,
+            data.len() as i32,
+            data,
+            &pending_op,
+            fd_states,
+            buffer_pool,
+            None,
+            origin_heap,
+            gen,
+        ),
         Err(e) => Completion::err(id, crate::io::io_error("io-error", e, origin_heap)),
     })
 }

--- a/tests/elle/stdin-longline.lisp
+++ b/tests/elle/stdin-longline.lisp
@@ -1,0 +1,111 @@
+(elle/epoch 12)
+## tests/elle/stdin-longline.lisp
+##
+## A line on STDIN longer than the buffer `port/read-line` reserves is
+## answered without loss, and the read after it still frames the stream.
+## See docs/io.md § "A read that overshoots keeps the rest for the same
+## port": what a read reserves is not a bound on what it answers with.
+##
+## The trap is the stdin sibling of the one tests/elle/port-longline.lisp
+## names — treating the reserved buffer as a bound. Stdin has its own
+## worker (`src/io/threadpool/stdin.rs`) and its own converter, and a
+## converter that stages the worker's bytes into the fiber's
+## pre-allocated buffer under `data.len().min(dst_cap)` drops everything
+## past 64 KiB. `read_line_with_cancel` reads to the newline however far
+## away it is, so those bytes are already out of the kernel and nothing is
+## left to read them again: the fiber gets a truncated line with no way to
+## tell that it was truncated.
+##
+## Stdin reaches the StdinThread on either backend, so unlike
+## port-longline this file has no `--no-uring` counterpart to pin: there
+## is one mechanism, and it is the one that runs here.
+##
+## The counter-factual: a payload under 64 KiB passes every assertion here
+## whether or not the bytes past the reservation survive. The line has to
+## outgrow the reservation before the property is measurable, which is why
+## the payload is 200 KiB.
+##
+## We test through a subprocess so `make test` can run this without piping
+## stdin into the runner itself.
+
+(def line-size 200000)
+
+(def long-line
+  (let [@buf @""
+        @i 0]
+    (while (< i line-size)
+      (push buf (string (mod i 10)))
+      (assign i (+ i 1)))
+    (freeze buf)))
+
+## The child joins what each read answers with, the way port-longline
+## does, so a backend that answers a long line in pieces and one that
+## answers it whole both pass — what is pinned is that no byte is lost. It
+## rebuilds the same digit pattern and compares, so a read that answers
+## with the right LENGTH but the wrong bytes still fails.
+(def inner-script
+  "(def line-size 200000)
+   (def expected
+     (let [@buf @\"\"
+           @i 0]
+       (while (< i line-size)
+         (push buf (string (mod i 10)))
+         (assign i (+ i 1)))
+       (freeze buf)))
+   (def first-line
+     (let [@got @\"\"
+           @more true]
+       (while (and more (< (length got) line-size))
+         (let [piece (port/read-line (*stdin*))]
+           (if (nil? piece) (assign more false) (push got piece))))
+       (freeze got)))
+   (def second-line (port/read-line (*stdin*)))
+   (println (length first-line))
+   (println (if (= first-line expected) \"same\" \"differs\"))
+   (println second-line)
+   (sys/exit 0)")
+
+(def elle-bin
+  (cond
+    (file/exists? "./target/release/elle") "./target/release/elle"
+    (file/exists? "./target/debug/elle") "./target/debug/elle"
+    true (error {:error :test-skip
+                 :message "cannot find elle binary in ./target/"})))
+
+(def scratch (file/mktempdir))
+(def inner-path (path/join scratch "stdin-longline-inner.lisp"))
+(def input-path (path/join scratch "stdin-longline-input.txt"))
+(file/write inner-path inner-script)
+
+## The long line, then a short one. The second line is what proves the
+## overshoot was framed rather than merely delivered: a converter that
+## mislays the remainder loses it or replays part of the first line here.
+(file/write input-path (concat long-line "\ntail\n"))
+
+(def result
+  (subprocess/system "sh"
+                     ["-c"
+                      (string "cat '" input-path "' | '" elle-bin "' '"
+                              inner-path "'")]))
+
+(assert (= result:exit 0)
+        (string "subprocess exited " result:exit ": " result:stderr))
+
+(def lines (string/split (string/trim result:stdout) "\n"))
+(def reported-length (get lines 0))
+(def byte-verdict (get lines 1))
+(def next-line (get lines 2))
+
+(assert (= reported-length (string line-size))
+        (string "the whole line is answered: got " reported-length " of "
+                (string line-size)))
+(println "  1. a stdin line past its buffer is answered whole")
+
+(assert (= byte-verdict "same") "and byte for byte, not merely the right length")
+(println "  2. and byte for byte")
+
+(assert (= next-line "tail")
+        (string "the next read resumes after the newline: got " next-line))
+(println "  3. the read after it frames the stream correctly")
+
+(println "stdin-longline: ok")


### PR DESCRIPTION
## What was wrong

`port/read-line` reserves 64 KiB, and `docs/io.md` § "A read that overshoots keeps the rest for the same port" states the guarantee that goes with the reservation:

> What a read reserves before it runs is not a bound on what it answers with. […] No byte is dropped to make an answer fit — the backend has already taken those bytes from the kernel, so there would be nothing left to read them again.

Sockets and files keep that guarantee. They cook through `pool_to_completion` → `complete_port_op`, where `assemble_read` joins the worker's bytes to the port's remainder and `read_result` answers from the requesting instance's heap when they outgrow the reservation. `tests/elle/port-longline.lisp` pins it.

Stdin did not. It has its own worker (`src/io/threadpool/stdin.rs`) and its own converter, and `stdin_to_completion` staged the worker's bytes into the fiber's pre-allocated buffer under `data.len().min(dst_cap)`:

```rust
let copy_len = data.len().min(dst_cap);
std::ptr::copy_nonoverlapping(data.as_ptr(), dst, copy_len);
```

`read_line_with_cancel` reads to the newline however far away it is, so a line over 64 KiB lost its tail. Those bytes were already out of the kernel, so reading on could not recover them — it returned the *next* line. The fiber received a truncated line with no way to tell that it was truncated.

## What the change does

Cook the stdin worker's bytes through `process_raw_completion`, the way the pool worker's are, passing the `fd_states` and `gen` that `cook_raw` already holds.

The empty-data (EOF) and error arms are unchanged, so EOF and cancellation semantics on stdin are untouched. The buffer handle is still released before the call, so `None` is passed for it.

## How it was measured

A downstream program whose transport is stdin sends a 149,191-byte s-expression on one line. Before: the reader received 65,536 bytes and the parse failed mid-expression with an unterminated list. After: it receives all 149,191 and parses.

Reduced to the corpus, at 200,000 bytes: before, the first read answers with 65,536 characters and the bytes past it are gone; after, the line arrives whole and byte for byte, and the following read still returns the next line.

## What pins it

`tests/elle/stdin-longline.lisp` — the stdin sibling of `tests/elle/port-longline.lisp`. It asserts the length, the bytes, and that the read after the long line still frames the stream. It joins what each read answers with, as `port-longline` does, so a backend that answers a long line in pieces and one that answers it whole both pass: what is pinned is that no byte is lost.

Without this change it reports `got 65536 of 200000`.

Stdin reaches the `StdinThread` on either backend, so there is no `--no-uring` counterpart to add: one mechanism, and the file exercises it.

## Verification

Run on macOS (arm64):

- `cargo fmt --check` — clean
- `cargo clippy -p elle -- -D warnings` — clean, the same command the `macOS Smoke` job runs
- `elle fmt --check` on the new file — clean
- `tests/elle/stdin-longline.lisp` passes on this branch and reports `got 65536 of 200000` with the converter change reverted

`make smoke ELLE=./target/release/elle CARGO_PROFILE=--release` is running locally; I will report it here. The `--all-features` arms (`make qa`, `cargo test --workspace --all-features`) need LLVM/MLIR 22, which the QA and MLIR jobs provision on their Linux runners, so they were not run locally.
