### PR TITLE
io: a pool worker outlives the operation it was started for

### DIFF
--- a/docs/io.md
+++ b/docs/io.md
@@ -68,10 +68,10 @@ teardown sweep, after the sweep had freed part of what it holds.
 timer's, whichever lost — so cancellation runs constantly rather than at
 the edges. Two things come back when it does, on either backend:
 
-- **The worker.** A thread-pool operation runs on an OS thread. A
-  cancelled operation reports completion like any other, so its thread is
-  released; only the result is thrown away. `(ev/report):workers` counts
-  the threads currently out.
+- **The worker.** A thread-pool operation runs on a worker thread. A
+  cancelled operation reports completion like any other, so its worker
+  goes back to the pool for the next operation; only the result is thrown
+  away. `(ev/report):workers` counts the operations out right now.
 - **The descriptor.** A cancelled read stops rather than going on
   reading, and so does a cancelled write whose peer stopped taking bytes.
   Whatever arrives next belongs to whoever reads the port next:
@@ -96,14 +96,31 @@ the edges. Two things come back when it does, on either backend:
 ### How many operations run at once
 
 However many the OS allows. The thread-pool backend runs each operation
-on its own thread, so the ceiling is `RLIMIT_NPROC`, `kernel.threads-max`
-and the memory for the stacks; when the OS refuses a thread, `port/read`
-and friends signal that refusal rather than the runtime pre-empting it
-with a smaller number of its own. io_uring runs its operations in the
-kernel and has no such ceiling.
+on a worker thread and starts one whenever no worker is free, so the
+ceiling is `RLIMIT_NPROC`, `kernel.threads-max` and the memory for the
+stacks; when the OS refuses a thread, `port/read` and friends signal that
+refusal rather than the runtime pre-empting it with a smaller number of
+its own. io_uring runs its operations in the kernel and has no such
+ceiling.
 
-`(io/workers backend)` reports how many worker threads a backend has out,
-and `ev/report` carries the running scheduler's count as `:workers`.
+A worker that finishes an operation waits for the next one instead of
+exiting, and retires after ten idle seconds. So a program that keeps
+asking for I/O pays for a thread once rather than per operation, and one
+that stops asking stops paying.
+
+`*io-keepalive*` is that wait, in seconds. A scheduler reads it when it
+makes its backend, so bind it around the `ev/run` whose I/O it should
+govern; `0` turns reuse off, and every operation then starts and ends a
+thread of its own.
+
+```lisp
+# (parameterize ((*io-keepalive* 0))
+#   (ev/run (fn [] ...)))    # a thread per operation, nothing kept
+```
+
+`(io/workers backend)` reports how many operations a backend has out —
+the workers busy right now, not the ones waiting for work — and
+`ev/report` carries the running scheduler's count as `:workers`.
 
 ## Ports
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -42,6 +42,16 @@ redirects output:
 #   (println "goes to my-port, not terminal"))
 ```
 
+`*io-keepalive*` is how long an idle I/O worker thread waits for another
+operation before it retires, in seconds. `nil` takes the runtime's own
+default; `0` turns worker reuse off. A scheduler reads it when it makes
+its backend, so bind it around the `ev/run` whose I/O it should govern:
+
+```lisp
+# (parameterize ((*io-keepalive* 0))
+#   (ev/run (fn [] ...)))
+```
+
 ---
 
 ## See also

--- a/docs/posix-signals.md
+++ b/docs/posix-signals.md
@@ -171,8 +171,10 @@ process killer.
    `pthread_sigmask`-unblocking the watched signals on the
    threadpool worker thread that calls `kevent()`. The kernel picks
    that worker as the delivery target, runs the no-op, and the
-   knote activates so `kevent()` returns. None of this is visible to
-   Lisp.
+   knote activates so `kevent()` returns. The unblock lasts for that
+   read alone: a worker runs the operations submitted after it too,
+   and every other one needs the thread unselectable for delivery.
+   None of this is visible to Lisp.
 
 `(os/sig-mask)` always reflects the actual `pthread_sigmask` on the
 calling thread — i.e. the main thread (and other elle-spawned
@@ -223,7 +225,7 @@ kernel fd based on platform and CLI flags:
 | Platform | Default | `--no-uring` |
 |----------|---------|--------------|
 | Linux | `IORING_OP_READ` on the signalfd, via the dedicated `submit_uring_sig_next` SQE helper. The read is queued on the io_uring instance and the kernel completes a CQE when one or more `signalfd_siginfo` records become available. No worker thread is involved on the elle side. | The threadpool worker waits for the signalfd and for the operation's stop pipe together, then `read(2)`s the signalfd. Uses one OS thread per outstanding `os/sig-next`, given back when the read completes or is cancelled. |
-| macOS | n/a — io_uring is Linux-only | A threadpool worker waits for the kqueue and the stop pipe together, then calls `kevent()` with a zero timeout on a per-receiver kqueue registered with `EVFILT_SIGNAL`. The worker temporarily `pthread_sigmask`-unblocks the watched signals on itself so the kernel can pick it as the delivery target (see "macOS: per-receive worker unblock + no-op handler" above). |
+| macOS | n/a — io_uring is Linux-only | A threadpool worker waits for the kqueue and the stop pipe together, then calls `kevent()` with a zero timeout on a per-receiver kqueue registered with `EVFILT_SIGNAL`. The worker `pthread_sigmask`-unblocks the watched signals on itself for that read so the kernel can pick it as the delivery target, and blocks them again before it takes another operation (see "macOS: per-receive worker unblock + no-op handler" above). |
 
 The threadpool path on Linux is exercised only when `--no-uring` is
 passed on the CLI or `io_uring_setup(2)` fails on the host kernel

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -158,7 +158,7 @@ struct:
 |---|---|
 | `:runnable` | fibers queued to run on the next drain |
 | `:io` | submitted I/O operations with no completion yet |
-| `:workers` | background worker threads out for those operations (zero on io_uring, which runs them in the kernel) |
+| `:workers` | those operations that a background worker is busy with, idle workers excluded (zero on io_uring, which runs them in the kernel) |
 | `:joins` | fibers with at least one join waiter |
 | `:selects` | fibers parked on a select set |
 | `:forwarded` | I/O submitted for a child scheduler |

--- a/src/io/AGENTS.md
+++ b/src/io/AGENTS.md
@@ -22,7 +22,8 @@ to a backend for execution.
 | `sockaddr.rs` | Sockaddr construction, formatting, parsing — single source of truth |
 | `threadpool.rs` | `CompletionHub` (the one shared completion channel), `RawCompletion`, `PoolOp`, `PoolCompletion`, `StdinThread` — typed thread-pool I/O. Every spawned worker calls `crate::io::sigfd::mask_all_signals_on_this_thread()` first so the kernel never selects it as a POSIX-signal delivery target. |
 | `threadpool/opbound.rs` | `Bounds` and `OpBound` — the declared and the live half of one operation's bound — plus `Wake`, the stop pipe, `take_when_ready` and `pace_retry`. |
-| `threadpool/submitop.rs` | `CompletionHub::submit`: spawn the worker, run the operation, publish the result. The `match` there names each operation's runner and the descriptor its bound watches. |
+| `threadpool/submitop.rs` | `CompletionHub::submit`: hand the operation to a worker, run it, publish the result. The `match` there names each operation's runner and the descriptor its bound watches. |
+| `threadpool/pool.rs` | `WorkerPool`, `Crew` and `Job` — the parked workers' handoffs, and the choice between handing a job to one of them and starting a thread. See § "How a worker is reused". |
 | `threadpool/{stream,net,event,child,open}.rs` | The runners, grouped by what they wait on: byte streams, sockets, event descriptors (inotify / kqueue / signalfd), a child's exit, a file open. |
 | `uring.rs` | io_uring SQE submission and CQE processing (Linux only). The standing `POLL_ADD` on the hub's bridge eventfd carries the `EVENTFD_USER_DATA` sentinel; `drain_cqes` reports it as `eventfd_fired` and the wait/poll path clears + re-arms it. |
 | `eventfd.rs` | Bridge eventfd helpers — `create`/`signal`/`drain` (Linux only). One definition of each eventfd syscall, shared by the io_uring bridge and `primitives::chan`'s wake fd. |
@@ -122,7 +123,7 @@ Typed thread-pool submission and completion:
   cooked `Completion` (the cook fns need main-thread `pending`/`fd_states`/
   `buffer_pool`/`origin_heap`), so it sends its raw result; the receiver matches
   once and dispatches to `pool_to_completion` / `stdin_to_completion`.
-- `CompletionHub { sender, receiver, in_flight, eventfd }` — the **one** completion
+- `CompletionHub { sender, receiver, in_flight, eventfd, stops, pool }` — the **one** completion
   channel all background work feeds: every thread-pool worker and the stdin worker
   holds a `Sender<RawCompletion>` clone. Collapsing the former platform-pool,
   network-pool, and stdin channels into one means the scheduler's blocking wait
@@ -133,7 +134,8 @@ Typed thread-pool submission and completion:
   cancelled op's reaped completion still decrements; `io/cancel` must not also
   decrement). `eventfd` is the Linux/uring bridge fd (`None` on the pool-only
   platforms) a worker writes after `send` so the ring's single wait observes the
-  edge.
+  edge. `stops` is the write end of each submitted operation's stop pipe, by id.
+  `pool` is the crew that runs the operations — see § "How a worker is reused".
 
 ### ConnectAddr
 
@@ -546,22 +548,105 @@ exit cleanly. Pinned by `closing_a_listener_ends_its_parked_pool_accept`
 
 ### How many operations run at once
 
-The OS decides. A pool operation is one `std::thread::Builder::spawn`, so
-the ceiling is `RLIMIT_NPROC`, `kernel.threads-max` and the memory for the
-stacks — limits the operator set, on a machine the runtime cannot survey.
+The OS decides. A pool operation runs on a worker thread, and a thread is
+started whenever no idle worker is there to take the job, so the ceiling is
+`RLIMIT_NPROC`, `kernel.threads-max` and the memory for the stacks — limits
+the operator set, on a machine the runtime cannot survey.
 `Builder::spawn` rather than `thread::spawn` is what makes deferring to
 them possible: `thread::spawn` panics when the OS refuses, while a
 `Builder` refusal becomes the error `io/submit` returns and the calling
 fiber can handle.
 
+Nothing caps the count, and nothing may. An operation can wait for an event
+outside this process — an accept nobody connects to, a read whose peer never
+writes — and such an operation ends only through its deadline or its stop
+pipe. Under a cap the next submission would queue behind that wait, and the
+fiber that would issue the write ending it is a fiber the cap is holding up.
+So the crew grows to whatever is asked of it.
+
 `io/workers` reports how many operations are submitted and not yet reaped
-— the threads out right now — and `ev/report` carries it as `:workers`.
-That is a measurement, not a budget: nothing consults it to decide whether
-a submission may proceed.
+— the workers busy right now, not the ones parked waiting for work — and
+`ev/report` carries it as `:workers`. That is a measurement, not a budget:
+nothing consults it to decide whether a submission may proceed.
 
 io_uring has no equivalent count. Its operations run in the kernel, so
 `workers()` is zero there and the only limit is the 256-entry submission
 queue, which drains as it is submitted.
+
+### How a worker is reused
+
+A worker that finishes an operation waits for another instead of exiting, so
+the next submission costs a channel send rather than a thread. `WorkerPool`
+(`threadpool/pool.rs`) is the crew and the handoffs that reach it.
+What reuse buys is wall clock under contention: starting and tearing down a
+thread costs kernel work that scales with how many elle processes are doing it
+at once, while the operation itself costs the same either way.
+
+Each parked worker posts a **handoff** — a channel of its own — and a
+submission takes one out of the list and sends the job through it, or starts a
+thread when the list is empty. A worker leaves only by withdrawing its own
+handoff under the same lock, so a claimed worker is committed to the job it was
+handed. That is what keeps the handover from becoming the cap the section above
+forbids: a job never waits behind a parked operation, because a job is only
+ever handed to a worker that is already waiting for one.
+
+**A worker sleeps rather than spins, and that is measured.** The handoff is a
+condition variable, not a channel, because a channel receiver spins before it
+sleeps and this wait happens once per operation. Where there are more cores
+than threads that spin is free and often saves the sleep; where there are
+fewer, it burns the cores the rest of the program is waiting for. On a
+three-core runner the channel cost the heaviest corpus files **twice the user
+CPU** they cost with no pool at all — 2.4s → 5.5s on one of them — while the
+same files on a thirty-two-core box were unchanged either way. That is the
+whole reason this is a `Condvar` and a slot rather than four lines of
+crossbeam, and why a machine with spare cores cannot measure it.
+
+**The list is a stack.** A submission takes the worker that parked most
+recently: it is the one still warm, and the workers the traffic no longer
+reaches sit at the bottom and age out of the keepalive instead of being woken
+in turn. This is a reasoned default rather than a measured win — the wake order
+was not what the three-core runner was punishing — but it is the order the crew
+is built on, so a test pins it.
+
+A worker that parks for the keepalive without being handed a job retires, so a
+program that stops doing I/O stops paying for threads. It retires only if it can
+withdraw its own handoff. Finding nothing to withdraw means a submission took it
+already and a job is on its way, so the worker waits on without a deadline
+rather than leaving and stranding it. Under the stack, the workers that age out
+this way are the ones the traffic no longer reaches.
+
+The keepalive is the program's, not the process's: `*io-keepalive*` binds the
+seconds, a scheduler reads that parameter when it builds its backend, and
+`(io/backend :async k)` carries it to the hub. `nil` takes `DEFAULT_KEEPALIVE`,
+which is where the default number and the two costs it trades off are written
+down. `0` retires a worker as soon as it has nothing to do — the
+counter-factual switch, one thread per operation, and what makes the difference
+reuse buys measurable rather than asserted. Two schedulers in one process can
+answer differently, so this is a parameter rather than a dialect.
+
+Pinned by `a_backend_takes_the_keepalive_it_was_given`
+(`src/io/aio/tests/backend.rs`) for the path from the argument to the crew, and
+by `tests/elle/io.lisp` § "worker keepalive" for the parameter and the forms
+`io/backend` accepts.
+
+Dropping the backend drops every posted handoff, so each parked worker's wait
+reports the disconnect, and it sets the flag that a worker still running an
+operation reads when it goes to park. The crew winds down on both paths with
+nothing to join.
+
+A worker outlives the operations it runs, so what an operation does to its
+thread must not survive it. Blocking every asynchronous signal is therefore
+what a worker is started with rather than what each job does
+(`mask_all_signals_on_this_thread`), and the one operation that needs a
+different mask — the macOS `EVFILT_SIGNAL` read, which must be selectable for
+delivery — puts back what it found
+(`the_macos_signal_read_blocks_again_what_it_unblocked`,
+`src/io/threadpool/tests/signals.rs`).
+
+Pinned by `src/io/threadpool/tests/pool.rs`: a second submission runs on the
+first one's thread, the next job goes to the worker that parked last, a parked
+operation delays no other submission, an idle worker retires, and a zero
+keepalive gives every operation its own thread.
 
 ## One id, one operation
 

--- a/src/io/aio.rs
+++ b/src/io/aio.rs
@@ -101,17 +101,30 @@ impl AsyncBackend {
     ///
     /// On Linux with the `io-uring` feature, attempts io_uring first.
     /// Falls back to thread-pool on failure or on non-Linux platforms.
-    /// Uses the process-default Unicode generation; a backend serving a VM
-    /// with an explicit generation is built via [`Self::new_with_unicode`].
+    /// Uses the process-default Unicode generation and the default worker
+    /// keepalive; a backend serving a VM with an explicit generation, or a
+    /// program that asked for a keepalive of its own, is built via
+    /// [`Self::new_with_unicode`].
     pub fn new() -> Result<Self, String> {
-        Self::new_with_unicode(crate::config::get().unicode_generation())
+        Self::new_with_unicode(crate::config::get().unicode_generation(), None)
     }
 
     /// Create a new async backend serving a VM with the given Unicode
     /// generation.
-    pub fn new_with_unicode(gen: crate::segment::Generation) -> Result<Self, String> {
+    ///
+    /// `keepalive` is how long an idle pool worker waits for another operation
+    /// before it retires — what the submitting program bound `*io-keepalive*`
+    /// to. `None` takes `DEFAULT_KEEPALIVE`. It reaches the pool platform only;
+    /// io_uring runs its operations in the kernel and keeps no workers.
+    pub fn new_with_unicode(
+        gen: crate::segment::Generation,
+        keepalive: Option<Duration>,
+    ) -> Result<Self, String> {
         let mut platform = Self::create_platform_backend();
-        let mut hub = CompletionHub::new();
+        let mut hub = match keepalive {
+            Some(d) => CompletionHub::with_keepalive(d),
+            None => CompletionHub::new(),
+        };
         // On the uring platform, wire the eventfd bridge: a hub worker raises
         // the eventfd after publishing, and a standing POLL_ADD on the ring
         // turns that edge into a CQE so the scheduler's single io_uring wait
@@ -150,6 +163,15 @@ impl AsyncBackend {
     /// comes up with.
     #[cfg(test)]
     pub(crate) fn new_thread_pool() -> Result<Self, String> {
+        Self::new_thread_pool_with_keepalive(None)
+    }
+
+    /// A thread-pool backend whose workers retire after `keepalive` without a
+    /// job, as `*io-keepalive*` asks of one. `None` takes the default.
+    #[cfg(test)]
+    pub(crate) fn new_thread_pool_with_keepalive(
+        keepalive: Option<Duration>,
+    ) -> Result<Self, String> {
         Ok(AsyncBackend {
             inner: RefCell::new(AsyncBackendInner {
                 unicode_generation: crate::config::get().unicode_generation(),
@@ -160,7 +182,10 @@ impl AsyncBackend {
                 buffer_pool: BufferPool::new(),
                 stdin_thread: None,
                 platform: PlatformBackend::ThreadPool,
-                hub: CompletionHub::new(),
+                hub: match keepalive {
+                    Some(d) => CompletionHub::with_keepalive(d),
+                    None => CompletionHub::new(),
+                },
                 origin_heap: std::ptr::null_mut(),
                 submitter: crate::io::pending::Submitter::detached(std::ptr::null_mut()),
             }),
@@ -234,6 +259,13 @@ impl AsyncBackend {
     #[cfg(all(target_os = "linux", test))]
     pub(crate) fn is_uring(&self) -> bool {
         matches!(self.inner.borrow().platform, PlatformBackend::Uring(_))
+    }
+
+    /// How long this backend's idle pool workers wait for another operation
+    /// before retiring — what `*io-keepalive*` asked for, or the default.
+    #[cfg(test)]
+    pub(crate) fn keepalive(&self) -> Duration {
+        self.inner.borrow().hub.keepalive()
     }
 
     /// The ids of every operation still in flight, ascending. Tests pin the

--- a/src/io/aio/tests/backend.rs
+++ b/src/io/aio/tests/backend.rs
@@ -6,6 +6,34 @@ fn test_async_backend_new() {
     assert!(backend.is_ok());
 }
 
+/// The keepalive a program names reaches the crew that reads it.
+///
+/// `(io/backend :async k)` is the whole path from `*io-keepalive*` to the
+/// worker that parks: the primitive turns the seconds into a `Duration`, the
+/// backend hands it to the hub, and the hub's pool is what waits. Nothing a
+/// completion carries reports the wait, so the plumbing is pinned here and the
+/// behavior it buys is pinned in `src/io/threadpool/tests/pool.rs`.
+///
+/// The counter-factual: a backend that dropped the argument and built its hub
+/// with `CompletionHub::new()` passes every other test in this file.
+#[test]
+fn a_backend_takes_the_keepalive_it_was_given() {
+    let named = AsyncBackend::new_thread_pool_with_keepalive(Some(Duration::from_millis(250)))
+        .expect("a pool backend");
+    assert_eq!(named.keepalive(), Duration::from_millis(250));
+
+    let off =
+        AsyncBackend::new_thread_pool_with_keepalive(Some(Duration::ZERO)).expect("a pool backend");
+    assert!(off.keepalive().is_zero(), "zero turns worker reuse off");
+
+    let unnamed = AsyncBackend::new_thread_pool().expect("a pool backend");
+    assert_eq!(
+        unnamed.keepalive(),
+        crate::io::threadpool::DEFAULT_KEEPALIVE,
+        "a backend given no keepalive takes the default"
+    );
+}
+
 #[test]
 fn test_submit_returns_monotonic_ids() {
     crate::value::arena::with_test_region(|| {

--- a/src/io/threadpool.rs
+++ b/src/io/threadpool.rs
@@ -220,9 +220,16 @@ mod opbound;
 pub(super) use opbound::Bounds;
 use opbound::*;
 
-// `submitop` is the frame every operation shares — spawn, run, publish. The
-// rest are the runners it dispatches to, grouped by what they wait on.
+// `submitop` is the frame every operation shares — hand over, run, publish.
+// The rest are the runners it dispatches to, grouped by what they wait on.
 mod submitop;
+
+mod pool;
+/// The wait a backend that named no keepalive of its own takes, so a test can
+/// tell "the default" from a value a caller asked for.
+#[cfg(test)]
+pub(in crate::io) use pool::DEFAULT_KEEPALIVE;
+use pool::{Job, WorkerPool};
 
 mod child;
 mod event;
@@ -247,9 +254,9 @@ pub(super) struct CompletionHub {
     ///
     /// Two readers, and neither caps anything: `AsyncBackend::wait` asks whether
     /// there is any worker out before it blocks on the channel, and `io/workers`
-    /// reports it. Concurrency is uncapped by design — `submit` spawns a thread
-    /// per operation and lets the OS say how many may run (see its doc), so
-    /// there is no cap for this count to enforce.
+    /// reports it. Concurrency is uncapped by design — the pool starts a worker
+    /// whenever none is free and lets the OS say how many may run (see
+    /// `WorkerPool`), so there is no cap for this count to enforce.
     in_flight: usize,
     /// Linux/uring bridge fd. `None` on the pool-only platforms, where the hub
     /// channel is itself the sole waitable. When `Some`, a worker writes it
@@ -260,10 +267,23 @@ pub(super) struct CompletionHub {
     /// ends the operation without disturbing the descriptor — which a port the
     /// caller still holds would not survive.
     stops: HashMap<u64, RawFd>,
+    /// The worker threads the operations run on. A finished worker parks here
+    /// for the next submission instead of ending, and the pool starts a thread
+    /// only when none is parked.
+    pool: WorkerPool,
 }
 
 impl CompletionHub {
+    /// A hub whose workers wait `DEFAULT_KEEPALIVE` for another job. This is
+    /// what a backend that was given no keepalive of its own takes.
     pub(super) fn new() -> Self {
+        Self::with_keepalive(pool::DEFAULT_KEEPALIVE)
+    }
+
+    /// A hub whose workers retire after `keepalive` without a job — what the
+    /// program asked for through `*io-keepalive*`, and what a test that wants
+    /// to watch a worker retire names rather than sitting out the default.
+    pub(super) fn with_keepalive(keepalive: Duration) -> Self {
         let (sender, receiver) = crossbeam_channel::unbounded();
         CompletionHub {
             sender,
@@ -271,6 +291,7 @@ impl CompletionHub {
             in_flight: 0,
             eventfd: None,
             stops: HashMap::new(),
+            pool: WorkerPool::new(keepalive),
         }
     }
 
@@ -329,6 +350,13 @@ impl CompletionHub {
     /// True when any pool/stdin op is submitted-but-unreaped.
     pub(super) fn in_flight(&self) -> usize {
         self.in_flight
+    }
+
+    /// How long this hub's workers wait for another job before retiring. The
+    /// test that pins `*io-keepalive*` reaching the crew reads it here.
+    #[cfg(test)]
+    pub(crate) fn keepalive(&self) -> Duration {
+        self.pool.keepalive()
     }
 
     /// Account one submitted worker op (a pool submit or a stdin request).

--- a/src/io/threadpool/event.rs
+++ b/src/io/threadpool/event.rs
@@ -97,19 +97,13 @@ pub(super) fn kq_sig_read(
         trace,
         format_args!("macos: kq_sig_read entered kq={} signals={:?}", kq, signals),
     );
-    // Unblock the watched signals on this thread for the lifetime of the
-    // worker. The worker is single-use (each PoolOp spawns a fresh thread that
-    // exits after sending the completion), so we don't restore on return.
-    let mut to_unblock: libc::sigset_t = unsafe { std::mem::zeroed() };
-    unsafe { libc::sigemptyset(&mut to_unblock) };
-    for &s in signals {
-        unsafe { libc::sigaddset(&mut to_unblock, s) };
-    }
-    let unblock_ret =
-        unsafe { libc::pthread_sigmask(libc::SIG_UNBLOCK, &to_unblock, std::ptr::null_mut()) };
+    // Unblock the watched signals on this thread for this read, and no longer:
+    // a worker runs the operations that come after this one too, and every
+    // other operation needs the thread unselectable for delivery.
+    let unblocked = Unblocked::on_this_thread(signals);
     posix_trace(
         trace,
-        format_args!("macos: kq_sig_read SIG_UNBLOCK ret={}", unblock_ret),
+        format_args!("macos: kq_sig_read SIG_UNBLOCK ret={}", unblocked.ret),
     );
 
     let mut eventlist: [libc::kevent; 32] = unsafe { std::mem::zeroed() };
@@ -130,6 +124,38 @@ pub(super) fn kq_sig_read(
         data.extend_from_slice(&count.to_le_bytes());
     }
     (data.len() as i32, data)
+}
+
+/// A set of signals this thread has unblocked, blocked again when dropped.
+///
+/// Restoring is a plain `SIG_BLOCK` of the same set because a worker starts
+/// with every asynchronous signal blocked (`mask_all_signals_on_this_thread`),
+/// so blocking what this unblocked is exactly the mask it found.
+#[cfg(target_os = "macos")]
+pub(super) struct Unblocked {
+    set: libc::sigset_t,
+    /// What `pthread_sigmask` reported, for the operation's trace.
+    ret: libc::c_int,
+}
+
+#[cfg(target_os = "macos")]
+impl Unblocked {
+    pub(super) fn on_this_thread(signals: &[libc::c_int]) -> Self {
+        let mut set: libc::sigset_t = unsafe { std::mem::zeroed() };
+        unsafe { libc::sigemptyset(&mut set) };
+        for &s in signals {
+            unsafe { libc::sigaddset(&mut set, s) };
+        }
+        let ret = unsafe { libc::pthread_sigmask(libc::SIG_UNBLOCK, &set, std::ptr::null_mut()) };
+        Unblocked { set, ret }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for Unblocked {
+    fn drop(&mut self) {
+        unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, &self.set, std::ptr::null_mut()) };
+    }
 }
 
 /// Take one batch of events from `kq` under the operation's bound.

--- a/src/io/threadpool/pool.rs
+++ b/src/io/threadpool/pool.rs
@@ -1,0 +1,358 @@
+//! The crew of worker threads a [`CompletionHub`] runs its operations on.
+//!
+//! A worker outlives the operation it was started for: it parks on the job
+//! queue and takes the next submission, so a program that keeps asking for I/O
+//! pays for a thread once rather than per operation. See src/io/AGENTS.md
+//! § "How a worker is reused" for what that costs and what it must not cost.
+
+use super::*;
+use crossbeam_channel::Sender;
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Instant;
+
+/// How long a parked worker waits for a job when the caller named no keepalive
+/// of its own — `(io/backend :async nil)`, and every backend built from Rust.
+///
+/// The number trades two costs, and neither is a cliff: a worker that retires
+/// too eagerly makes the next operation pay for a thread, and one that lingers
+/// holds a stack and costs a wakeup per period. Ten seconds is longer than the
+/// gap between operations of a program that is doing I/O at all, and short
+/// enough that one which has stopped gives its threads back while it is still
+/// running. A program with a reason to prefer another number says so through
+/// `*io-keepalive*` (docs/parameters.md) rather than living with this one.
+pub(in crate::io) const DEFAULT_KEEPALIVE: Duration = Duration::from_secs(10);
+
+/// One operation, and everything the worker that runs it needs to report it.
+///
+/// The channel and the bridge descriptor travel with the job rather than with
+/// the worker: a worker serves whatever is queued, and each job answers to the
+/// hub that submitted it.
+pub(super) struct Job {
+    pub(super) id: u64,
+    pub(super) kind: OpKind,
+    pub(super) op: PoolOp,
+    pub(super) bounds: Bounds,
+    pub(super) sender: Sender<RawCompletion>,
+    pub(super) eventfd: Option<RawFd>,
+}
+
+impl Job {
+    /// Run the operation to its result and package that for the hub channel.
+    fn run(self) -> Delivery {
+        let Job {
+            id,
+            kind,
+            op,
+            bounds,
+            sender,
+            eventfd,
+        } = self;
+        let (result_code, data) = submitop::run(op, bounds);
+        Delivery {
+            sender,
+            eventfd,
+            completion: RawCompletion::Pool(PoolCompletion {
+                id,
+                kind,
+                result_code,
+                data,
+            }),
+        }
+    }
+}
+
+/// A finished operation's result, and where it goes back to.
+struct Delivery {
+    sender: Sender<RawCompletion>,
+    eventfd: Option<RawFd>,
+    completion: RawCompletion,
+}
+
+impl Delivery {
+    fn publish(self) {
+        publish_completion(&self.sender, self.eventfd, self.completion);
+    }
+}
+
+/// The workers a hub runs operations on, and the handoffs that reach the parked
+/// ones.
+pub(super) struct WorkerPool {
+    /// What the workers share.
+    crew: Arc<Crew>,
+    /// How many threads this pool has started. Names them, and the number is
+    /// the worker's identity when it withdraws its own handoff.
+    started: u64,
+}
+
+/// The half of the pool a worker holds: the parked workers' handoffs and how
+/// long one waits before retiring.
+struct Crew {
+    parked: Mutex<Parked>,
+    /// How long a worker waits for another job before it retires — what the
+    /// program bound `*io-keepalive*` to, or [`DEFAULT_KEEPALIVE`]. Zero turns
+    /// reuse off, and `next_job` is where that is exact.
+    keepalive: Duration,
+}
+
+/// The parked workers, and whether the pool they serve is still there.
+struct Parked {
+    /// One handoff per parked worker, **most recently parked last**.
+    ///
+    /// A submission takes from the end, so the next job goes to the worker that
+    /// stopped working most recently — the warm one — and the workers the
+    /// traffic no longer reaches sit at the bottom and age out of the
+    /// keepalive. See src/io/AGENTS.md § "How a worker is reused" for what this
+    /// order is and is not known to buy.
+    workers: Vec<Handoff>,
+    /// True once the pool is gone. A worker still running a job when that
+    /// happens retires when it finishes rather than parking for a keepalive
+    /// nobody will interrupt.
+    closed: bool,
+}
+
+/// One parked worker: the slot a submission leaves its job in, and the identity
+/// the worker withdraws that slot by.
+struct Handoff {
+    worker: u64,
+    slot: Arc<Slot>,
+}
+
+/// Where one worker waits, and what it waits for.
+///
+/// A condition variable rather than a channel, because this wait happens once
+/// per operation and a channel receiver **spins** before it sleeps. On a
+/// machine with more cores than threads that spin is free and often saves the
+/// sleep; on one with fewer, it burns the cores the rest of the program is
+/// waiting for — twice the user CPU for the heaviest corpus files, measured on
+/// a three-core runner. `wait_timeout` sleeps immediately, so an operation that
+/// hands work over pays a wake and nothing else.
+struct Slot {
+    state: Mutex<SlotState>,
+    filled: Condvar,
+}
+
+struct SlotState {
+    /// The job a submission left here, taken by the worker that owns the slot.
+    job: Option<Job>,
+    /// True once the pool is gone, so a parked worker stops waiting for a job
+    /// that can no longer be handed to it.
+    closed: bool,
+}
+
+impl Slot {
+    fn new() -> Arc<Slot> {
+        Arc::new(Slot {
+            state: Mutex::new(SlotState {
+                job: None,
+                closed: false,
+            }),
+            filled: Condvar::new(),
+        })
+    }
+
+    /// Leave `job` for the worker that owns this slot and wake it. The slot is
+    /// empty by construction: a submission gets here only by taking this
+    /// worker's handoff, and the worker posts one handoff at a time.
+    fn fill(&self, job: Job) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.job = Some(job);
+        drop(state);
+        self.filled.notify_one();
+    }
+
+    /// Tell the worker that owns this slot that nothing more is coming.
+    fn close(&self) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.closed = true;
+        drop(state);
+        self.filled.notify_one();
+    }
+
+    /// Wait up to `limit` for a job. `None` means the wait ended without one —
+    /// the keepalive elapsed, or the pool went away.
+    fn wait(&self, limit: Duration) -> Option<Job> {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let deadline = Instant::now() + limit;
+        loop {
+            if let Some(job) = state.job.take() {
+                return Some(job);
+            }
+            if state.closed {
+                return None;
+            }
+            let left = deadline.saturating_duration_since(Instant::now());
+            if left.is_zero() {
+                return None;
+            }
+            state = self
+                .filled
+                .wait_timeout(state, left)
+                .unwrap_or_else(|e| e.into_inner())
+                .0;
+        }
+    }
+
+    /// Wait without a deadline for the job a submission has already committed
+    /// to leaving here.
+    fn wait_committed(&self) -> Option<Job> {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        loop {
+            if let Some(job) = state.job.take() {
+                return Some(job);
+            }
+            if state.closed {
+                return None;
+            }
+            state = self.filled.wait(state).unwrap_or_else(|e| e.into_inner());
+        }
+    }
+}
+
+impl WorkerPool {
+    pub(super) fn new(keepalive: Duration) -> Self {
+        WorkerPool {
+            crew: Arc::new(Crew {
+                parked: Mutex::new(Parked {
+                    workers: Vec::new(),
+                    closed: false,
+                }),
+                keepalive,
+            }),
+            started: 0,
+        }
+    }
+
+    /// How long this pool's workers wait for another job before retiring.
+    #[cfg(test)]
+    pub(super) fn keepalive(&self) -> Duration {
+        self.crew.keepalive
+    }
+
+    /// Run `job`: hand it to a parked worker, or start one for it.
+    ///
+    /// The error is the OS refusing a thread. `Builder::spawn` rather than
+    /// `thread::spawn` is what makes that a report: `thread::spawn` panics,
+    /// while a refusal here becomes the error `io/submit` returns and the
+    /// calling fiber can handle.
+    pub(super) fn run(&mut self, job: Job) -> Result<(), String> {
+        // A claimed worker waits on its slot until this job arrives in it: it
+        // can leave only by withdrawing its own handoff under the lock the
+        // claim just held, so the job reaches the worker the claim took.
+        match self.crew.claim_parked() {
+            Some(slot) => {
+                slot.fill(job);
+                Ok(())
+            }
+            None => self.start_worker(job),
+        }
+    }
+
+    fn start_worker(&mut self, job: Job) -> Result<(), String> {
+        let crew = Arc::clone(&self.crew);
+        self.started += 1;
+        let me = self.started;
+        std::thread::Builder::new()
+            .name(format!("elle-io-{}", me))
+            .spawn(move || crew.work(me, job))
+            .map(|_detached| ())
+            .map_err(|e| format!("async I/O: cannot start a worker thread: {}", e))
+    }
+}
+
+impl Drop for WorkerPool {
+    fn drop(&mut self) {
+        // Closing every parked worker's slot ends its wait now rather than at
+        // its keepalive, and the flag catches the workers still running a job:
+        // both retire without a shutdown protocol and without anything to join.
+        let mut parked = self.crew.parked.lock().unwrap_or_else(|e| e.into_inner());
+        parked.closed = true;
+        for handoff in parked.workers.drain(..) {
+            handoff.slot.close();
+        }
+    }
+}
+
+impl Crew {
+    /// Run `first`, then every job handed over afterwards, until this worker
+    /// retires or the pool goes away. `me` is what its handoff is filed under.
+    fn work(&self, me: u64, first: Job) {
+        // Block every asynchronous signal on this worker so the kernel never
+        // selects it as the delivery target for a watched POSIX signal. The
+        // fault set stays deliverable. This is the thread's mask rather than
+        // one job's, because the thread outlives the job.
+        // See src/io/sigfd.rs and docs/posix-signals.md.
+        crate::io::sigfd::mask_all_signals_on_this_thread();
+        // One slot for this worker's whole life: it waits in the same place
+        // after every operation, so parking allocates nothing.
+        let slot = Slot::new();
+        let mut job = first;
+        loop {
+            let delivery = job.run();
+            match self.next_job(me, &slot, delivery) {
+                Some(next) => job = next,
+                None => return,
+            }
+        }
+    }
+
+    /// Post this worker's handoff, publish `delivery`, and wait for the next
+    /// job.
+    ///
+    /// The handoff is posted before the completion is published because the
+    /// completion is how a caller learns the operation ended, and the next
+    /// submission follows it immediately: a worker that posted afterwards would
+    /// be missed by the very submission it is there to take, which starts a
+    /// thread instead. Nothing between the two can park — a send on an
+    /// unbounded channel, and on the uring bridge an eventfd write.
+    ///
+    /// `None` retires this worker.
+    fn next_job(&self, me: u64, slot: &Arc<Slot>, delivery: Delivery) -> Option<Job> {
+        {
+            let mut parked = self.parked.lock().unwrap_or_else(|e| e.into_inner());
+            // Reuse turned off, or the pool gone: retire without ever posting a
+            // handoff. Posting one and withdrawing it would leave an instant in
+            // which a submission could still hand this worker a job, and a
+            // program that asked for no reuse would see reuse anyway.
+            if self.keepalive.is_zero() || parked.closed {
+                drop(parked);
+                delivery.publish();
+                return None;
+            }
+            parked.workers.push(Handoff {
+                worker: me,
+                slot: Arc::clone(slot),
+            });
+        }
+        delivery.publish();
+        match slot.wait(self.keepalive) {
+            // A submission took this worker's handoff and filled its slot.
+            Some(job) => Some(job),
+            // The keepalive elapsed, or the pool closed the slot.
+            None => self.retire_or_wait(me, slot),
+        }
+    }
+
+    /// Retire this worker if its handoff is still posted, or wait on for the
+    /// job that took it.
+    ///
+    /// Withdrawing under the lock is what makes the two outcomes exclusive: a
+    /// submission that claimed this worker took the handoff out of the list
+    /// already, so finding nothing to withdraw means a job is on its way and
+    /// leaving would strand it.
+    fn retire_or_wait(&self, me: u64, slot: &Slot) -> Option<Job> {
+        {
+            let mut parked = self.parked.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(at) = parked.workers.iter().position(|h| h.worker == me) {
+                parked.workers.remove(at);
+                return None;
+            }
+        }
+        slot.wait_committed()
+    }
+
+    /// Take the most recently parked worker's slot, if any worker is parked.
+    fn claim_parked(&self) -> Option<Arc<Slot>> {
+        let mut parked = self.parked.lock().unwrap_or_else(|e| e.into_inner());
+        parked.workers.pop().map(|handoff| handoff.slot)
+    }
+}

--- a/src/io/threadpool/submitop.rs
+++ b/src/io/threadpool/submitop.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl CompletionHub {
-    /// Submit a blocking I/O operation on a background worker thread; the worker
+    /// Submit a blocking I/O operation to a background worker thread; the worker
     /// reports its result back through the hub channel as a `RawCompletion::Pool`.
     ///
     /// `bounds` is how long the operation may wait and how `io/cancel` ends it.
@@ -10,13 +10,11 @@ impl CompletionHub {
     /// `src/io/AGENTS.md` § "The stop pipe" for the two conditions that decide
     /// which kind an operation needs.
     ///
-    /// How many operations may run at once is the OS's to say. The worker is
-    /// started with `Builder::spawn` rather than `thread::spawn` for exactly
-    /// that reason: `thread::spawn` panics when the OS refuses a thread, and a
-    /// refusal is something the calling fiber can be told about and handle.
-    /// So the ceiling here is `RLIMIT_NPROC`, `threads-max` and the memory for
-    /// the stacks — the limits the operator set — reported where they bind
-    /// rather than guessed at in advance.
+    /// How many operations may run at once is the OS's to say: the pool hands
+    /// the job to a worker that is already there or starts one, and the ceiling
+    /// is `RLIMIT_NPROC`, `threads-max` and the memory for the stacks — the
+    /// limits the operator set — reported where they bind rather than guessed
+    /// at in advance.
     pub(in crate::io) fn submit(
         &mut self,
         id: SubmissionId,
@@ -27,43 +25,28 @@ impl CompletionHub {
         // travels with it so the completion can be checked against the entry the
         // id resolves through — a submission table that has drifted is then a
         // report rather than a wrong-arm free (see `OpKind`).
-        let raw_id = id.as_u64();
-        let kind = op.kind();
-        let sender = self.sender();
-        let eventfd = self.eventfd();
-        let started = std::thread::Builder::new().spawn(move || {
-            let id = raw_id;
-            // Block every asynchronous signal on this worker so the kernel
-            // never selects it as the delivery target for a watched POSIX
-            // signal. The fault set stays deliverable.
-            // See src/io/sigfd.rs and docs/posix-signals.md.
-            crate::io::sigfd::mask_all_signals_on_this_thread();
-            let (result_code, data) = run(op, bounds);
-            publish_completion(
-                &sender,
-                eventfd,
-                RawCompletion::Pool(PoolCompletion {
-                    id,
-                    kind,
-                    result_code,
-                    data,
-                }),
-            );
-        });
-        match started {
-            Ok(_) => {
-                // Counted only once the worker exists, so a refused spawn
+        let job = Job {
+            id: id.as_u64(),
+            kind: op.kind(),
+            op,
+            bounds,
+            sender: self.sender(),
+            eventfd: self.eventfd(),
+        };
+        match self.pool.run(job) {
+            Ok(()) => {
+                // Counted only once a worker has the job, so a refused spawn
                 // leaves nothing behind to reap. Nothing can reap between the
                 // two either: the drain runs on this thread.
                 self.note_submit();
                 Ok(())
             }
             Err(e) => {
-                // A refused spawn drops the closure it was given, and the
-                // `Bounds` inside close the stop pipe's read end with them. The
-                // write end is the hub's, so retire it here.
+                // A refused spawn drops the job it was given, and the `Bounds`
+                // inside close the stop pipe's read end with them. The write
+                // end is the hub's, so retire it here.
                 self.forget_stop(id);
-                Err(format!("async I/O: cannot start a worker thread: {}", e))
+                Err(e)
             }
         }
     }
@@ -81,7 +64,7 @@ impl CompletionHub {
 /// `Task` and `Resolve` take no bound because nothing can bound them; their
 /// submissions say so with `Bounds::uninterruptible`, and dropping the bounds
 /// here is what disposes of them.
-fn run(op: PoolOp, bounds: Bounds) -> (i32, Vec<u8>) {
+pub(super) fn run(op: PoolOp, bounds: Bounds) -> (i32, Vec<u8>) {
     match op {
         PoolOp::Read { fd, size } => stream::read(OpBound::new(fd, bounds), fd, size),
         PoolOp::ReadExact {

--- a/src/io/threadpool/tests/mod.rs
+++ b/src/io/threadpool/tests/mod.rs
@@ -1,6 +1,7 @@
 // Unit tests for the threadpool backend, split by concern:
 //   - `hub`:      CompletionHub in_flight accounting (the one-channel invariant)
 //   - `opbound`:  the per-operation timeout bound, on a pipe
+//   - `pool`:     worker reuse: the crew's handover, growth, and retirement
 //   - `process`:  ProcessWait completion encoding
 //   - `openfile`: Open op fd/errno results
 //   - `signals`:  forked signalfd/kqueue read + close-time drain regressions
@@ -8,6 +9,7 @@
 mod hub;
 mod opbound;
 mod openfile;
+mod pool;
 mod process;
 mod signals;
 mod stdin;

--- a/src/io/threadpool/tests/pool.rs
+++ b/src/io/threadpool/tests/pool.rs
@@ -1,0 +1,252 @@
+//! Worker reuse, and the two costs it must not bring with it.
+//!
+//! A finished operation gives its worker back to the crew rather than ending
+//! the thread, so these tests ask three things of that crew: that the next
+//! operation lands on the worker already there, that an operation which parks
+//! never delays one behind it, and that a crew nobody is using shrinks.
+//!
+//! `PoolOp::Task` is the operation that must finish — its closure reports the
+//! thread it ran on, which is the one thing that tells a reused worker from a
+//! fresh one — and a `PoolOp::Read` on a pipe nobody writes to is the operation
+//! that must park.
+
+use super::super::*;
+use crate::io::SubmissionId;
+use std::time::{Duration, Instant};
+
+/// How long a test waits for a completion before calling the crew broken.
+const PATIENCE: Duration = Duration::from_secs(5);
+
+/// An operation that reports the OS thread it ran on.
+///
+/// Rust never reuses a `ThreadId` within a process, so two of these are equal
+/// exactly when one worker ran both operations.
+fn whoami() -> PoolOp {
+    PoolOp::Task(Box::new(|| {
+        (0, format!("{:?}", std::thread::current().id()).into_bytes())
+    }))
+}
+
+/// Submit `whoami()` under `id`, wait for its completion, and report the thread
+/// it named. The caller must have nothing else in flight.
+fn thread_of_next_operation(hub: &mut CompletionHub, id: u64) -> String {
+    hub.submit(
+        SubmissionId::from_raw(id),
+        whoami(),
+        Bounds::uninterruptible(),
+    )
+    .expect("the pool must accept the submission");
+    match hub.recv_blocking(Some(PATIENCE)) {
+        Some(RawCompletion::Pool(pc)) => {
+            assert_eq!(pc.id, id, "the completion must answer the submission");
+            String::from_utf8(pc.data).expect("the worker names its thread in UTF-8")
+        }
+        _ => panic!("no completion for submission {id} within {PATIENCE:?}"),
+    }
+}
+
+/// The second of two operations runs on the worker the first one left behind.
+///
+/// The trap this also guards: a worker that counted itself idle only *after*
+/// publishing its completion would make this race. A caller learns the
+/// operation ended by reaping that completion, and submits the next one the
+/// moment it has — so anything the crew must be true by then has to be true
+/// before the completion is sent.
+#[test]
+fn a_second_submission_runs_on_the_first_workers_thread() {
+    let mut hub = CompletionHub::new();
+    let first = thread_of_next_operation(&mut hub, 1);
+    let second = thread_of_next_operation(&mut hub, 2);
+    assert_eq!(
+        first, second,
+        "the worker that finished the first operation must take the second"
+    );
+}
+
+/// The next job goes to the worker that parked most recently.
+///
+/// The claim is that the warm worker takes the work and the ones the traffic
+/// no longer reaches age out of the keepalive at the bottom of the stack. It
+/// is a reasoned order, not a measured one: a run that changed only this
+/// order, on the three-core runner where the pool's costs show, moved nothing
+/// that could be told from noise.
+///
+/// The counter-factual: taking from the front of the list — the worker that
+/// has slept longest — passes every other test in this file and fails this
+/// one, so the order cannot drift unnoticed.
+#[test]
+fn the_next_job_goes_to_the_worker_that_parked_last() {
+    let mut hub = CompletionHub::new();
+    // Each task blocks until its gate opens, so both workers are busy at once
+    // and the order they park in is this test's to choose.
+    let (open_first, first_gate) = crossbeam_channel::bounded::<()>(1);
+    let (open_second, second_gate) = crossbeam_channel::bounded::<()>(1);
+    let gated = |gate: crossbeam_channel::Receiver<()>| {
+        PoolOp::Task(Box::new(move || {
+            let _ = gate.recv();
+            (0, format!("{:?}", std::thread::current().id()).into_bytes())
+        }))
+    };
+
+    for (id, gate) in [(1u64, first_gate), (2u64, second_gate)] {
+        hub.submit(
+            SubmissionId::from_raw(id),
+            gated(gate),
+            Bounds::uninterruptible(),
+        )
+        .expect("the pool must accept a gated submission");
+    }
+    assert_eq!(hub.in_flight(), 2, "two workers are busy");
+
+    let mut thread_of = |gate: crossbeam_channel::Sender<()>, id: u64| {
+        gate.send(()).expect("the worker is waiting on its gate");
+        match hub.recv_blocking(Some(PATIENCE)) {
+            Some(RawCompletion::Pool(pc)) => {
+                assert_eq!(pc.id, id, "the completion must answer the submission");
+                String::from_utf8(pc.data).expect("the worker names its thread in UTF-8")
+            }
+            _ => panic!("no completion for submission {id} within {PATIENCE:?}"),
+        }
+    };
+    let parked_first = thread_of(open_first, 1);
+    let parked_last = thread_of(open_second, 2);
+    assert_ne!(
+        parked_first, parked_last,
+        "two operations that overlap run on two workers"
+    );
+
+    let next = thread_of_next_operation(&mut hub, 3);
+    assert_eq!(
+        next, parked_last,
+        "the job must go to the most recently parked worker, not the coldest one"
+    );
+}
+
+/// A worker nobody gives another job to retires, and the submission after that
+/// starts a fresh one.
+///
+/// The counter-factual: a crew that parks its workers and never retires them
+/// passes the reuse test above and fails this one — a program that does a
+/// little I/O and then stops would hold those stacks for the rest of the
+/// process.
+#[test]
+fn an_idle_worker_retires_and_the_next_submission_starts_another() {
+    let keepalive = Duration::from_millis(50);
+    let mut hub = CompletionHub::with_keepalive(keepalive);
+    let first = thread_of_next_operation(&mut hub, 1);
+    // Ten keepalives, because what is being waited for is a loaded machine
+    // scheduling the worker's wakeup, not the wait itself.
+    std::thread::sleep(keepalive * 10);
+    let second = thread_of_next_operation(&mut hub, 2);
+    assert_ne!(
+        first, second,
+        "a worker that waited out its keepalive must be gone"
+    );
+}
+
+/// A zero keepalive is the counter-factual switch: no reuse at all.
+///
+/// `(*io-keepalive* 0)` is what a program binds to measure what reuse buys, so
+/// it has to mean what it says — a worker that retires the moment it has
+/// nothing to do, and a thread per operation.
+#[test]
+fn a_zero_keepalive_gives_every_operation_its_own_thread() {
+    let mut hub = CompletionHub::with_keepalive(Duration::ZERO);
+    let first = thread_of_next_operation(&mut hub, 1);
+    let second = thread_of_next_operation(&mut hub, 2);
+    assert_ne!(
+        first, second,
+        "a worker with no keepalive must not wait for a second operation"
+    );
+}
+
+/// Operations that park delay no submission behind them.
+///
+/// The counter-factual: a crew of some fixed size would pass every other test
+/// here and fail this one. The eight reads below wait on a pipe nobody writes
+/// to and end only when `stop` reaches them, so a crew that hands out a bounded
+/// number of workers has none left for the ninth submission — and the fiber
+/// that would write to the pipe is exactly the fiber such a bound would be
+/// holding up.
+#[test]
+fn parked_operations_do_not_delay_the_next_submission() {
+    const PARKED: u64 = 8;
+    const PROMPT: u64 = 100;
+
+    let mut hub = CompletionHub::new();
+    // One pipe for all eight reads: they are told to wait on a descriptor that
+    // never becomes readable, and one such descriptor serves however many
+    // operations wait on it.
+    let mut fds = [0 as libc::c_int; 2];
+    assert_eq!(
+        unsafe { libc::pipe(fds.as_mut_ptr()) },
+        0,
+        "the test needs a pipe"
+    );
+    let (read_fd, write_fd) = (fds[0], fds[1]);
+
+    for id in 1..=PARKED {
+        let id = SubmissionId::from_raw(id);
+        // A stop pipe and no deadline: nothing but `stop` ends these.
+        let bounds = hub.bounds(id, None);
+        hub.submit(
+            id,
+            PoolOp::Read {
+                fd: read_fd,
+                size: 16,
+            },
+            bounds,
+        )
+        .expect("the pool must accept a parking submission");
+    }
+
+    hub.submit(
+        SubmissionId::from_raw(PROMPT),
+        whoami(),
+        Bounds::uninterruptible(),
+    )
+    .expect("the pool must accept a submission behind eight parked ones");
+    assert_eq!(
+        hub.in_flight(),
+        PARKED as usize + 1,
+        "nine operations are out"
+    );
+
+    let deadline = Instant::now() + PATIENCE;
+    loop {
+        match hub.recv_blocking(Some(PATIENCE)) {
+            Some(RawCompletion::Pool(pc)) if pc.id == PROMPT => break,
+            Some(other) => panic!(
+                "only the ninth operation can complete while the pipe is silent, got id {}",
+                match other {
+                    RawCompletion::Pool(pc) => pc.id,
+                    RawCompletion::Stdin(sc) => sc.id,
+                }
+            ),
+            None => assert!(
+                Instant::now() < deadline,
+                "the operation behind eight parked ones never ran"
+            ),
+        }
+    }
+
+    // Wind the parked reads down before the pipe goes: each reports
+    // `-ECANCELED` once its stop pipe is written.
+    for id in 1..=PARKED {
+        hub.stop(SubmissionId::from_raw(id));
+    }
+    let deadline = Instant::now() + PATIENCE;
+    while hub.in_flight() > 0 {
+        hub.recv_blocking(Some(PATIENCE));
+        assert!(
+            Instant::now() < deadline,
+            "{} stopped operations never reported",
+            hub.in_flight()
+        );
+    }
+
+    unsafe {
+        libc::close(read_fd);
+        libc::close(write_fd);
+    }
+}

--- a/src/io/threadpool/tests/signals.rs
+++ b/src/io/threadpool/tests/signals.rs
@@ -1,5 +1,48 @@
 use super::super::*;
 
+/// The macOS signal read leaves the thread's mask as it found it.
+///
+/// The trap: `EVFILT_SIGNAL` only fires when the kernel can pick a thread to
+/// deliver to, so the read unblocks the watched signals on its own worker. A
+/// worker runs the operations submitted after that one too, and every one of
+/// them needs the thread unselectable for delivery — so the unblock has to end
+/// with the read rather than with the thread.
+///
+/// The counter-factual: without the restore this test's second assertion is the
+/// only thing that fails. Everything the signal path itself does still works —
+/// the leak shows up in some later operation's thread being chosen for a signal
+/// nobody meant it to take.
+#[cfg(target_os = "macos")]
+#[test]
+fn the_macos_signal_read_blocks_again_what_it_unblocked() {
+    fn blocked(signum: libc::c_int) -> bool {
+        let mut set: libc::sigset_t = unsafe { std::mem::zeroed() };
+        unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, std::ptr::null(), &mut set) };
+        unsafe { libc::sigismember(&set, signum) == 1 }
+    }
+
+    // Stand this thread up as a worker does: the signal blocked to start with.
+    let mut usr1: libc::sigset_t = unsafe { std::mem::zeroed() };
+    unsafe { libc::sigemptyset(&mut usr1) };
+    unsafe { libc::sigaddset(&mut usr1, libc::SIGUSR1) };
+    let mut previous: libc::sigset_t = unsafe { std::mem::zeroed() };
+    unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, &usr1, &mut previous) };
+
+    {
+        let _unblocked = super::super::event::Unblocked::on_this_thread(&[libc::SIGUSR1]);
+        assert!(
+            !blocked(libc::SIGUSR1),
+            "the read must make this thread selectable for delivery"
+        );
+    }
+    assert!(
+        blocked(libc::SIGUSR1),
+        "the read must block again what it unblocked"
+    );
+
+    unsafe { libc::pthread_sigmask(libc::SIG_SETMASK, &previous, std::ptr::null_mut()) };
+}
+
 /// Bounds for a signal read in a forked child. Every case here sends the signal
 /// it waits for, so the deadline is only there to make a regression a failed
 /// assertion rather than a child that hangs until the parent's own timeout.

--- a/src/primitives/io.rs
+++ b/src/primitives/io.rs
@@ -33,19 +33,59 @@ fn prim_is_io_backend(
     )
 }
 
-/// (io/backend kind) → backend
+/// A span of seconds an argument names, as an int or a float.
+///
+/// Three primitives take one — `ev/sleep`, `ev/poll-fd` and `io/backend` — and
+/// all three refuse the same values: not a number, negative, or infinite. The
+/// error names the caller and its kind, so a refusal reads as that primitive's.
+fn seconds(value: &Value, what: &str) -> Result<std::time::Duration, (&'static str, String)> {
+    let secs = if let Some(n) = value.as_int() {
+        n as f64
+    } else if let Some(f) = value.as_float() {
+        f
+    } else {
+        return Err((
+            "type-error",
+            format!("{}: expected a number of seconds", what),
+        ));
+    };
+    if secs < 0.0 || !secs.is_finite() {
+        return Err((
+            "argument-error",
+            format!("{}: seconds must be finite and non-negative", what),
+        ));
+    }
+    Ok(std::time::Duration::from_secs_f64(secs))
+}
+
+/// `(io/backend kind)` or `(io/backend kind keepalive)` → backend
+///
+/// `keepalive` is how long an idle worker thread waits for another operation
+/// before it retires, in seconds — what the program bound `*io-keepalive*` to.
+/// `nil` (or a call that omits it) takes the runtime's own default. It reaches
+/// the thread-pool platform only; io_uring keeps no workers to retire.
 fn prim_io_backend(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
 ) -> (SignalBits, Value) {
-    match args[0].as_keyword_name().as_deref() {
-        Some("async") => match AsyncBackend::new_with_unicode(ctx.unicode_generation()) {
-            Ok(backend) => {
-                let any = AnyBackend(Box::new(backend));
-                (SIG_OK, ctx.external("io-backend", any))
-            }
-            Err(msg) => (SIG_ERROR, ctx.error("io-error", msg)),
+    let keepalive = match args.get(1) {
+        None => None,
+        Some(v) if v.is_nil() => None,
+        Some(v) => match seconds(v, "io/backend") {
+            Ok(d) => Some(d),
+            Err((kind, msg)) => return (SIG_ERROR, ctx.error(kind, msg)),
         },
+    };
+    match args[0].as_keyword_name().as_deref() {
+        Some("async") => {
+            match AsyncBackend::new_with_unicode(ctx.unicode_generation(), keepalive) {
+                Ok(backend) => {
+                    let any = AnyBackend(Box::new(backend));
+                    (SIG_OK, ctx.external("io-backend", any))
+                }
+                Err(msg) => (SIG_ERROR, ctx.error("io-error", msg)),
+            }
+        }
         Some("mock") => {
             let any = AnyBackend(Box::new(MockBackend::new()));
             (SIG_OK, ctx.external("io-backend", any))
@@ -227,32 +267,10 @@ fn prim_ev_sleep(
     args: &[Value],
 ) -> (SignalBits, Value) {
     use crate::io::request::IoOp;
-    use std::time::Duration;
 
-    let duration = if let Some(n) = args[0].as_int() {
-        if n < 0 {
-            return (
-                SIG_ERROR,
-                ctx.error("argument-error", "ev/sleep: duration must be non-negative"),
-            );
-        }
-        Duration::from_secs(n as u64)
-    } else if let Some(f) = args[0].as_float() {
-        if f < 0.0 || !f.is_finite() {
-            return (
-                SIG_ERROR,
-                ctx.error(
-                    "argument-error",
-                    "ev/sleep: duration must be a finite non-negative number",
-                ),
-            );
-        }
-        Duration::from_secs_f64(f)
-    } else {
-        return (
-            SIG_ERROR,
-            ctx.error("type-error", "ev/sleep: argument must be a number"),
-        );
+    let duration = match seconds(&args[0], "ev/sleep") {
+        Ok(d) => d,
+        Err((kind, msg)) => return (SIG_ERROR, ctx.error(kind, msg)),
     };
 
     (SIG_IO, IoRequest::portless(ctx, IoOp::Sleep { duration }))
@@ -267,8 +285,6 @@ fn prim_ev_poll_fd(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
 ) -> (SignalBits, Value) {
-    use std::time::Duration;
-
     let fd = match args[0].as_int() {
         Some(n) if n >= 0 => n as std::os::unix::io::RawFd,
         _ => {
@@ -305,32 +321,10 @@ fn prim_ev_poll_fd(
     };
 
     let timeout = if args.len() == 3 {
-        let secs = if let Some(n) = args[2].as_int() {
-            if n < 0 {
-                return (
-                    SIG_ERROR,
-                    ctx.error("argument-error", "ev/poll-fd: timeout must be non-negative"),
-                );
-            }
-            n as f64
-        } else if let Some(f) = args[2].as_float() {
-            if f < 0.0 || !f.is_finite() {
-                return (
-                    SIG_ERROR,
-                    ctx.error(
-                        "argument-error",
-                        "ev/poll-fd: timeout must be a finite non-negative number",
-                    ),
-                );
-            }
-            f
-        } else {
-            return (
-                SIG_ERROR,
-                ctx.error("type-error", "ev/poll-fd: timeout must be a number"),
-            );
-        };
-        Some(Duration::from_secs_f64(secs))
+        match seconds(&args[2], "ev/poll-fd") {
+            Ok(d) => Some(d),
+            Err((kind, msg)) => return (SIG_ERROR, ctx.error(kind, msg)),
+        }
     } else {
         None
     };
@@ -360,9 +354,9 @@ primitive! {
     }
     "io/backend" => prim_io_backend {
         signal: Signal::errors(),
-        arity: Arity::Exact(1),
-        doc: "Create an I/O backend. :async for asynchronous, :mock for testing.",
-        params: &["kind"],
+        arity: Arity::Range(1, 2),
+        doc: "Create an I/O backend. :async for asynchronous, :mock for testing. Optional second arg is the worker keepalive in seconds (nil for the default): how long an idle I/O worker thread waits for another operation before it retires.",
+        params: &["kind", "keepalive"],
         category: "io",
         example: "(io/backend :async)",
         effect: RegionEffect::Fresh,

--- a/src/stdlib.lisp
+++ b/src/stdlib.lisp
@@ -1705,6 +1705,13 @@
 (def *scheduler* (make-parameter nil))
 (def *io-backend* (make-parameter nil))
 
+## How long an idle I/O worker thread waits for another operation before it
+## retires, in seconds. nil takes the runtime's default; 0 turns worker reuse
+## off, so every operation starts and ends a thread of its own. A scheduler
+## reads this when it makes its backend, so bind it around the `ev/run` whose
+## I/O it should govern.
+(def *io-keepalive* (make-parameter nil))
+
 ## ── Output ──────────────────────────────────────────────────────────
 
 (defn print [& args]
@@ -1745,7 +1752,7 @@
    :spawn — (fn [fiber]) registers fiber for async execution.
    :pump — (fn []) pumps event loop until all fibers complete.
    :shutdown — (fn [timeout-ms]) signal shutdown; pump-fn executes it."
-  (let [backend (io/backend :async)
+  (let [backend (io/backend :async (*io-keepalive*))
         runnable @[]
         pending @{}  # id → fiber (I/O submissions)
         fiber-io @{}  # fiber → id (reverse lookup for io/cancel)
@@ -2758,6 +2765,7 @@
    :*spawn* *spawn*
    :*scheduler* *scheduler*
    :*io-backend* *io-backend*
+   :*io-keepalive* *io-keepalive*
    :ev/spawn ev/spawn
    :make-async-scheduler make-async-scheduler
    :ev/run ev/run

--- a/src/wasm/host.rs
+++ b/src/wasm/host.rs
@@ -383,6 +383,10 @@ impl ElleHost {
             Some(_) => self.io_backend.as_ref().unwrap(),
             None => match crate::io::aio::AsyncBackend::new_with_unicode(
                 unsafe { &*self.vm }.unicode_generation(),
+                // This backend serves inline I/O for a WASM module rather than
+                // a scheduler a program parameterized, so nothing named a
+                // keepalive for it: the default stands.
+                None,
             ) {
                 Ok(be) => {
                     self.io_backend = Some(AnyBackend(Box::new(be)));

--- a/tests/elle/io.lisp
+++ b/tests/elle/io.lisp
@@ -75,6 +75,39 @@
 (let [[ok? _] (protect ((fn () (io/backend :invalid))))]
   (assert (not ok?) "io/backend :invalid errors"))
 
+# === worker keepalive ===
+#
+# The second argument is how long an idle I/O worker waits for another
+# operation before it retires, in seconds; nil takes the runtime's default and
+# 0 turns reuse off. Nothing a program can observe distinguishes the crews —
+# `io/workers` counts operations, not threads — so what is asserted here is
+# that each form is accepted, refused, and still does the I/O it was given.
+
+(assert (parameter? *io-keepalive*) "*io-keepalive* is a parameter")
+(assert (nil? (*io-keepalive*)) "*io-keepalive* defaults to the runtime's own")
+
+(assert (io-backend? (io/backend :async nil)) "nil keepalive builds a backend")
+(assert (io-backend? (io/backend :async 0)) "a zero keepalive builds a backend")
+(assert (io-backend? (io/backend :async 0.25))
+        "a fractional keepalive builds a backend")
+
+(let [[ok? _] (protect ((fn () (io/backend :async "soon"))))]
+  (assert (not ok?) "a keepalive that is not a number errors"))
+(let [[ok? _] (protect ((fn () (io/backend :async -1))))]
+  (assert (not ok?) "a negative keepalive errors"))
+
+# A scheduler reads the parameter when it makes its backend, so this whole
+# program's I/O runs on a crew that retires every worker at once.
+(assert (= "reuse off"
+           (parameterize ((*io-keepalive* 0))
+             (ev/run (fn []
+                       (with-temp-dir dir
+                                      (let [fpath (path/join dir "keepalive")]
+                                        (spit fpath "reuse off")
+                                        (string (port/read-all (port/open fpath
+                                        :read)))))))))
+        "I/O works with worker reuse turned off")
+
 # === stream I/O ===
 
 (with-temp-dir dir


### PR DESCRIPTION
## What was wrong

`CompletionHub::submit` started one OS thread per I/O operation and detached
it. There was no pool and no reuse. Every non-Linux build runs this backend for
everything, and a Linux box runs it under `--no-uring`, so the churn is what
macOS pays for all of its I/O.

Fixes #990.

## What the change does

A worker now outlives the operation it was started for: when it finishes it
waits for another, so a submission that meets a parked worker costs a wake
rather than a thread. `WorkerPool` and `Crew` (`src/io/threadpool/pool.rs`) are
the crew and the handoffs that reach it.

**Concurrency stays uncapped, and it has to.** An operation can wait for an
event outside the process — an accept nobody connects to, a read whose peer
never writes — and ends only through its deadline or its stop pipe. Under a cap
the next submission would queue behind that wait, and the fiber that would
issue the write ending it is a fiber the cap is holding up. So a job is only
ever handed to a worker already waiting for one, and a submission that finds
none starts a thread, exactly as before. An OS refusal is still the error
`io/submit` returns.

**A parked worker sleeps rather than spins.** Each waits on a condition
variable of its own rather than on a channel, because a channel receiver spins
before it sleeps and this wait now happens once per operation. Where there are
more cores than threads the spin is free; where there are fewer it burns the
cores the rest of the program needs. This was the whole difference between a
regression and a win, and it is invisible on a large box — see the numbers
below.

**The keepalive is a dynamic parameter, not a process switch.**
`*io-keepalive*` is how long an idle worker waits, in seconds; a scheduler
reads it when it builds its backend and `(io/backend :async k)` carries it to
the crew. `nil` takes the runtime's default (10 s, argued on
`DEFAULT_KEEPALIVE`); `0` turns reuse off, one thread per operation. Two
schedulers in one process can answer differently.

**macOS mask.** The `EVFILT_SIGNAL` read unblocks the watched signals on its
own worker so the kernel can pick that thread for delivery. A reused worker
runs later operations, all of which need the thread unselectable, so the read
now blocks again what it unblocked (`Unblocked`, an RAII guard).

## How it was measured

The corpus's VM-only per-file pass on a three-core macOS runner — `parallel
-j4`, 30 s per file, the shape that decides this backend's CI. Same runner
class throughout:

| | main | this branch |
|---|---|---|
| whole VM-only pass | 248s | **155s** |
| `h2-bidi-recycle` | 21.5s | **12.5s** |
| `h2-load-volume` | 21.7s | **10.8s** |
| `h2-bidi-unary` | 15.8s | **9.6s** |
| `region-jit-io-suspend-uaf` | 19.9s | **8.1s** |

Threads created per file on Linux, counted with `strace -f -c -e
trace=clone,clone3`:

| file | main | this branch |
|---|---|---|
| `h2-load-volume` | 10024 | 5 |
| `h2-bidi-recycle` | 7438 | 4 |
| `h2-timeout-recycle` | 4953 | 5 |
| `h2-load-bodies` | 4024 | 4 |

The spin is worth its own line, because a channel handoff looked right on
Linux and was not. With a crossbeam channel the same macOS pass ran 188s and
timed out `h2-bidi-recycle` at 30.2s, and the heaviest files burned twice
main's **user** CPU (`h2-bidi-messages` 2.4s → 5.5s user) — while on a
32-core Linux box that same build was uniformly faster than main and showed
nothing. The condition variable is what closed it.

## Tests

New, in `src/io/threadpool/tests/pool.rs`:

- `a_second_submission_runs_on_the_first_workers_thread` — the reuse itself.
  Fails on main (`ThreadId(4)` vs `ThreadId(8)`), passes here.
- `parked_operations_do_not_delay_the_next_submission` — eight reads parked on
  a pipe nobody writes to, and a ninth submission that must still run. Passes
  on main; it is the guard against the fixed-size pool that would otherwise be
  the obvious fix.
- `the_next_job_goes_to_the_worker_that_parked_last` — the handoff order.
- `an_idle_worker_retires_and_the_next_submission_starts_another` — the crew
  shrinks.
- `a_zero_keepalive_gives_every_operation_its_own_thread` — `0` means what it
  says.

Also `a_backend_takes_the_keepalive_it_was_given` (`src/io/aio/tests/backend.rs`)
for the path from the argument to the crew,
`the_macos_signal_read_blocks_again_what_it_unblocked`
(`src/io/threadpool/tests/signals.rs`, macOS only) for the mask, and
`tests/elle/io.lisp` § "worker keepalive" for the parameter and the forms
`io/backend` accepts.

`make test` (smoke, smoke-nouring, qa, unit and integration) passes.

## Docs

`src/io/AGENTS.md` § "How a worker is reused" is the design: why nothing may
cap the crew, why the wait is a condition variable, the handoff order, and
teardown. It also records what the order is *not* known to buy, since only the
spin was measured. `docs/io.md`, `docs/parameters.md` and `docs/scheduler.md`
carry the program-facing half — `io/workers` counts operations, not threads.
