### PR TITLE
region: an io park's request is released by the install that ends it

### DIFF
--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -280,31 +280,51 @@ parked fiber's accounting symmetric with its unpark:
   therefore the discharge's on a fiber that never runs again, and the DISPLACING install's
   on one that does: `fiber/resume`'s delivery and `fiber/abort` / `fiber/refuse`'s injected
   error each replace the payload in the slot, and each owes it a release as it does.
-  Which parks are that shape is read two ways, because the bits answer for only one of
-  them. An io park is its `SIG_IO` bit, and its release is
-  `release_parked_signal` — resume-only, because a `Fresh` io op builds its completion
-  buffer IN the request's region and hands that back as the resume value, where the
-  resumer's release of the resume result is the second consumer and a release here would
-  free the buffer under the caller. A denial parks under the WITHHELD capability's bits,
+  Which parks are that shape is read two ways, because the bits answer for neither on
+  their own. An io park is a `SIG_IO` park whose payload IS an `IoRequest`, a value only
+  an io primitive builds, and `release_displaced_io_request` releases the region that
+  payload lives in. A denial parks under the WITHHELD capability's bits,
   which say nothing about who built the payload and are indistinguishable from an
   `(emit :fs v)` of a body-allocated value — so the classifier records the payload in the
   ledger (`park_denial`, an uncounted marker compared bit-wise like the mint record) and
   `release_displaced_denial_payload` releases exactly what the record names, taking it
-  (`take_bodyless`) as the receipt, on both installs. The injected error takes no skip: it
-  is not a delivery, and the abort's own `AbortDelivery` mint funds the consumer it does
-  have.
+  (`take_bodyless`) as the receipt. Both readings run at every install, and neither asks
+  what the other did.
 
-  **The two readings overlap on one denial, and the record wins it.** `:io` is a
-  withheld capability like any other, so a fiber denied `:io` parks under `SIG_IO` —
-  the very bit the io arm reads — and there the denial payload and an `IoRequest`
-  cannot be told apart by bits at all. One reference is owed, so `fiber/resume` asks
-  the record first and skips the io arm when it claims the park; running both frees
-  the payload under the mediator that is still reading it. Every other install
-  displaces on the record alone, the io arm never having reached them. Gauged by
-  `tests/elle/region-denial-park.lisp` per install and by
-  `tests/elle/region-capability-denial-resume-leak.lisp` per denial position, and pinned
-  guardfree by `tests/elle/region-denial-park-uaf.lisp`, whose `:io` witnesses are the
-  collision.
+  **What is resume-only is the SKIP, not the release.** A `Fresh` io op
+  (`port/read`, `accept`) builds its completion buffer IN the request's region and hands
+  that buffer back as the resume value, so at a resume that region is still live and the
+  resumer's release of the resume result is its second consumer — releasing there too
+  would free the buffer under the caller. `release_resumed_io_request` is that skip and
+  nothing else; every other install reaches the release directly. An injected error is
+  not a delivery — the abort's own `AbortDelivery` mint funds the consumer it does have —
+  so an error value that happens to live in the request's region owes this release all
+  the same, and the skip must not travel to the injection.
+
+  **An in-flight request needs no waiting on.** An abort reaches a fiber whose request
+  the scheduler already submitted, where the release must not free a buffer the kernel
+  is still writing into. It cannot, because the submitted operand is one of Rule 8's
+  escape sites ([rules.md](rules.md) Rule 8): the pending entry increfs every value its
+  completion reads and decrefs when the entry is disposed. A `Fresh` op's completion
+  buffer lives in the request's own region, so that retain is a count on the region for
+  the operation's whole lifetime, and the install's release drops the suspend retain and
+  no more. `tests/elle/grpc.lisp`'s `with-server` teardown is the full-scheduler shape,
+  and the `region_fiber_abort_io_protect_uaf` fixture the minimal one.
+
+  **The bits collide on one denial, and each reading refuses it on its own.** `:io` is
+  a withheld capability like any other, so a fiber denied `:io` parks under `SIG_IO` and
+  the bit alone hands that one park to both readings, where one reference is owed and
+  not two. Ordering the two calls does not settle it, because the record is written on
+  the fiber that WAS denied and an install can reach a fiber that merely relays the
+  park — the outer fiber of a `protect`ed denial, whose slot holds the same payload and
+  whose ledger holds nothing. There the io arm would find no record to defer to. So the
+  refusal is each reading's own: a denial's payload is a struct and never an
+  `IoRequest`, so the io arm has no claim on it wherever the install lands. Gauged by
+  `tests/elle/region-denial-park.lisp` and `tests/elle/region-io-park.lisp` per install,
+  and by `tests/elle/region-capability-denial-resume-leak.lisp` per denial position;
+  pinned guardfree by `tests/elle/region-denial-park-uaf.lisp` and
+  `tests/elle/region-io-park-uaf.lisp`, whose `:io` witnesses are the collision, direct
+  and relayed.
 - **What yields is the emit OPERATION, not the `Emit` node.** A first argument the compiler
   cannot read as a keyword set falls through to the `emit` primitive
   ([../../signals/emit.md](../../signals/emit.md) § "Dynamic emit"), which parks the same way

--- a/src/primitives/fiber_introspect.rs
+++ b/src/primitives/fiber_introspect.rs
@@ -199,12 +199,20 @@ fn inject_error_at_suspension(
     // tables claim (docs/impl/region/owner.md § "Park/unpark symmetry").
     let parked = handle.with(|fiber| fiber.signal);
     crate::vm::fiber::release_displaced_terminal_signal(ctx.heap_mut(), fiber_value, parked);
-    // A parked CAPABILITY-DENIAL payload is the one non-terminal park this
-    // install does answer for: the runtime built it, so the child's continuation
-    // releases nothing for it, and refusing the denied call displaces it exactly
-    // as a resume would (docs/impl/region/owner.md § "Park/unpark symmetry" —
-    // "A payload the RUNTIME built is released by the install that displaces
-    // it").
+    // A park whose payload the RUNTIME built is what this install does answer
+    // for: the child's continuation releases nothing for such a value, and
+    // raising at the suspension point displaces it exactly as a resume would
+    // (docs/impl/region/owner.md § "Park/unpark symmetry" — "A payload the
+    // RUNTIME built is released by the install that displaces it"). Two parks
+    // are that shape and each has its own reading — a capability denial's
+    // payload by the classifier's record, a yielding io op's `IoRequest` by the
+    // payload's own type — so the two name disjoint payloads and both run. The
+    // io arm goes first because it is the one that READS the parked value to
+    // decide, and the denial arm's release may have been the payload's last.
+    // The resume's `Fresh`-op skip does not travel here: an injected error is
+    // not a delivery, so an error value living in the request's region owes this
+    // release all the same.
+    crate::vm::fiber::release_displaced_io_request(ctx.heap_mut(), parked);
     crate::vm::fiber::release_displaced_denial_payload(ctx.heap_mut(), handle);
     handle.with_mut(|fiber| {
         fiber.signal = Some((SIG_ERROR, error_value));

--- a/src/primitives/fibers.rs
+++ b/src/primitives/fibers.rs
@@ -158,14 +158,14 @@ pub(crate) fn prim_fiber_resume(
             // The park's payload is the RUNTIME's, not the body's, in two shapes,
             // and each owes one release as this resume displaces it: a
             // capability-denial struct, named by the classifier's record, and a
-            // yielding io op's `IoRequest`, named by its `SIG_IO` bit. They are
-            // asked in that order because a fiber denied `:io` parks under
-            // `SIG_IO` too, so the bit alone cannot tell that one denial from a
-            // real io park — the record can, and one reference is owed, not two
-            // (docs/impl/region/owner.md § "Park/unpark symmetry").
-            if !crate::vm::fiber::release_displaced_denial_payload(ctx.heap_mut(), handle) {
-                crate::vm::fiber::release_parked_signal(ctx.heap_mut(), parked, resume_value);
-            }
+            // yielding io op's `IoRequest`, named by the payload's own type. The
+            // two readings name disjoint payloads, so both run
+            // (docs/impl/region/owner.md § "Park/unpark symmetry"). The io arm
+            // goes first because it is the one that READS the parked value to
+            // decide, and the denial arm's release may have been the payload's
+            // last (`release_displaced_denial_payload`).
+            crate::vm::fiber::release_resumed_io_request(ctx.heap_mut(), parked, resume_value);
+            crate::vm::fiber::release_displaced_denial_payload(ctx.heap_mut(), handle);
             // And a parked TERMINAL result this resume displaces (a restarted
             // `:error` fiber, a re-resumed drained stream source): its
             // park-retain + recorded content edge counted on the free-time

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -234,16 +234,22 @@ primitive never returns, so nothing mints the reference that release consumes:
 ledger (`Fiber::delivery` — `park_primitive` / `park_denial`) and
 `do_fiber_resume_single` takes it (`take_resume_funding`) as it delivers.
 
-The denial owes one more, in the other direction. Its payload is the RUNTIME's,
-so the body names it nowhere and no continuation releases it — the install that
-displaces the park does, through `release_displaced_denial_payload` off the
-ledger's record (`park_denial` writes it, `take_bodyless` consumes it):
-`fiber/resume`, the `fiber/abort` / `fiber/refuse` injection, and the three
-`FiberResume` deliveries that reach an inner fiber directly. `fiber/resume` asks
-the record before `release_parked_signal`'s io arm and skips that arm when the
-record claims the park, a fiber denied `:io` parking under the same `SIG_IO` bit
-an io request does. See docs/impl/region/owner.md § "A payload the RUNTIME built
-is released by the install that displaces it".
+A runtime-built payload owes one more, in the other direction. The body names it
+nowhere and no continuation releases it — the install that displaces the park
+does. Two parks are that shape, and each has its own reading. A DENIAL's payload
+is named by the ledger's record (`park_denial` writes it,
+`release_displaced_denial_payload` takes it through `take_bodyless`); an io
+park's payload is named by BEING an `IoRequest` under `SIG_IO`
+(`release_displaced_io_request`). The readings name disjoint payloads — a
+denial's struct is never an `IoRequest` — so both run and neither asks what the
+other did, which is what a fiber denied `:io` needs: it parks under the same
+`SIG_IO` bit, and the install may reach a fiber that only relays the park and
+holds no record to defer to. The installs are `fiber/resume`, the `fiber/abort` /
+`fiber/refuse` injection, and the three `FiberResume` deliveries that reach an
+inner fiber directly. Only the resume adds a skip of its own
+(`release_resumed_io_request`), for the `Fresh` op whose completion buffer lives
+in the request's region. See docs/impl/region/owner.md § "A payload the RUNTIME
+built is released by the install that displaces it".
 
 Key methods:
 - `execute_bytecode_from_ip`: Executes from a given IP with Rc bytecode/constants

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -51,8 +51,8 @@ mod borrow_tests;
 pub(crate) use owned::{kill_fiber, parked_owner_nodes, release_fiber_owned, take_fiber_owned};
 use refcount::{incref_signal_region, release_discarded_signal};
 pub(crate) use refcount::{
-    is_terminal_signal, release_displaced_denial_payload, release_displaced_terminal_signal,
-    release_parked_signal,
+    is_terminal_signal, release_displaced_denial_payload, release_displaced_io_request,
+    release_displaced_terminal_signal, release_resumed_io_request,
 };
 // Re-exported for the WASM resume path (`crate::vm::fiber::record_terminal_signal_park`),
 // the only external caller; `owned::kill_fiber` reaches it by module path. Unused

--- a/src/vm/fiber/propagate.rs
+++ b/src/vm/fiber/propagate.rs
@@ -22,8 +22,9 @@ impl VM {
     /// or no consumer:
     ///
     /// - A NON-TERMINAL signal (a yield, an io request). The fiber runs again,
-    ///   so the resume path proper governs the payload — `release_parked_signal`
-    ///   for an io request, the resumed body's own pending release otherwise.
+    ///   so the resume path proper governs the payload —
+    ///   `release_resumed_io_request` for an io request, the resumed body's own
+    ///   pending release otherwise.
     ///   `with_child_fiber` step 6a excludes exactly this set from its park
     ///   retain for the same reason ("retaining here would leak"), and the
     ///   delivery follows the park.

--- a/src/vm/fiber/refcount.rs
+++ b/src/vm/fiber/refcount.rs
@@ -80,9 +80,10 @@ pub(crate) fn is_terminal_signal(bits: SignalBits) -> bool {
 /// than allocates is given a body reference of its own at the `Emit`
 /// (docs/impl/region/owner.md § "Park/unpark symmetry" — "A fiber body owns one
 /// reference of every value it yields"). Distinct from
-/// [`release_parked_signal`], whose io gate and shared-region skip are
-/// resume-path concerns: at a discard there is no resume value and no body to
-/// double-release against (docs/impl/region/owner.md § "Park/unpark symmetry").
+/// [`release_displaced_io_request`], which answers for the ONE payload a
+/// discharged park has no body reference for; at a discard there is no install to
+/// owe that release and no body to double-release against
+/// (docs/impl/region/owner.md § "Park/unpark symmetry").
 /// A no-op for `None` or an immediate.
 pub(crate) fn release_discarded_signal(
     heap: &mut crate::value::fiberheap::FiberHeap,
@@ -108,11 +109,11 @@ pub(crate) fn release_discarded_signal(
 /// and each re-park stacks another — the free cascade then over-releases the
 /// payload region (the `region-fiber-park-symmetry.lisp` restart face).
 ///
-/// A no-op for `None`, a NON-terminal parked signal (a yield value / io
-/// request, whose escape retain the resume path proper consumes — see
-/// [`release_parked_signal`] below), or an immediate payload — mirroring
-/// exactly the conditions under which the park took the retain and recorded
-/// the edge.
+/// A no-op for `None`, a NON-terminal parked signal (a yield value, whose escape
+/// retain the resumed body consumes; an io request, which
+/// [`release_displaced_io_request`] below answers for), or an immediate payload —
+/// mirroring exactly the conditions under which the park took the retain and
+/// recorded the edge.
 pub(crate) fn release_displaced_terminal_signal(
     heap: &mut crate::value::fiberheap::FiberHeap,
     fiber_value: Value,
@@ -158,19 +159,21 @@ pub(crate) fn release_displaced_terminal_signal(
 /// park no longer names what is in the slot, and an `(emit :fs v)` under the same
 /// withheld bits is a body-allocated payload this must never touch.
 ///
-/// No resume-value skip, unlike [`release_parked_signal`]: that skip answers for
-/// a `Fresh` io op building its completion buffer IN the request's region, and a
-/// denial payload is complete before the park. A resume value read back OUT of
-/// the payload shares its region and still owes this release — the child's
+/// No resume-value skip, unlike [`release_resumed_io_request`]: that skip answers
+/// for a `Fresh` io op building its completion buffer IN the request's region,
+/// and a denial payload is complete before the park. A resume value read back OUT
+/// of the payload shares its region and still owes this release — the child's
 /// continuation releases the denied call's RESULT, which the delivery's own
 /// `ResumeDelivery` mint funds. A no-op for a fiber with no record, a record that
 /// no longer names the parked signal, or an immediate payload.
 ///
-/// Returns whether the park WAS a denial, so a caller that also runs
-/// [`release_parked_signal`] can keep the two exclusive. They overlap on exactly
-/// one denial and no other: a fiber denied `:io` parks under `SIG_IO`, the very
-/// bit that arm reads, so there the io request and the denial payload cannot be
-/// told apart by bits — and one reference is owed, not two.
+/// Runs beside [`release_displaced_io_request`], never in place of it: the two
+/// name disjoint payloads, this one whatever the record names and that one an
+/// `IoRequest`, which a denial's struct never is. Neither needs to know whether
+/// the other fired, but this one runs SECOND, because its decref may be the
+/// payload's last and the io arm reads the parked value to reach its verdict.
+/// This one never does: the record is compared to the slot bit-wise
+/// (`bit_identical`), and only a payload the record claims is dereferenced.
 ///
 /// The record is the delivery ledger's (`park_denial` writes it, this take
 /// consumes it; docs/impl/region/owner.md § "A park names its funding in the
@@ -178,45 +181,42 @@ pub(crate) fn release_displaced_terminal_signal(
 pub(crate) fn release_displaced_denial_payload(
     heap: &mut crate::value::fiberheap::FiberHeap,
     handle: &crate::value::fiber::FiberHandle,
-) -> bool {
+) {
     let displaced = handle.with_mut(|fiber| {
         let record = fiber.delivery.take_bodyless()?;
         let (_, payload) = fiber.signal?;
         record.bit_identical(payload).then_some(payload)
     });
     let Some(payload) = displaced else {
-        return false;
+        return;
     };
     let region = crate::value::arena::region_of(heap, payload);
     crate::value::arena::decref_region(heap, region);
-    true
 }
 
-/// Release the `SuspendEscape` an io op left on its IoRequest's region when a
-/// parked fiber is resumed and that request — held in `fiber.signal` across the
-/// park — is replaced by `resume_value`. This reclaims the IoRequest region of a
-/// yielding io op; the gauge is `oracle.lisp`'s `io-yield ev/sleep` probe, which
-/// measures the whole suspend/pump/resume round bounded.
+/// Release the `SuspendEscape` an io op left on its IoRequest's region when an
+/// install displaces that request from `fiber.signal`.
 ///
 /// A yielding io op (`ev/sleep`, `port/read`, …) returns its `IoRequest` with
 /// `SIG_IO`, whereupon the suspend adds a
 /// [`SuspendEscape`](crate::value::arena::EscapeSite::SuspendEscape) retain so the
-/// scheduler can read the request out of `fiber.signal`. The request's own
-/// allocation ref is consumed by the scheduler's `fiber/value` read while it
-/// submits, so at resume the `SuspendEscape` is the request region's *sole*
-/// remaining reference. On resume the io call "returns" `resume_value` (the
-/// completion), so the caller's `DecrefValueRegion` targets THAT region, never
-/// the request's — orphaning the `SuspendEscape` and leaking the request region,
-/// unbounded in a long-running io loop. One decref here, the symmetric
-/// counterpart of the suspend-time incref, frees it: the request is dead (the
-/// scheduler already consumed it), so its region holds nothing live.
+/// scheduler can read the request out of `fiber.signal`. The request is the
+/// RUNTIME's value: the native built it, the body never named it, and no
+/// `decref_point` names its region — so the continuation past the suspend
+/// releases nothing for it and the suspend retain is what the allocation leaves
+/// behind. Whatever ends the park owes that release, exactly as it does for a
+/// capability denial's payload
+/// (docs/impl/region/owner.md § "Park/unpark symmetry" — "A payload the RUNTIME
+/// built is released by the install that displaces it"): the resume that
+/// delivers a completion, and the injected error `fiber/abort` / `fiber/refuse`
+/// raise at the fiber's own suspension point.
 ///
-/// **Skip when `resume_value` shares the region** — the `Fresh` io ops
-/// (`port/read`/`accept`) build their completion buffer *in* the IoRequest's
-/// region and hand it back as the resume value, so that region is still live;
-/// there the caller's `DecrefValueRegion` on the buffer balances the
-/// `SuspendEscape`, and a decref here would free the buffer out from under the
-/// caller (a use-after-free).
+/// **In flight is no reason to wait.** An abort reaches a fiber whose request
+/// the scheduler already submitted, and a `Fresh` op's completion buffer lives in
+/// that very region. The pending entry increfs each value its completion reads
+/// and decrefs when the entry is disposed (docs/impl/region/rules.md Rule 8, the
+/// submitted-I/O-operand escape site), so the region is counted for the
+/// operation's whole lifetime and this decref drops the suspend retain alone.
 ///
 /// Gated on `SIG_IO`. A user `(yield v)` / `(emit …)` value is **body-owned** —
 /// the resumed body itself releases the reference it held across the suspend, and
@@ -224,31 +224,84 @@ pub(crate) fn release_displaced_denial_payload(
 /// so releasing it here would double-free. The other runtime-built park payload,
 /// a capability denial's struct, parks under the withheld capability's bits and
 /// so cannot be told from that `(emit …)` by its bits at all; it is released by
-/// [`release_displaced_denial_payload`], off the classifier's record, on every
-/// install that displaces it rather than on the resume alone.
+/// [`release_displaced_denial_payload`], off the classifier's record. The two run
+/// side by side and name disjoint payloads — see the reading below.
 /// A no-op for a non-io signal, an immediate / `None` value, or a region-0 value.
-pub(crate) fn release_parked_signal(
+pub(crate) fn release_displaced_io_request(
+    heap: &mut crate::value::fiberheap::FiberHeap,
+    parked: Option<(SignalBits, Value)>,
+) {
+    if let Some(region) = io_request_region(heap, parked) {
+        crate::value::arena::decref_region(heap, Some(region));
+    }
+}
+
+/// The region a park's `IoRequest` lives in, or `None` where the park owes this
+/// accounting nothing — no park at all, a payload some other holder answers for,
+/// or an immediate. One reading of "which parks are io parks", so the release and
+/// the resume's skip below cannot come to disagree about it.
+///
+/// **The payload's TYPE is the reading, not the `SIG_IO` bit alone.** `:io` is a
+/// withheld capability like any other, so a fiber denied `:io` parks its denial
+/// struct under the same bit — and that payload belongs to the ledger record
+/// (`release_displaced_denial_payload`), which is written on the fiber that was
+/// denied. An install reaching a fiber that merely relays the park, the outer
+/// fiber of a `protect`ed denial, finds no record there and would claim the
+/// struct on the bit alone; releasing it here and at the record's own install
+/// frees it under the mediator. An `IoRequest` is a value only an io primitive
+/// builds, so asking for one makes the two readings name disjoint payloads
+/// instead of asking every install to order them.
+///
+/// The bits decide before the payload is touched at all, and the region is taken
+/// before the type is read. A park under other bits belongs to whoever does own
+/// its accounting, and reading its payload is a deref this arm cannot justify —
+/// one whose region may already be gone. `region_of` answers that case with the
+/// generation stamp's stale-read panic; `as_external` would read the freed page,
+/// so it goes second.
+fn io_request_region(
+    heap: &mut crate::value::fiberheap::FiberHeap,
+    parked: Option<(SignalBits, Value)>,
+) -> Option<crate::hir::region::RuntimeRegion> {
+    let (bits, value) = parked?;
+    if !bits.intersects(crate::value::SIG_IO) {
+        return None;
+    }
+    let region = crate::value::arena::region_of(heap, value)?;
+    value
+        .as_external::<crate::io::request::IoRequest>()
+        .is_some()
+        .then_some(region)
+}
+
+/// [`release_displaced_io_request`] as the RESUME path takes it: the one install
+/// that hands a value back in place of the request, and so the one that can find
+/// the request's region still live.
+///
+/// The `Fresh` io ops (`port/read`/`accept`) build their completion buffer *in*
+/// the IoRequest's region and hand it back as `resume_value`. There the caller's
+/// `DecrefValueRegion` on the buffer balances the `SuspendEscape`, and a decref
+/// here would free the buffer out from under the caller. So a resume value
+/// sharing the request's region is the signature that the region is still live,
+/// and the release stands down.
+///
+/// The skip is a fact about a DELIVERY, which is why it lives here rather than in
+/// the release: an injected error is not one — the abort's own `AbortDelivery`
+/// mint funds the consumer it has — so an error value that happens to live in the
+/// request's region owes the release all the same. The gauges are `oracle.lisp`'s
+/// `io-yield ev/sleep` probe for this path and `tests/elle/region-io-park.lisp`
+/// per install.
+pub(crate) fn release_resumed_io_request(
     heap: &mut crate::value::fiberheap::FiberHeap,
     parked: Option<(SignalBits, Value)>,
     resume_value: Value,
 ) {
-    let Some((bits, value)) = parked else {
+    let Some(region) = io_request_region(heap, parked) else {
         return;
     };
-    if !bits.intersects(crate::value::SIG_IO) {
+    if crate::value::arena::region_of(heap, resume_value) == Some(region) {
         return;
     }
-    let region = crate::value::arena::region_of(heap, value);
-    if region.is_none() {
-        return;
-    }
-    // The resume value sharing the request's region is the `Fresh`-io-op signature
-    // (the completion buffer is built there): that region is still live, so leave
-    // it to the caller's `DecrefValueRegion`.
-    if crate::value::arena::region_of(heap, resume_value) == region {
-        return;
-    }
-    crate::value::arena::decref_region(heap, region);
+    crate::value::arena::decref_region(heap, Some(region));
 }
 
 #[cfg(test)]

--- a/src/vm/fiber/refcount/tests.rs
+++ b/src/vm/fiber/refcount/tests.rs
@@ -24,6 +24,29 @@ fn foreign(heap: &mut crate::value::fiberheap::FiberHeap) -> Value {
     alloc_in_fresh_region(heap, cons()).0
 }
 
+/// An `IoRequest` on a region of its own — the payload a yielding io op parks,
+/// and the one thing the io arm answers for. A `Sleep` because it is the portless
+/// op: nothing else in the request has to be built for the type to be right.
+fn io_request(
+    heap: &mut crate::value::fiberheap::FiberHeap,
+) -> (Value, crate::hir::region::RuntimeRegion) {
+    use crate::value::heap::ExternalObject;
+    let obj = HeapObject::External {
+        obj: ExternalObject {
+            type_name: "io-request",
+            data: Rc::new(crate::io::request::IoRequest {
+                op: crate::io::request::IoOp::Sleep {
+                    duration: std::time::Duration::from_secs(1),
+                },
+                port: Value::NIL,
+                timeout: None,
+            }),
+        },
+        traits: Value::NIL,
+    };
+    alloc_in_fresh_region(heap, obj)
+}
+
 fn test_closure() -> Rc<Closure> {
     use crate::value::types::Arity;
     use crate::value::ClosureTemplate;
@@ -65,9 +88,8 @@ fn a_recorded_denial_park_is_released_by_the_install() {
     let handle = parked_fiber(SIG_YIELD, p, Some(p));
     let before = region_rc(&heap, rid);
 
-    let claimed = release_displaced_denial_payload(&mut heap, &handle);
+    release_displaced_denial_payload(&mut heap, &handle);
 
-    assert!(claimed, "the record claims the park it names");
     assert_eq!(
         region_rc(&heap, rid),
         before - 1,
@@ -87,9 +109,8 @@ fn a_record_that_no_longer_names_the_parked_signal_releases_nothing() {
     let handle = parked_fiber(SIG_YIELD, parked, Some(stale));
     let before = region_rc(&heap, rid);
 
-    let claimed = release_displaced_denial_payload(&mut heap, &handle);
+    release_displaced_denial_payload(&mut heap, &handle);
 
-    assert!(!claimed, "a stale record claims nothing");
     assert_eq!(
         region_rc(&heap, rid),
         before,
@@ -110,9 +131,8 @@ fn an_unrecorded_park_under_the_same_bits_releases_nothing() {
     let handle = parked_fiber(SIG_YIELD, p, None);
     let before = region_rc(&heap, rid);
 
-    let claimed = release_displaced_denial_payload(&mut heap, &handle);
+    release_displaced_denial_payload(&mut heap, &handle);
 
-    assert!(!claimed, "an unrecorded park is not a denial");
     assert_eq!(
         region_rc(&heap, rid),
         before,
@@ -132,15 +152,11 @@ fn the_record_is_taken_so_a_second_install_releases_nothing() {
     let (p, rid) = payload(&mut heap);
     let handle = parked_fiber(SIG_YIELD, p, Some(p));
 
-    assert!(release_displaced_denial_payload(&mut heap, &handle));
+    release_displaced_denial_payload(&mut heap, &handle);
     let after_first = region_rc(&heap, rid);
 
-    let claimed = release_displaced_denial_payload(&mut heap, &handle);
+    release_displaced_denial_payload(&mut heap, &handle);
 
-    assert!(
-        !claimed,
-        "the record is gone — the second install claims nothing"
-    );
     assert_eq!(
         region_rc(&heap, rid),
         after_first,
@@ -148,40 +164,105 @@ fn the_record_is_taken_so_a_second_install_releases_nothing() {
     );
 }
 
-/// A fiber denied `:io` parks under `SIG_IO`, the very bit an io request's park
-/// carries, so there the two readings name the same park. The record answers, and
-/// `prim_fiber_resume` skips the io arm on this `true` — running both frees the
-/// payload under the mediator that is still reading it.
+/// A fiber denied `:io` parks under `SIG_IO`, the very bit a yielding io op's
+/// request park carries, so the bits alone would hand one park to both readings.
+/// The record answers and the io arm stands down, because the payload is a
+/// struct rather than an `IoRequest` — one reference is owed, not one per
+/// reading.
+///
+/// The trap: the record lives on the fiber that was DENIED, and an install can
+/// reach a fiber that merely relays the park (the outer fiber of a `protect`ed
+/// denial), where there is no record to ask. So the exclusion cannot be an
+/// ordering between the two calls — it has to be each reading's own, which is
+/// what the type test buys. Ordering instead frees the struct under the mediator
+/// on exactly that route.
 #[test]
-fn an_io_denial_is_claimed_by_the_record_that_names_it() {
+fn an_io_denial_answers_to_the_record_and_not_to_the_io_arm() {
     let mut heap = crate::value::fiberheap::FiberHeap::new();
     let (p, rid) = payload(&mut heap);
     let handle = parked_fiber(SIG_IO, p, Some(p));
     let before = region_rc(&heap, rid);
 
-    let claimed = release_displaced_denial_payload(&mut heap, &handle);
+    release_displaced_io_request(&mut heap, Some((SIG_IO, p)));
+    let after_io_arm = region_rc(&heap, rid);
+    release_displaced_denial_payload(&mut heap, &handle);
 
-    assert!(claimed, "the record tells the denial from the io request");
+    assert_eq!(
+        after_io_arm, before,
+        "a denial payload is not an IoRequest — the io arm has no claim on it",
+    );
     assert_eq!(
         region_rc(&heap, rid),
         before - 1,
-        "the collision owes ONE reference, not one per reading",
+        "the collision owes ONE reference, and it is the record's",
     );
 }
 
-// -- release_parked_signal: the io arm, gated on SIG_IO alone --
+// -- release_displaced_io_request: the io arm, on a park's own IoRequest --
 
-/// The io arm keeps its shared-region skip: a `Fresh` io op builds its completion
+/// An io park's request is the runtime's value, so whatever ends the park owes
+/// the reference the allocation left. The injection `fiber/abort` and
+/// `fiber/refuse` share reaches this arm with no resume value at all.
+#[test]
+fn a_displaced_io_request_is_released() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (request, rid) = io_request(&mut heap);
+    let before = region_rc(&heap, rid);
+
+    release_displaced_io_request(&mut heap, Some((SIG_IO, request)));
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before - 1,
+        "the install that displaces an io park owes its request one decref",
+    );
+}
+
+/// The counter-factual for the io gate: a `yield`/`emit` payload is body-owned.
+/// The resumed body releases the reference it held across the suspend, so a
+/// decref here would free the value under every holder that outlives the fiber.
+#[test]
+fn a_non_io_park_releases_nothing() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (p, rid) = payload(&mut heap);
+    let before = region_rc(&heap, rid);
+
+    release_displaced_io_request(&mut heap, Some((SIG_YIELD, p)));
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before,
+        "the io arm answers for io requests alone",
+    );
+}
+
+/// The trap: the bits must be read BEFORE the payload is dereferenced. A park
+/// this arm has no claim on is one whose region another holder may already have
+/// released, and `region_of` answers such a value with a stale-deref panic rather
+/// than with `None`. Reading the value first turns every non-io park into that
+/// panic once its region is gone.
+#[test]
+fn a_non_io_park_is_answered_without_dereferencing_its_payload() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (p, rid) = payload(&mut heap);
+    crate::value::arena::decref_region(&mut heap, Some(rid));
+
+    release_displaced_io_request(&mut heap, Some((SIG_YIELD, p)));
+}
+
+// -- release_resumed_io_request: the same arm, plus the delivery's skip --
+
+/// The resume adds a shared-region skip: a `Fresh` io op builds its completion
 /// buffer in the request's own region and hands it back as the resume value, so
 /// that region is still live and the caller's release answers for it.
 #[test]
 fn an_io_park_whose_resume_value_shares_its_region_releases_nothing() {
     let mut heap = crate::value::fiberheap::FiberHeap::new();
-    let (request, rid) = payload(&mut heap);
+    let (request, rid) = io_request(&mut heap);
     let completion = heap.alloc_in_region(cons(), rid);
     let before = region_rc(&heap, rid);
 
-    release_parked_signal(&mut heap, Some((SIG_IO, request)), completion);
+    release_resumed_io_request(&mut heap, Some((SIG_IO, request)), completion);
 
     assert_eq!(
         region_rc(&heap, rid),
@@ -195,11 +276,11 @@ fn an_io_park_whose_resume_value_shares_its_region_releases_nothing() {
 #[test]
 fn an_io_park_whose_resume_value_is_foreign_is_released() {
     let mut heap = crate::value::fiberheap::FiberHeap::new();
-    let (request, rid) = payload(&mut heap);
+    let (request, rid) = io_request(&mut heap);
     let completion = foreign(&mut heap);
     let before = region_rc(&heap, rid);
 
-    release_parked_signal(&mut heap, Some((SIG_IO, request)), completion);
+    release_resumed_io_request(&mut heap, Some((SIG_IO, request)), completion);
 
     assert_eq!(
         region_rc(&heap, rid),
@@ -208,21 +289,28 @@ fn an_io_park_whose_resume_value_is_foreign_is_released() {
     );
 }
 
-/// The counter-factual for the io gate: a `yield`/`emit` payload is body-owned.
-/// The resumed body releases the reference it held across the suspend, so a
-/// decref here would free the value under every holder that outlives the fiber.
+/// The skip belongs to the DELIVERY, not to the io park: an injected error that
+/// happens to live in the request's region is not a resume value, so the
+/// injection's release stands. Sharing a region is what the resume reads as
+/// "still live"; here it means nothing.
 #[test]
-fn a_non_io_park_releases_nothing() {
+fn a_displaced_io_request_takes_no_skip_from_a_payload_sharing_its_region() {
     let mut heap = crate::value::fiberheap::FiberHeap::new();
-    let (p, rid) = payload(&mut heap);
-    let resume_value = foreign(&mut heap);
+    let (request, rid) = io_request(&mut heap);
+    let error_value = heap.alloc_in_region(cons(), rid);
     let before = region_rc(&heap, rid);
 
-    release_parked_signal(&mut heap, Some((SIG_YIELD, p)), resume_value);
+    release_resumed_io_request(&mut heap, Some((SIG_IO, request)), error_value);
+    let after_resume_reading = region_rc(&heap, rid);
+    release_displaced_io_request(&mut heap, Some((SIG_IO, request)));
 
     assert_eq!(
+        after_resume_reading, before,
+        "the resume reading skips on a shared region — which is why it must not travel",
+    );
+    assert_eq!(
         region_rc(&heap, rid),
-        before,
-        "the io arm answers for io requests alone",
+        before - 1,
+        "an injected error sharing the request's region still owes the release",
     );
 }

--- a/tests/elle/plumb.lisp
+++ b/tests/elle/plumb.lisp
@@ -22,15 +22,6 @@
 # verdict never carries across processes.
 (each l in ["discriminator (live-growth)" "region discriminator (live-growth)"]
   (put by-design l true))
-# An io park displaced by `fiber/abort` or `fiber/refuse` strands the
-# `IoRequest` region the runtime built for it: `release_parked_signal` runs on
-# the resume path only, and the injection site runs the displaced-terminal and
-# denial releases but nothing for an io request (docs/impl/region/owner.md
-# § "Park/unpark symmetry" — a park with no body reference owes one release
-# where it is displaced). One region and the request it holds, per op, on both
-# displacing routes; `io-drop` is the reclaiming control, the same park whose
-# fiber nobody displaces, covered by the free-path discharge.
-(declare-root :f2 ["io-abort" "io-abort@regions" "io-refuse" "io-refuse@regions"])
 
 # ── Discriminators ────────────────────────────────────────────────────
 (def @disc-sink @[])
@@ -81,10 +72,17 @@
                        (get io :rate))))
 
 # ── The displaced io park ─────────────────────────────────────────────
-# The three exits of a parked io op — see the F2 declaration above for the
-# mechanism. The three must stay together: `io-drop` removes the displacing
-# install, so the gap between it and either displacing route isolates the
-# install's owed release from the park itself.
+# The three exits of a parked io op. Its `IoRequest` is the RUNTIME's value —
+# the native built it and the body names it nowhere — so no continuation
+# releases it and whatever ends the park owes that release
+# (docs/impl/region/owner.md § "Park/unpark symmetry"). `io-drop` is the exit
+# with no install at all, covered by the free-path discharge; `io-abort` and
+# `io-refuse` each end the park by raising at the fiber's own suspension point.
+# The three must stay together: `io-drop` removes the displacing install, so the
+# gap between it and either displacing route isolates the install's owed release
+# from the park itself. The per-install leak gauge is
+# tests/elle/region-io-park.lisp and the guardfree face is
+# tests/elle/region-io-park-uaf.lisp; these read the same shapes as rates.
 (defn mk-io []
   (fiber/new (fn []
                (let [r (ev/sleep 10000)]
@@ -107,8 +105,8 @@
     (pin r opin)
     (pin rr rpin)))
 (pin-io-2 "io-drop" probe-io-drop 0 0)
-(pin-io-2 "io-abort" probe-io-abort 1 1)
-(pin-io-2 "io-refuse" probe-io-refuse 1 1)
+(pin-io-2 "io-abort" probe-io-abort 0 0)
+(pin-io-2 "io-refuse" probe-io-refuse 0 0)
 
 # ── The split headline ────────────────────────────────────────────────
 (println "── split ──")

--- a/tests/elle/region-denial-park-uaf.lisp
+++ b/tests/elle/region-denial-park-uaf.lisp
@@ -111,11 +111,12 @@
       (length (get p :primitive)))))
 
 # ── (f) the bits collision — the shape a second release detonates on ─────────
-# A fiber denied `:io` parks under `SIG_IO`, the very bit `release_parked_signal`
-# reads to recognize a yielding io op's request. So this park answers to BOTH
-# routes at a resume, and exactly one reference is owed: run them both and the
-# payload's region is freed while the mediator still holds it. That is the whole
-# reason the record is asked FIRST and the io arm skipped when it claims the park.
+# A fiber denied `:io` parks under `SIG_IO`, the bit a yielding io op's request
+# park also carries. Exactly one reference is owed, so the io arm must refuse this
+# park on its own account: it asks for an `IoRequest`, and a denial's payload is a
+# struct. Reading the bit instead frees the payload's region while the mediator
+# still holds it. The relayed face — the same denial inside a `protect`, where the
+# install reaches a fiber holding no ledger record — is in region-io-park-uaf.lisp.
 (defn io-denied-body ()
   (println "never runs — the fiber is denied :io"))
 (defn w-io-resume (n)
@@ -133,6 +134,14 @@
       (fiber/refuse f :denied)
       (assert (= (get p :error) :capability-denied)
               "an :io denial's payload was released twice at the refusal")
+      (length (get p :primitive)))))
+(defn w-io-abort (n)
+  (let [f (fiber/new io-denied-body |:error :io| :deny |:io|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/abort f :done)
+      (assert (= (get p :error) :capability-denied)
+              "an :io denial's payload was released twice at the abort")
       (length (get p :primitive)))))
 
 # ── (g) the abort face ───────────────────────────────────────────────────────
@@ -179,6 +188,7 @@
   (var k 0)
   (var m 0)
   (var n 0)
+  (var p 0)
   (while (%lt i reps)
     (assign a (w-hold-resume i))
     (assign b (w-alias-resume i))
@@ -188,12 +198,13 @@
     (assign f (w-protect-refuse i))
     (assign g (w-io-resume i))
     (assign h (w-io-refuse i))
+    (assign p (w-io-abort i))
     (assign k (w-abort i))
     (assign m (c-emit-resume i))
     (assign n (c-emit-refuse i))
     (assign denials @[])
     (assign i (%add i 1)))
-  (list a b c d e f g h k m n))
+  (list a b c d e f g h k m n p))
 
 (let [r (drive 300)]
   (assert (> (get r 0) 0) "payload freed under a held read past the resume")
@@ -206,6 +217,7 @@
   (assert (> (get r 7) 0) ":io denial's payload released twice at the refusal")
   (assert (> (get r 8) 0) "payload freed under the read past the abort")
   (assert (> (get r 9) 0) "control: emit payload freed by the resume install")
-  (assert (> (get r 10) 0) "control: emit payload freed by the refusal install"))
+  (assert (> (get r 10) 0) "control: emit payload freed by the refusal install")
+  (assert (> (get r 11) 0) ":io denial's payload released twice at the abort"))
 
 (println "region-denial-park-uaf: ok")

--- a/tests/elle/region-io-park-uaf.lisp
+++ b/tests/elle/region-io-park-uaf.lisp
@@ -1,0 +1,272 @@
+(elle/epoch 12)
+# An io park's `IoRequest` is released by the install that displaces it — the
+# soundness face (docs/impl/region/owner.md § "Park/unpark symmetry").
+#
+# The leak face is region-io-park.lisp: an aborted or refused io park stranded
+# its request, because the release that answers for a runtime-built payload ran
+# on the resume path alone. Closing it makes `fiber/refuse` and `fiber/abort`
+# each run a decref that fired on no path before, so each is a fresh chance to
+# free the request under a reader that still holds it.
+#
+# The trap: the mediator reads the request BEFORE it ends the park — that is what
+# reading `(fiber/value f)` on a `SIG_IO` signal is for — and may still hold it
+# afterwards. `fiber/value` is pass-through, so a binding of the request carries a
+# counted reference of its own; the release must consume the allocation's
+# reference and no other. Every witness below therefore DEREFERENCES the request
+# after the displacing install. A bare status check passes over a freed request
+# and would have missed this.
+#
+# The second trap is the bits collision. A fiber denied `:io` parks under
+# `SIG_IO`, the very bit that would say "this park's payload is an `IoRequest`",
+# so bits alone hand one park to both readings and one reference is owed, not
+# two. The io arm asks for an `IoRequest` instead, which a denial's struct never
+# is, so the two name disjoint payloads. Ordering the two calls cannot stand in
+# for that: the ledger record lives on the fiber that was DENIED, and the
+# `protect` witnesses below install on a fiber that merely RELAYS the park, where
+# there is no record to ask first. Both faces are here, bare and through
+# `protect`, and each frees the payload under the mediator's read if the io arm
+# claims what the record owns.
+#
+# The third trap is the ORDER of the two arms. The io arm decides by reading the
+# parked value, and the record's release can be the payload's last, so the io arm
+# runs first. Only the witness that holds NOTHING can catch that — a bound payload
+# keeps the region alive across either order.
+#
+# The counter-factual is the release running twice, or running on a value the
+# body allocated: the region frees while a holder still names it, and the read
+# past the install faults at the deref under `--trace=guardfree`.
+
+# ── the parked subject ───────────────────────────────────────────────────────
+# A timer nothing will fire, under a mask that brings the park back to this
+# driver as data.
+(defn io-body ()
+  (let [r (ev/sleep 10000)]
+    (length "done")))
+(defn mk ()
+  (fiber/new io-body |:io :error|))
+
+# ── (a) the request held across an abort, read after ─────────────────────────
+(defn w-hold-abort (n)
+  (let [f (mk)]
+    (fiber/resume f)
+    (let [req (fiber/value f)]
+      (fiber/abort f (string "stop" n))
+      (assert (= (type-of req) :io-request)
+              "held request lost its type across the abort")
+      (length (string req)))))
+
+# ── (b) the request held across a refusal, read after ────────────────────────
+(defn w-hold-refuse (n)
+  (let [f (mk)]
+    (fiber/resume f)
+    (let [req (fiber/value f)]
+      (fiber/refuse f (string "no" n))
+      (assert (= (type-of req) :io-request)
+              "held request lost its type across the refusal")
+      (length (string req)))))
+
+# ── (c) the request outlives the fiber, in a container ───────────────────────
+# Nothing on the stack holds it once the driver moves on; the holder that must
+# still find it alive is the array read back out.
+(def @requests @[])
+(defn w-stored (n)
+  (let [f (mk)]
+    (fiber/resume f)
+    (push requests (fiber/value f))
+    (fiber/abort f n)
+    (length (string (get requests (%sub (length requests) 1))))))
+
+# ── (d) the refusal chain — the body catches and parks again ─────────────────
+# Each refusal ends the park it answers, and the driver reads the PREVIOUS
+# request after the next release has run.
+(defn twice-body ()
+  (let [[ok1? e1] (protect (ev/sleep 10000))
+        [ok2? e2] (protect (ev/sleep 10000))]
+    (list ok1? ok2?)))
+(defn w-refuse-twice (n)
+  (let [f (fiber/new twice-body |:io :error|)]
+    (fiber/resume f)
+    (let [first-r (fiber/value f)]
+      (fiber/refuse f :first)
+      (assert (= (type-of first-r) :io-request)
+              "first request freed by the refusal that displaced it")
+      (let [second-r (fiber/value f)]
+        (fiber/refuse f :second)
+        (assert (= (type-of first-r) :io-request)
+                "first request freed by the second refusal")
+        (length (string second-r))))))
+
+# ── (e) the park inside a `protect` ──────────────────────────────────────────
+# `protect` runs the body in an inner fiber, so the request parks THERE and the
+# outer fiber awaits it through a `FiberResume` frame. The request the mediator
+# reads is the inner park's, and it must survive the install on this route too.
+(defn protect-body ()
+  (let [[ok? e] (protect (ev/sleep 10000))]
+    (if ok? 1 0)))
+(defn w-protect-abort (n)
+  (let [f (fiber/new protect-body |:io :error|)]
+    (fiber/resume f)
+    (let [req (fiber/value f)]
+      (fiber/abort f n)
+      (assert (= (type-of req) :io-request)
+              "inner park's request freed by the abort install")
+      (length (string req)))))
+(defn w-protect-refuse (n)
+  (let [f (fiber/new protect-body |:io :error|)]
+    (fiber/resume f)
+    (let [req (fiber/value f)]
+      (fiber/refuse f n)
+      (assert (= (type-of req) :io-request)
+              "inner park's request freed by the refusal install")
+      (length (string req)))))
+
+# ── (f) the bits collision, at the two installs the io arm newly reaches ─────
+# A fiber denied `:io` parks under `SIG_IO` with a payload the DENIAL path built,
+# not a request. The record owns that payload's release and the io arm has no
+# claim on it. Claim it anyway and the struct frees while the mediator holds it —
+# the field read below is what faults.
+(defn io-denied-body ()
+  (println "never runs — the fiber is denied :io"))
+(defn w-denied-abort (n)
+  (let [f (fiber/new io-denied-body |:error :io| :deny |:io|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/abort f n)
+      (assert (= (get p :error) :capability-denied)
+              "an :io denial's payload was released twice at the abort")
+      (length (get p :primitive)))))
+(defn w-denied-refuse (n)
+  (let [f (fiber/new io-denied-body |:error :io| :deny |:io|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/refuse f n)
+      (assert (= (get p :error) :capability-denied)
+              "an :io denial's payload was released twice at the refusal")
+      (length (get p :primitive)))))
+
+# ── (g) the collision on a fiber that RELAYS the park ────────────────────────
+# `protect` runs the denied call in an inner fiber, so the ledger record is
+# written THERE while the outer fiber's slot holds the same payload under the
+# same `SIG_IO`. The install reaches the outer fiber and finds no record, so
+# asking the record first cannot make the two readings exclusive here — only the
+# io arm's own reading can. Reading the payload's type is what keeps this witness
+# standing; reading the bit frees the struct under the mediator.
+(defn denied-protect-body ()
+  (let [[ok? e] (protect (ev/sleep 1))]
+    (if ok? 1 0)))
+(defn w-denied-protect-abort (n)
+  (let [f (fiber/new denied-protect-body |:error :io| :deny |:io|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/abort f n)
+      (assert (= (get p :error) :capability-denied)
+              "a relayed :io denial's payload was released twice at the abort")
+      (length (get p :primitive)))))
+(defn w-denied-protect-refuse (n)
+  (let [f (fiber/new denied-protect-body |:error :io| :deny |:io|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/refuse f n)
+      (assert (= (get p :error) :capability-denied)
+              "a relayed :io denial's payload was released twice at the refusal")
+      (length (get p :primitive)))))
+
+# ── (h) the collision with NOTHING holding the payload ───────────────────────
+# The two readings run one after the other at every install, and the denial arm's
+# decref can be the payload's last — nobody here reads `(fiber/value f)`, so no
+# counted reference stands behind it. The io arm reaches its verdict by READING
+# the parked value, so it must run first; run it after and it dereferences a value
+# the denial arm just freed. The witnesses above cannot see this: binding the
+# payload is what keeps the region alive across the install, so every held face
+# passes either way. What faults here is the runtime's own read, so completing IS
+# the assertion.
+(defn w-denied-unheld-resume (n)
+  (let [f (fiber/new io-denied-body |:error :io| :deny |:io|)]
+    (fiber/resume f)
+    (fiber/resume f n)
+    (fiber/status f)))
+(defn w-denied-unheld-abort (n)
+  (let [f (fiber/new io-denied-body |:error :io| :deny |:io|)]
+    (fiber/resume f)
+    (fiber/abort f n)
+    (fiber/status f)))
+
+# ── controls — a body-allocated park payload, ended the same two ways ────────
+# Its body owns a reference of its own, so the install owes nothing. A release
+# reaching this park would free the payload under these very reads.
+(defn emit-body (n)
+  (let [r (emit :yield {:tag (string "e" n)})]
+    5))
+(defn c-emit-abort (n)
+  (let [f (fiber/new (fn () (emit-body n)) |:yield :error|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/abort f :done)
+      (length (get p :tag)))))
+(defn c-emit-refuse (n)
+  (let [f (fiber/new (fn () (emit-body n)) |:yield :error|)]
+    (fiber/resume f)
+    (let [p (fiber/value f)]
+      (fiber/refuse f :no)
+      (length (get p :tag)))))
+
+# ── drive: a fresh park per iteration keeps region ids churning, so a recycled
+# id detonates on its generation stamp rather than reading stale bytes.
+(defn drive (reps)
+  (var i 0)
+  (var a 0)
+  (var b 0)
+  (var c 0)
+  (var d 0)
+  (var e 0)
+  (var f 0)
+  (var g 0)
+  (var h 0)
+  (var k 0)
+  (var m 0)
+  (var q 0)
+  (var r 0)
+  (var s :none)
+  (var t :none)
+  (while (%lt i reps)
+    (assign a (w-hold-abort i))
+    (assign b (w-hold-refuse i))
+    (assign c (w-stored i))
+    (assign d (w-refuse-twice i))
+    (assign e (w-protect-abort i))
+    (assign f (w-protect-refuse i))
+    (assign g (w-denied-abort i))
+    (assign h (w-denied-refuse i))
+    (assign q (w-denied-protect-abort i))
+    (assign r (w-denied-protect-refuse i))
+    (assign s (w-denied-unheld-resume i))
+    (assign t (w-denied-unheld-abort i))
+    (assign k (c-emit-abort i))
+    (assign m (c-emit-refuse i))
+    (assign requests @[])
+    (assign i (%add i 1)))
+  (list a b c d e f g h k m q r s t))
+
+(let [r (drive 200)]
+  (assert (> (get r 0) 0) "request freed under a held read past the abort")
+  (assert (> (get r 1) 0) "request freed under a held read past the refusal")
+  (assert (> (get r 2) 0) "stored request freed under the container read")
+  (assert (> (get r 3) 0) "request freed across a refusal chain")
+  (assert (> (get r 4) 0) "inner park's request freed by the abort install")
+  (assert (> (get r 5) 0) "inner park's request freed by the refusal install")
+  (assert (> (get r 6) 0) ":io denial's payload released twice at the abort")
+  (assert (> (get r 7) 0) ":io denial's payload released twice at the refusal")
+  (assert (> (get r 8) 0) "control: emit payload freed by the abort install")
+  (assert (> (get r 9) 0) "control: emit payload freed by the refusal install")
+  (assert (> (get r 10) 0)
+          "relayed :io denial's payload released twice at the abort")
+  (assert (> (get r 11) 0)
+          "relayed :io denial's payload released twice at the refusal")
+  # Answering the denied `println` lets the body run on to its next `:io` call,
+  # which is denied in turn — so a resumed `:io`-denied fiber parks again.
+  (assert (= (get r 12) :paused)
+          "an unheld :io denial did not run on after its resume answered it")
+  (assert (= (get r 13) :error)
+          "an unheld :io denial did not end :error under its abort"))
+
+(println "region-io-park-uaf: ok")

--- a/tests/elle/region-io-park.lisp
+++ b/tests/elle/region-io-park.lisp
@@ -1,0 +1,196 @@
+(elle/epoch 12)
+# An io park's `IoRequest` is released by the install that displaces it
+# (docs/impl/region/owner.md § "Park/unpark symmetry").
+#
+# A yielding io op returns its `IoRequest` with `SIG_IO`, and the suspend retains
+# the region it lives in so the scheduler can read the request out of
+# `fiber.signal`. The request is the RUNTIME's value, not the body's: the native
+# built it, the body never named it, and no `decref_point` names its region — so
+# the continuation past the suspend releases nothing for it. The reference the
+# allocation left is owed by whatever ends the park. A fiber that never runs again
+# takes the discard discharge; a fiber whose park is REPLACED owes the release to
+# the install that replaces it, and there are three of those: a resume delivering
+# the completion, a refusal raising at the fiber's own call site, and an abort
+# ending it where it stopped.
+#
+# The trap: the resume's release carries a skip — a `Fresh` io op (`port/read`,
+# `accept`) builds its completion buffer IN the request's region and hands that
+# buffer back as the resume value, so there the region is still live and the
+# resumer's own release of the result answers for it. That skip is a fact about a
+# DELIVERY. An injected error is not one, so the skip must not travel to the
+# refusal and the abort, which is what the counter-factual for this file is: leave
+# them with the resume's release and every park they end strands its request.
+#
+# This file is the LEAK gauge — an `arena/count` delta over a fixed window, which
+# must be BOUNDED for every install. The soundness complement is
+# region-io-park-uaf.lisp; the in-flight face, where the scheduler has already
+# submitted the request an abort ends, is `region_fiber_abort_io_protect_uaf`.
+
+(def window 300)
+
+(defn measure (thunk warm window)
+  (var i 0)
+  (while (%lt i warm)
+    (thunk)
+    (assign i (%add i 1)))
+  (def before (arena/count))
+  (var j 0)
+  (while (%lt j window)
+    (thunk)
+    (assign j (%add j 1)))
+  (%sub (arena/count) before))
+
+# A body that parks on a timer nothing will ever fire. The mask catches `:io` so
+# the park comes back to this driver as data rather than reaching a scheduler,
+# and `:error` so a refusal the body does not catch is data too.
+(defn io-body ()
+  (let [r (ev/sleep 10000)]
+    5))
+
+(defn mk ()
+  (fiber/new io-body |:io :error|))
+
+# subjects — the three displacing installs ─────────────────────────────────────
+
+# (a) abort: the fiber is ended where it stopped.
+(defn w-abort ()
+  (let [f (mk)]
+    (fiber/resume f)
+    (fiber/abort f :done)
+    (fiber/status f)))
+
+# (b) refuse: the refusal is raised at the fiber's own call site.
+(defn w-refuse ()
+  (let [f (mk)]
+    (fiber/resume f)
+    (fiber/refuse f :denied)
+    (fiber/status f)))
+
+# (c) resume: the mediator answers the io call with a completion value. Already
+# bounded before the abort and refusal faces were, so it is the reading that says
+# the other two are the install's strand and not the park's.
+(defn w-resume ()
+  (let [f (mk)]
+    (fiber/resume f)
+    (fiber/resume f 7)))
+
+# (d) the park displaced twice — the body catches its own refusal and parks again,
+# so the second install must account exactly like the first.
+(defn twice-body ()
+  (let [[ok1? e1] (protect (ev/sleep 10000))
+        [ok2? e2] (protect (ev/sleep 10000))]
+    (if ok1? 1 (if ok2? 2 0))))
+(defn w-twice ()
+  (let [f (fiber/new twice-body |:io :error|)]
+    (fiber/resume f)
+    (fiber/refuse f :first)
+    (fiber/refuse f :second)
+    (fiber/value f)))
+
+# (e) the park inside a `protect`, which runs the body in an INNER fiber. The
+# request parks there and the outer fiber awaits it through a `FiberResume` frame,
+# so the install reaches a second route into the same rule.
+(defn protect-body ()
+  (let [[ok? e] (protect (ev/sleep 10000))]
+    (if ok? 1 0)))
+(defn mk-protect ()
+  (fiber/new protect-body |:io :error|))
+(defn w-protect-abort ()
+  (let [f (mk-protect)]
+    (fiber/resume f)
+    (fiber/abort f :done)
+    (fiber/status f)))
+(defn w-protect-refuse ()
+  (let [f (mk-protect)]
+    (fiber/resume f)
+    (fiber/refuse f :denied)
+    (fiber/value f)))
+(defn w-protect-resume ()
+  (let [f (mk-protect)]
+    (fiber/resume f)
+    (fiber/resume f 7)))
+
+# controls ─────────────────────────────────────────────────────────────────────
+
+# (f) the io park nobody displaces: the discard discharge releases it, so this
+# face was already bounded and proves the strand is the install's.
+(defn c-cold ()
+  (let [f (mk)]
+    (fiber/resume f)
+    3))
+
+# (g) hard kill — the teardown route, likewise already bounded.
+(defn c-cancel ()
+  (let [f (mk)]
+    (fiber/resume f)
+    (fiber/cancel f :gone)
+    3))
+
+# (h) an ordinary `emit` park displaced by the same installs. Its payload IS
+# body-allocated, so the body's own continuation release answers for it and the
+# install owes nothing — an io release that reached this park would free the
+# payload under its reader.
+(defn emit-body ()
+  (let [r (emit :yield {:a 1})]
+    5))
+(defn mk-emit ()
+  (fiber/new emit-body |:yield :error|))
+(defn c-emit-abort ()
+  (let [f (mk-emit)]
+    (fiber/resume f)
+    (fiber/abort f :done)
+    (fiber/status f)))
+(defn c-emit-refuse ()
+  (let [f (mk-emit)]
+    (fiber/resume f)
+    (fiber/refuse f :denied)
+    (fiber/status f)))
+
+(def abort-d (measure w-abort 60 window))
+(def refuse-d (measure w-refuse 60 window))
+(def resume-d (measure w-resume 60 window))
+(def twice-d (measure w-twice 60 window))
+(def protect-abort-d (measure w-protect-abort 60 window))
+(def protect-refuse-d (measure w-protect-refuse 60 window))
+(def protect-resume-d (measure w-protect-resume 60 window))
+(def cold-d (measure c-cold 60 window))
+(def cancel-d (measure c-cancel 60 window))
+(def emit-abort-d (measure c-emit-abort 60 window))
+(def emit-refuse-d (measure c-emit-refuse 60 window))
+
+(println "region-io-park deltas over " window " iters:")
+(println "  abort " abort-d "  refuse " refuse-d "  resume " resume-d "  twice "
+         twice-d)
+(println "  through protect: abort " protect-abort-d "  refuse "
+         protect-refuse-d "  resume " protect-resume-d)
+(println "  controls: cold " cold-d "  cancel " cancel-d "  emit+abort "
+         emit-abort-d "  emit+refuse " emit-refuse-d)
+
+# Every strand in this class is one whole `IoRequest` per ended park, so a
+# survivor reads ≥300 over the window. 60 is slack for the one-time intercept.
+(defn bounded? (d label)
+  (assert (%lt d 60) (concat label " leaks, delta=" (number->string d))))
+
+(bounded? cold-d "control: an io park nobody displaces")
+(bounded? cancel-d "control: an io park hard-killed")
+(bounded? emit-abort-d "control: an emit park ended by an abort")
+(bounded? emit-refuse-d "control: an emit park ended by a refusal")
+(bounded? resume-d "io request displaced by a resume")
+(bounded? abort-d "io request displaced by an abort")
+(bounded? refuse-d "io request displaced by a refusal")
+(bounded? twice-d "two io parks refused in one session")
+(bounded? protect-abort-d "io park inside a `protect`, ended by an abort")
+(bounded? protect-refuse-d "io park inside a `protect`, ended by a refusal")
+(bounded? protect-resume-d "io park inside a `protect`, ended by a resume")
+
+# Value preservation: the release must not change what the mediation reads.
+(assert (= (w-abort) :error) "an aborted io park did not end :error")
+(assert (= (w-refuse) :error) "a refusal the body does not catch is an error")
+(assert (= (w-resume) 5) "a resumed io park lost the body's result")
+(assert (= (w-twice) 0) "both refusals should have failed their calls")
+(assert (= (w-protect-refuse) 0)
+        "a refusal through `protect` did not fail the call")
+(assert (= (w-protect-resume) 1)
+        "a resume through `protect` did not answer the call")
+
+(println "region-io-park: ok")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -639,6 +639,26 @@ fn region_denial_park_uaf() {
     );
 }
 
+// Guard — the other park a payload the RUNTIME built (docs/impl/region/owner.md
+// § "Park/unpark symmetry"): a yielding io op's `IoRequest`, which the native
+// built and the body never named, so no continuation releases it. Every install
+// that displaces the park owes that release, and `fiber/abort` / `fiber/refuse`
+// each run one where none ran before. The mediator reads the request out of the
+// park before it ends it — `fiber/value` is pass-through, so a binding carries a
+// counted reference of its own — and every witness DEREFERENCES the request after
+// the install; a bare status check passes over a freed one. The `:io` denial
+// witnesses are the bits collision: a fiber denied `:io` parks under `SIG_IO`, so
+// the ledger record and the io bit both answer for one park and exactly one
+// reference is owed. Running both frees the payload under the mediator's read —
+// SIGSEGV under guardfree. The leak face is `tests/elle/region-io-park.lisp`.
+#[test]
+fn region_io_park_uaf() {
+    run_elle_script_with_args(
+        "region-io-park-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — `fiber/propagate` installs the child's parked payload as this fiber's
 // own `signal`, which is a fresh park and owes its own delivery reference
 // (docs/impl/region/owner.md § "Park/unpark symmetry"). The propagating fiber's


### PR DESCRIPTION
Closes #979.

## What was wrong

A yielding io op returns its `IoRequest` with `SIG_IO`, and the suspend retains
the region it lives in so the scheduler can read the request out of
`fiber.signal`. That request is the runtime's value: the native built it, the
body names it nowhere, and no `decref_point` names its region — so the
continuation past the suspend releases nothing for it, and whatever ends the
park owes the reference the allocation left.

Only the resume path ran one. `fiber/abort` and `fiber/refuse` displace the
park with an injected error and released the displaced terminal signal and the
denial payload, but nothing for an io request — one live region per aborted or
refused park, growing without bound.

## What the change does

The io release becomes `release_displaced_io_request`, which
`inject_error_at_suspension` now runs beside the denial-payload release. What
stays on the resume path is the **skip**, not the release
(`release_resumed_io_request`): a `Fresh` io op builds its completion buffer IN
the request's region and hands that buffer back as the resume value, where the
resumer's own release of the result answers for it. An injected error is not a
delivery — the abort's `AbortDelivery` mint funds the consumer it has — so an
error value that happens to live in the request's region owes the release all
the same.

**An in-flight request needs no waiting on.** An abort reaches a fiber whose
request the scheduler already submitted, and a `Fresh` op's completion buffer
lives in that region. The submitted operand is one of Rule 8's escape sites, so
the pending entry increfs each value its completion reads and decrefs when the
entry is disposed — the region is counted for the operation's whole lifetime,
and the install's release drops the suspend retain and no more.

**The io arm reads the payload's type, not the `SIG_IO` bit.** `:io` is a
withheld capability like any other, so a fiber denied `:io` parks its denial
struct under the same bit, and one reference is owed rather than two. Ordering
the two releases cannot settle it: the ledger record is written on the fiber
that was DENIED, and an install can reach a fiber that merely relays the park —
the outer fiber of a `protect`ed denial — where there is no record to defer to.
Asking for an `IoRequest`, a value only an io primitive builds, makes the two
readings name disjoint payloads wherever the install lands. The io arm still
runs first, because it decides by reading the parked value and the record's
release can be that value's last.

## How it was measured

`tests/elle/plumb.lisp`, the io leak dashboard: `io-abort` and `io-refuse` fall
from a pinned rate of 1 to 0 on both the object and region gauges, beside the
flat `io-drop` control that removes the displacing install. Both pins are
lowered and the file's `declare-root` for F2 is gone, so it reports `open
defects: 0 across 0 roots`.

`tests/elle/oracle.lisp` reports `oracle: ok` (no pin regressed) and
`make smoke-elle` passes the whole corpus on the release binary. The guardfree
family — `cargo test -p elle --test lib region_` — is 95/95, and `make qa` is
clean.

Each counter-factual was run: the release omitted (401 regions per 400 aborts),
the io arm reading the bit alone (SIGSEGV on the `:io` denial witnesses), the
two arms in the wrong order (SIGSEGV on the unheld witness), and the release
doubled (SIGSEGV on the held-reader witnesses).

## Which tests pin it

- `tests/elle/region-io-park.lisp` — the per-install leak gauge: abort, refuse,
  resume, a park displaced twice, and each of the three through `protect`
  (which parks in an inner fiber), against `cold` / `cancel` / `emit` controls.
- `tests/elle/region-io-park-uaf.lisp` — the guardfree face, registered as
  `region_io_park_uaf`. Every witness dereferences the request after the
  install; the `:io` collision is covered direct, relayed through `protect`, and
  with nothing holding the payload.
- `tests/elle/region-denial-park-uaf.lisp` — gains the abort face of the
  collision.
- `vm::fiber::refcount::tests` — each reading, the delivery skip, that the skip
  does not travel to the injection, and that the bits decide before the payload
  is dereferenced.

`docs/impl/region/owner.md` § "Park/unpark symmetry" and `src/vm/AGENTS.md`
carry the rule.
