### PR TITLE
smoke: a corpus file gets the wall-clock budget its own work needs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,40 @@ define RUN_PLUMB
 		|| { echo "FAILED: plumb.lisp ($(1))"; exit 1; }
 endef
 
+# Two corpus files spend most of a per-file budget on work the case needs:
+# h2-load-volume drives 500 requests over one h2 session, and
+# region-jit-io-suspend-uaf reads 20000 lines to drive one function hot enough
+# for the JIT to compile it. Cut either volume and the shape stops reaching the
+# state it pins. Both fit TIMEOUT with room on an idle box, and both have been
+# killed at it on CI, where the runner is shared and slower by an order of
+# magnitude. A killed file is exit 124 — no output, no assertion message — so it
+# reads as a flaky runner rather than as a budget that was never wide enough.
+# They get a wider one, which is the bargain ORACLE_TIMEOUT already makes, in
+# per-file form: an override for the files that need it, so every other file
+# still fails fast on a hang. The pins are tests/integration/budget.rs.
+#
+# The wider budget is a BACKSTOP, not the deadline. h2-load-volume carries its
+# own deadline and reports which request stalled and how long it waited; that
+# message is the reason to run the file, and it only ever prints if the outer
+# kill lands after it. Keep this above any in-file deadline, and read both from
+# a timed run rather than from a number written here — remembering that a run
+# `timeout` killed reports the cap, not what the file would have cost.
+WIDE_TIMEOUT ?= 120s
+WIDE_FILES   := -e h2-load-volume.lisp -e region-jit-io-suspend-uaf.lisp
+
+# The budget for ONE corpus file: `parallel` substitutes the path into `{}` and
+# the pass's shell picks a budget, once per file. Every pass that runs the corpus
+# one file at a time spells `timeout $(FILE_TIMEOUT)` — a pass that spells
+# `timeout $(TIMEOUT)` hands the narrow budget to the two files above.
+#
+# A `case` reads better here and does not survive the trip. `parallel` runs this
+# under the platform's `/bin/sh`, which on macOS is bash 3.2, and that parser
+# ends a `$(…)` at the first `)` inside it — the one closing a case pattern. The
+# corpus then dies file by file on a syntax error rather than on anything it
+# tests. `grep` needs no parentheses, and matches the shape the skip lists above
+# already use. tests/integration/budget.rs runs the real thing under `sh`.
+FILE_TIMEOUT = $$(echo {} | grep -q $(WIDE_FILES) && echo $(WIDE_TIMEOUT) || echo $(TIMEOUT))
+
 # One corpus pass with ONE PROCESS PER FILE, under a wall-clock TIMEOUT. Each
 # file starts, runs as a whole program, and exits — the shape `elle test` never
 # takes, and the only one that covers program teardown and process-global modes.
@@ -69,7 +103,7 @@ define RUN_PER_FILE
 	@printf '%s\n' tests/elle/*.lisp \
 		| grep -v $(1) | grep -v $(ORACLE_FILE) | grep -v $(PLUMB_FILE) \
 		| parallel -j $(JOBS) --tag --joblog target/smoke-$(4).joblog \
-			'timeout $(TIMEOUT) $(ELLE) $(2) {}' \
+			'timeout $(FILE_TIMEOUT) $(ELLE) $(2) {}' \
 		|| { \
 			echo "--- files that failed the $(3) ---"; \
 			awk 'NR > 1 && ($$7 != 0 || $$8 != 0) { \
@@ -322,7 +356,7 @@ smoke-mlir: elle-mlir  ## Corpus via elle test (+ mlir-cpu tier) + whole-file --
 	@printf '%s\n' tests/elle/*.lisp | \
 		grep -v $(ORACLE_FILE) | grep -v $(PLUMB_FILE) | \
 		parallel -j $(JOBS) --tag \
-			'timeout $(TIMEOUT) $(ELLE) --mlir=eager {}' \
+			'timeout $(FILE_TIMEOUT) $(ELLE) --mlir=eager {}' \
 		|| { echo "FAILED: elle tests MLIR pass (eager)"; exit 1; }
 	$(call RUN_ORACLE,--mlir=eager)
 	$(call RUN_PLUMB,--mlir=eager)

--- a/tests/elle/chan-select-fiber.lisp
+++ b/tests/elle/chan-select-fiber.lisp
@@ -6,21 +6,37 @@
 # cannot fire its chan/send while the parent is parked inside a synchronous
 # crossbeam Select::select_timeout — the bug originally reproduced in
 # ~/git/grace/infra/repro-spawn-chan-select.lisp.
+#
+# Every case below times a resume.  A select that lost its wake still comes back
+# with a value — the wrapper's post-park chan/try-select finds it — so the only
+# thing that separates a lost wake from a served one is that the lost one first
+# waited out its timeout.  `prompt-cap` draws that line: above the cost of
+# scheduling a producer on a loaded box, below the plateau at `select-timeout`.
+#
+# The trap is that only one of those two moves.  The plateau is a constant; the
+# scheduling cost tracks machine load, and a shared CI runner is loaded.  On 32
+# cores oversubscribed four to one, the slowest served resume here measured
+# 0.57 s.  Both numbers are read off that measurement: the cap above it, the
+# timeout far enough above the cap to keep a lost wake distinguishable.  A cap
+# chosen as a fraction of the timeout only looks calibrated — anything under
+# 0.6 s fires against working code on a loaded box, whatever it is a fraction of.
+
+(def select-timeout 2000)  # ms, what every case hands chan/select
+(def prompt-cap 1.0)  # s, above this the select waited on something
 
 # ============================================================================
 # Test A: ev/spawn'd producer + chan/select with timeout.
 #
-# A trivial fiber sends a value on a channel.  The parent chan/selects with a
-# 1s timeout.  If chan/select is scheduler-aware, the parent yields, the fiber
-# runs, sends, and the parent resumes with the value well under the timeout.
-# If chan/select parks the OS thread, the fiber never runs and the parent
-# hits the timeout.
+# A trivial fiber sends a value on a channel.  The parent chan/selects.  If
+# chan/select is scheduler-aware, the parent yields, the fiber runs, sends, and
+# the parent resumes with the value well under the timeout.  If chan/select
+# parks the OS thread, the fiber never runs and the parent hits the timeout.
 # ============================================================================
 
 (let [[tx rx] (chan)
       _ (ev/spawn (fn [] (chan/send tx :hello-from-fiber)))
       t0 (clock/monotonic)
-      sel (chan/select @[rx] 1000)
+      sel (chan/select @[rx] select-timeout)
       elapsed (- (clock/monotonic) t0)]
   (assert (array? sel) "chan/select should return an array")
   (assert (= (length sel) 2)
@@ -28,8 +44,8 @@
   (assert (= (get sel 0) 0) "select index should be 0 (the only receiver)")
   (assert (= (get sel 1) :hello-from-fiber)
           "select should observe the fiber's send")
-  (assert (< elapsed 0.5)
-          "select must resume promptly, not wait out the 1s timeout"))
+  (assert (< elapsed prompt-cap)
+          "select must resume promptly, not wait out the timeout"))
 
 # ============================================================================
 # Test B: chan/select with no producer must still hit the timeout.
@@ -50,7 +66,7 @@
           "select with no producer must return [:timeout]")
   (assert (>= elapsed 0.04)
           "select must actually wait the timeout, not return immediately")
-  (assert (< elapsed 0.5) "select must not over-wait the timeout"))
+  (assert (< elapsed prompt-cap) "select must not over-wait the timeout"))
 
 # ============================================================================
 # Test C: ev/spawn'd producer that yields before sending.
@@ -65,14 +81,14 @@
                     (ev/sleep 0.02)
                     (chan/send tx :after-sleep)))
       t0 (clock/monotonic)
-      sel (chan/select @[rx] 1000)
+      sel (chan/select @[rx] select-timeout)
       elapsed (- (clock/monotonic) t0)]
   (assert (= (length sel) 2) "parked select must wake when the producer fires")
   (assert (= (get sel 1) :after-sleep)
           "parked select must observe the producer's value")
   (assert (>= elapsed 0.02)
           "parked select must wait at least the producer's sleep")
-  (assert (< elapsed 0.5)
+  (assert (< elapsed prompt-cap)
           "parked select must resume on the producer's send, not the timeout"))
 
 # ============================================================================
@@ -91,13 +107,14 @@
                         (time/sleep 0.02)
                         (chan/send tx :hello-from-os-thread)))
       t0 (clock/monotonic)
-      sel (chan/select @[rx] 1000)
+      sel (chan/select @[rx] select-timeout)
       elapsed (- (clock/monotonic) t0)]
   (assert (= (length sel) 2)
           "cross-thread select must wake when producer thread fires")
   (assert (= (get sel 1) :hello-from-os-thread)
           "cross-thread select must observe the thread's value")
-  (assert (< elapsed 0.5) "cross-thread select must not wait out the timeout"))
+  (assert (< elapsed prompt-cap)
+          "cross-thread select must not wait out the timeout"))
 
 # ============================================================================
 # Test E: cross-thread race stress.
@@ -106,7 +123,13 @@
 # initial chan/try-select frequently sees :empty just before the send arrives —
 # exactly the race that the post-register re-check in chan/wait-ready closes.
 # If the race is open, at least one of the chan/selects will park on an
-# eventfd no one will signal, hit the 500ms timeout, and the test will fail.
+# eventfd no one will signal and wait out `select-timeout`.
+#
+# This is the case where machine load bites hardest: 200 VM threads spawned in
+# sequence, each racing the parent, so it samples the tail of the spawn latency
+# 200 times over.  On an idle box the slowest iteration lands near 0.05 s; at
+# four-to-one oversubscription, near 0.57 s.  A lost wake lands at
+# `select-timeout`, and `prompt-cap` sits between the two.
 # ============================================================================
 
 (let [iterations 200]
@@ -114,18 +137,13 @@
     (let [[tx rx] (chan)
           producer (sys/spawn-vm (fn [] (chan/send tx i)))
           t0 (clock/monotonic)
-          sel (chan/select @[rx] 500)
+          sel (chan/select @[rx] select-timeout)
           elapsed (- (clock/monotonic) t0)]
       (sys/join producer)
       (assert (= (length sel) 2)
               (string "iteration " i ": cross-thread select hit timeout"))
-      (assert (= (get sel 1) i) (string "iteration " i ": value mismatch"))  # Per-iteration cap — a lost-wake race pushes elapsed to ~500ms
-      # (the timeout) while still returning a value via the wrapper's
-      # post-park chan/try-select, so the discriminating boundary sits
-      # near the timeout.  The cap must tolerate ordinary OS scheduling
-      # latency: spawning a VM thread under machine load routinely costs
-      # 50-100ms, which is noise, not a lost wake.
-      (assert (< elapsed 0.25)
+      (assert (= (get sel 1) i) (string "iteration " i ": value mismatch"))
+      (assert (< elapsed prompt-cap)
               (string "iteration " i ": cross-thread select waited too long: "
                       elapsed " s — race likely lost the wake")))))
 
@@ -140,7 +158,7 @@
 (let [[tx0 rx0] (chan)
       [tx1 rx1] (chan)
       _ (ev/spawn (fn [] (chan/send tx1 :from-one)))
-      sel (chan/select @[rx0 rx1] 1000)]
+      sel (chan/select @[rx0 rx1] select-timeout)]
   (assert (= (length sel) 2)
           "multi-receiver select must resolve to [i v], not :timeout")
   (assert (= (get sel 0) 1)
@@ -155,7 +173,7 @@
 (let [[tx0 rx0] (chan)
       [tx1 rx1] (chan)
       _ (ev/spawn (fn [] (chan/send tx0 :zero)))
-      sel (chan/select @[rx0 rx1] 1000)]
+      sel (chan/select @[rx0 rx1] select-timeout)]
   (assert (= (get sel 0) 0) "select picks the receiver that has a value")
   (assert (= (get sel 1) :zero) "select returns the right value")  # The unused channel must still be empty.
   (let [r1 (chan/recv rx1)]
@@ -177,12 +195,13 @@
                     (ev/sleep 0.02)  # Close every sender so the receiver observes disconnect.
                     (chan/close tx)))
       t0 (clock/monotonic)
-      [ok? result] (protect (chan/select @[rx] 1000))
+      [ok? result] (protect (chan/select @[rx] select-timeout))
       elapsed (- (clock/monotonic) t0)]
   (assert ok? "select must return cleanly when the sender closes mid-park")
   (assert (= (get result 0) :disconnected)
           "select must observe :disconnected after the sender closes")
-  (assert (< elapsed 0.5) "select must wake on close, not wait the full timeout"))
+  (assert (< elapsed prompt-cap)
+          "select must wake on close, not wait the full timeout"))
 
 # ============================================================================
 # Test H: ev/abort cancels a parked select cleanly.
@@ -202,7 +221,7 @@
   # same channel must work — confirms the WakeList wasn't left with a
   # dangling fd that would mis-fire or cause errors.
   (let [_ (ev/spawn (fn [] (chan/send tx :after-abort)))
-        sel (chan/select @[rx] 1000)]
+        sel (chan/select @[rx] select-timeout)]
     (assert (= (length sel) 2)
             "post-abort select on the same channel must still work")
     (assert (= (get sel 1) :after-abort)

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -107,6 +107,7 @@ Tests are organized by feature area in separate files:
 | `paths.rs` | The paths and URLs the Makefile and the doc generator name in text, checked against the tree |
 | `bytecode_doc.rs` | The instruction names and source paths the bytecode documents spell, checked against the `Instruction` enum |
 | `workflows.rs` | The PR workflow's merge gate: every job needed and enforced by `all-checks`, no job serializing the corpus and the Rust suite, no shared cache key |
+| `budget.rs` | The wall-clock budget the Makefile's per-file corpus passes give one file |
 | `environment.rs` | Environment variables |
 | `escape.rs` | Escape analysis |
 | `arena.rs` | Arena allocation |

--- a/tests/integration/budget.rs
+++ b/tests/integration/budget.rs
@@ -1,0 +1,308 @@
+// The wall-clock budget the corpus per-file passes give one file.
+//
+// `RUN_PER_FILE` runs every corpus file as its own process under `timeout`, and
+// a file that outlives its budget is killed: exit 124, no output, no assertion
+// message. That budget is a single number for the whole corpus, and two files
+// spend most of it on work they need — one drives 500 requests over one h2
+// session, the other reads 20000 lines to drive a function hot enough for the
+// JIT to compile it. On an idle box each finishes with seconds to spare; on a
+// loaded CI runner it does not, and the gate reports a kill rather than a
+// defect.
+//
+// So those two are named in the Makefile and given a wider budget. The names
+// are shell text, and both halves fail quietly: a renamed file stops matching
+// and silently drops back to the narrow budget, and a new pass that spells the
+// narrow budget directly gives it to every file. Nothing compiles either one.
+// These tests are the standing check, and they cost a read of the Makefile and
+// a few `sh` invocations.
+//
+// The trap, and why the selector is executed here rather than pattern-matched:
+// the shell that parses it is the platform's `/bin/sh`, and they do not agree.
+// bash 3.2, which is what macOS supplies, ends a `$(…)` at the first `)` inside
+// it, so a construct that carries one — a `case` pattern — parses on the
+// development box and dies file by file on the macOS runner.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn makefile() -> String {
+    fs::read_to_string(repo_root().join("Makefile")).expect("read the Makefile")
+}
+
+/// Every simple variable assignment in the Makefile, by name.
+///
+/// A definition opens at column zero and its operator is one of `:=`, `?=` or
+/// `=`. Rules (`target: prerequisite`) and recipe lines are not assignments and
+/// do not land here.
+fn assignments(text: &str) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for line in text.lines() {
+        if line.starts_with([' ', '\t', '#']) {
+            continue;
+        }
+        let Some((head, value)) = line.split_once('=') else {
+            continue;
+        };
+        let name = head.trim_end_matches([':', '?', '+']).trim();
+        if name.is_empty() || !name.chars().all(|c| c.is_ascii_uppercase() || c == '_') {
+            continue;
+        }
+        out.insert(name.to_string(), value.trim().to_string());
+    }
+    out
+}
+
+/// One Makefile variable, expanded.
+///
+/// Only `$(NAME)` references to other variables are resolved; a `$(...)` whose
+/// body is not a bare variable name — the shell substitution below is one — is
+/// left alone. `expanded_budget_selector` asserts that nothing unresolved
+/// remains, so a reference this cannot follow fails the test rather than
+/// reaching `sh` as literal text.
+fn expand(name: &str, vars: &BTreeMap<String, String>) -> String {
+    let mut text = vars
+        .get(name)
+        .unwrap_or_else(|| panic!("the Makefile defines {name}"))
+        .clone();
+    for _ in 0..8 {
+        let mut next = String::new();
+        let mut rest = text.as_str();
+        while let Some(at) = rest.find("$(") {
+            let (before, from) = rest.split_at(at);
+            next.push_str(before);
+            let body = &from[2..];
+            match body.split_once(')') {
+                Some((inner, after)) if vars.contains_key(inner) => {
+                    next.push_str(&vars[inner]);
+                    rest = after;
+                }
+                _ => {
+                    next.push_str("$(");
+                    rest = body;
+                }
+            }
+        }
+        next.push_str(rest);
+        if next == text {
+            return text;
+        }
+        text = next;
+    }
+    panic!("{name} expands without settling; a variable references itself");
+}
+
+/// The names the Makefile gives the wider budget, as corpus file names.
+///
+/// `WIDE_FILES` is a `grep` pattern list, `-e one.lisp -e two.lisp` — the shape
+/// the per-pass skip lists beside it already use.
+fn wide_file_names() -> Vec<String> {
+    let text = makefile();
+    let patterns = expand("WIDE_FILES", &assignments(&text));
+    let names: Vec<String> = patterns
+        .split_whitespace()
+        .filter(|word| *word != "-e")
+        .map(str::to_string)
+        .collect();
+    assert!(
+        !names.is_empty() && names.iter().all(|n| n.ends_with(".lisp")),
+        "WIDE_FILES does not read as a `grep` pattern list over corpus files: {patterns}"
+    );
+    names
+}
+
+/// The Makefile's budget selector with `{}` replaced by `path`, ready for `sh`.
+fn expanded_budget_selector(path: &str) -> String {
+    let text = makefile();
+    let selector = expand("FILE_TIMEOUT", &assignments(&text)).replace("$$", "$");
+    // What survives expansion is shell. A `$(NAME)` still standing is a make
+    // reference this could not follow, and handing it to `sh` would measure
+    // something other than what the pass runs.
+    let unresolved = selector
+        .match_indices("$(")
+        .any(|(at, _)| selector[at + 2..].starts_with(|c: char| c.is_ascii_uppercase()));
+    assert!(
+        !unresolved,
+        "the budget selector still carries a make variable: {selector}"
+    );
+    selector.replace("{}", path)
+}
+
+/// A `timeout` argument as a number: `120s` is 120.
+fn seconds(budget: &str) -> u64 {
+    budget
+        .trim()
+        .trim_end_matches('s')
+        .parse()
+        .unwrap_or_else(|_| panic!("a budget is a whole number of seconds: {budget}"))
+}
+
+/// The budget one corpus file gets, read the way the pass reads it: `parallel`
+/// substitutes the path into the selector and evaluates it in `sh`, which is
+/// the shell a make recipe runs under.
+fn budget_for(path: &str) -> String {
+    let script = format!("printf '%s' {}", expanded_budget_selector(path));
+    let out = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(&script)
+        .output()
+        .expect("run the budget selector");
+    assert!(
+        out.status.success(),
+        "the budget selector is not valid `sh`: {script}"
+    );
+    String::from_utf8(out.stdout).expect("the selector prints a budget")
+}
+
+// A file named in `WIDE_FILES` that no longer exists is not an error anywhere:
+// the `case` alternative simply stops matching, and the file it was written for
+// — under whatever name it now has — goes back to the narrow budget and starts
+// dying on exit 124 under load. The counter-factual: rename one of the two
+// heavy corpus files without touching the Makefile, and every gate still
+// passes until a runner is slow enough.
+#[test]
+fn every_file_named_for_the_wider_budget_is_a_corpus_file() {
+    let root = repo_root();
+    for name in wide_file_names() {
+        let path = root.join("tests/elle").join(&name);
+        assert!(
+            path.exists(),
+            "the Makefile gives `{name}` the wider per-file budget, but \
+             {} does not exist. The `case` alternative matches nothing, so \
+             whatever that file is called now runs under TIMEOUT.",
+            path.display()
+        );
+    }
+}
+
+// The selector is shell text in a make variable: nothing compiles it, and a
+// pattern that matches nothing still runs — every file just takes the fallback.
+// This drives the real thing under a real shell, once per outcome. The
+// counter-factual: misspell one name so it can never match a path, and the two
+// heavy files quietly return to the narrow budget.
+#[test]
+fn the_selector_widens_the_named_files_and_nothing_else() {
+    let text = makefile();
+    let vars = assignments(&text);
+    let wide = expand("WIDE_TIMEOUT", &vars);
+    let narrow = expand("TIMEOUT", &vars);
+    assert!(
+        seconds(&wide) > seconds(&narrow),
+        "WIDE_TIMEOUT is {wide}, which is not wider than TIMEOUT at {narrow}"
+    );
+
+    for name in wide_file_names() {
+        let path = format!("tests/elle/{name}");
+        assert_eq!(
+            budget_for(&path),
+            wide,
+            "{path} is named in WIDE_FILES but the selector gives it {narrow}"
+        );
+    }
+
+    // Ordinary corpus files keep the narrow budget: it is what makes a hang
+    // fail fast, and widening it for everything would trade that away. Both
+    // controls have to exist, or this arm is measured against a path the pass
+    // would never run.
+    for path in ["tests/elle/arithmetic.lisp", "tests/elle/strings.lisp"] {
+        assert!(repo_root().join(path).exists(), "{path} is gone");
+        assert_eq!(
+            budget_for(path),
+            narrow,
+            "{path} is not named in WIDE_FILES but the selector widened it"
+        );
+    }
+}
+
+// The trap, guarded where it can be caught. bash 3.2 — macOS's `/bin/sh` —
+// ends a `$(…)` at the first `)` inside it, so a selector carrying one is cut
+// in half before the shell ever reads what it does. Every later shell parses
+// the same text correctly, which is what makes this expensive: it passes on the
+// development box, passes on Linux CI, and takes the whole corpus down file by
+// file on the macOS runner with a syntax error naming none of it. The
+// counter-factual is the obvious spelling — `$(case {} in */a.lisp) echo …;;
+// *) echo …;; esac)` — which reads better, works everywhere it is tried, and
+// cannot ship.
+#[test]
+fn the_selector_carries_no_parenthesis_a_shell_could_end_it_on() {
+    let selector = expanded_budget_selector("tests/elle/arithmetic.lisp");
+    let inner = selector
+        .trim()
+        .strip_prefix("$(")
+        .and_then(|rest| rest.strip_suffix(')'))
+        .unwrap_or_else(|| panic!("the budget selector is not one substitution: {selector}"));
+    assert!(
+        !inner.contains('(') && !inner.contains(')'),
+        "the budget selector carries a parenthesis: {selector}\n\
+         macOS's /bin/sh ends the substitution at the first one, so the corpus \
+         dies on a syntax error there while every other platform passes."
+    );
+}
+
+// A pass that writes `timeout $(TIMEOUT)` into its own command line hands that
+// budget to every file it runs, including the two that cannot fit it — and the
+// failure is exit 124 with no output, which reads as a flaky runner rather than
+// as a budget that was never wide enough. Every pass over the corpus takes its
+// budget from the selector, which is the only thing that knows about them.
+#[test]
+fn no_corpus_pass_spells_the_narrow_budget_directly() {
+    // Recipe lines only: a recipe is what runs, and the comment above
+    // FILE_TIMEOUT quotes both spellings to contrast them.
+    let offender = makefile()
+        .lines()
+        .find(|line| line.starts_with('\t') && line.contains("timeout $(TIMEOUT)"))
+        .map(str::to_string);
+    assert!(
+        offender.is_none(),
+        "a Makefile recipe runs `timeout $$(TIMEOUT)` directly:\n  {}\n\
+         Use `timeout $$(FILE_TIMEOUT)`, which gives the files named in \
+         WIDE_FILES the budget they need and every other file TIMEOUT.",
+        offender.unwrap_or_default().trim()
+    );
+}
+
+// The wider budget is a backstop, not the deadline. A file that carries its own
+// `deadline` reports on it — which request stalled, how long it waited — and
+// that message is the reason to run the file at all. If the outer `timeout`
+// fires first the message is never printed: the process dies on a signal and
+// the gate reports exit 124. The counter-factual: set the wider budget below
+// the in-file deadline and a genuine h2 stall is indistinguishable from a busy
+// runner, which is the failure this whole mechanism exists to end.
+#[test]
+fn the_wider_budget_outlives_the_in_file_deadline_it_backstops() {
+    let text = makefile();
+    let budget = seconds(&expand("WIDE_TIMEOUT", &assignments(&text)));
+    let root = repo_root();
+    let mut checked = 0;
+    for name in wide_file_names() {
+        let source = fs::read_to_string(root.join("tests/elle").join(&name))
+            .expect("read a file named for the wider budget");
+        let Some((_, rest)) = source.split_once("(def deadline ") else {
+            continue;
+        };
+        let deadline: u64 = rest
+            .split(')')
+            .next()
+            .and_then(|n| n.trim().parse().ok())
+            .unwrap_or_else(|| panic!("{name} declares a deadline this cannot read"));
+        assert!(
+            budget > deadline,
+            "{name} gives itself {deadline} s to report a stall, and the pass \
+             kills it at {budget} s. The kill lands first, so the file's own \
+             diagnostic can never print."
+        );
+        checked += 1;
+    }
+    assert!(
+        checked > 0,
+        "no file named for the wider budget declares a deadline. Either the \
+         declaration changed shape or the argument no longer applies — teach \
+         this test the new shape rather than letting it pass by matching \
+         nothing."
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -171,6 +171,9 @@ mod bytecode_doc {
 mod workflows {
     include!("workflows.rs");
 }
+mod budget {
+    include!("budget.rs");
+}
 
 // Temporarily disabled while sorting out compilation caching.
 // mod fn_flow {


### PR DESCRIPTION
Restores #1014, which was merged into #1013's head branch after that branch had already landed on main, so its change never reached main. The commits are unchanged, reparented onto main.

## What was wrong

Three corpus files fail the per-file smoke passes on wall-clock margins, on
whichever file the runner happens to be slow for (#1010). Two are killed by the
pass's `timeout`; the third fails a timing assert of its own.

**The two that are killed.** `h2-load-volume` drives 500 requests over one h2
session, and `region-jit-io-suspend-uaf` reads 20000 lines to drive one function
past the JIT's compile threshold. Both volumes are the point: the stream-table
state one asserts on only accumulates over hundreds of requests, and a function
called once never gets hot. Both fit the 30 s budget with room on an idle box —
3.1–3.9 s on the release binary, 20.5–28.5 s on a debug one — and both have been
killed at 30 s on CI. A killed file is exit 124: no output, no assertion
message, so it reads as a flaky runner rather than as a budget that was never
wide enough.

**The one that asserts.** `chan-select-fiber` times how long each `chan/select`
took to resume. A select that lost its wake still returns a value — the
wrapper's post-park `chan/try-select` finds it — so the only thing separating a
lost wake from a served one is that the lost one first waited out the select
timeout. The file drew that line at half the timeout: 0.5 s against 1000 ms, and
0.25 s against 500 ms in the 200-iteration cross-thread stress case. Half a
timeout is not a measurement. Scheduling a VM thread on a loaded box costs most
of 0.25 s, so the cap sat inside the noise it was supposed to ignore.

## What the change does

**A per-file budget, the bargain `ORACLE_TIMEOUT` already makes.** `WIDE_FILES`
names the two heavy files; `FILE_TIMEOUT` resolves to `WIDE_TIMEOUT` (120 s) for
them and `TIMEOUT` (30 s) for every other file, evaluated in the pass's shell
once per file. Every pass that runs the corpus one file at a time uses it —
`smoke-vm`, `smoke-jit`, `smoke-noffi`, `smoke-nouring`, and the whole-file
`--mlir=eager` pass — so every other file still fails fast on a hang.

120 s is above `h2-load-volume`'s own 60 s deadline on purpose. That deadline is
what names the request that stalled and how long it waited; it can only print if
the outer kill lands after it. A run `timeout` killed reports the cap, not what
the file would have cost, so the budget is read from the in-file deadline and
from timed runs rather than from the failures.

**Two numbers instead of six pairs in `chan-select-fiber`.** `select-timeout`
(2000 ms) and `prompt-cap` (1.0 s) replace every hand-written timeout and cap in
the file. The cap is now read off the measured scheduling latency, and the
timeout is set far enough above the cap to keep a lost wake distinguishable.

## How I measured it

The stress case reproduces on demand by oversubscribing the box. Worst
per-iteration elapsed over 200 iterations, debug binary, `--jit=eager`, 32
cores:

| load | worst served resume | with a 500 ms timeout | with a 2000 ms timeout |
| --- | --- | --- | --- |
| idle | 0.052 s | passes | passes |
| 2× oversubscribed | 0.27 s | 6 of 200 over 0.25 s | passes |
| 4× oversubscribed | 0.57 s | some iterations return no value at all | passes |
| 8× oversubscribed | 1.07 s | — | at the 1.0 s cap |

At four to one, a 500 ms select timeout is itself too tight: iterations expire
with no value, which no cap can rescue. At eight to one the served resume
reaches the new cap — that is where this pair stops holding, well past anything
a 4-core runner at `-j 4` produces.

For the two heavy files, three of them run at once on the debug binary — the
contention a per-file pass creates — and both named files land past 30 s and
inside the new budget:

```
tests/elle/chan-select-fiber.lisp        exit=124  (2.032s, control at a 2s cap)
tests/elle/region-jit-io-suspend-uaf.lisp exit=0   (42.348s)
tests/elle/h2-load-volume.lisp            exit=0   (46.809s)
```

## Tests

`tests/integration/budget.rs` pins the four ways this goes quiet. The Makefile
is not compiled, so a name in it is text nothing checks, and each failure below
leaves every gate green:

- a file named for the wider budget that no longer exists — the `case`
  alternative stops matching and the file silently returns to `TIMEOUT`;
- a selector that widens the wrong set — it runs the real `case` under `sh`,
  once per outcome, and checks both the named files and ordinary ones;
- a pass that spells `timeout $(TIMEOUT)` directly, which hands the narrow
  budget to every file it runs;
- a wider budget under the in-file deadline it backstops, which puts the kill
  ahead of the diagnostic again.

Each was confirmed by mutating the Makefile that way and watching the matching
test fail.

Closes #1010.
