### PR TITLE
ci: the corpus and the Rust suite are separate jobs on every platform

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -218,14 +218,15 @@ jobs:
       - name: make check-wasm
         run: make check-wasm
 
+  # The corpus half of the AArch64 tier. Its Rust half is `aarch64-tests`
+  # below, running at the same time on its own runner — the two share no build
+  # and no run, so serializing them made this platform cost the sum. See
+  # docs/analysis/ci.md § "Why each platform has two test jobs".
   aarch64:
     name: AArch64 Smoke
     needs: changes
     runs-on: ubuntu-24.04-arm
     if: needs.changes.outputs.source == 'true'
-    env:
-      PROPTEST_CASES: 8
-      RUST_TEST_THREADS: 2
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -242,6 +243,26 @@ jobs:
         run: make doctest
       - name: make smoke
         run: make smoke
+
+  # The Rust half of the AArch64 tier, mirroring the x86_64 `tests-combined`
+  # job: `cargo test` builds and runs everything it needs, so this job installs
+  # no packages and never invokes the Makefile. Its cache key is its own — it
+  # fills the target directory with dev-profile artifacts, where `aarch64`
+  # fills one with release artifacts.
+  aarch64-tests:
+    name: AArch64 Rust Tests
+    needs: changes
+    runs-on: ubuntu-24.04-arm
+    if: needs.changes.outputs.source == 'true'
+    env:
+      PROPTEST_CASES: 8
+      RUST_TEST_THREADS: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: aarch64-tests
       - name: Run integration tests
         run: cargo test --test '*' -- --skip property
       - name: Run property tests
@@ -252,9 +273,6 @@ jobs:
     needs: changes
     runs-on: ubuntu-24.04-arm
     if: needs.changes.outputs.source == 'true'
-    env:
-      PROPTEST_CASES: 8
-      RUST_TEST_THREADS: 2
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -292,14 +310,16 @@ jobs:
       - name: Cross-check Android
         run: cargo check --target aarch64-linux-android --no-default-features -p elle
 
+  # The corpus half of the macOS tier. Its Rust half is `macos-tests` below,
+  # running at the same time on its own runner. This is the slowest platform in
+  # the workflow, so it is the one the split buys the most from — see
+  # docs/analysis/ci.md § "Why each platform has two test jobs".
   macos:
     name: macOS Smoke
     needs: changes
     runs-on: macos-latest
     if: needs.changes.outputs.source == 'true'
     env:
-      PROPTEST_CASES: 8
-      RUST_TEST_THREADS: 2
       # The release profile strips the symbol table (Cargo.toml: strip =
       # "symbols"), which turns the timeout photograph (src/test.lisp
       # photograph-threads → /usr/bin/sample) into unreadable `???` frames.
@@ -344,10 +364,6 @@ jobs:
       # The panic itself needs CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS, set above.
       - name: make smoke
         run: make smoke ELLE_TEST_FLAGS=--trace=scrub
-      - name: Run integration tests
-        run: cargo test --test '*' -- --skip property
-      - name: Run property tests
-        run: "cargo test --test lib property::"
       # A batch killed by a signal leaves the batch number and nothing else. The
       # kernel's crash report has the faulting thread's stack, and the symbol
       # table is kept on this runner (CARGO_PROFILE_RELEASE_STRIP above), so the
@@ -370,9 +386,60 @@ jobs:
             cat "$r"
           done
 
+  # The Rust half of the macOS tier. It skips the clippy gate and the Makefile
+  # targets that `macos` above owns, and keeps its own cache key: `cargo test`
+  # fills the target directory with dev-profile artifacts, where `macos` fills
+  # one with release artifacts.
+  macos-tests:
+    name: macOS Rust Tests
+    needs: changes
+    runs-on: macos-latest
+    if: needs.changes.outputs.source == 'true'
+    env:
+      PROPTEST_CASES: 8
+      RUST_TEST_THREADS: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: macos-tests
+      # Only zstd, not the GNU parallel and coreutils the `macos` job needs:
+      # those two are Makefile tools, and this job runs no Makefile target. The
+      # tests spawn the elle binary, which loads libzstd for CAS compression —
+      # and libzstd is not a macOS system library. Homebrew installs it under
+      # /opt/homebrew/lib, which library_candidates probes explicitly (dyld
+      # does not search there for a bare soname).
+      - name: Install zstd
+        run: brew install zstd
+      - name: Run integration tests
+        run: cargo test --test '*' -- --skip property
+      - name: Run property tests
+        run: "cargo test --test lib property::"
+      # Same argument as the `macos` job's copy: a test whose elle subprocess
+      # dies on a signal reports an exit status and nothing else, and the
+      # kernel's report is the only stack. The dev profile keeps its symbols,
+      # so this job needs no CARGO_PROFILE_RELEASE_STRIP to read the frames.
+      - name: Crash reports
+        if: failure()
+        run: |
+          sleep 15
+          dir=~/Library/Logs/DiagnosticReports
+          shopt -s nullglob
+          reports=("$dir"/elle*.ips "$dir"/elle*.crash)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "no crash report for elle under $dir"
+            ls -la "$dir" 2>/dev/null || echo "$dir does not exist"
+            exit 0
+          fi
+          for r in "${reports[@]}"; do
+            echo "===== $r ====="
+            cat "$r"
+          done
+
   all-checks:
     name: All Checks Passed
-    needs: [changes, qa, tests-combined, tests, nouring, wasm, mlir, aarch64, aarch64-noffi, android, macos]
+    needs: [changes, qa, docs, tests-combined, tests, nouring, wasm, mlir, aarch64, aarch64-tests, aarch64-noffi, android, macos, macos-tests]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -398,8 +465,14 @@ jobs:
       - name: Check WASM
         if: needs.wasm.result == 'failure'
         run: exit 1
+      - name: Check documentation build
+        if: needs.docs.result == 'failure'
+        run: exit 1
       - name: Check aarch64
         if: needs.aarch64.result == 'failure'
+        run: exit 1
+      - name: Check aarch64 Rust tests
+        if: needs.aarch64-tests.result == 'failure'
         run: exit 1
       - name: Check aarch64-noffi
         if: needs.aarch64-noffi.result == 'failure'
@@ -409,6 +482,9 @@ jobs:
         run: exit 1
       - name: Check macOS
         if: needs.macos.result == 'failure'
+        run: exit 1
+      - name: Check macOS Rust tests
+        if: needs.macos-tests.result == 'failure'
         run: exit 1
       - name: Check changes detection
         if: needs.changes.result == 'failure'

--- a/docs/analysis/ci.md
+++ b/docs/analysis/ci.md
@@ -4,16 +4,58 @@ CI structure, local workflow, and failure diagnosis.
 
 ## CI structure
 
+`.github/workflows/pr.yml` runs on every pull request. `Detect Changes` reads
+the diff and sets `source`, which gates every job below it except
+`Documentation Build` — that one runs on a Markdown-only PR too, because a
+renamed heading breaks the site generator.
 
-| Job | Trigger | What | Proptest cases |
-|-----|---------|------|----------------|
-| examples | Always | All `.lisp` files in `examples/` | — |
-| test-rust | After examples | Unit + integration tests (skip property) | — |
-| test-property | After test-rust | All property tests | 8 (PR) / 16 (merge queue) |
-| toolchain-check | Weekly | Full suite on beta/nightly | 128 |
+| Job | Runner | What | Proptest cases |
+|-----|--------|------|----------------|
+| Detect Changes | ubuntu | Sets `source` from the changed paths | — |
+| QA | ubuntu | `cargo fmt`, clippy, the macOS cross-check, rustdoc | — |
+| Documentation Build | ubuntu | `make docs` and the Elle doc site, minus the publish | — |
+| VM+JIT Tests | ubuntu | `doctest`, `smoke-vm`, `smoke-jit` | — |
+| Rust Tests | ubuntu | Integration tests, then property tests | 16 |
+| Thread-Pool I/O Tests | ubuntu | The corpus on the thread-pool I/O backend | — |
+| MLIR Tests | ubuntu | `smoke-mlir` | — |
+| WASM Build | ubuntu | `check-wasm` — the feature compiles, the tier boots | — |
+| AArch64 Smoke | ubuntu-arm | `make smoke` | — |
+| AArch64 Rust Tests | ubuntu-arm | Integration tests, then property tests | 8 |
+| AArch64 No-Features | ubuntu-arm | `smoke-noffi` | — |
+| Android Cross-Check | ubuntu | `cargo check` for `aarch64-linux-android` | — |
+| macOS Smoke | macos | clippy, then `make smoke` under `--trace=scrub` | — |
+| macOS Rust Tests | macos | Integration tests, then property tests | 8 |
+| All Checks Passed | ubuntu | The one status check branch protection requires | — |
 
-Examples gate everything. Fast tier (PR): ~5 minutes. Thorough tier (merge
-queue): ~30 minutes. Weekly: full coverage on beta/nightly.
+The merge queue (`merge-queue.yml`) runs `make smoke` alone, with
+`PROPTEST_CASES=1`. The weekly schedule (`weekly.yml`) runs the whole workspace
+suite on beta and nightly at 128 cases, plus a dependency audit.
+
+### Why each platform has two test jobs
+
+The corpus and the Rust suite share no work. The corpus drives the release
+binary through `elle test` and through one process per file; the Rust suite
+builds separate test binaries under the dev profile. A job that runs both pays
+the sum of two build trees and two run times, in series, and the pull request
+waits for whichever platform does that.
+
+So each platform splits them: a Smoke job for the corpus, a Rust Tests job for
+`cargo test`. The two jobs run at the same time, and the platform costs the
+slower of the pair instead of the sum. The split doubles the runner minutes the
+platform spends and roughly halves the wall clock, which is the trade the merge
+gate cares about.
+
+Each job keeps its own `Swatinem/rust-cache` `shared-key`. The pair builds
+different profiles, so one shared key would make the two jobs overwrite each
+other's cache on alternating runs.
+
+### Adding a job
+
+`All Checks Passed` is the only status check branch protection requires
+(`.github/BRANCH_PROTECTION.md`). A new job that is missing from that job's
+`needs` list runs, reports, and cannot block a merge. Add the job to `needs`
+and give it a check step. `tests/integration/workflows.rs` fails when either
+is missing.
 
 
 ## Local development workflow

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -106,6 +106,7 @@ Tests are organized by feature area in separate files:
 | `elle_scripts.rs` | Process-global runtime-mode pins (guardfree/no-uring/mlir-off); the corpus itself runs via `elle test` |
 | `paths.rs` | The paths and URLs the Makefile and the doc generator name in text, checked against the tree |
 | `bytecode_doc.rs` | The instruction names and source paths the bytecode documents spell, checked against the `Instruction` enum |
+| `workflows.rs` | The PR workflow's merge gate: every job needed and enforced by `all-checks`, no job serializing the corpus and the Rust suite, no shared cache key |
 | `environment.rs` | Environment variables |
 | `escape.rs` | Escape analysis |
 | `arena.rs` | Arena allocation |

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -168,6 +168,9 @@ mod paths {
 mod bytecode_doc {
     include!("bytecode_doc.rs");
 }
+mod workflows {
+    include!("workflows.rs");
+}
 
 // Temporarily disabled while sorting out compilation caching.
 // mod fn_flow {

--- a/tests/integration/workflows.rs
+++ b/tests/integration/workflows.rs
@@ -1,0 +1,230 @@
+// What `.github/workflows/pr.yml` claims to gate must be what it gates.
+//
+// The workflow is not compiled and not linted. GitHub checks that a `needs`
+// entry names a real job and stops there, so both halves of the merge gate can
+// rot without anything reporting it: a job absent from `all-checks`'s `needs`
+// runs and reports next to a pull request it can never block, and a job named
+// in `needs` with no `exit 1` step is waited for and then ignored. Branch
+// protection requires the single "All Checks Passed" context
+// (.github/BRANCH_PROTECTION.md), so that job's hand-maintained list IS the
+// gate. These tests are the standing check on it.
+//
+// The argument for the shape the second test pins — one Smoke job and one Rust
+// Tests job per platform, never both in one — is in docs/analysis/ci.md
+// § "Why each platform has two test jobs".
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+fn workflow_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".github/workflows/pr.yml")
+}
+
+fn workflow_text() -> String {
+    fs::read_to_string(workflow_path())
+        .unwrap_or_else(|e| panic!("read {}: {e}", workflow_path().display()))
+}
+
+/// `  name:` at exactly two spaces of indent — a key in the `jobs` mapping.
+/// A comment at that indent has no bare identifier before the colon, so the
+/// character check rejects it.
+fn job_header(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("  ")?;
+    if rest.starts_with(' ') {
+        return None;
+    }
+    let name = rest.strip_suffix(':')?;
+    let ident = |c: char| c.is_ascii_alphanumeric() || c == '-' || c == '_';
+    if name.is_empty() || !name.chars().all(ident) {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+/// Every job in the workflow, as (name, body). Comment lines are dropped from
+/// the body: the trap is that several jobs discuss commands they do not run —
+/// the WASM job's comment names `make smoke-wasm` while running `check-wasm` —
+/// so a body scan that kept comments would read those as steps.
+fn jobs(text: &str) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    let mut current: Option<(String, String)> = None;
+    let mut in_jobs = false;
+
+    for line in text.lines() {
+        if line == "jobs:" {
+            in_jobs = true;
+            continue;
+        }
+        if !in_jobs {
+            continue;
+        }
+        // Any other top-level key closes the `jobs` mapping.
+        if !line.starts_with(' ') && !line.trim().is_empty() {
+            break;
+        }
+        if let Some(name) = job_header(line) {
+            out.extend(current.take());
+            current = Some((name, String::new()));
+            continue;
+        }
+        if let Some((_, body)) = current.as_mut() {
+            if !line.trim_start().starts_with('#') {
+                body.push_str(line);
+                body.push('\n');
+            }
+        }
+    }
+    out.extend(current);
+    out
+}
+
+/// The gate job: the one whose result branch protection requires.
+const GATE: &str = "all-checks";
+
+fn gate_body(text: &str) -> String {
+    jobs(text)
+        .into_iter()
+        .find(|(name, _)| name == GATE)
+        .map(|(_, body)| body)
+        .unwrap_or_else(|| panic!("{} defines no `{GATE}` job", workflow_path().display()))
+}
+
+/// The jobs `all-checks` waits for, from its `needs: [...]` list.
+fn declared_needs(gate: &str) -> BTreeSet<String> {
+    let (_, rest) = gate
+        .split_once("needs: [")
+        .expect("`all-checks` declares `needs` as a bracketed list");
+    let (inner, _) = rest.split_once(']').expect("the `needs` list closes");
+    inner
+        .split(',')
+        .map(|name| name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .collect()
+}
+
+/// The jobs `all-checks` actually fails on, from its `needs.NAME.result` steps.
+fn enforced_results(gate: &str) -> BTreeSet<String> {
+    gate.split("needs.")
+        .skip(1)
+        .filter_map(|rest| rest.split_once(".result").map(|(name, _)| name.to_string()))
+        .collect()
+}
+
+// A job outside `all-checks`'s `needs` burns runner minutes and reports a status
+// nothing reads: the required context is "All Checks Passed", which never waited
+// for it. The counter-factual: add a job that runs `exit 1`, leave the `needs`
+// list alone, and every gate ahead of the merge still goes green.
+#[test]
+fn all_checks_waits_for_every_job() {
+    let text = workflow_text();
+    let defined: BTreeSet<String> = jobs(&text)
+        .into_iter()
+        .map(|(name, _)| name)
+        .filter(|name| name != GATE)
+        .collect();
+
+    // A parse that matched nothing would assert nothing. The workflow has run
+    // well over five jobs since the platform tiers landed.
+    assert!(
+        defined.len() > 5,
+        "found only {} jobs in {}; the parse is broken, not the workflow",
+        defined.len(),
+        workflow_path().display()
+    );
+
+    let needs = declared_needs(&gate_body(&text));
+    let ungated: Vec<_> = defined.difference(&needs).collect();
+    assert!(
+        ungated.is_empty(),
+        "these jobs are outside `{GATE}`'s `needs` list, so they run on every \
+         pull request and cannot block one: {ungated:?}"
+    );
+
+    let stale: Vec<_> = needs.difference(&defined).collect();
+    assert!(
+        stale.is_empty(),
+        "`{GATE}` needs these, which no job defines: {stale:?}"
+    );
+}
+
+// The other half: a `needs` entry makes `all-checks` WAIT for a job, and
+// nothing more. `if: always()` means the gate then reports success unless some
+// step fails it, so a job with no `needs.NAME.result` step is a job whose
+// failure is waited for and discarded. The counter-factual: delete the "Check
+// macOS" step, keep `macos` in `needs`, and a red macOS job merges green.
+#[test]
+fn all_checks_fails_on_every_job_it_waits_for() {
+    let gate = gate_body(&workflow_text());
+    let needs = declared_needs(&gate);
+    let enforced = enforced_results(&gate);
+
+    let unenforced: Vec<_> = needs.difference(&enforced).collect();
+    assert!(
+        unenforced.is_empty(),
+        "`{GATE}` waits for these jobs but has no step failing on their result, \
+         so their failures are discarded: {unenforced:?}"
+    );
+
+    let orphaned: Vec<_> = enforced.difference(&needs).collect();
+    assert!(
+        orphaned.is_empty(),
+        "`{GATE}` reads the result of these jobs without needing them, so it may \
+         read them before they finish: {orphaned:?}"
+    );
+}
+
+// The corpus and the Rust suite share no build and no run, so a job that does
+// both costs the sum. The pull request waits for the slowest job, which makes
+// any such job the wall clock for its whole platform. Splitting the pair into
+// two jobs trades runner minutes for that wall clock — the argument is in
+// docs/analysis/ci.md § "Why each platform has two test jobs".
+//
+// The counter-factual: before the split, `macos` and `aarch64` each ran
+// `make smoke` and then `cargo test`, and every other gate stayed green while
+// the slowest platform took twice the time it needed.
+#[test]
+fn no_job_serializes_the_corpus_and_the_rust_suite() {
+    let text = workflow_text();
+    let both: Vec<String> = jobs(&text)
+        .into_iter()
+        .filter(|(_, body)| body.contains("make smoke") && body.contains("cargo test"))
+        .map(|(name, _)| name)
+        .collect();
+
+    assert!(
+        both.is_empty(),
+        "these jobs run the corpus and the Rust suite in series, so their \
+         platform costs the sum of the two instead of the slower one: {both:?}. \
+         Split each into a Smoke job and a Rust Tests job."
+    );
+}
+
+// A split pair that shares one `Swatinem/rust-cache` `shared-key` is worse than
+// no cache: the Smoke job populates the key with release artifacts, the Rust
+// Tests job restores those and saves dev-profile ones over them, and the two
+// overwrite each other on alternating runs. Every job that names a `shared-key`
+// must name its own.
+#[test]
+fn no_two_jobs_share_a_cache_key() {
+    let text = workflow_text();
+    let mut seen: Vec<(String, String)> = Vec::new();
+
+    for (name, body) in jobs(&text) {
+        for part in body.split("shared-key: ").skip(1) {
+            let key = part.lines().next().unwrap_or("").trim().to_string();
+            if let Some((other, _)) = seen.iter().find(|(_, k)| *k == key) {
+                panic!(
+                    "jobs `{other}` and `{name}` both cache under shared-key \
+                     `{key}`, so each run saves over the other's artifacts"
+                );
+            }
+            seen.push((name.clone(), key));
+        }
+    }
+
+    assert!(
+        !seen.is_empty(),
+        "no job names a shared-key; the parse is broken, not the workflow"
+    );
+}


### PR DESCRIPTION
The macOS and AArch64 jobs each ran `make smoke` and then `cargo test`, in series, on one runner. The two share no build and no run: the corpus drives the release binary through `elle test` and through one process per file, the Rust suite builds separate test binaries under the dev profile. So each of those platforms cost the sum of two build trees and two run times, and the pull request waited for whichever platform did that. x86_64 has not paid this since it split into `VM+JIT Tests` and `Rust Tests`.

## The split

| Before | After |
|---|---|
| `AArch64 Smoke` — `make smoke`, then `cargo test` | `AArch64 Smoke` — the corpus<br>`AArch64 Rust Tests` — integration, then property |
| `macOS Smoke` — clippy, `make smoke`, then `cargo test` | `macOS Smoke` — clippy and the corpus<br>`macOS Rust Tests` — integration, then property |

Each pair runs at the same time, so the platform costs the slower of the two instead of the sum. This doubles the runner minutes those two platforms spend, which is the trade the merge gate wants.

Each new job carries its own rust-cache `shared-key`. One key across a pair would have the release job and the dev-profile job saving over each other's artifacts on alternating runs.

Env moves to whichever job reads it: `CARGO_PROFILE_RELEASE_STRIP` and `CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS` stay with the smoke jobs that build the release binary, `PROPTEST_CASES` and `RUST_TEST_THREADS` go to the test jobs. `AArch64 No-Features` declared both proptest variables and runs no `cargo test`; they are gone.

`macOS Rust Tests` installs zstd and not the GNU parallel and coreutils its smoke half needs — those two are Makefile tools and this job runs no Makefile target, but the elle binary it spawns still loads libzstd for CAS compression. It also keeps the crash-report step: a `cargo test` subprocess killed by a signal leaves an exit status and nothing else, and the kernel's report is the only stack.

## One fix outside the split

`Documentation Build` was missing from the `all-checks` `needs` list. Branch protection requires only "All Checks Passed", so that job ran on every pull request and could never block one — while its own comment says it exists to catch a broken site generator before the merge rather than after it. It is in the list now, with a check step. This makes the documentation build blocking; say so and I will drop the two hunks if that is not the policy you want.

## Tests

`tests/integration/workflows.rs` is the standing check on the merge gate, which nothing else reads: GitHub verifies that a `needs` entry names a real job and stops there, so an unlisted job and a listed job with no `exit 1` step both parse.

| Test | Counter-factual |
|---|---|
| `no_job_serializes_the_corpus_and_the_rust_suite` | Failed before this change, naming `["aarch64", "macos"]` |
| `all_checks_waits_for_every_job` | Failed before this change, naming `["docs"]` |
| `all_checks_fails_on_every_job_it_waits_for` | Deleted the `Check macOS Rust tests` step; failed, then restored it |
| `no_two_jobs_share_a_cache_key` | Pointed `macos-tests` at the `macos` key; failed, then restored it |

## Docs

`docs/analysis/ci.md` described `examples`, `test-rust` and `test-property`, none of which have existed for some time. It now lists the real jobs, states the argument for two test jobs per platform, and says what to do when adding a job.

## Not done

`make doctest` runs as its own step and again inside `make smoke`, which depends on it — a duplicate doctest run on both slow platforms. Dropping the standalone step saves that, at the cost of failing later rather than early. Left alone here.

I could not run a YAML parser locally to confirm the file parses. The test's own parse finds every job, `needs` entry and cache key at the expected indentation, and I read each changed region, but that is not the same as a parse — this PR's own run is the first real one.
