### PR TITLE
regions: the adopt runs before any park inside its scope

### DIFF
--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -64,7 +64,17 @@ gates, each refusing to Shared (the always-legal baseline):
   enclosing structural scope (the adopt site; a cross-lambda SCC refuses), and no
   `While`/`Loop` encloses a member's allocation without also enclosing the adopt site
   (adopt-per-iteration is sound — fresh regions each round; alloc-inside/adopt-outside is
-  not — the static suppression would outlive the slot's last iteration value).
+  not — the static suppression would outlive the slot's last iteration value);
+- **the park split** — no park may run between a member's allocation and its adopt. In
+  that interval the members are `Counted`, and their own releases are already suppressed
+  under the suppress ⊆ adopt contract. A route that abandons such a park therefore
+  strands the whole SCC: no release table names the members, and no node adopted them.
+  So when the adopt scope can park (`Signal::may_park` — any inferred bit outside
+  `:error`/`:halt`/`:ffi`, or a polymorphic propagation), the walk sites a second,
+  earlier adopt ahead of every reachable park (the park split, below). A shape the
+  split cannot order refuses to Shared. A park ordered before every member allocation
+  needs no gate: no member exists when it parks, and the early adopt still precedes
+  every later one.
 
 The lowerer emits one value-resolved `AdoptIntoActivation` per member at the adopt site
 (`emit_adopt_into_activation`, driven by `emit_decrefs_for` exactly like the co-owned
@@ -76,12 +86,40 @@ node member's demise. The members stay `Counted` between construction and the ad
 RC absorbs the interval — an outside holder's earlier cascade decref just lowers the count
 the adopt then consumes); from the adopt to the activation's completion they are `Owned`,
 and the node's release frees the cycle wholesale, interior m↔c references reclaiming with
-the set. Pinned by `regions::tests::adopt::activation_adopts_capture_back_edge_scc`
+the set.
+
+**The park split — the adopt runs before any park.** `emit_decrefs_for` fires for every
+node right after its own lowering; for a binding init it fires right after the binding's
+store (`lower_let`/`lower_letrec`'s deferral). An adopt keyed at ANY node therefore runs
+at that node's completion. When the adopt scope can park, the walk uses this to close the
+`Counted` interval ahead of every park
+(`compute_activation_adopts`' park split). It descends the scope's sequential spine — a
+`Let`/`Letrec`'s binding inits then body, a `Begin`/`Block`'s statements, each constituent
+completing before the next begins — to the last constituent that allocates a member,
+recursing while that constituent both allocates and parks. It keys a second adopt there,
+so `activation_adopt_sites` carries two entries for one SCC. Every member's binding store
+completes with that constituent, so the early adopt loads populated slots. Every park in a
+later constituent finds the members already `Owned`, and the parked frame carries them in
+its owner node (the park rules below). The scope-exit adopt stays beside the early one: a
+path that leaves the scope before its end (a `break` past the early key) still adopts
+there, and the channel's idempotence makes a second adopt of an `Owned` member a no-op.
+The early adopt may precede the SCC's own interior stores. That is sound: `incref`/
+`decref` are inert on an `Owned` region, and the store still records its edge, which the
+node's set-drop walks like any other. A shape the spine cannot order — a park between two
+members' allocations, or a park and an allocation inside one non-sequential constituent (a
+branch, a call) — refuses at admission (the park-split gate above).
+
+Pinned by `regions::tests::adopt::activation_adopts_capture_back_edge_scc`
 (rooted and bare shapes, funnel-recovered stores),
-`…::activation_adopt_excludes_other_mechanisms` (merge/group disjointness), and at runtime
+`…::activation_adopt_sites_ahead_of_park` (the park split: two sites, the early key
+ordered after every member allocation and before the park),
+`…::activation_adopt_refuses_park_between_allocations` (the refusal),
+`…::activation_adopt_excludes_other_mechanisms` (merge/group disjointness), at runtime
 by `runtime::tests::ownership::region_ownership_capture_back_edge_cycle_reclaims`
 (bounded flag-on beside the leaking flag-off counterfactual, panic-clean, on the
-interpreter and under the JIT).
+interpreter and under the JIT), and end-to-end by the `adopt-park-*` oracle family
+(`tests/elle/oracle.lisp`: a park inside the adopt scope reclaims on the handle-drop,
+abort, and cancel routes alike; the `ap-*` controls attribute each ingredient).
 
 **The transferred returned subtree — owner = the consuming activation.** The second
 containment shape no region root can own is the **returned cycle**: a callee builds an

--- a/src/hir/expr/traverse.rs
+++ b/src/hir/expr/traverse.rs
@@ -141,8 +141,9 @@ impl Hir {
     /// so out-of-crate analysis and tests can walk the tree the same way the
     /// compiler does — consistent with the already-public `Hir::{kind, id}`. The
     /// mutating twin (`for_each_child_mut`) stays crate-private: rewriting the HIR
-    /// is an internal concern.
-    pub fn for_each_child(&self, mut f: impl FnMut(&Hir)) {
+    /// is an internal concern. The callback's references live as long as `self`,
+    /// so a search may return the child it finds.
+    pub fn for_each_child<'a>(&'a self, mut f: impl FnMut(&'a Hir)) {
         match &self.kind {
             HirKind::Nil
             | HirKind::EmptyList

--- a/src/hir/region/infer/ownership/activation.rs
+++ b/src/hir/region/infer/ownership/activation.rs
@@ -21,10 +21,15 @@ use super::subtree::innermost_enclosing_scope;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 /// The activation-adopt map the lowerer consumes
-/// (`RegionInfo::activation_adopt_sites`): adopt-site HirId — the innermost
-/// structural scope enclosing every member's allocation — → the capture-back-edge
-/// SCC members to `AdoptIntoActivation` there, in allocation program order.
-/// Run by the ownership pass in `analyze_regions_with`.
+/// (`RegionInfo::activation_adopt_sites`): adopt-site HirId → the
+/// capture-back-edge SCC members to `AdoptIntoActivation` there, in allocation
+/// program order. The primary site is the innermost structural scope enclosing
+/// every member's allocation; a scope that can park carries a SECOND entry for
+/// the same members — an early key on the scope's sequential spine, ahead of
+/// every park (gate 6, the park split). The channel is idempotent on an Owned
+/// member, so the scope-exit adopt behind the early key is a structural no-op
+/// on the paths that ran both. Run by the ownership pass in
+/// `analyze_regions_with`.
 ///
 /// Admission (each gate refusing to Shared, the always-legal baseline):
 ///
@@ -61,6 +66,15 @@ use rustc_hash::{FxHashMap, FxHashSet};
 ///    site. Adopt-per-iteration is sound (each iteration adopts that round's
 ///    fresh regions); alloc-inside/adopt-outside is not — the static suppression
 ///    covers every iteration while the slot-loaded adopt reaches only the last.
+/// 6. **The park split.** No park may run between a member's allocation and its
+///    adopt: in that interval the members are `Counted` with their own releases
+///    suppressed, so a route that abandons such a park strands the whole SCC —
+///    no release table names the members, and no node adopted them. When the
+///    adopt scope can park (`Signal::may_park` on its aggregated signal), the
+///    walk finds an early adopt key on the scope's sequential spine
+///    ([`park_split_key`]) and emits the adopt there too; a shape the spine
+///    cannot order refuses to Shared
+///    (docs/impl/region/owner.md § "Owner nodes" — "The park split").
 ///
 /// The **free** needs no post-dominance check of its own: the adopt only
 /// transfers ownership, and the node's release at the activation's completion is
@@ -199,10 +213,27 @@ pub(in crate::hir::region::infer) fn compute_activation_adopts(
         if loop_seam {
             continue;
         }
+        // Gate 6 — the park split: a parking adopt scope gets an early key
+        // ahead of every park, or refuses. The scope-exit entry stays beside
+        // the early one — a path that leaves the scope before the key (a
+        // `break` past it) still adopts there, and the channel's idempotence
+        // absorbs the double adopt on paths that run both.
+        let mut early_key = None;
+        if let Some(site_node) = find_node(hir, site) {
+            if site_node.signal.may_park() {
+                match park_split_key(site_node, &targets, false) {
+                    Some(k) => early_key = Some(k),
+                    None => continue,
+                }
+            }
+        }
         for &m in scc {
             taken.insert(m);
         }
         out.entry(site).or_default().extend(scc.iter().copied());
+        if let Some(k) = early_key {
+            out.entry(k).or_default().extend(scc.iter().copied());
+        }
     }
     // Deterministic member order per site: allocation program order (region ids
     // order nothing).
@@ -210,6 +241,92 @@ pub(in crate::hir::region::infer) fn compute_activation_adopts(
         members.sort_by_key(|m| region_alloc_hir.get(m).map(|&h| ord(h)).unwrap_or(0));
     }
     out
+}
+
+/// The node with `id` in `hir`'s tree, by structural search — the adopt site's
+/// `&Hir` for the park-split gate (gate 6), which reads its aggregated signal
+/// and its spine.
+fn find_node(hir: &Hir, id: HirId) -> Option<&Hir> {
+    if hir.id == id {
+        return Some(hir);
+    }
+    let mut found = None;
+    hir.for_each_child(|c| {
+        if found.is_none() {
+            found = find_node(c, id);
+        }
+    });
+    found
+}
+
+/// The node's sequential constituents in execution order — a `Let`/`Letrec`'s
+/// binding inits then body, a `Begin`/`Block`'s statements — each completing
+/// before the next begins, so `emit_decrefs_for` on a constituent's id runs
+/// between it and its successor (for a binding init, after the binding's
+/// store). `None` for any other node: its interior execution order is not one
+/// this walk can read, so the park split refuses rather than guess.
+fn sequential_constituents(node: &Hir) -> Option<Vec<&Hir>> {
+    match &node.kind {
+        HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => Some(
+            bindings
+                .iter()
+                .map(|(_b, init)| init)
+                .chain(std::iter::once(&**body))
+                .collect(),
+        ),
+        HirKind::Begin(items) => Some(items.iter().collect()),
+        HirKind::Block { body, .. } => Some(body.iter().collect()),
+        _ => None,
+    }
+}
+
+/// Does `hir`'s subtree contain any of `targets` (the members' allocation
+/// sites)?
+fn contains_any(hir: &Hir, targets: &FxHashSet<HirId>) -> bool {
+    if targets.contains(&hir.id) {
+        return true;
+    }
+    let mut found = false;
+    hir.for_each_child(|c| {
+        if !found {
+            found = contains_any(c, targets);
+        }
+    });
+    found
+}
+
+/// The park split (gate 6): the node whose `emit_decrefs_for` is the early
+/// adopt key — ordered after every member allocation and before every park
+/// that could strand one — or `None` where no such node exists on the
+/// sequential spine.
+///
+/// Per spine level, the key candidate is the LAST constituent containing a
+/// member allocation: every member's binding store completes with it, and
+/// every later constituent's park finds the members already Owned. A park in
+/// an EARLIER constituent refuses only where a member allocation precedes it
+/// (`allocs_before` carries that fact into recursion) — a park before every
+/// member allocation strands nothing, because no member exists when it parks.
+/// When the candidate itself both allocates and parks, the walk recurses into
+/// it; a non-sequential candidate ([`sequential_constituents`] `None`) or a
+/// member allocated outside every constituent refuses.
+fn park_split_key(node: &Hir, targets: &FxHashSet<HirId>, allocs_before: bool) -> Option<HirId> {
+    let cs = sequential_constituents(node)?;
+    let has_alloc: Vec<bool> = cs.iter().map(|c| contains_any(c, targets)).collect();
+    let last_a = has_alloc.iter().rposition(|&a| a)?;
+    for (i, c) in cs.iter().enumerate() {
+        if i >= last_a || !c.signal.may_park() {
+            continue;
+        }
+        if allocs_before || has_alloc[..=i].iter().any(|&a| a) {
+            return None;
+        }
+    }
+    if cs[last_a].signal.may_park() {
+        let inner_before = allocs_before || has_alloc[..last_a].iter().any(|&a| a);
+        park_split_key(cs[last_a], targets, inner_before)
+    } else {
+        Some(cs[last_a].id)
+    }
 }
 
 /// Every `While`/`Loop` node's post-order subtree interval `[low, order]`, so

--- a/src/hir/region/infer/tests/adopt/cuts.rs
+++ b/src/hir/region/infer/tests/adopt/cuts.rs
@@ -178,6 +178,161 @@ fn activation_adopt_refuses_escaping_hull() {
     );
 }
 
+/// The Emit node of a shape carrying exactly one `(emit …)` — the park whose
+/// position the park-split pins compare against.
+fn sole_emit(hir: &Hir) -> HirId {
+    fn walk(h: &Hir, out: &mut Vec<HirId>) {
+        if matches!(h.kind, HirKind::Emit { .. }) {
+            out.push(h.id);
+        }
+        h.for_each_child(|c| walk(c, out));
+    }
+    let mut emits = Vec::new();
+    walk(hir, &mut emits);
+    assert_eq!(emits.len(), 1, "shape must carry exactly one emit");
+    emits[0]
+}
+
+/// The allocation HirId of `r`, from the walk's `alloc_region` inversion.
+fn alloc_site_of(info: &RegionInfo, r: Region) -> HirId {
+    info.alloc_region
+        .iter()
+        .find(|(_, &reg)| reg == r)
+        .map(|(&h, _)| h)
+        .expect("member has an allocation site")
+}
+
+#[test]
+fn activation_adopt_sites_ahead_of_park() {
+    // The park split (docs/impl/region/owner.md § "Owner nodes" — "The park
+    // split"): a park inside the adopt scope, AFTER the members' allocations,
+    // keeps the SCC admitted — the walk keys a SECOND, earlier adopt after the
+    // last member allocation, so the members are Owned (riding the parked
+    // frame's owner node) before the park can strand them. The scope-exit site
+    // stays beside it (the channel is idempotent on an Owned member).
+    let (hir, info) = analyze_full(
+        "(begin (let [root (@array) m (@array)] \
+                  (let [c (fn [] (length m))] \
+                    (begin (%array-push m c) (c) (%array-push root m) \
+                           (emit :yield 0) nil))) \
+                nil)",
+    );
+    let c = sole_closure_region(&hir, &info);
+    let m = info
+        .containment_edges
+        .iter()
+        .find(|(_, s, _)| *s == c)
+        .map(|&(_, _, d)| d)
+        .expect("precondition: a funnel-recovered store edge m ⊇ c");
+    assert_eq!(
+        info.activation_adopt_sites.len(),
+        2,
+        "a parking adopt scope carries the early key AND the scope-exit site; \
+         got {:?}",
+        info.activation_adopt_sites,
+    );
+    let expected: rustc_hash::FxHashSet<Region> = [m, c].into_iter().collect();
+    for members in info.activation_adopt_sites.values() {
+        let set: rustc_hash::FxHashSet<Region> = members.iter().copied().collect();
+        assert_eq!(
+            set, expected,
+            "both sites adopt the whole m↔c SCC (the second adopt is a no-op \
+             on an Owned member)",
+        );
+    }
+    for &r in &[m, c] {
+        assert!(
+            info.suppressed_decref_regions.contains(&r),
+            "member r{}'s own decref stays suppressed under the park split",
+            r.0,
+        );
+    }
+    // The ordering that closes the leak: every member allocation completes at
+    // or before the early key, and the early key precedes the park; the
+    // scope-exit site post-dominates the park. Post-order agrees with
+    // execution order here — the compared nodes sit in sibling constituents.
+    let order = compute_order(&hir);
+    let ord = |id: HirId| order.get(&id).copied().expect("ordered node");
+    let emit = ord(sole_emit(&hir));
+    let mut sites: Vec<u32> = info
+        .activation_adopt_sites
+        .keys()
+        .map(|&s| ord(s))
+        .collect();
+    sites.sort_unstable();
+    let (early, late) = (sites[0], sites[1]);
+    assert!(
+        early < emit && emit < late,
+        "the early key must precede the park and the scope-exit site must \
+         follow it (early={early}, emit={emit}, late={late})",
+    );
+    for &r in &[m, c] {
+        assert!(
+            ord(alloc_site_of(&info, r)) <= early,
+            "member r{}'s allocation must complete by the early key",
+            r.0,
+        );
+    }
+
+    // A park ordered BEFORE every member allocation strands nothing (no member
+    // exists when it parks). Multi-binding `let` desugars to nested
+    // single-binding lets (hir/AGENTS.md invariant 10), so this park sits in
+    // an ENCLOSING scope's init, outside the adopt site's subtree: the SCC
+    // stays admitted with the single scope-exit site, exactly as with no park.
+    let (_, info) = analyze_full(
+        "(begin (let [z (emit :yield 0) root (@array) m (@array)] \
+                  (let [c (fn [] (length m))] \
+                    (begin (%array-push m c) (c) (%array-push root m) nil))) \
+                nil)",
+    );
+    assert_eq!(
+        info.activation_adopt_sites.len(),
+        1,
+        "a park before every member allocation must not refuse or double-site \
+         the SCC; got {:?}",
+        info.activation_adopt_sites,
+    );
+}
+
+#[test]
+fn activation_adopt_refuses_park_between_allocations() {
+    // A park BETWEEN two members' allocations: no adopt point covers the
+    // already-allocated member across the park, so the park split cannot order
+    // the shape and the SCC refuses to Shared — no site, no suppression (the
+    // members keep their baseline releases).
+    let (hir, info) = analyze_full(
+        "(begin (let [m (@array)] \
+                  (begin (emit :yield 0) \
+                         (let [c (fn [] (length m))] \
+                           (begin (%array-push m c) (c) nil)))) \
+                nil)",
+    );
+    assert!(
+        info.activation_adopt_sites.is_empty(),
+        "a park between the members' allocations must refuse the SCC; got {:?}",
+        info.activation_adopt_sites,
+    );
+    let c = sole_closure_region(&hir, &info);
+    assert!(
+        !info.suppressed_decref_regions.contains(&c),
+        "a refused SCC leaves no suppression behind (suppress ⊆ adopt)",
+    );
+
+    // The control twin — the same nesting with no park — admits, so the
+    // refusal above is attributable to the park alone.
+    let (_, info) = analyze_full(
+        "(begin (let [m (@array)] \
+                  (begin nil \
+                         (let [c (fn [] (length m))] \
+                           (begin (%array-push m c) (c) nil)))) \
+                nil)",
+    );
+    assert!(
+        !info.activation_adopt_sites.is_empty(),
+        "precondition: the no-park twin is admitted",
+    );
+}
+
 // ── ownership inference: the transferred-returned-subtree cut ───────────────
 //
 // A producer lambda builds an externally-unique cyclic subtree and returns its

--- a/src/hir/region/info.rs
+++ b/src/hir/region/info.rs
@@ -814,13 +814,16 @@ pub struct RegionInfo {
     /// `region::infer::ownership::compute_transfer_adopts`.
     pub transfer_adopt_regions: FxHashSet<Region>,
     /// Ownership forest, **activation-owner** cut, populated by the ownership pass;
-    /// empty when no capture-back-edge SCC is present. Adopt-site HirId — the innermost
-    /// structural scope enclosing every member's allocation — → the member regions of
-    /// a capture-back-edge SCC (a container captured by a closure it holds:
-    /// `m ⊇ c` by store, `c ⊇ m` by capture — the cycle no region root can own;
-    /// docs/impl/region/owner.md § "Owner nodes" — "The capture-back-edge SCC").
-    /// At the site the lowerer emits one value-resolved `AdoptIntoActivation` per
-    /// member (`emit_adopt_into_activation`), moving it `Counted → Owned` under the
+    /// empty when no capture-back-edge SCC is present. Adopt-site HirId → the member
+    /// regions of a capture-back-edge SCC (a container captured by a closure it
+    /// holds: `m ⊇ c` by store, `c ⊇ m` by capture — the cycle no region root can
+    /// own; docs/impl/region/owner.md § "Owner nodes" — "The capture-back-edge
+    /// SCC"). The primary site is the innermost structural scope enclosing every
+    /// member's allocation; an SCC whose scope can park carries a SECOND entry for
+    /// the same members, keyed ahead of every park (the park split — the channel's
+    /// idempotence absorbs the double adopt). At each site the lowerer emits one
+    /// value-resolved `AdoptIntoActivation` per member
+    /// (`emit_adopt_into_activation`), moving it `Counted → Owned` under the
     /// executing activation's owner node; each member's own compiler decref is
     /// suppressed (`suppressed_decref_regions`, the suppress ⊆ adopt contract), so
     /// the node's completion release is the members' sole demise — the interior

--- a/src/lir/types/instr.rs
+++ b/src/lir/types/instr.rs
@@ -450,8 +450,9 @@ pub enum LirInstr {
     /// JIT (`elle_jit_adopt_into_activation`); handled structurally (no-op)
     /// on WASM; GPU-ineligible. Emitted by the ownership forest for the
     /// capture-back-edge SCC (a container captured by a closure it holds —
-    /// `RegionInfo::activation_adopt_sites`, one adopt per member at the SCC's
-    /// enclosing-scope site) and for the transferred returned subtree (a
+    /// `RegionInfo::activation_adopt_sites`, one adopt per member per site: the
+    /// SCC's enclosing scope, plus an early key ahead of any park — the park
+    /// split) and for the transferred returned subtree (a
     /// summarized producer's consumer sites — `RegionInfo::transfer_adopt_regions`,
     /// where this replaces the result's `DecrefValueRegion`). The handlers are
     /// idempotent on an already-Owned child (a re-delivered region keeps its

--- a/src/runtime/tests/ownership/anode.rs
+++ b/src/runtime/tests/ownership/anode.rs
@@ -2,9 +2,11 @@ use super::*;
 
 /// End-to-end exercise of the ACTIVATION OWNER NODE on the interpreter
 /// (docs/impl/region/owner.md § "Owner nodes — an activation as a forest root").
-/// No production lowering emits `AdoptIntoActivation` yet, so the activation body
-/// is hand-emitted bytecode: load a fresh-region member from the constant pool,
-/// adopt it into the current activation's (lazily-minted) owner node, return nil.
+/// The body is hand-emitted bytecode — isolating the runtime node mechanism
+/// from the compiler's adopt siting (the production emitters are the
+/// capture-back-edge and transfer cuts): load a fresh-region member from the
+/// constant pool, adopt it into the current activation's (lazily-minted) owner
+/// node, return nil.
 /// The activation's NORMAL completion — the trampoline's clean break — must free
 /// the node, whose subtree drop reclaims the member: its generation bumps (pages
 /// returned) and the live region count stays bounded across 50 activations. The

--- a/src/runtime/tests/ownership/owner.rs
+++ b/src/runtime/tests/ownership/owner.rs
@@ -46,6 +46,56 @@ fn region_ownership_capture_back_edge_cycle_reclaims() {
     );
 }
 
+/// The capture-back-edge SCC with a park INSIDE the adopt scope, on the two
+/// in-process abandonment routes — the park split end-to-end
+/// (docs/impl/region/owner.md § "Owner nodes" — "The park split"; inference pin
+/// `region::infer::tests::adopt::activation_adopt_sites_ahead_of_park`; the
+/// abort route and both heap dimensions ride the `adopt-park-*` oracle family).
+/// The early adopt runs after the members' allocations and before the yield, so
+/// the parked frame carries the members in its activation owner node; the
+/// handle drop's free-path discharge and the cancel's terminal teardown then
+/// free node + members. The trap this gauges: the scope-exit adopt alone sits
+/// PAST the yield, so a route that abandons the park would strand the whole
+/// SCC (~2 regions per op) — suppressed members that no release table names
+/// and no node ever adopted.
+#[test]
+fn region_ownership_parked_capture_back_edge_scc_reclaims_on_abandonment() {
+    const PRELUDE: &str = "(def body (fn [] (let [root (@array) m (@array)] \
+        (let [c (fn [] (length m))] \
+          (begin (%array-push m c) (c) (%array-push root m) \
+                 (emit :yield 0) (length root))))))";
+    let leak = mid_run_discriminator(Runtime::without_stdlib(), "arena/region-count");
+    assert!(
+        leak > 150,
+        "gauge live: the self-referential accumulator must grow (~200); got {leak}",
+    );
+    let routes = [
+        (
+            "drop",
+            "(let [f (fiber/new body 2)] (begin (fiber/resume f) nil))",
+        ),
+        (
+            "cancel",
+            "(let [f (fiber/new body 2)] \
+               (begin (fiber/resume f) (fiber/cancel f :dead) nil))",
+        ),
+    ];
+    for (route, body) in routes {
+        let growth = mid_run_growth(
+            Runtime::without_stdlib(),
+            PRELUDE,
+            body,
+            "arena/region-count",
+        );
+        assert!(
+            growth < 50,
+            "a park inside the adopt scope must reclaim the SCC on the {route} \
+             route — per-op region growth must be near zero over 200 iterations, \
+             got {growth} (the discriminator grows {leak})",
+        );
+    }
+}
+
 /// End-to-end reclamation of the **transferred returned cycle** — the
 /// consuming-activation owner cut (docs/impl/region/owner.md § "Owner nodes" —
 /// "The transferred returned subtree"; inference pin

--- a/src/signals/AGENTS.md
+++ b/src/signals/AGENTS.md
@@ -35,6 +35,7 @@ Each predicate asks a specific question. No vague "is_inert".
 | Predicate | Meaning |
 |-----------|---------|
 | `may_suspend()` | Can suspend execution? (yield, debug, or polymorphic) |
+| `may_park()` | Can park a frame? (any bit outside `:error`/`:halt`/`:ffi`, or polymorphic) — the static face of `dispatch::is_suspending` |
 | `may_yield()` | Can yield? (SIG_YIELD) |
 | `may_error()` | Can signal an error? (SIG_ERROR) |
 | `may_ffi()` | Calls foreign code? (SIG_FFI) |

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -401,6 +401,19 @@ impl Signal {
         self.bits.intersects(SIG_YIELD)
     }
 
+    /// Can this function PARK — suspend its frame into a continuation only a
+    /// resume revives? The static face of [`dispatch::is_suspending`], asked
+    /// of an inferred signal whose bits are a UNION of possible raises: any
+    /// bit outside the two unwinding exits (`:error`, `:halt`) can park, so a
+    /// compound like `:io`+`:error` answers true where the runtime predicate
+    /// classifies one concrete raise at a time. `SIG_FFI` marks a foreign
+    /// call, not a raise, and never parks. A polymorphic signal may park
+    /// through its argument, so it answers true.
+    pub const fn may_park(&self) -> bool {
+        let non_park = SIG_ERROR.union(SIG_HALT).union(SIG_FFI);
+        self.propagates != 0 || !self.bits.subtract(non_park).is_empty()
+    }
+
     /// Can this function error?
     pub const fn may_error(&self) -> bool {
         self.bits.intersects(SIG_ERROR)

--- a/tests/elle/oracle.lisp
+++ b/tests/elle/oracle.lisp
@@ -124,10 +124,13 @@
                     "del-wrapper" "set-del-wrapper" "set-add"])
 (declare-root :f2 ["fiber-nested" "multi-resume" "yield-discard"
                    "yield-multimut" "protect-while" "denied-discard"
-                   "denied-discard@regions" "cancel-discard" "adopt-park-drop"
-                   "adopt-park-drop@regions" "adopt-park-abort"
-                   "adopt-park-abort@regions" "adopt-park-cancel"
-                   "adopt-park-cancel@regions"])
+                   "denied-discard@regions" "cancel-discard"])
+# The `adopt-park-*` family is CLOSED on both dimensions (undeclared, like
+# `rest-array-copy`, so a regression to open trips the completeness gate loudly
+# rather than being absorbed under F2): the park split keys a second adopt
+# ahead of the park, so an abandoned park's discharge frees the SCC through the
+# parked frame's owner node (docs/impl/region/owner.md § "Owner nodes" — "The
+# park split"; the `ap-*` defns below hold the attribution set).
 # `abort-tail-result` and `abort-mask-caught-literal` are CLOSED controls now
 # (undeclared, like `rest-array-copy`, so a regression to open trips the
 # completeness gate loudly rather than being absorbed back under F2). What they
@@ -262,9 +265,9 @@
     "denied-discard" 2
     "abort-discard" 0
     "cancel-discard" 0
-    "adopt-park-drop" 2
-    "adopt-park-abort" 2
-    "adopt-park-cancel" 2
+    "adopt-park-drop" 0
+    "adopt-park-abort" 0
+    "adopt-park-cancel" 0
     "adopt-complete" 0
     "adopt-nopark" 0
     "plain-park-drop" 0
@@ -855,22 +858,21 @@
 (def emit-sig :yield)
 (def emit-error-sig :error)
 (def emit-subject (string "emit-subject"))
-# The activation-adopt scope crossed by a park. `ap-adopting-body` is the
-# capture-back-edge shape (`capture-backedge` below) with a `(yield j)` INSIDE
-# the scope enclosing the members' allocations — the adopt site is the
-# innermost structural scope enclosing every member's allocation
-# (docs/impl/region/owner.md § "Owner nodes"), so the park sits between the
-# allocations and the adopt. The members' own decrefs are suppressed under the
-# suppress ⊆ adopt contract, so a route that abandons the park holds members
-# no release table names and a node that never adopted them: the whole SCC
-# strands, on the handle drop, the abort, and the cancel alike. The set must
-# stay together, because only its gaps attribute the strand: `ap-before-body`
-# differs ONLY in the yield's position (after the scope closes, so the adopt
-# runs before the park — every abandonment route reclaims), `ap-plain-body`
-# removes the SCC, `ap-nopark-body` removes the park, and `adopt-complete`
-# removes the abandonment. The completion control also settles admission: the
-# Shared baseline leaks this cycle per call, so completion at 0 proves the
-# activation cut is active for the shape.
+# The activation-adopt scope crossed by a park — the park split's end-to-end
+# family. `ap-adopting-body` is the capture-back-edge shape (`capture-backedge`
+# below) with a `(yield j)` INSIDE the scope enclosing the members'
+# allocations. The walk keys a second adopt after the last member allocation
+# and ahead of the yield (docs/impl/region/owner.md § "Owner nodes" — "The park
+# split"), so the parked frame carries the members in its activation owner
+# node and every abandonment route frees them: the handle drop's free-path
+# discharge, the abort's discharge, and the cancel's terminal teardown alike.
+# The set must stay together, because only its gaps attribute a regression:
+# `ap-before-body` differs ONLY in the yield's position (after the scope
+# closes, so the single scope-exit adopt covers it), `ap-plain-body` removes
+# the SCC, `ap-nopark-body` removes the park, and `adopt-complete` removes the
+# abandonment. The completion control also settles admission: the Shared
+# baseline leaks this cycle per call, so completion at 0 proves the activation
+# cut is active for the shape — the park did not refuse it.
 (defn ap-adopting-body [j]
   (let [root @[]
         m @[]]
@@ -1385,22 +1387,22 @@
         (fiber/resume f)
         (get (fiber/value f) :error))) 2]
    # The adopt-park family and its controls — the `ap-*` defns above hold the
-   # attribution set. Open on both dimensions; the region pins live in
-   # `@dual-read`.
+   # attribution set. CLOSED controls on both dimensions (see the ledger note
+   # beside `declare-root :f2`); the region pins live in `@dual-read`.
    ["adopt-park-drop"
     (fn [j]
       (let [f (fiber/new (fn [] (ap-adopting-body j)) |:yield|)]
-        (fiber/resume f))) 3]
+        (fiber/resume f))) 0]
    ["adopt-park-abort"
     (fn [j]
       (let [f (fiber/new (fn [] (ap-adopting-body j)) |:yield|)]
         (fiber/resume f)
-        (protect (fiber/abort f "boom")))) 3]
+        (protect (fiber/abort f "boom")))) 0]
    ["adopt-park-cancel"
     (fn [j]
       (let [f (fiber/new (fn [] (ap-adopting-body j)) |:yield|)]
         (fiber/resume f)
-        (fiber/cancel f :dead))) 3]
+        (fiber/cancel f :dead))) 0]
    ["adopt-complete"
     (fn [j]
       (let [f (fiber/new (fn [] (ap-adopting-body j)) |:yield|)]


### PR DESCRIPTION
A park between a capture-back-edge SCC member's allocation and its adopt stranded the whole SCC on every abandonment route (#986). The members' own decrefs are suppressed under the suppress ⊆ adopt contract, so an abandoned park held members no release table names and a node that never adopted them. The oracle measured 3 objects and 2 regions per op on the handle-drop, abort, and cancel routes alike, with the completion control at 0.

The close keeps the cut and splits the adopt around the park:

- `Signal::may_park` (signals/mod.rs) is the static face of `dispatch::is_suspending`: any inferred bit outside `:error`/`:halt`/`:ffi`, or a polymorphic propagation, can park.
- When the adopt scope can park, `compute_activation_adopts` descends the scope's sequential spine — `Let`/`Letrec` binding inits then body, `Begin`/`Block` statements — to the last constituent that allocates a member, and keys a second adopt there. `emit_decrefs_for` fires for a binding init right after the binding's store, so the early adopt loads populated slots and runs ahead of every park; the parked frame then carries the members in its activation owner node, which the discharge and teardown routes already free. No lowerer or runtime change is needed.
- The scope-exit adopt stays beside the early key: a `break` past the key still adopts there, and the `AdoptIntoActivation` channel is idempotent on an Owned member. Adopting before the SCC's interior stores is sound because incref/decref are inert on an Owned region while the store still records its edge for the set-drop.
- A shape the spine cannot order — a park between two members' allocations — refuses to Shared (gate 6).

Measured with the release oracle: the `adopt-park-drop`/`abort`/`cancel` pins fall 3→0 on the object count and 2→0 on the region count, with the `ap-*` controls (`adopt-complete`, `adopt-nopark`, `plain-park-drop`, `adopt-before-park-*`) unchanged at 0.

Pinned by `regions::tests::adopt::activation_adopt_sites_ahead_of_park` and `activation_adopt_refuses_park_between_allocations` (counter-factual: both fail without the walk change), and end to end by `runtime::tests::ownership::region_ownership_parked_capture_back_edge_scc_reclaims_on_abandonment` beside the oracle family. Full smoke, smoke-nouring, qa, unit, and integration suites are green.

Closes #986.
