### PR TITLE
regions: the page ladder is rooted at the page the kernel charges for

### DIFF
--- a/docs/impl/region/diagnostics.md
+++ b/docs/impl/region/diagnostics.md
@@ -100,16 +100,19 @@ the region rules ([rules.md](rules.md)) honest.
 - `--stats`: prints exit-time statistics, including a **page-claim size
   histogram** — one `[stats] page-claim size=<bytes> claims=<n> bytes=<n>` line
   per size class (`size=0` = the oversized one-off bucket). It measures how often
-  geometric page growth (4 KiB doubling up to 4 MiB) escalates past `BASE_PAGE` —
-  the precondition for the only place region attribution can be misled, a pointer
-  deep inside a page larger than `BASE_PAGE` (`region_of_ptr`'s sub-alignment
-  walk; the page-header magic and ownership validation make that search sound, so
-  this is for *policy* analysis, not correctness). Off by default and zero-cost
-  then. Each `elle test` worker aggregates into the one process-wide histogram
-  (`elle test --stats …`); sum the lines across batched runs for a corpus-wide
-  distribution. Measured baseline: ~99.9 % of claims are 4 KiB; large pages come
-  overwhelmingly from large *single* allocations (`alloc_data` right-sizing a
-  buffer), not from the doubling ladder.
+  geometric page growth (the base page doubling up to 4 MiB) escalates past
+  `base_page()` — the precondition for the only place region attribution can be
+  misled, a pointer deep inside a page larger than `base_page()`
+  (`region_of_ptr`'s sub-alignment walk; the page-header magic and ownership
+  validation make that search sound, so this is for *policy* analysis, not
+  correctness). Off by default and zero-cost then. Each `elle test` worker
+  aggregates into the one process-wide histogram (`elle test --stats …`); sum the
+  lines across batched runs for a corpus-wide distribution. The size classes
+  scale with the host page, so compare distributions across hosts by class, not
+  by byte count ([model.md](model.md) § "The base page is the OS page").
+  Measured baseline on a 4 KiB-page host: ~99.9 % of claims are one base page;
+  large pages come overwhelmingly from large *single* allocations (`alloc_data`
+  right-sizing a buffer), not from the doubling ladder.
 
 ## Validation
 

--- a/docs/impl/region/generations.md
+++ b/docs/impl/region/generations.md
@@ -82,9 +82,9 @@ it instead, and the program dies with a byte count and no diagnosis.
 
 Those two requirements pull in opposite directions, and what leaves room between
 them is a ratio rather than any absolute size. A live region owns at least one
-4 KiB page (Rule 6), so a program holding N regions at once already holds at
-least 4N KiB of pages, while the table for those ids costs
-N × `size_of::<Option<RegionEntry>>()` — about a twentieth as much. Set
+OS page (Rule 6), which is 4 KiB at the smallest, so a program holding N regions
+at once already holds at least 4N KiB of pages, while the table for those ids
+costs N × `size_of::<Option<RegionEntry>>()` — about a twentieth as much. Set
 `MAX_PLAUSIBLE_REGION_ID` past the live-region count a machine's memory permits,
 and the table at that bound stays within what the same machine can allocate. At
 `1 << 28` that is 1 TiB of pages against a ~56 GB table.

--- a/docs/impl/region/model.md
+++ b/docs/impl/region/model.md
@@ -117,6 +117,39 @@ consumer-facing performance account is in
 - **sibling page-amortization** — collapse sibling regions with coincident
   lifetimes and no edge between them. A later rider, not yet implemented.
 
+### The base page is the OS page
+
+`base_page()` (`pagepool.rs`) asks the OS for its page size once and caches the
+answer. Class 0 of the size-class ladder is that page, and every larger class is
+a power-of-two multiple of it, so a region page is always a whole number of OS
+pages. `--region-page-size` rejects anything below `base_page()`.
+
+The rejected alternative is a fixed 4096. It is right on Linux x86-64 and wrong
+on every host with a larger page — macOS aarch64 uses 16384, and Linux aarch64
+can be built for 4096, 16384, or 65536. On such a host a fixed 4096 costs four
+things at once, and the OS query removes all four together:
+
+- **The ladder splits one physical page across three free lists.** Classes 0, 1
+  and 2 name 4096, 8192 and 16384 bytes, but the kernel charges a full
+  16384-byte page for each. `release` files a page by its recorded length, so a
+  released class-0 page — physically 16384 bytes — cannot serve a class-2 claim,
+  and the pool maps a fresh page instead.
+- **`cached_bytes` undercounts, so `--page-pool-max` does not bound what it
+  names.** `release` adds the page's recorded length. A class-0 page records
+  4096 and holds 16384, so a 4 MB pool retains up to 16 MB per thread.
+- **The trim `munmap` gets an address the kernel refuses.** A class-1 page
+  over-allocates 16384 bytes and unmaps the suffix at `base + 8192`, which lands
+  half an OS page past a page boundary, so `munmap` answers `EINVAL`. The
+  mapping survives to `Drop`, which unmaps the whole rounded-up range, but until
+  then the page holds 16384 bytes and records 8192.
+- **`mapped_bytes` reports the same understatement.** It records the length each
+  `mmap` asked for, not the mapping the kernel made, so the gauge that says
+  whether a worker gave its heap back is short by 4× for every class-0 page.
+
+Every accounting claim the pool makes rests on one identity: the size a page
+records is the size the kernel charges. That holds only when class 0 is the OS
+page.
+
 ## Page recycling: a claim is a free-list pop
 
 **A page moves between a region and the pool untouched, in both directions.**

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,7 +242,8 @@ pub struct Config {
     pub trace_keywords: Vec<String>,
 
     /// Initial page size for region allocation (CLI: --region-page-size).
-    /// Must be a power of two >= 4096. Default: 4096.
+    /// Must be a power of two >= the OS page size, which is also the default
+    /// (docs/impl/region/model.md § "The base page is the OS page").
     pub region_page_size: usize,
 
     /// Maximum bytes to cache in the per-thread page pool
@@ -282,7 +283,7 @@ impl Default for Config {
             anf: true,
             dump: HashSet::new(),
             trace_keywords: Vec::new(),
-            region_page_size: 4096,
+            region_page_size: crate::value::fiberheap::pagepool::base_page(),
             page_pool_max: 4 * 1024 * 1024,
             unicode: None,
         }

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -203,10 +203,15 @@ impl Config {
                 let n: usize = rest
                     .parse()
                     .map_err(|_| format!("--region-page-size: expected integer, got '{}'", rest))?;
-                if n < 4096 || !n.is_power_of_two() {
+                // The floor is the OS page, not a fixed 4096: a smaller page
+                // costs a whole OS page anyway, and the size-class ladder is
+                // rooted at the OS page (docs/impl/region/model.md § "The base
+                // page is the OS page").
+                let floor = crate::value::fiberheap::pagepool::base_page();
+                if n < floor || !n.is_power_of_two() {
                     return Err(format!(
-                        "--region-page-size: must be a power of two >= 4096, got {}",
-                        n
+                        "--region-page-size: must be a power of two >= {}, got {}",
+                        floor, n
                     ));
                 }
                 config.region_page_size = n;

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,6 +1,7 @@
 //! Unit tests (`super` is the parent impl module).
 
 use super::*;
+use crate::value::fiberheap::pagepool::base_page;
 
 /// Trace state is per-instance: a `RuntimeConfig` reads and writes its own
 /// [`TraceCell`], so a diagnostic toggle on one instance never reaches another.
@@ -110,4 +111,45 @@ fn trace_keywords_are_known() {
             kw
         );
     }
+}
+
+// ── `--region-page-size` (docs/impl/region/model.md § "The base page is the OS
+// page") ──
+
+fn parse_args(args: &[&str]) -> Result<Config, String> {
+    let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    Config::parse(&owned).map(|(c, _)| c)
+}
+
+/// A region's first page is one OS page, so a program that sets nothing gets
+/// the page the kernel charges for rather than a fraction of it.
+#[test]
+fn region_page_size_defaults_to_the_base_page() {
+    assert_eq!(Config::default().region_page_size, base_page());
+    assert_eq!(parse_args(&[]).unwrap().region_page_size, base_page());
+}
+
+/// The floor is the OS page, not a fixed 4096. A smaller page still costs a
+/// whole OS page, and `MmapPage::new` would trim it to an address `munmap`
+/// refuses.
+#[test]
+fn region_page_size_below_the_base_page_is_rejected() {
+    let err = parse_args(&["--region-page-size=2048"]).unwrap_err();
+    assert!(
+        err.contains(&base_page().to_string()),
+        "the rejection must name the floor it applied, got {err:?}",
+    );
+    assert!(parse_args(&["--region-page-size=6000"]).is_err());
+    assert_eq!(
+        parse_args(&[&format!("--region-page-size={}", base_page())])
+            .unwrap()
+            .region_page_size,
+        base_page(),
+    );
+    assert_eq!(
+        parse_args(&[&format!("--region-page-size={}", 4 * base_page())])
+            .unwrap()
+            .region_page_size,
+        4 * base_page(),
+    );
 }

--- a/src/value/fiberheap/pagepool.rs
+++ b/src/value/fiberheap/pagepool.rs
@@ -12,15 +12,35 @@
 //! read through a pointer that outlived its region detonates instead of
 //! returning plausible bytes. See docs/impl/region/model.md § "Page recycling".
 
+/// The smallest base page this runtime uses, and the floor
+/// `--region-page-size` applies. No supported host reports an OS page below
+/// this.
+const MIN_BASE_PAGE: usize = 4096;
+
 /// The OS base page size — the smallest region page and the unit that `mmap`,
 /// `munmap`, `mprotect`, and RSS accounting all work in. Region pages never go
 /// below this: a sub-page "page" would still cost a full OS page (no RSS win),
 /// and would break per-region `munmap` and the guardfree `mprotect` (both
 /// OS-page-granular). Size classes are powers-of-two multiples of it.
-pub(crate) const BASE_PAGE: usize = 4096;
+///
+/// Asked of the OS once and cached. Both accounting gauges the pool keeps
+/// (`cached_bytes` and [`mapped_bytes`]) count the length a page records, so
+/// that length has to be the length the kernel charges — see
+/// docs/impl/region/model.md § "The base page is the OS page".
+pub(crate) fn base_page() -> usize {
+    static BASE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *BASE.get_or_init(|| derive_base_page(unsafe { libc::sysconf(libc::_SC_PAGESIZE) }))
+}
 
-/// `log2(BASE_PAGE)` — the size-class shift (class 0 == `BASE_PAGE`).
-const BASE_PAGE_BITS: u32 = BASE_PAGE.trailing_zeros();
+/// The base page for an OS-reported page size. An answer the size-class
+/// arithmetic cannot use — a `sysconf` failure (`-1`), a page below
+/// [`MIN_BASE_PAGE`], or a non-power-of-two — takes the floor instead.
+fn derive_base_page(os_page: libc::c_long) -> usize {
+    match usize::try_from(os_page) {
+        Ok(n) if n >= MIN_BASE_PAGE && n.is_power_of_two() => n,
+        _ => MIN_BASE_PAGE,
+    }
+}
 
 /// What a dying region wrote into one of its pages: the object slots it filled,
 /// bumping up, and the inline-data suffix it filled, bumping down. The gap
@@ -73,6 +93,52 @@ impl PageDirty {
     }
 }
 
+/// The cut that turns an over-allocated mapping into a self-aligned page: the
+/// aligned base to keep, and the two runs to give back.
+struct Trim {
+    /// Base of the `len`-byte, `len`-aligned page to keep.
+    base: usize,
+    /// Bytes below `base`, unmapped.
+    prefix: usize,
+    /// Bytes above the page, unmapped.
+    suffix: usize,
+}
+
+impl Trim {
+    /// The first `len`-aligned `len`-byte window inside `alloc` bytes at `raw`.
+    ///
+    /// All three pieces are whole OS pages: `len` is a power-of-two multiple of
+    /// [`base_page()`], and `mmap` answers with an OS-page-aligned address.
+    /// `munmap` refuses any other address.
+    fn new(raw: usize, alloc: usize, len: usize) -> Self {
+        debug_assert!(len.is_power_of_two() && alloc >= 2 * len);
+        let base = (raw + len - 1) & !(len - 1);
+        let prefix = base - raw;
+        Trim {
+            base,
+            prefix,
+            suffix: alloc - prefix - len,
+        }
+    }
+}
+
+/// Give `len` bytes at `addr` back to the OS, and check the kernel took them.
+///
+/// # Safety
+/// `addr` must name a mapping this process owns, of at least `len` bytes.
+unsafe fn unmap(addr: usize, len: usize) {
+    if len == 0 {
+        return;
+    }
+    let rc = libc::munmap(addr as *mut libc::c_void, len);
+    debug_assert_eq!(
+        rc,
+        0,
+        "munmap({addr:#x}, {len}) failed: {}",
+        std::io::Error::last_os_error(),
+    );
+}
+
 /// An mmap-backed page of memory with a known size.
 ///
 /// On Drop, the page is munmapped — the OS reclaims the physical memory
@@ -89,12 +155,12 @@ impl MmapPage {
     /// This is required by `region_of_page_ptr`, which masks a pointer
     /// with `!(len - 1)` to find the page base.
     ///
-    /// For 4K pages, `mmap` already guarantees 4K alignment. For larger
-    /// pages we over-allocate 2× and trim (munmap prefix/suffix) to get
-    /// a `len`-aligned sub-range.
+    /// For a base page, `mmap` already answers with a page-aligned address.
+    /// For larger pages we over-allocate 2× and trim (munmap prefix/suffix) to
+    /// get a `len`-aligned sub-range.
     fn new(len: usize) -> Option<Self> {
-        debug_assert!(len >= BASE_PAGE && len.is_power_of_two());
-        if len == BASE_PAGE {
+        debug_assert!(len >= base_page() && len.is_power_of_two());
+        if len == base_page() {
             return Self::new_raw(len);
         }
         // Over-allocate to guarantee len-alignment.
@@ -112,26 +178,19 @@ impl MmapPage {
         if raw == libc::MAP_FAILED {
             return None;
         }
-        let addr = raw as usize;
-        let aligned = (addr + len - 1) & !(len - 1);
-        let prefix = aligned - addr;
-        let suffix = alloc - prefix - len;
+        let trim = Trim::new(raw as usize, alloc, len);
         unsafe {
-            if prefix > 0 {
-                libc::munmap(raw, prefix);
-            }
-            if suffix > 0 {
-                libc::munmap((aligned + len) as *mut libc::c_void, suffix);
-            }
+            unmap(raw as usize, trim.prefix);
+            unmap(trim.base + len, trim.suffix);
         }
         MAPPED_BYTES.fetch_add(len as u64, Ordering::Relaxed);
         Some(MmapPage {
-            ptr: aligned as *mut u8,
+            ptr: trim.base as *mut u8,
             len,
         })
     }
 
-    /// Raw mmap without alignment trimming (used for 4K pages).
+    /// Raw mmap without alignment trimming (used for base pages).
     fn new_raw(len: usize) -> Option<Self> {
         let ptr = unsafe {
             libc::mmap(
@@ -201,9 +260,7 @@ impl MmapPage {
 
 impl Drop for MmapPage {
     fn drop(&mut self) {
-        unsafe {
-            libc::munmap(self.ptr as *mut libc::c_void, self.len);
-        }
+        unsafe { unmap(self.ptr as usize, self.len) };
         MAPPED_BYTES.fetch_sub(self.len as u64, Ordering::Relaxed);
     }
 }
@@ -226,19 +283,25 @@ static MAPPED_BYTES: AtomicU64 = AtomicU64::new(0);
 // SAFETY: MmapPage owns its virtual memory exclusively.
 unsafe impl Send for MmapPage {}
 
-/// Size class index for a given page size.
-/// Classes are powers of two: 4K=0, 8K=1, 16K=2, 32K=3, 64K=4, etc.
+/// Size class index for a given page size. Class 0 is [`base_page()`]; each
+/// class above it doubles.
 fn size_class(size: usize) -> usize {
-    debug_assert!(size >= BASE_PAGE && size.is_power_of_two());
-    (size.trailing_zeros() - BASE_PAGE_BITS) as usize // class 0 == BASE_PAGE
+    size_class_of(base_page(), size)
 }
 
-#[allow(dead_code)]
-fn class_size(class: usize) -> usize {
-    BASE_PAGE << class
+/// [`size_class`] against an explicit base — the ladder as a pure function, so
+/// its arithmetic is checkable for a page size this host does not have.
+pub(crate) fn size_class_of(base: usize, size: usize) -> usize {
+    debug_assert!(size >= base && size.is_power_of_two());
+    (size.trailing_zeros() - base.trailing_zeros()) as usize
 }
 
-/// Number of size classes to track (4K through 4MB = 11 classes).
+/// The page size of class `class` on a ladder rooted at `base`.
+pub(crate) fn class_size_of(base: usize, class: usize) -> usize {
+    base << class
+}
+
+/// Number of size classes to track: the base page through `base << 10`.
 const NUM_CLASSES: usize = 11;
 
 // ── Page-claim histogram (a `--stats` exit summary, for page-size analysis) ──
@@ -246,7 +309,7 @@ const NUM_CLASSES: usize = 11;
 // Under `--stats`, every `claim` records its (power-of-two) size into a global
 // per-size-class histogram, printed at process exit alongside the other
 // `[stats]` lines. It measures how often geometric growth escalates past
-// `BASE_PAGE` across a run — the precondition for the large-page
+// `base_page()` across a run — the precondition for the large-page
 // region-attribution cost (a large page is the only place `region_of_ptr`'s
 // sub-alignment search can be fooled; see docs/impl/region/diagnostics.md).
 // Off by default and zero-cost then: the per-claim path is a single config-flag
@@ -299,7 +362,11 @@ pub(crate) fn dump_page_hist() {
             continue;
         }
         let bytes = PAGE_CLAIM_BYTES[c].load(Ordering::Relaxed);
-        let size = if c < NUM_CLASSES { BASE_PAGE << c } else { 0 };
+        let size = if c < NUM_CLASSES {
+            class_size_of(base_page(), c)
+        } else {
+            0
+        };
         eprintln!("[stats] page-claim size={size} claims={n} bytes={bytes}");
     }
 }
@@ -379,7 +446,7 @@ impl PagePool {
     /// fault on memory that is already resident. The caller stamps the header,
     /// which until then still carries the dead region's stamp.
     pub fn claim(&mut self, size: usize) -> MmapPage {
-        let size = size.next_power_of_two().max(BASE_PAGE);
+        let size = size.next_power_of_two().max(base_page());
         record_claim(size);
         self.counters.claims += 1;
         let class = size_class(size);
@@ -413,7 +480,7 @@ impl PagePool {
             return;
         }
         let size = page.len();
-        let class = size_class(size.next_power_of_two().max(BASE_PAGE));
+        let class = size_class(size.next_power_of_two().max(base_page()));
         if class < NUM_CLASSES && self.cached_bytes + size <= self.max_cached {
             self.cached_bytes += size;
             if crate::value::fiberheap::freelog::scrub_armed() {
@@ -434,14 +501,14 @@ impl PagePool {
     #[cfg(test)]
     pub fn peek_cached(&mut self, size: usize) -> Option<&mut MmapPage> {
         self.free_lists
-            .get_mut(size_class(size.next_power_of_two().max(BASE_PAGE)))?
+            .get_mut(size_class(size.next_power_of_two().max(base_page())))?
             .last_mut()
     }
 }
 
 impl Default for PagePool {
     fn default() -> Self {
-        Self::new(BASE_PAGE, 4 * 1024 * 1024)
+        Self::new(base_page(), 4 * 1024 * 1024)
     }
 }
 

--- a/src/value/fiberheap/pagepool/tests.rs
+++ b/src/value/fiberheap/pagepool/tests.rs
@@ -2,19 +2,164 @@
 
 use super::*;
 
+/// The host's page size, asked of the OS here rather than taken from the module
+/// under test — the independent expectation the ladder must agree with.
+fn os_page() -> usize {
+    let n = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    assert!(n > 0, "sysconf(_SC_PAGESIZE) answered {n}");
+    n as usize
+}
+
 #[test]
 fn claim_returns_valid_page() {
     let mut pool = PagePool::default();
-    let page = pool.claim(BASE_PAGE);
-    assert_eq!(page.len(), BASE_PAGE);
+    let page = pool.claim(base_page());
+    assert_eq!(page.len(), base_page());
     assert!(!page.as_ptr().is_null());
 }
 
 #[test]
 fn claim_rounds_up_to_power_of_two() {
     let mut pool = PagePool::default();
-    let page = pool.claim(5000); // rounds to 8192
-    assert_eq!(page.len(), 8192);
+    // A request between two classes takes the larger one.
+    let page = pool.claim(base_page() + 1);
+    assert_eq!(page.len(), 2 * base_page());
+}
+
+// ── The base page is the OS page (docs/impl/region/model.md § "The base page
+// is the OS page") ──
+
+#[test]
+fn base_page_is_the_os_page() {
+    assert_eq!(
+        base_page(),
+        os_page().max(MIN_BASE_PAGE),
+        "the smallest region page must be the page the kernel actually charges \
+         for; a smaller one costs a whole OS page and accounts for a fraction \
+         of it",
+    );
+}
+
+#[test]
+fn derive_base_page_takes_the_os_answer_and_floors_it() {
+    // The three page sizes a supported host reports: 4096 (Linux x86-64, and
+    // Linux aarch64 as usually built), 16384 (macOS aarch64, Linux aarch64
+    // built for 16K), 65536 (Linux aarch64 built for 64K).
+    assert_eq!(derive_base_page(4096), 4096);
+    assert_eq!(derive_base_page(16384), 16384);
+    assert_eq!(derive_base_page(65536), 65536);
+    // The floor covers an answer no region page could be built from: a page
+    // below the floor, and the -1 `sysconf` returns when it cannot answer.
+    assert_eq!(derive_base_page(512), MIN_BASE_PAGE);
+    assert_eq!(derive_base_page(-1), MIN_BASE_PAGE);
+    assert_eq!(derive_base_page(0), MIN_BASE_PAGE);
+    // A non-power-of-two is not a page size any of the masking arithmetic can
+    // use, so it takes the floor rather than corrupting the ladder.
+    assert_eq!(derive_base_page(6000), MIN_BASE_PAGE);
+}
+
+/// The hypothetical hosts the ladder is checked against. The host running the
+/// test only ever exercises its own page size, and 4096 is the one that hides
+/// every consequence of a fixed base.
+const HOST_PAGES: [libc::c_long; 3] = [4096, 16384, 65536];
+
+#[test]
+fn every_size_class_is_a_whole_number_of_os_pages() {
+    // The counter-factual: a ladder rooted at a fixed 4096 puts 4096 and 8192
+    // on it. On a 16384-byte-page host the kernel charges a full 16384 for
+    // each, so classes 0, 1 and 2 are one physical size filed under three free
+    // lists, and `cached_bytes` counts a quarter of what class 0 holds.
+    for os in HOST_PAGES {
+        let base = derive_base_page(os);
+        let os = os as usize;
+        for class in 0..NUM_CLASSES {
+            let len = class_size_of(base, class);
+            assert_eq!(
+                len % os,
+                0,
+                "class {class} of a base-{base} ladder is {len} bytes, not a \
+                 whole number of {os}-byte OS pages",
+            );
+            assert_eq!(
+                size_class_of(base, len),
+                class,
+                "class {class} does not round-trip through its size {len}",
+            );
+        }
+    }
+}
+
+#[test]
+fn a_trim_gives_back_whole_os_pages() {
+    // The trap: `munmap` refuses an address that is not page-aligned. Trimming
+    // an over-allocation down to an 8192-byte page on a 16384-byte-page host
+    // hands it `base + 8192` and gets EINVAL, and the return value is the only
+    // place that shows. Whole-OS-page classes are what makes every trim legal.
+    for os in HOST_PAGES {
+        let base = derive_base_page(os);
+        let os = os as usize;
+        for class in 0..NUM_CLASSES {
+            let len = class_size_of(base, class);
+            let alloc = 2 * len;
+            // `mmap` answers with an OS-page-aligned address; sweep the offsets
+            // within one class that the kernel could pick.
+            for step in 0..(len / os).max(1) {
+                let raw = 16 * len + step * os;
+                let trim = Trim::new(raw, alloc, len);
+                assert_eq!(trim.base % len, 0, "trimmed base is not self-aligned");
+                assert_eq!(
+                    trim.prefix + len + trim.suffix,
+                    alloc,
+                    "the trim loses or invents bytes",
+                );
+                assert_eq!(
+                    trim.prefix % os,
+                    0,
+                    "munmap would refuse the {}-byte prefix at {raw:#x} on an \
+                     {os}-byte-page host",
+                    trim.prefix,
+                );
+                assert_eq!(
+                    (trim.base + len) % os,
+                    0,
+                    "munmap would refuse the suffix address for a {len}-byte \
+                     page on an {os}-byte-page host",
+                );
+                assert_eq!(trim.suffix % os, 0, "the suffix is a partial OS page");
+            }
+        }
+    }
+}
+
+#[test]
+fn the_smallest_claim_is_one_whole_os_page() {
+    // A one-byte region still costs a page from the kernel. The pool must hand
+    // out — and account for — exactly what the kernel charges.
+    let mut pool = PagePool::default();
+    let page = pool.claim(1);
+    assert_eq!(
+        page.len(),
+        os_page().max(MIN_BASE_PAGE),
+        "the smallest page the pool hands out is not the page the kernel maps",
+    );
+}
+
+#[test]
+fn a_released_page_is_cached_at_the_size_the_kernel_charged() {
+    // `cached_bytes` is what `--page-pool-max` bounds. It counts the page's
+    // recorded length, so that length has to be the mapping's real size.
+    let mut pool = PagePool::default();
+    let page = pool.claim(1);
+    let len = page.len();
+    let dirty = all_of(&page);
+    pool.release(page, dirty);
+    assert_eq!(pool.cached_bytes(), len);
+    assert_eq!(
+        len % os_page(),
+        0,
+        "a cached page of {len} bytes holds a fraction of an OS page, so the \
+         pool retains more memory than `--page-pool-max` names",
+    );
 }
 
 /// A page whose whole span the caller may have written — what a test that does
@@ -26,13 +171,13 @@ fn all_of(page: &MmapPage) -> PageDirty {
 #[test]
 fn release_and_reclaim() {
     let mut pool = PagePool::default();
-    let page = pool.claim(BASE_PAGE);
+    let page = pool.claim(base_page());
     let ptr = page.as_ptr();
     let dirty = all_of(&page);
     pool.release(page, dirty);
-    assert_eq!(pool.cached_bytes(), BASE_PAGE);
+    assert_eq!(pool.cached_bytes(), base_page());
 
-    let page2 = pool.claim(BASE_PAGE);
+    let page2 = pool.claim(base_page());
     // Should reuse the cached page (same address)
     assert_eq!(page2.as_ptr(), ptr);
     assert_eq!(pool.cached_bytes(), 0);
@@ -40,23 +185,24 @@ fn release_and_reclaim() {
 
 #[test]
 fn cache_limit_drops_excess() {
-    // max_cached = 8192 → can hold two 4K pages
-    let mut pool = PagePool::new(BASE_PAGE, 8192);
-    let p1 = pool.claim(BASE_PAGE);
-    let p2 = pool.claim(BASE_PAGE);
-    let p3 = pool.claim(BASE_PAGE);
+    // A cache with room for exactly two base pages.
+    let cap = 2 * base_page();
+    let mut pool = PagePool::new(base_page(), cap);
+    let p1 = pool.claim(base_page());
+    let p2 = pool.claim(base_page());
+    let p3 = pool.claim(base_page());
     let (d1, d2, d3) = (all_of(&p1), all_of(&p2), all_of(&p3));
     pool.release(p1, d1);
     pool.release(p2, d2);
-    assert_eq!(pool.cached_bytes(), 8192);
+    assert_eq!(pool.cached_bytes(), cap);
     // Third release exceeds limit → dropped (munmapped)
     pool.release(p3, d3);
-    assert_eq!(pool.cached_bytes(), 8192);
+    assert_eq!(pool.cached_bytes(), cap);
 }
 
 #[test]
 fn geometric_growth_sizes() {
-    let mut pool = PagePool::new(BASE_PAGE, 4 * 1024 * 1024);
+    let mut pool = PagePool::new(base_page(), 4 * 1024 * 1024);
     // Simulate geometric doubling
     let mut size = pool.initial_page_size();
     for _ in 0..5 {
@@ -66,8 +212,8 @@ fn geometric_growth_sizes() {
         pool.release(page, dirty);
         size *= 2;
     }
-    // sizes: 4K, 8K, 16K, 32K, 64K
-    assert_eq!(size, 128 * 1024);
+    // Five doublings from the base page.
+    assert_eq!(size, base_page() << 5);
 }
 
 // ── The page-recycle contract (docs/impl/region/model.md § "Page recycling") ──
@@ -95,14 +241,14 @@ fn claiming_a_recycled_page_touches_no_page_byte() {
     // back exactly as released. This is the hot path of a short-lived region
     // holding one small object, and it must cost nothing per page.
     let mut pool = PagePool::default();
-    let page = pool.claim(BASE_PAGE);
-    pool.release(page, PageDirty::new(HEADER..64, BASE_PAGE..BASE_PAGE));
+    let page = pool.claim(base_page());
+    pool.release(page, PageDirty::new(HEADER..64, base_page()..base_page()));
     let cached = pool
-        .peek_cached(BASE_PAGE)
+        .peek_cached(base_page())
         .expect("the released page must be in the cache");
     unsafe { std::ptr::write(cached.as_mut_ptr().add(HEADER), 0x5A) };
 
-    let recycled = pool.claim(BASE_PAGE);
+    let recycled = pool.claim(base_page());
     assert_eq!(
         pool.counters().recycles(),
         1,
@@ -122,7 +268,7 @@ fn reset_covers_the_written_spans_and_spares_the_header() {
     // A region's page has two written spans — the object slots and the
     // inline-data suffix — with an untouched gap between them. A reset clears
     // both and nothing else, so a page holding one 48-byte object behind a
-    // 16-byte header costs 48 bytes of work rather than 4096.
+    // 16-byte header costs 48 bytes of work rather than a whole page.
     //
     // The header is spared on purpose: a cached page keeps the
     // `(region, generation, store)` stamp of the region that died on it, which
@@ -130,17 +276,18 @@ fn reset_covers_the_written_spans_and_spares_the_header() {
     // the generation mismatch a panic at the deref site
     // (docs/impl/region/generations.md).
     let mut pool = PagePool::default();
-    let mut page = pool.claim(BASE_PAGE);
+    let mut page = pool.claim(base_page());
+    let len = page.len();
     unsafe {
         std::ptr::write_bytes(page.as_mut_ptr(), 0xFF, HEADER);
         std::ptr::write_bytes(page.as_mut_ptr().add(HEADER), 0xAB, 48);
-        std::ptr::write_bytes(page.as_mut_ptr().add(BASE_PAGE - 100), 0xCD, 100);
+        std::ptr::write_bytes(page.as_mut_ptr().add(len - 100), 0xCD, 100);
     }
 
-    let written = page.reset(&PageDirty::new(HEADER..64, BASE_PAGE - 100..BASE_PAGE));
+    let written = page.reset(&PageDirty::new(HEADER..64, len - 100..len));
     assert_eq!(written, 48 + 100);
 
-    let bytes = unsafe { std::slice::from_raw_parts(page.as_ptr(), BASE_PAGE) };
+    let bytes = unsafe { std::slice::from_raw_parts(page.as_ptr(), len) };
     assert_eq!(
         &bytes[..HEADER],
         [0xFFu8; HEADER],
@@ -160,15 +307,15 @@ fn reset_of_an_untouched_page_writes_nothing() {
     // A region that claimed a page and died before allocating into it wrote
     // only the header, which the reset spares. The spans are then empty.
     let mut pool = PagePool::default();
-    let mut page = pool.claim(BASE_PAGE);
-    let written = page.reset(&PageDirty::new(HEADER..HEADER, BASE_PAGE..BASE_PAGE));
+    let mut page = pool.claim(base_page());
+    let written = page.reset(&PageDirty::new(HEADER..HEADER, base_page()..base_page()));
     assert_eq!(written, 0);
 }
 
 #[test]
 fn write_and_read_page_contents() {
     let mut pool = PagePool::default();
-    let mut page = pool.claim(BASE_PAGE);
+    let mut page = pool.claim(base_page());
     // Write to the page
     unsafe {
         let ptr = page.as_mut_ptr();
@@ -179,7 +326,11 @@ fn write_and_read_page_contents() {
 
 #[test]
 fn large_pages_are_self_aligned() {
-    for &size in &[8192, 16384, 32768, 65536] {
+    // `region_of_page_ptr` finds a page's base by masking a pointer with
+    // `!(len - 1)`, so every page above class 0 has to be aligned to its own
+    // length — which `mmap` alone does not give.
+    for class in 1..5 {
+        let size = class_size_of(base_page(), class);
         let page = MmapPage::new(size).unwrap();
         assert_eq!(
             page.as_ptr() as usize % size,

--- a/src/value/fiberheap/regionpool/tests.rs
+++ b/src/value/fiberheap/regionpool/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests (`super` is the parent impl module).
 
-use super::super::pagepool::BASE_PAGE;
+use super::super::pagepool::{base_page, class_size_of};
 use super::*;
 use crate::value::heap::Pair;
 
@@ -11,7 +11,7 @@ fn pool_for(region_id: u32) -> RegionPool {
     RegionPool::new(
         region_id,
         PageStamp::default(),
-        BASE_PAGE,
+        base_page(),
         std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
     )
 }
@@ -63,7 +63,7 @@ fn dual_ended_layout() {
     // Then an object.
     let v = rp.alloc_obj(cons_obj(), &mut pool);
 
-    // Both should be on the same page (single 4K page).
+    // Both should be on the same page.
     assert_eq!(rp.pages.len(), 1);
     assert_eq!(s.as_slice(), b"test data");
     assert!(v.is_heap());
@@ -74,13 +74,15 @@ fn page_growth_when_full() {
     let mut pool = PagePool::default();
     let mut rp = pool_for(1);
 
-    // Fill a 4K page: (4096 - 8) / 48 = ~85 objects max
-    // Allocate enough to spill into a second page.
-    for _ in 0..100 {
+    // One object slot per `HeapObject`, so a page holds at most
+    // `base_page() / size_of::<HeapObject>()` of them. Ask for one more than a
+    // full page's worth, on whatever page size the host uses.
+    let spill = base_page() / size_of::<HeapObject>() + 1;
+    for _ in 0..spill {
         rp.alloc_obj(cons_obj(), &mut pool);
     }
     assert!(rp.pages.len() >= 2, "should have claimed multiple pages");
-    assert_eq!(rp.obj_count(), 100);
+    assert_eq!(rp.obj_count(), spill);
 }
 
 #[test]
@@ -148,9 +150,9 @@ fn teardown_returns_a_page_that_still_names_its_region() {
     rp.teardown(&mut pool);
 
     let cached = pool
-        .peek_cached(BASE_PAGE)
+        .peek_cached(base_page())
         .expect("teardown must return the page to the cache");
-    let rid = unsafe { region_of_page_ptr(cached.as_ptr() as *const (), BASE_PAGE) };
+    let rid = unsafe { region_of_page_ptr(cached.as_ptr() as *const (), base_page()) };
     assert_eq!(
         rid, 42,
         "the cached page lost the stamp of the region that died on it, so a \
@@ -209,7 +211,7 @@ fn page_header_region_id() {
 
     // Read region_id from the page header.
     let ptr = v.as_heap_ptr().unwrap();
-    let rid = unsafe { region_of_page_ptr(ptr, 4096) };
+    let rid = unsafe { region_of_page_ptr(ptr, base_page()) };
     assert_eq!(rid, 42);
 }
 
@@ -225,12 +227,12 @@ fn page_header_stamp_roundtrip() {
     let mut rp = RegionPool::new(
         42,
         stamp,
-        4096,
+        base_page(),
         std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
     );
     let v = rp.alloc_obj(cons_obj(), &mut pool);
     let ptr = v.as_heap_ptr().unwrap();
-    let (rid, read_back) = unsafe { header_of_page_ptr(ptr, 4096) };
+    let (rid, read_back) = unsafe { header_of_page_ptr(ptr, base_page()) };
     assert_eq!(rid, 42);
     assert_eq!(read_back, stamp);
 }
@@ -239,29 +241,34 @@ fn page_header_stamp_roundtrip() {
 fn large_inline_data_claims_bigger_page() {
     let mut pool = PagePool::default();
     let mut rp = pool_for(1);
-    // Allocate data larger than a 4K page.
-    let big_data = vec![0xABu8; 8000];
+    // Allocate data larger than the region's first page.
+    let big_data = vec![0xABu8; 2 * base_page()];
     let s = rp.alloc_region_slice(&big_data, &mut pool);
     assert_eq!(s.as_slice(), &big_data[..]);
 }
 
 #[test]
 fn region_of_page_ptr_on_grown_page() {
-    // After geometric growth, objects may be on pages larger than 4K.
-    // region_of_page_ptr must still find the correct region ID.
+    // After geometric growth, objects may be on pages larger than the base
+    // page. region_of_page_ptr must still find the correct region ID.
     let mut pool = PagePool::default();
     let mut rp = pool_for(99);
 
-    // Fill the first 4K page to force a second (8K) page.
-    for _ in 0..100 {
+    // Fill the first page to force a second, double-sized one.
+    let mut allocated = 0;
+    while rp.pages.len() < 2 {
         rp.alloc_obj(cons_obj(), &mut pool);
+        allocated += 1;
+        assert!(
+            allocated < 100_000,
+            "the region never claimed a second page"
+        );
     }
-    assert!(rp.pages.len() >= 2, "should have grown to multiple pages");
 
     // Allocate on the grown page.
     let v = rp.alloc_obj(cons_obj(), &mut pool);
     let ptr = v.as_heap_ptr().unwrap();
-    let rid = unsafe { region_of_page_ptr(ptr, 4096) };
+    let rid = unsafe { region_of_page_ptr(ptr, base_page()) };
     assert_eq!(rid, 99, "region_of_page_ptr must work on grown pages");
 }
 
@@ -276,14 +283,15 @@ fn header_lookup_rejects_mid_page_false_match() {
     // header — region id 0xffffff45 — which then drove `ensure_raw` to a 584 GB
     // resize. The `size_tag` magic rejects the mid-page match.
     //
-    // Counterfactual: pre-magic, `header_of_page_ptr` matched the forged 8 KiB
-    // sub-base (its byte 12 equals log2 8192) and returned the forged region id;
-    // post-magic the forged tag lacks the magic, so the walk reaches the true
-    // 16 KiB base and returns region 42.
-    let mut pool = PagePool::new(BASE_PAGE, 8 * 1024 * 1024);
-    // A 16 KiB page (log2 = 14), self-aligned by `claim`.
-    let page = pool.claim(4 * BASE_PAGE);
-    assert_eq!(page.len(), 4 * BASE_PAGE);
+    // Counterfactual: pre-magic, `header_of_page_ptr` matched the forged
+    // half-size sub-base (its byte 12 equals that size's log2) and returned the
+    // forged region id; post-magic the forged tag lacks the magic, so the walk
+    // reaches the true base and returns region 42.
+    let mut pool = PagePool::new(base_page(), 8 * 1024 * 1024);
+    // A class-2 page, self-aligned by `claim`.
+    let big = class_size_of(base_page(), 2);
+    let page = pool.claim(big);
+    assert_eq!(page.len(), big);
     let base = page.as_ptr() as usize;
     // Stamp the real header at the true base (region 42).
     let _rp = RegionPage::new(
@@ -294,18 +302,19 @@ fn header_lookup_rejects_mid_page_false_match() {
             store: 7,
         },
     );
-    // Forge a "smaller page" header mid-page, at the 8 KiB-aligned sub-base: a
-    // garbage region id, and a bare `log2(8192)` at the `size_tag` offset (12)
-    // WITHOUT the magic — exactly the mid-page object data that fooled the old
-    // single-byte check.
-    let sub_base = base + 2 * BASE_PAGE; // 8 KiB in — 8 KiB-aligned
+    // Forge a "smaller page" header mid-page, at the class-1-aligned sub-base:
+    // a garbage region id, and a bare `log2(half)` at the `size_tag` offset
+    // (12) WITHOUT the magic — exactly the mid-page object data that fooled the
+    // old single-byte check.
+    let half = class_size_of(base_page(), 1);
+    let sub_base = base + half; // half a page in — half-page-aligned
     unsafe {
         *(sub_base as *mut u32) = 0xDEAD_BEEF; // forged region_id
-        *((sub_base + 12) as *mut u32) = (2 * BASE_PAGE).trailing_zeros(); // bare log2, no magic
+        *((sub_base + 12) as *mut u32) = half.trailing_zeros(); // bare log2, no magic
     }
-    // A pointer deep in the page, past the forged 8 KiB sub-base.
+    // A pointer deep in the page, past the forged sub-base.
     let deep = (sub_base + 0x620) as *const ();
-    let rid = unsafe { region_of_page_ptr(deep, BASE_PAGE) };
+    let rid = unsafe { region_of_page_ptr(deep, base_page()) };
     assert_eq!(
         rid, 42,
         "region_of_page_ptr resolved a deep pointer to a mid-page false header \

--- a/src/value/fiberheap/regionstore.rs
+++ b/src/value/fiberheap/regionstore.rs
@@ -259,7 +259,7 @@ impl Drop for RegionStore {
 impl Default for RegionStore {
     fn default() -> Self {
         Self::new(
-            super::pagepool::BASE_PAGE,
+            super::pagepool::base_page(),
             4 * 1024 * 1024,
             std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
         )


### PR DESCRIPTION
Closes #1002.

## What was wrong

`BASE_PAGE` was a hardcoded 4096, and nothing in the tree asked the OS for its
page size. On a host whose page is larger — macOS aarch64 (16384), Linux aarch64
built for 16K or 64K — one fixed constant costs four things at once:

1. **Three free lists, one physical page.** Classes 0, 1 and 2 name 4096, 8192
   and 16384 bytes, but the kernel charges a full 16384-byte page for each.
   `release` files a page by its recorded length, so a released class-0 page —
   physically 16384 bytes — cannot serve a class-2 claim, and the pool maps a
   fresh page instead.
2. **`--page-pool-max` does not bound what it names.** `cached_bytes` adds the
   page's recorded length. A class-0 page records 4096 and holds 16384, so a
   4 MB pool retains up to 16 MB per thread.
3. **The class-1 trim `munmap` fails, unchecked.** It unmaps the suffix at
   `base + 8192`, half an OS page past a page boundary, and `munmap` answers
   `EINVAL`. Nothing leaks — `Drop` unmaps the whole rounded-up range — but the
   page holds 16384 bytes while recording 8192, and the return value was
   discarded.
4. **`mapped_bytes` understates by the same factor.** It records the length each
   `mmap` asked for, not the mapping the kernel made, so the gauge that says
   whether a worker gave its heap back is short by 4× for every class-0 page.

Linux x86-64 has a 4096-byte page and never showed any of it.

## What the change does

- `base_page()` asks `sysconf(_SC_PAGESIZE)` once and caches the answer. Class 0
  of the size-class ladder is that page, so a region page is always a whole
  number of OS pages. `MIN_BASE_PAGE` (4096) is the floor for an answer the
  ladder cannot use — a `sysconf` failure, a smaller page, a non-power-of-two.
- `size_class_of` / `class_size_of` take the base explicitly. The ladder is a
  pure function, so a 4 KiB host can check the arithmetic for a 16 KiB host.
- `Trim::new` names the cut an over-allocated mapping takes: the aligned base,
  the prefix, the suffix. Every piece is a whole OS page.
- `unmap` checks the `munmap` return under `debug_assertions`; both trims and
  `Drop` go through it.
- `--region-page-size` floors at `base_page()` and names that floor when it
  rejects a value. Its default is `base_page()` too.
- The design argument lives in docs/impl/region/model.md § "The base page is the
  OS page".

## Tests

New, in `pagepool::tests`:

- `base_page_is_the_os_page` — the module's base against `sysconf`, asked
  independently by the test.
- `derive_base_page_takes_the_os_answer_and_floors_it` — 4096/16384/65536 pass
  through; `-1`, `0`, `512` and a non-power-of-two take the floor.
- `every_size_class_is_a_whole_number_of_os_pages` — the full ladder against
  each of the three page sizes a supported host reports.
- `a_trim_gives_back_whole_os_pages` — every trim address on that ladder is
  OS-page-aligned, sweeping the offsets `mmap` could answer with. This is the
  `EINVAL` above.
- `the_smallest_claim_is_one_whole_os_page` and
  `a_released_page_is_cached_at_the_size_the_kernel_charged` — the two
  accounting gauges.

New, in `config::tests`: `region_page_size_defaults_to_the_base_page` and
`region_page_size_below_the_base_page_is_rejected`.

The existing pagepool and regionpool tests were page-size-relative wherever they
had baked 4096, 8192 or an object count that only fills a 4 KiB page.

## How it was measured

Counter-factual: with `derive_base_page` pinned to 4096 — main's behavior
through the new seam — three of the new tests fail on this x86-64 host,
including the trim one:

```
class 0 of a base-4096 ladder is 4096 bytes, not a whole number of
16384-byte OS pages
```

With the OS query in place: `cargo test -p elle --lib` (2306 tests), `make qa`,
and `make smoke` are green.
