### PR TITLE
lir: a match/destructure `rest` alias is borrowed

### DIFF
--- a/src/lir/lower/binding/destructure.rs
+++ b/src/lir/lower/binding/destructure.rs
@@ -93,6 +93,11 @@ impl<'a> Lowerer<'a> {
                 }
                 // Bind the remaining tail to the rest pattern
                 if let Some(rest_pat) = rest {
+                    // A list rest is a borrowed subview of the scrutinee —
+                    // mark its bindings (see `destructure_alias_bindings`).
+                    for b in rest_pat.bindings().bindings {
+                        self.destructure_alias_bindings.insert(b);
+                    }
                     self.lower_destructure(rest_pat, current, strict)?;
                 }
                 Ok(())

--- a/src/lir/lower/control.rs
+++ b/src/lir/lower/control.rs
@@ -96,6 +96,7 @@ impl<'a> Lowerer<'a> {
             // route is position-independent (the frame never owns a constant).
             HirKind::Var(binding) => {
                 (self.in_lambda && self.upvalue_bindings.contains(binding))
+                    || self.destructure_alias_bindings.contains(binding)
                     || self
                         .immutable_values
                         .get(binding)

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -204,6 +204,27 @@ pub struct Lowerer<'a> {
     /// Set of bindings that are upvalues (captures/parameters in lambda)
     /// These use LoadCapture/StoreCapture, not LoadLocal/StoreLocal
     upvalue_bindings: std::collections::HashSet<Binding>,
+    /// Bindings bound to a BORROWED SUBVIEW of a scrutinee by destructuring:
+    /// a `(a & rest)` list pattern, a `(entry & rest)` head, an array element,
+    /// a struct value — every binding a structural ELEMENT load (`First`/`Rest`/
+    /// `Index`/`Key`) reaches reads a pointer aliased into the scrutinee's
+    /// region pages with NO owning reference (the region solver only registers
+    /// counted container reads for *call-site* `rest()`/`first()`/`get()`, never
+    /// for pattern loads). Marking them borrowed makes
+    /// `arg_leaf_is_borrowed`/`tail_arg_is_borrowed` treat a call arg naming one
+    /// like any other borrowed arg: the caller mints a fresh owning reference at
+    /// the call that the callee's release balances, leaving the scrutinee's own
+    /// reference untouched. `Slice`/`StructRest` (array/struct `& rest`) are
+    /// excluded: they mint fresh owned containers.
+    ///
+    /// Computed ONCE over the whole HIR at `lower()` entry by
+    /// [`Self::precompute_destructure_aliases`] — before any body lowering — so
+    /// a `match` compound used as a tail argument has its aliases registered
+    /// before `tail_arg_is_borrowed` consults them (a call's arguments are
+    /// classified before they are lowered). The decision-tree / seq / destructure
+    /// walks also insert as they go; both routes fill the same set, and an
+    /// insert is idempotent.
+    destructure_alias_bindings: std::collections::HashSet<Binding>,
     /// Current span for emitted instructions
     current_span: Span,
     /// Intrinsic operations for operator specialization.
@@ -439,6 +460,7 @@ impl<'a> Lowerer<'a> {
             num_captures: 0,
             num_local_params: 0,
             upvalue_bindings: std::collections::HashSet::new(),
+            destructure_alias_bindings: std::collections::HashSet::new(),
             current_span: Span::synthetic(),
             intrinsics: FxHashMap::default(),
             call_classification: crate::hir::CallClassification::default(),
@@ -741,6 +763,32 @@ impl<'a> Lowerer<'a> {
         self.region_info.scope_has_local_allocs(hir_id)
     }
 
+    /// Collect, over the whole HIR, the bindings each `match`/`destructure`
+    /// pattern binds to a BORROWED subview of its scrutinee — the structural
+    /// element positions (`First`/`Rest`/`Index`/`Key`), excluding fresh-owned
+    /// collectors (`Slice`/`StructRest`, the `& rest` of array/struct patterns).
+    ///
+    /// Runs once at `lower()` entry, before any body lowering, so a `match`
+    /// compound in tail-argument position has its aliases registered before the
+    /// call site classifies that argument. `Hir::for_each_child` deliberately
+    /// does NOT enumerate pattern bindings (patterns are not HIR children), so
+    /// this walk enumerates `Match` arms / `Destructure` patterns itself and
+    /// recurses through `for_each_child` for the ordinary expression tree.
+    fn precompute_destructure_aliases(&mut self, hir: &Hir) {
+        match &hir.kind {
+            HirKind::Match { arms, .. } => {
+                for (pat, _, _) in arms {
+                    collect_pattern_aliases(pat, &mut self.destructure_alias_bindings, false);
+                }
+            }
+            HirKind::Destructure { pattern, .. } => {
+                collect_pattern_aliases(pattern, &mut self.destructure_alias_bindings, false);
+            }
+            _ => {}
+        }
+        hir.for_each_child(|c| self.precompute_destructure_aliases(c));
+    }
+
     /// Lower a HIR expression to an LIR module.
     ///
     /// Returns an `LirModule` with the entry function and a flat list of
@@ -752,6 +800,16 @@ impl<'a> Lowerer<'a> {
         // closures. Computing it here keeps the pass on every real lowering path
         // through a single chokepoint; `tail_callee_defers_release` reads it.
         self.escape_info = analyze_escape(hir, self.arena, &self.call_classification);
+
+        // Same whole-module contract: compute the destructure-alias set once
+        // over the full HIR before body lowering begins, so a `match` compound
+        // used as a tail argument has its aliases registered before the call
+        // site classifies that argument (arguments are classified, then
+        // lowered). The decision-tree/seq/destructure walks re-insert as they
+        // go; that stays idempotent and covers any pattern the walk reaches
+        // that the precompute pass did not enumerate.
+        self.destructure_alias_bindings.clear();
+        self.precompute_destructure_aliases(hir);
 
         self.current_func = LirFunction::new(Arity::Exact(0));
         self.current_block = BasicBlock::new(Label(0));
@@ -877,6 +935,83 @@ fn assert_cells_outlive_their_readers(module: &LirModule) {
                 }
             }
         }
+    }
+}
+
+/// Collect the bindings one pattern binds to a BORROWED subview of its
+/// scrutinee into `out` — the structural ELEMENT positions, mirroring
+/// `access_is_borrowed_element`'s access-path gate over the source pattern
+/// shape. `in_element` is true when this pattern is itself reached through an
+/// element load (so a bare `Var` at that position is an element binding, while
+/// a `Var` pattern at the top bound to the whole scrutinee is not).
+///
+/// Fresh-owned collectors are excluded: the `& rest` of a `Tuple`/`Array`
+/// compiles to `Slice` (a new owned array), and of a `Struct`/`Table` to
+/// `StructRest` (a new owned struct) — a binding reached under one owns its
+/// new container. The cons `rest` of a `List`/`Pair` is NOT excluded: it is
+/// `AccessPath::Rest`, a borrowed view into the scrutinee's cells.
+fn collect_pattern_aliases(
+    pat: &HirPattern,
+    out: &mut std::collections::HashSet<Binding>,
+    in_element: bool,
+) {
+    match pat {
+        HirPattern::Var(b) => {
+            if in_element {
+                out.insert(*b);
+            }
+        }
+        HirPattern::Pair { head, tail } => {
+            // head = First, tail = Rest — both borrowed cell views.
+            collect_pattern_aliases(head, out, true);
+            collect_pattern_aliases(tail, out, true);
+        }
+        HirPattern::List { elements, rest } => {
+            // list element N = First of N rests — borrowed; the cons rest
+            // itself is AccessPath::Rest — borrowed.
+            for e in elements {
+                collect_pattern_aliases(e, out, true);
+            }
+            if let Some(r) = rest {
+                collect_pattern_aliases(r, out, true);
+            }
+        }
+        HirPattern::Tuple { elements, rest } | HirPattern::Array { elements, rest } => {
+            // array element = Index — borrowed. The & rest (Slice) mints a
+            // fresh owned array; a binding under it owns the slice.
+            for e in elements {
+                collect_pattern_aliases(e, out, true);
+            }
+            let _ = rest; // slice rest: fresh-owned, not a borrower
+        }
+        HirPattern::Struct { entries, rest } | HirPattern::Table { entries, rest } => {
+            // entry value = Key — borrowed. The & rest (StructRest) mints a
+            // fresh owned struct; a binding under it owns the rest-struct.
+            for (_, v) in entries {
+                collect_pattern_aliases(v, out, true);
+            }
+            let _ = rest; // struct rest: fresh-owned, not a borrower
+        }
+        HirPattern::NamedStruct { entries } => {
+            for (_, v) in entries {
+                collect_pattern_aliases(v, out, true);
+            }
+        }
+        HirPattern::Set { binding } | HirPattern::SetMut { binding } => {
+            // A set pattern binds the WHOLE value (type-guard only) — Root, not
+            // an element — but if it sits inside an element load (e.g. an array
+            // of sets), the set value itself is that element: pass in_element
+            // through so a Var at that depth is marked when reached sideways.
+            collect_pattern_aliases(binding, out, in_element);
+        }
+        HirPattern::Or(alternatives) => {
+            // An or-pattern binds the same names in every arm, each reached
+            // through the same access path — collect each arm identically.
+            for alt in alternatives {
+                collect_pattern_aliases(alt, out, in_element);
+            }
+        }
+        HirPattern::Wildcard | HirPattern::Nil | HirPattern::Literal(_) => {}
     }
 }
 

--- a/src/lir/lower/pattern.rs
+++ b/src/lir/lower/pattern.rs
@@ -1,12 +1,36 @@
 //! Pattern matching lowering
 
 use super::*;
-use crate::hir::decision::{Constructor, DecisionTree};
+use crate::hir::decision::{AccessPath, Constructor, DecisionTree};
 use crate::hir::{HirPattern, PatternKey, PatternLiteral};
 
 mod keyed;
 mod matching;
 mod seq;
+
+/// Does an access path reach a binding through a BORROWED structural element
+/// load — `First`/`Rest`/`Index`/`Key`? The match decision tree loads these
+/// with intrinsics that carry NO owning reference: the region solver only
+/// registers a counted container read for *call-site* `rest()`/`first()`/`get()`,
+/// never for pattern loads. A binding reached this way is a BORROWED subview of
+/// the scrutinee — passing it as an owned-param call argument lets
+/// the callee's release free the caller's still-live scrutinee region.
+///
+/// `Slice` and `StructRest` (array/struct `& rest` patterns) are excluded: they
+/// mint a FRESH OWNED container (`vm/data.rs::handle_array_slice_from`), so a
+/// path through them is not a borrow of the scrutinee — a binding reached under
+/// one owns its new container, and the charged cascade frees it.
+pub(super) fn access_is_borrowed_element(access: &AccessPath) -> bool {
+    match access {
+        AccessPath::Root => false,
+        AccessPath::First(_inner) | AccessPath::Rest(_inner) => true,
+        AccessPath::Index(_inner, _) | AccessPath::Key(_inner, _) => true,
+        // Slice/StructRest mint a fresh owned container — a path through
+        // them (and whatever element loads sit beneath them) is not a
+        // borrow of the scrutinee.
+        AccessPath::Slice(..) | AccessPath::StructRest(..) => false,
+    }
+}
 
 impl<'a> Lowerer<'a> {
     // ── Decision tree lowering ─────────────────────────────────────
@@ -69,6 +93,11 @@ impl<'a> Lowerer<'a> {
                 // and keeping it on the operand stack would leak intermediates.
                 for (binding, access) in bindings {
                     let val_reg = self.load_access_path(access, scrutinee_slot)?;
+                    // A borrowed subview of the scrutinee — mark it
+                    // (see `destructure_alias_bindings`).
+                    if access_is_borrowed_element(access) {
+                        self.destructure_alias_bindings.insert(*binding);
+                    }
                     let slot = if let Some(&existing) = self.binding_to_slot.get(binding) {
                         existing
                     } else {
@@ -129,6 +158,11 @@ impl<'a> Lowerer<'a> {
                 // Establish bindings — pop after each store (same as Leaf).
                 for (binding, access) in bindings {
                     let val_reg = self.load_access_path(access, scrutinee_slot)?;
+                    // A borrowed subview of the scrutinee — mark it
+                    // (see `destructure_alias_bindings`).
+                    if access_is_borrowed_element(access) {
+                        self.destructure_alias_bindings.insert(*binding);
+                    }
                     let slot = if let Some(&existing) = self.binding_to_slot.get(binding) {
                         existing
                     } else {

--- a/src/lir/lower/pattern/seq.rs
+++ b/src/lir/lower/pattern/seq.rs
@@ -82,6 +82,11 @@ impl<'a> Lowerer<'a> {
                 });
 
                 // Match tail pattern
+                // The tail is a borrowed subview of the scrutinee — mark
+                // its bindings (see `destructure_alias_bindings`).
+                for b in tail.bindings().bindings {
+                    self.destructure_alias_bindings.insert(b);
+                }
                 self.lower_pattern_match(tail, tail_reg, fail_label)?;
 
                 Ok(())
@@ -162,7 +167,12 @@ impl<'a> Lowerer<'a> {
                 }
 
                 if let Some(rest_pat) = rest {
-                    // With & rest: bind remaining tail to rest pattern
+                    // With & rest: bind remaining tail to rest pattern.
+                    // The tail is a borrowed subview — mark its bindings
+                    // (see `destructure_alias_bindings`).
+                    for b in rest_pat.bindings().bindings {
+                        self.destructure_alias_bindings.insert(b);
+                    }
                     self.lower_pattern_match(rest_pat, current_reg, fail_label)?;
                 } else {
                     // Without rest: check that tail is empty_list (exact length)

--- a/tests/elle/region-match-rest-tail-move-uaf.lisp
+++ b/tests/elle/region-match-rest-tail-move-uaf.lisp
@@ -1,0 +1,104 @@
+(elle/epoch 12)
+# A `match`-destructured `rest` alias is a BORROWED subview of the scrutinee
+# (the `Rest` intrinsic loads the cdr pointer into the scrutinee's region pages,
+# but the region solver only registers a counted container read for *call-site*
+# `rest()`/`first()`, not for pattern loads). Passing such an alias as an
+# owned-param CALL ARGUMENT makes the callee's param release free
+# the caller's still-live scrutinee region — a use-after-free on the caller's
+# original list.
+#
+# Witness: a self-recursive `match` walk passes `rest` to its own tail call;
+# the caller's scratch list (built by `map`) must survive the walk intact.
+# GREEN since the lowerer marks destructure-rest bindings borrowed
+# (`destructure_alias_bindings` → the borrowed-arg incref at the call site).
+# RED before the fix (the freed tail prints as <heap:...> / length fails).
+
+(defn find-entry [entries name]
+  (match entries
+    () nil
+    (entry & rest)
+      (if (= (get entry :name) name) entry (find-entry rest name))
+    _ nil))
+
+# ── witnesses: passing a match-bound alias to an owned-param callee ──────────
+# Each witness tail-passes a pattern-bound ELEMENT alias into a self-recursive
+# owned-param callee. Without the borrowed marking, the callee's param release
+# frees the caller's still-live scrutinee region (stale-region deref / SIGSEGV
+# under --trace=guardfree). All four element positions are covered: cons Rest,
+# cons First, array Index, struct Key.
+
+# (a) Rest: the tail of a cons (match `(entry & rest)`), self-recursive walk.
+(defn consume [entry depth]
+  (if (%lt depth 1) (get entry :name) (consume entry (%add depth -1))))
+
+(defn w_rest [entries]
+  (match entries
+    () nil
+    (entry & rest) (consume2 rest 3)
+    _ nil))
+
+# (b) First: the HEAD of a cons — the review's minimal head-element witness.
+(defn w_first [entries]
+  (match entries
+    () nil
+    (entry & rest) (consume entry 3)
+    _ nil))
+
+# (c) Index: an immutable-array element `[a b]`.
+(defn consume2 [a depth]
+  (if (%lt depth 1) a (consume2 a (%add depth -1))))
+
+(defn w_index [arr]
+  (match arr
+    [a b] (consume2 a 3)
+    _ nil))
+
+# (d) Key: an immutable-struct value `{:k v}`.
+(defn consume3 [v depth]
+  (if (%lt depth 1) v (consume3 v (%add depth -1))))
+
+(defn w_key [st]
+  (match st
+    {:k v} (consume3 v 3)
+    _ nil))
+
+# (e) Ordering: a `match` compound in TAIL-ARGUMENT position whose arm value is
+# the pattern's own rest binding. The call site classifies the argument BEFORE
+# the match is lowered, so the alias must be precomputed, not discovered during
+# the match walk.
+(defn w_order [xs depth]
+  (if (%lt depth 1) (length xs) (w_order xs (%add depth -1))))
+
+(defn w_order_driver [entries]
+  (w_order (match entries
+             () ()
+             (a & r) r
+             _ ()) 3))
+# (f) Destructure: `(def (a & r) xs)` — the binding-destructure route. The
+# original patch marked only the cons REST here; the HEAD (`a`) is a First
+# element load and needs the same borrowed marking (precompute covers it).
+(defn w_destructure_rest [xs]
+  (def (a & r) xs)
+  (consume2 r 3))
+
+(defn w_destructure_head [xs]
+  (def (a & r) xs)
+  (consume2 a 3))
+
+(var i 0)
+(while (%lt i 2000)
+  (let* [r2 (map (fn [u] u) (list {:name "a"} {:name "b"} {:name "c"} {:name "d"}))
+         found (find-entry r2 "c")
+         arr2 [1 2]]
+    (assert (= (get found :name) "c") "find-entry returns the matching entry")
+    (assert (= (length r2) 4) "the map-built list survives a tail-recursive match walk")
+    (assert (= (length (w_rest r2)) 3) "cons Rest alias survives the owned-param self-call")
+    (assert (= (w_first r2) "a") "cons First (head) alias survives the owned-param self-call")
+    (assert (= (w_index arr2) 1) "array Index element alias survives the owned-param self-call")
+    (assert (= (w_key {:k 99 :j 88}) 99) "struct Key value alias survives the owned-param self-call")
+    (assert (= (w_order_driver r2) 3) "ordering: a match-compound tail arg is classified after its aliases are registered")
+    (assert (= (length (w_destructure_rest r2)) 3) "destructure rest alias survives the owned-param self-call")
+    (assert (= (w_destructure_head r2) {:name "a"}) "destructure head alias survives the owned-param self-call"))
+  (assign i (%add i 1)))
+
+(println "region-match-rest-tail-move-uaf: ok")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -140,6 +140,22 @@ fn region_match_rest_uaf() {
     );
 }
 
+// Guard — a match-destructured `rest` alias (`(a & rest)`) is a BORROWED subview
+// of the scrutinee, but the region solver never registered a counted container
+// read for the pattern load (only for call-site `rest()`/`first()`). Passing the
+// alias as an owned-param call argument (tail or not) made the callee's param
+// release free the caller's still-live scrutinee region — a use-after-free on
+// the caller's original list (SIGSEGV/SIGBUS under guardfree). The lowerer now
+// marks destructure-rest bindings borrowed so the call site mints a fresh
+// owning reference the callee's release balances.
+#[test]
+fn region_match_rest_tail_move_uaf() {
+    run_elle_script_with_args(
+        "region-match-rest-tail-move-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — native-tail-return of a heap pass-through result (`(first xs)`/
 // `(get xs 0)`/`(xs i)`) must keep the ReturnValue retain, so the caller's
 // DecrefValueRegion does not free it under its borrow (which would SIGSEGV


### PR DESCRIPTION
Closes #999

## Summary

A `match`/destructure pattern binds each structural ELEMENT (`First`/`Rest` of a cons, `Index` of an array, `Key` of a struct) to a **borrowed subview** of the scrutinee: the decision tree loads them with intrinsics that return pointers into the scrutinee's region pages with **no owning reference**. The region solver registers a counted container read for *call-site* `rest()`/`first()`/`get()` only — never for pattern loads.

Passing such an aliased binding as an **owned-param call argument** makes the callee's owned-param `DecrefValueRegion` release a reference that was never minted, freeing the caller's still-live scrutinee region. The caller's original list/array/struct then corrupts (use-after-free).

## Fix

Mark those bindings **borrowed** so `arg_leaf_is_borrowed` / `tail_arg_is_borrowed` treat a call argument naming one like any other borrowed arg: the caller mints a fresh owning reference at the call that the callee's release balances. `Slice`/`StructRest` (array/struct `& rest`) are excluded — they mint fresh owned containers.

- `Lowerer.destructure_alias_bindings: HashSet<Binding>` — computed ONCE over the whole HIR at `lower()` entry (`precompute_destructure_aliases`), so a `match` compound used as a tail argument has its aliases registered before the call site classifies that argument (closes the ordering gap: a call classifies its arguments before lowering them).
- `pattern.rs` — `access_is_borrowed_element()`; the decision-tree walk marks bindings reached through `Rest`/`First`/`Index`/`Key` (each an equally uncounted pattern load — not just `Rest`).
- `pattern/seq.rs` — marks `Pair` head/tail and `List` rest-pattern bindings.
- `binding/destructure.rs` — marks `(def (a & r))` rest bindings.
- `control.rs` — `arg_leaf_is_borrowed` consults the alias set.
- Regression `tests/elle/region-match-rest-tail-move-uaf.lisp` + pinned guardfree runner entry (`region_match_rest_tail_move`), with witnesses for every element position (cons Rest, cons First/head, array Index, struct Key) plus the tail-argument ordering gap and the `(def (a & r))` destructure route.

## Verification

The guardfree oracle (`--jit=adaptive --mlir=off --trace=guardfree`) on the expanded regression:

| state | result |
|---|---|
| fix reverted to `Rest`-only marking (the original patch) | **SIGBUS** (exit 138) — the First/Index/Key/destructure-head witnesses catch the unclosed defect class |
| this branch | `region-match-rest-tail-move-uaf: ok` |

`cargo test --test lib region_match_rest_tail_move` — RED without the fix, GREEN with it. `cargo test --test lib region_` — 95 passed.