### PR TITLE
regions: a spliced call reclaims the args array it built

### DIFF
--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -81,6 +81,54 @@ Pinned by `regions::tests::inline::*`, the leak face
 result, so everything the callee hands back that is not freshly its own must ride a
 counted edge.
 
+## A spliced call's arguments come out of an array the convention owns
+
+A call with a spliced argument — `(f ;args)`, and the `apply` it underlies — cannot
+push its arguments onto the operand stack, because how many there are is a runtime
+fact. So the lowerer builds them into a fresh `@array` and hands that array to
+`CallArrayMut` / `TailCallArrayMut`, which spreads it across the callee's parameters.
+The array is the operand stack spelled as a heap value: the calling convention builds
+it, the call consumes it, and no binding of the program ever names it.
+
+Three rules follow, and each is the spliced half of a pair the plain call already
+states.
+
+**The array has a region of its own.** `MakeArrayMut` and the call are two
+allocations, and a static region slot names one allocation execution between drops
+(model.md § "The per-execution region model"), so the array takes a managed slot
+of its own rather than the call's. Sharing the call's slot orphans the array's
+physical region the moment the call maps its own mint over it, and no route can name
+an orphan afterwards — not the value route, which needs a binding, and not the
+abandoned-frame walk, which reads the slot.
+
+**The call releases the array.** The array dies where the arguments are read out of
+it, which is *inside* the call — a point no instruction can follow, because a
+frame-replacing tail callee never arrives at the block after `TailCallArrayMut`. So
+the release is the runtime's: each dispatcher takes the array's slot and frees the
+region once the callee holds what it needs. Taking the slot is what keeps the release
+single. A frame abandoned between the array's construction and the call — an
+`ArrayMutExtend` over a source that is not a sequence raises there — still has the
+slot mapped, so the walk reclaims it, and a frame that reached the call does not.
+
+**The callee mints its own reference to every argument.** The store funnel counts each
+`ArrayMutPush` / `ArrayMutExtend`, so the array holds one counted reference per
+element and freeing it cascades that reference away. A spliced call therefore hands
+the callee nothing of the frame's, and the callee mints one owning reference per
+parameter (`own_params`) in tail position exactly as in call position — the same
+answer `tail_arg_is_borrowed` gives for a captured upvalue, and for the same reason:
+the reference belongs to the holder that built it, not to this activation. So a
+spliced tail call **moves nothing**, and every release the frame owes is relocated
+ahead of the frame replacement (§ "A release past a frame-replacing tail call is not
+a release") instead of being exempted as an ownership move. Reading a spliced
+argument as a moved operand instead strands one region per call for each source the
+splice read, and leaves the freed element still named by a source the frame never
+released.
+
+Pinned by `tests/elle/region-splice-args.lisp` — one bounded rate per callee kind and
+call position — and by the soundness complement `region-splice-args-uaf.lisp` under
+`--trace=guardfree`, where the release the array's reclaim adds must not reach a value
+the callee still reads.
+
 ## The return mint is emitted exactly once
 
 The callee half of that convention is **one** mint per returned value: a function

--- a/docs/impl/region/model.md
+++ b/docs/impl/region/model.md
@@ -70,7 +70,11 @@ binding, and routing them all through the Begin's single region slot would
 orphan every cell but the last (at stdlib scale, thousands of cells plus
 everything they pin). Pre-allocated capture cells therefore get **one region
 per cell** (`begin_cell_regions`), each released by its own `DecrefRegion` at
-its binding's last use.
+its binding's last use. A spliced call's args array is the same obligation with
+a different resolution: it takes a managed slot of its own so the call's result
+mint cannot orphan it, and its drop is the call's own — the runtime takes that
+slot (mechanism.md § "A spliced call's arguments come out of an array the
+convention owns").
 
 ## Constants lower as ordinary allocations, not promoted values
 

--- a/src/compiler/bytecode/disasm.rs
+++ b/src/compiler/bytecode/disasm.rs
@@ -144,7 +144,7 @@ pub fn disassemble_lines(instructions: &[u8]) -> Vec<String> {
                 // No operands
             }
             Instruction::CallArrayMut | Instruction::TailCallArrayMut
-                if i + 3 < instructions.len() =>
+                if i + 7 < instructions.len() =>
             {
                 let region_id = u32::from_be_bytes([
                     instructions[i],
@@ -152,8 +152,17 @@ pub fn disassemble_lines(instructions: &[u8]) -> Vec<String> {
                     instructions[i + 2],
                     instructions[i + 3],
                 ]);
-                line.push_str(&format!(" (region={})", region_id));
-                i += 4;
+                let args_region = u32::from_be_bytes([
+                    instructions[i + 4],
+                    instructions[i + 5],
+                    instructions[i + 6],
+                    instructions[i + 7],
+                ]);
+                line.push_str(&format!(
+                    " (region={}, args_region={})",
+                    region_id, args_region
+                ));
+                i += 8;
             }
             Instruction::IntToFloat | Instruction::FloatToInt => {
                 // No operands — pop one, push one

--- a/src/jit/calls/callops/arraycall.rs
+++ b/src/jit/calls/callops/arraycall.rs
@@ -3,6 +3,12 @@
 use super::*;
 
 /// Unpacks the array and delegates to elle_jit_call.
+///
+/// `args_region` is the args array's own static slot: the array is the calling
+/// convention's, so the call that consumes it reclaims it, on this tier exactly
+/// as on the interpreter's (`VM::release_splice_args`,
+/// docs/impl/region/mechanism.md § "A spliced call's arguments come out of an
+/// array the convention owns").
 #[no_mangle]
 pub extern "C" fn elle_jit_call_array(
     func_tag: u64,
@@ -11,12 +17,17 @@ pub extern "C" fn elle_jit_call_array(
     args_array_payload: u64,
     vm: *mut (),
     region_id: u32,
+    args_region: u32,
 ) -> JitValue {
     let args_val = Value {
         tag: args_array_tag,
         payload: args_array_payload,
     };
     let vm_ref = unsafe { &mut *(vm as *mut crate::vm::VM) };
+    let args_slot = crate::hir::region::StaticRegion::new(args_region)
+        .expect("JIT region slot is nonzero — emitter invariant");
+    // Claimed before the callee can park, exactly as on the interpreter tier.
+    let args_array = vm_ref.take_splice_args(args_slot);
 
     let args: Vec<Value> = if let Some(arr) = args_val.as_array_mut() {
         arr.borrow().to_vec()
@@ -30,11 +41,12 @@ pub extern "C" fn elle_jit_call_array(
                 args_val.type_name()
             ),
         );
+        vm_ref.release_splice_args(args_array);
         return JitValue::nil();
     };
 
     let nargs = args.len() as u32;
-    if args.is_empty() {
+    let result = if args.is_empty() {
         elle_jit_call(
             func_tag,
             func_payload,
@@ -45,11 +57,19 @@ pub extern "C" fn elle_jit_call_array(
         )
     } else {
         elle_jit_call(func_tag, func_payload, args.as_ptr(), nargs, vm, region_id)
-    }
+    };
+    // The callee holds its own reference to every argument by now, so the
+    // array's counted edges are surplus.
+    unsafe { &mut *(vm as *mut crate::vm::VM) }.release_splice_args(args_array);
+    result
 }
 
 /// Tail-call a function with arguments from an array value.
-/// Unpacks the array and delegates to elle_jit_tail_call.
+/// Unpacks the array and delegates to the shared tail-call body.
+///
+/// A spliced tail call MOVES nothing — its arguments came out of the args array,
+/// not off this frame — so the callee mints one reference per parameter
+/// (`own_params`), and the array's reclaim balances the pushes that built it.
 #[no_mangle]
 pub extern "C" fn elle_jit_tail_call_array(
     func_tag: u64,
@@ -58,12 +78,17 @@ pub extern "C" fn elle_jit_tail_call_array(
     args_array_payload: u64,
     vm: *mut (),
     region_id: u32,
+    args_region: u32,
 ) -> JitValue {
     let args_val = Value {
         tag: args_array_tag,
         payload: args_array_payload,
     };
     let vm_ref = unsafe { &mut *(vm as *mut crate::vm::VM) };
+    let args_slot = crate::hir::region::StaticRegion::new(args_region)
+        .expect("JIT region slot is nonzero — emitter invariant");
+    // Claimed before the callee can park, exactly as on the interpreter tier.
+    let args_array = vm_ref.take_splice_args(args_slot);
 
     let args: Vec<Value> = if let Some(arr) = args_val.as_array_mut() {
         arr.borrow().to_vec()
@@ -77,22 +102,34 @@ pub extern "C" fn elle_jit_tail_call_array(
                 args_val.type_name()
             ),
         );
+        vm_ref.release_splice_args(args_array);
         return JitValue::nil();
     };
 
     let nargs = args.len() as u32;
-    if args.is_empty() {
-        elle_jit_tail_call(
+    let result = if args.is_empty() {
+        jit_tail_call_inner(
             func_tag,
             func_payload,
             std::ptr::null(),
             nargs,
             vm,
             region_id,
+            true,
         )
     } else {
-        elle_jit_tail_call(func_tag, func_payload, args.as_ptr(), nargs, vm, region_id)
-    }
+        jit_tail_call_inner(
+            func_tag,
+            func_payload,
+            args.as_ptr(),
+            nargs,
+            vm,
+            region_id,
+            true,
+        )
+    };
+    unsafe { &mut *(vm as *mut crate::vm::VM) }.release_splice_args(args_array);
+    result
 }
 
 /// Create a closure from a template **blueprint** and captured environment.
@@ -214,6 +251,34 @@ pub extern "C" fn elle_jit_tail_call(
     vm: *mut (),
     region_id: u32,
 ) -> JitValue {
+    jit_tail_call_inner(
+        func_tag,
+        func_payload,
+        args_ptr,
+        nargs,
+        vm,
+        region_id,
+        false,
+    )
+}
+
+/// The body of [`elle_jit_tail_call`], shared with the spliced entry point
+/// [`elle_jit_tail_call_array`].
+///
+/// `spliced_args` is the same fact `tail_call_inner` reads on the interpreter
+/// tier: an ordinary tail call MOVES its arguments (the caller's reference
+/// transfers), while a spliced one holds them in an args array the convention
+/// owns and reclaims, so the callee mints one reference per parameter instead.
+#[allow(clippy::too_many_arguments)]
+fn jit_tail_call_inner(
+    func_tag: u64,
+    func_payload: u64,
+    args_ptr: *const Value,
+    nargs: u32,
+    vm: *mut (),
+    region_id: u32,
+    spliced_args: bool,
+) -> JitValue {
     let vm = unsafe { &mut *(vm as *mut crate::vm::VM) };
     let func = Value {
         tag: func_tag,
@@ -287,9 +352,11 @@ pub extern "C" fn elle_jit_tail_call(
             .collect();
 
         // Tail call: pure MOVE (own_params=false) — the caller's arg references
-        // transfer to the callee, which releases them. Per-value env minting via
+        // transfer to the callee, which releases them. A SPLICED tail call has
+        // no such reference of the frame's: its arguments came out of the args
+        // array, so the callee mints its own. Per-value env minting via
         // `populate_env`, same as the interpreter's `tail_call_inner`.
-        let new_env = match vm.build_tail_call_env(closure, &args) {
+        let new_env = match vm.build_tail_call_env(closure, &args, spliced_args) {
             Some(env) => env,
             None => return JitValue::nil(), // bad keyword args — error on fiber
         };

--- a/src/jit/helpers.rs
+++ b/src/jit/helpers.rs
@@ -303,9 +303,11 @@ impl<'a> FunctionTranslator<'a> {
     }
 
     /// Call the elle_jit_call_array / elle_jit_tail_call_array helper.
-    /// Signature: (func_tag, func_payload, arr_tag, arr_payload, vm, region_id)
-    /// -> (tag, payload). `region_id` routes the native result allocation and
-    /// gates the pass-through retain, exactly as for the non-array call path.
+    /// Signature: (func_tag, func_payload, arr_tag, arr_payload, vm, region_id,
+    /// args_region) -> (tag, payload). `region_id` routes the native result
+    /// allocation and gates the pass-through retain, exactly as for the non-array
+    /// call path; `args_region` names the args array's own slot, which the helper
+    /// takes to reclaim the array once the callee holds its arguments.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn call_helper_call_array(
         &mut self,
@@ -317,11 +319,20 @@ impl<'a> FunctionTranslator<'a> {
         arr_payload: cranelift_codegen::ir::Value,
         vm: cranelift_codegen::ir::Value,
         region_id: cranelift_codegen::ir::Value,
+        args_region: cranelift_codegen::ir::Value,
     ) -> Result<(cranelift_codegen::ir::Value, cranelift_codegen::ir::Value), JitError> {
         let func_ref = self.module.declare_func_in_func(func_id, builder.func);
         let call = builder.ins().call(
             func_ref,
-            &[func_tag, func_payload, arr_tag, arr_payload, vm, region_id],
+            &[
+                func_tag,
+                func_payload,
+                arr_tag,
+                arr_payload,
+                vm,
+                region_id,
+                args_region,
+            ],
         );
         Ok((builder.inst_results(call)[0], builder.inst_results(call)[1]))
     }

--- a/src/jit/translate/instr/async_ops.rs
+++ b/src/jit/translate/instr/async_ops.rs
@@ -317,14 +317,20 @@ impl<'a> FunctionTranslator<'a> {
             }
 
             LirInstr::CallArrayMut {
-                dst, func, args, ..
+                dst,
+                func,
+                args,
+                args_region,
+                ..
             } => {
                 let (ft, fp) = self.use_var_pair(builder, func.0);
                 let (art, arp) = self.use_var_pair(builder, args.0);
                 let vm = self.vm_ptr.ok_or_else(|| {
                     JitError::InvalidLir("CallArrayMut without vm pointer".to_string())
                 })?;
-                // call_array: (func_tag, func_payload, arr_tag, arr_payload, vm, region_id)
+                let args_region_const = builder.ins().iconst(I32, args_region.get() as i64);
+                // call_array: (func_tag, func_payload, arr_tag, arr_payload, vm,
+                // region_id, args_region)
                 let (rt, rp) = self.call_helper_call_array(
                     builder,
                     self.helpers.call_array,
@@ -334,6 +340,7 @@ impl<'a> FunctionTranslator<'a> {
                     arp,
                     vm,
                     region_id_const,
+                    args_region_const,
                 )?;
                 self.def_var_pair(builder, dst.0, rt, rp);
                 self.emit_exception_check_after_call(builder)?;
@@ -344,12 +351,18 @@ impl<'a> FunctionTranslator<'a> {
                 }
             }
 
-            LirInstr::TailCallArrayMut { func, args, .. } => {
+            LirInstr::TailCallArrayMut {
+                func,
+                args,
+                args_region,
+                ..
+            } => {
                 let (ft, fp) = self.use_var_pair(builder, func.0);
                 let (art, arp) = self.use_var_pair(builder, args.0);
                 let vm = self.vm_ptr.ok_or_else(|| {
                     JitError::InvalidLir("TailCallArrayMut without vm pointer".to_string())
                 })?;
+                let args_region_const = builder.ins().iconst(I32, args_region.get() as i64);
                 let (rt, rp) = self.call_helper_call_array(
                     builder,
                     self.helpers.tail_call_array,
@@ -359,6 +372,7 @@ impl<'a> FunctionTranslator<'a> {
                     arp,
                     vm,
                     region_id_const,
+                    args_region_const,
                 )?;
                 self.emit_pop_then_return(builder, rt, rp)?;
                 return Ok(true);

--- a/src/jit/vtable/helpers.rs
+++ b/src/jit/vtable/helpers.rs
@@ -72,8 +72,11 @@ pub(crate) fn declare_helpers(module: &mut JITModule) -> Result<RuntimeHelpers, 
     let push_param_sig = make_sig(module, &[I64, I64, I64], &[I64, I64]);
     // make_closure: (template_ptr, captures_ptr, count, region: I32, vm) -> (tag, payload)
     let make_closure_sig = make_sig(module, &[I64, I64, I64, I32, I64], &[I64, I64]);
-    // call_array: (func_tag, func_payload, arr_tag, arr_payload, vm, region_id) -> (tag, payload)
-    let call_array_sig = make_sig(module, &[I64, I64, I64, I64, I64, I32], &[I64, I64]);
+    // call_array: (func_tag, func_payload, arr_tag, arr_payload, vm, region_id,
+    // args_region) -> (tag, payload). `args_region` is the args array's own slot,
+    // which the helper takes to reclaim the array (docs/impl/region/mechanism.md
+    // § "A spliced call's arguments come out of an array the convention owns").
+    let call_array_sig = make_sig(module, &[I64, I64, I64, I64, I64, I32, I32], &[I64, I64]);
     // cons: (car_tag, car_pay, cdr_tag, cdr_pay, region, vm) -> (tag, payload).
     // The trailing vm pointer names the heap the cons cell is born on.
     let cons_sig = make_sig(module, &[I64, I64, I64, I64, I32, I64], &[I64, I64]);

--- a/src/lir/display.rs
+++ b/src/lir/display.rs
@@ -261,12 +261,29 @@ impl fmt::Display for LirInstr {
                 write!(f, "{} ← push({}, {})", dst, array, value)
             }
             LirInstr::CallArrayMut {
-                dst, func, args, ..
+                dst,
+                func,
+                args,
+                args_region,
+                ..
             } => {
-                write!(f, "{} ← {}(;{})", dst, func, args)
+                write!(
+                    f,
+                    "{} ← {}(;{}) [args-region {}]",
+                    dst, func, args, args_region
+                )
             }
-            LirInstr::TailCallArrayMut { func, args, .. } => {
-                write!(f, "tailcall {}(;{})", func, args)
+            LirInstr::TailCallArrayMut {
+                func,
+                args,
+                args_region,
+                ..
+            } => {
+                write!(
+                    f,
+                    "tailcall {}(;{}) [args-region {}]",
+                    func, args, args_region
+                )
             }
 
             // === Allocation Regions ===

--- a/src/lir/emit/instr/ops.rs
+++ b/src/lir/emit/instr/ops.rs
@@ -212,11 +212,13 @@ impl Emitter {
                 func,
                 args,
                 region,
+                args_region,
             } => {
                 // Stack: [func, args_array] → [result]
                 self.ensure_binary_on_top(*func, *args);
                 self.bytecode.emit(Instruction::CallArrayMut);
                 self.bytecode.emit_u32(region.get());
+                self.bytecode.emit_u32(args_region.get());
                 let call_resume_ip = self.bytecode.current_pos();
                 self.pop(); // args
                 self.pop(); // func
@@ -232,11 +234,17 @@ impl Emitter {
                 self.push_reg(*dst);
             }
 
-            LirInstr::TailCallArrayMut { func, args, region } => {
+            LirInstr::TailCallArrayMut {
+                func,
+                args,
+                region,
+                args_region,
+            } => {
                 // Stack: [func, args_array] → (tail call, no push)
                 self.ensure_binary_on_top(*func, *args);
                 self.bytecode.emit(Instruction::TailCallArrayMut);
                 self.bytecode.emit_u32(region.get());
+                self.bytecode.emit_u32(args_region.get());
                 self.pop(); // args
                 self.pop(); // func
             }

--- a/src/lir/lower/control/call.rs
+++ b/src/lir/lower/control/call.rs
@@ -716,6 +716,24 @@ impl<'a> Lowerer<'a> {
             // as in the non-splice path.
             let func_reg = self.lower_expr(func)?;
 
+            // The args array is the operand stack spelled as a heap value: the
+            // calling convention builds it, the call consumes it, and no binding
+            // of the program ever names it. So it takes a managed slot of its own
+            // rather than the call's — the call maps its own mint over that slot,
+            // and a static slot names one allocation execution between drops — and
+            // the release is the runtime's, carried on the call instruction
+            // (docs/impl/region/mechanism.md § "A spliced call's arguments come out
+            // of an array the convention owns").
+            let args_region = self.fresh_managed_region();
+            // A frame abandoned between the array's construction and the call —
+            // an `ArrayMutExtend` over a source that is not a sequence raises
+            // there — still has the slot mapped, so the walk reclaims it off this
+            // record (§ "An abandoned frame runs the releases it still owes"). A
+            // frame that reached the call does not: the call took the slot, and
+            // the walk's own take then finds nothing. The slot is minted per call
+            // site, so it can enter the table only once.
+            self.current_func.frame_release_regions.push(args_region);
+
             // Build the args array incrementally
             // Start with MakeArrayMut of the first run of non-spliced args
             let mut args_reg: Option<Reg> = None;
@@ -725,7 +743,7 @@ impl<'a> Lowerer<'a> {
                     (None, false) => {
                         // First arg, not spliced: create array with one element
                         let dst = self.fresh_reg();
-                        self.emit_alloc(|region| LirInstr::MakeArrayMut {
+                        self.emit_alloc_with_slot(args_region, |region| LirInstr::MakeArrayMut {
                             region,
                             dst,
                             elements: vec![*reg],
@@ -735,7 +753,7 @@ impl<'a> Lowerer<'a> {
                     (None, true) => {
                         // First arg, spliced: create empty array, then extend
                         let empty = self.fresh_reg();
-                        self.emit_alloc(|region| LirInstr::MakeArrayMut {
+                        self.emit_alloc_with_slot(args_region, |region| LirInstr::MakeArrayMut {
                             region,
                             dst: empty,
                             elements: vec![],
@@ -771,7 +789,7 @@ impl<'a> Lowerer<'a> {
 
             let final_args = args_reg.unwrap_or_else(|| {
                 let dst = self.fresh_reg();
-                self.emit_alloc(|region| LirInstr::MakeArrayMut {
+                self.emit_alloc_with_slot(args_region, |region| LirInstr::MakeArrayMut {
                     region,
                     dst,
                     elements: vec![],
@@ -785,14 +803,28 @@ impl<'a> Lowerer<'a> {
                     region,
                     func: func_reg,
                     args: final_args,
+                    args_region,
                 });
+                // A spliced call moves nothing: the array holds one counted
+                // reference per element and the callee mints its own, so every
+                // release the frame owes past this frame replacement is an
+                // ordinary release the relocation carries rather than an
+                // ownership move. Hence NO argument expressions in the exempt
+                // set — a spliced argument was consumed into the array, and the
+                // source the splice read is handed to no one. The callee's own
+                // region and this call's result placeholder still are.
+                if let Some(call_id) = self.current_hir_id {
+                    let operands = [final_args, func_reg];
+                    self.open_tail_exit_hoist(call_id, func, &[], &operands);
+                }
                 // ReturnValue retain on the native-completion fall-through —
                 // the splice/`apply` mirror of the non-splice `TailCall` arm
                 // above. A splice tail call to a heap pass-through native
                 // (`(first ;argv)`, `(get ;argv)`, an `apply`'d accessor) needs
                 // the same retain or its result is freed under the caller's
-                // borrow once the args-array leak that currently masks it is
-                // fixed (region-splice-tail-return.lisp; docs/impl/region/rules.md
+                // borrow — nothing outlives the call to hold it, the args array
+                // being reclaimed by the call itself
+                // (region-splice-tail-return.lisp; docs/impl/region/rules.md
                 // Rules 4/5). Dead for a frame-replacing closure tail call;
                 // no-op for an immediate result. The emitter peeks the operand
                 // stack top — the native's pushed result. Stands down under the
@@ -810,6 +842,7 @@ impl<'a> Lowerer<'a> {
                     dst,
                     func: func_reg,
                     args: final_args,
+                    args_region,
                 });
                 // ANF binds this Call's result; the binding's slot is
                 // recorded in `region_to_slot` by the enclosing

--- a/src/lir/lower/emitops.rs
+++ b/src/lir/lower/emitops.rs
@@ -148,7 +148,11 @@ impl<'a> Lowerer<'a> {
         self.emit_alloc_with_slot(slot, build);
     }
 
-    fn emit_alloc_with_slot(
+    /// `emit_alloc` against a slot the caller already holds — the solver's, via
+    /// the two wrappers above, or a synthetic one from
+    /// [`Self::fresh_managed_region`] for an allocation region inference does not
+    /// track (the splice args array, whose release is the calling convention's).
+    pub(super) fn emit_alloc_with_slot(
         &mut self,
         region: StaticRegion,
         build: impl FnOnce(StaticRegion) -> LirInstr,

--- a/src/lir/lower/tests/release/emission.rs
+++ b/src/lir/lower/tests/release/emission.rs
@@ -369,10 +369,8 @@ fn decref_region_emitted_once_for_merged_pair() {
 // The native-tail ReturnValue retain (the `IncrefValueRegion` the post-
 // `TailCall` block emits on the native-completion fall-through) is guarded by
 // Elle corpus tests, not a Rust LIR-structural assertion: the non-splice path
-// by region-native-tail-return-uaf.lisp (a true UAF witness, RED before the
-// fix under guardfree) and the splice/`apply` path by
-// region-splice-tail-return.lisp (a correctness guard — the splice UAF is
-// masked by the args-array leak, so it asserts the result value instead).
+// by region-native-tail-return-uaf.lisp and the splice/`apply` path by
+// region-splice-tail-return.lisp, each a UAF witness under guardfree.
 
 // ── The abandoned-frame release tables ───────────────────────────
 //
@@ -422,10 +420,29 @@ fn emitted_slot_route_regions(func: &LirFunction) -> Vec<u32> {
     out
 }
 
+/// Every splice args-array slot a function's call instructions carry. Their
+/// release is the runtime's rather than an emitted `DecrefRegion`, so the frame
+/// still owes it while the array exists and the call has not run.
+fn splice_args_regions(func: &LirFunction) -> Vec<u32> {
+    let mut out: Vec<u32> = func
+        .blocks
+        .iter()
+        .flat_map(|b| b.instructions.iter())
+        .filter_map(|i| match &i.instr {
+            LirInstr::CallArrayMut { args_region, .. }
+            | LirInstr::TailCallArrayMut { args_region, .. } => Some(args_region.get()),
+            _ => None,
+        })
+        .collect();
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
 #[test]
 fn frame_release_tables_name_exactly_the_routes_emitted() {
-    // The walk's whole premise: a table entry IS a release the function emits,
-    // so running it at an abandoned exit runs that instruction and no other.
+    // The walk's whole premise: a table entry IS a release the frame still owes,
+    // so running it at an abandoned exit runs that release and no other.
     // Counterfactual — a table built from the region set rather than from the
     // emit site would carry the routes the emitter declined (a mutated slot, a
     // cell box, a transfer adopt) and release a reference nobody owes.
@@ -444,6 +461,80 @@ fn frame_release_tables_name_exactly_the_routes_emitted() {
             regions,
             emitted_slot_route_regions(func),
             "frame_release_regions must be exactly the slots a DecrefRegion named",
+        );
+    }
+}
+
+#[test]
+fn a_splice_args_array_is_owed_by_the_frame_until_the_call_takes_it() {
+    // The second contributor to the region table: a spliced call's args array has
+    // no binding, so no `DecrefRegion` names it and the call reclaims it at
+    // runtime instead (docs/impl/region/mechanism.md § "A spliced call's arguments
+    // come out of an array the convention owns"). Between the array's
+    // construction and the call the frame still owes that release — an
+    // `ArrayMutExtend` over a non-sequence raises exactly there — so the slot is
+    // in the table, and the call's own take is what keeps it from running twice.
+    let module = compile_to_lir("(fn (xs) (let [n (g ;xs)] n))");
+    let func = std::iter::once(&module.entry)
+        .chain(module.closures.iter())
+        .find(|f| !splice_args_regions(f).is_empty())
+        .expect("a function lowering a spliced call");
+    let mut regions: Vec<u32> = func.frame_release_regions.iter().map(|r| r.get()).collect();
+    regions.sort_unstable();
+    for slot in splice_args_regions(func) {
+        assert!(
+            regions.contains(&slot),
+            "the splice args slot {slot} must be a release the abandoned frame owes",
+        );
+        assert!(
+            !emitted_slot_route_regions(func).contains(&slot),
+            "the splice args slot {slot} must have no emitted DecrefRegion — the call \
+             takes it, and a second release would over-free",
+        );
+    }
+}
+
+#[test]
+fn a_spliced_call_allocates_its_args_array_outside_the_call_region() {
+    // A static region slot names ONE allocation execution between drops
+    // (docs/impl/region/model.md § "The per-execution region model"). The args
+    // array and the call are two, so sharing the call's slot orphans the array's
+    // physical region the moment the call maps its own mint over it — the leak
+    // `tests/elle/region-splice-args.lisp` gauges. Counterfactual: with one slot
+    // for both, this assertion reads them equal.
+    let module = compile_to_lir("(fn (xs) (g ;xs))");
+    let func = std::iter::once(&module.entry)
+        .chain(module.closures.iter())
+        .find(|f| !splice_args_regions(f).is_empty())
+        .expect("a function lowering a spliced call");
+    let array_slots: Vec<u32> = func
+        .blocks
+        .iter()
+        .flat_map(|b| b.instructions.iter())
+        .filter_map(|i| match &i.instr {
+            LirInstr::MakeArrayMut { region, .. } => Some(region.get()),
+            _ => None,
+        })
+        .collect();
+    let call_slots: Vec<u32> =
+        func.blocks
+            .iter()
+            .flat_map(|b| b.instructions.iter())
+            .filter_map(|i| match &i.instr {
+                LirInstr::CallArrayMut { region, .. }
+                | LirInstr::TailCallArrayMut { region, .. } => Some(region.get()),
+                _ => None,
+            })
+            .collect();
+    assert!(!array_slots.is_empty(), "the splice path builds an @array");
+    for slot in &array_slots {
+        assert!(
+            !call_slots.contains(slot),
+            "the args array's slot {slot} must not be the call's own",
+        );
+        assert!(
+            splice_args_regions(func).contains(slot),
+            "the args array's slot {slot} must be the one the call carries",
         );
     }
 }

--- a/src/lir/types/instr.rs
+++ b/src/lir/types/instr.rs
@@ -288,17 +288,29 @@ pub enum LirInstr {
     ArrayMutPush { dst: Reg, array: Reg, value: Reg },
     /// Call a function with elements of an array as arguments.
     /// The array is unpacked into individual arguments at runtime.
+    ///
+    /// `args_region` is the managed slot the args array was allocated into, and
+    /// the runtime takes it to reclaim the array once the callee holds its own
+    /// reference to every argument. The array is the calling convention's own —
+    /// no binding of the program names it, so no emitted release can
+    /// (docs/impl/region/mechanism.md § "A spliced call's arguments come out of
+    /// an array the convention owns").
     CallArrayMut {
         dst: Reg,
         func: Reg,
         args: Reg,
         region: StaticRegion,
+        args_region: StaticRegion,
     },
-    /// Tail call with elements of an array as arguments.
+    /// Tail call with elements of an array as arguments. `args_region` is the
+    /// args array's own slot, as for [`LirInstr::CallArrayMut`] — and here it is
+    /// the only route there is, a frame-replacing callee never arriving at the
+    /// block after this instruction.
     TailCallArrayMut {
         func: Reg,
         args: Reg,
         region: StaticRegion,
+        args_region: StaticRegion,
     },
 
     // === Allocation Regions ===

--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -92,6 +92,15 @@ impl VM {
         instr_ip: usize,
         checked: bool,
     ) -> Option<SignalBits> {
+        // Both region operands are decoded first, so `ip` is past them however
+        // this handler leaves — the type-error arm below returns without calling.
+        let bc: &[u8] = &code.bytecode;
+        let region_id = self.read_static_region(bc, ip);
+        let args_region = self.read_static_region(bc, ip);
+        // Claimed before the callee can park: a suspending callee snapshots this
+        // activation's region map, and the array's entry must not travel into it.
+        let args_array = self.take_splice_args(args_region);
+
         let args_val = self
             .fiber
             .stack
@@ -116,13 +125,12 @@ impl VM {
                     args_val.type_name()
                 ),
             );
+            self.release_splice_args(args_array);
             self.fiber.stack.push(Value::NIL);
             return None;
         };
 
-        let bc: &[u8] = &code.bytecode;
-        let region_id = self.read_static_region(bc, ip);
-        self.call_inner(
+        let bits = self.call_inner(
             func,
             args,
             code,
@@ -131,7 +139,13 @@ impl VM {
             instr_ip,
             checked,
             region_id,
-        )
+        );
+        // The callee holds its own reference to every argument by now — the env's
+        // `CallArgument` incref for a closure, the pass-through retain for a
+        // native — so the array's counted edges are surplus and this reclaim
+        // balances the pushes that built it.
+        self.release_splice_args(args_array);
+        bits
     }
 
     /// Handle the TailCall instruction.
@@ -189,6 +203,7 @@ impl VM {
             defer_callee_release,
             deferred_release_slot,
             &borrowed_arg_slots,
+            false,
         )
     }
 
@@ -203,6 +218,9 @@ impl VM {
         checked: bool,
     ) -> Option<SignalBits> {
         let region_id = self.read_static_region(bytecode, ip);
+        let args_region = self.read_static_region(bytecode, ip);
+        // Claimed before the callee can park, as in the Call position above.
+        let args_array = self.take_splice_args(args_region);
 
         let args_val = self
             .fiber
@@ -228,6 +246,7 @@ impl VM {
                     args_val.type_name()
                 ),
             );
+            self.release_splice_args(args_array);
             return Some(SIG_ERROR);
         };
 
@@ -236,7 +255,15 @@ impl VM {
         // path yet — `false`/`None` keep today's behaviour (no regression). The
         // common `(f …)` tail call uses `TailCall`, which carries both — and the
         // borrowed-argument stash list with them.
-        self.tail_call_inner(func, args, checked, region_id, false, None, &[])
+        let bits = self.tail_call_inner(func, args, checked, region_id, false, None, &[], true);
+        // The array's reclaim, on the one path every outcome of this call passes
+        // through: a frame-replacing closure callee never arrives at the block
+        // after this instruction, so no emitted release could reach it. The
+        // callee has minted its own reference to every argument by now
+        // (`own_params`, from the `true` above), so the cascade here balances the
+        // pushes that built the array and nothing more.
+        self.release_splice_args(args_array);
+        bits
     }
 
     /// Dispatch a collection-as-function call-index (`(arr i)` / `(m :k)` /

--- a/src/vm/call/inner/tail.rs
+++ b/src/vm/call/inner/tail.rs
@@ -96,6 +96,16 @@ impl VM {
     /// exit owes too"). A terminal `:error` consumes them like any other exit and
     /// mints the payload's delivery instead
     /// ([`Self::mint_raised_argument_delivery`]).
+    ///
+    /// `spliced_args` says the arguments came out of an args array the calling
+    /// convention owns rather than off this frame's own operand stack. That
+    /// decides who holds the reference the callee's owned-param release consumes:
+    /// the array does, so a spliced tail call MOVES nothing and the callee mints
+    /// one reference per parameter of its own (`own_params`), exactly as a
+    /// call-position callee does. The caller reclaims the array once this returns,
+    /// and the cascade balances against those mints
+    /// (docs/impl/region/mechanism.md § "A spliced call's arguments come out of an
+    /// array the convention owns").
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn tail_call_inner(
         &mut self,
@@ -106,6 +116,7 @@ impl VM {
         defer_callee_release: bool,
         deferred_release_slot: Option<StaticRegion>,
         borrowed_arg_slots: &[u16],
+        spliced_args: bool,
     ) -> Option<SignalBits> {
         if let Some(def) = func.as_native_def() {
             let blocked = def
@@ -330,13 +341,18 @@ impl VM {
             // owned-param callee releases it. So NO caller incref here —
             // `own_params = false`. (The non-tail path, `build_closure_env`,
             // passes `true`.)
+            //
+            // A SPLICED tail call has no such reference to move: its arguments
+            // came out of an args array the calling convention owns, whose
+            // counted edge the caller reclaims once this returns. So the callee
+            // mints one of its own per parameter, as in call position.
             if !Self::populate_env(
                 &mut self.tail_call_env_cache,
                 unsafe { &mut *self.heap_ptr },
                 &mut self.fiber,
                 closure,
                 &args,
-                false,
+                spliced_args,
             ) {
                 return Some(SIG_ERROR);
             }

--- a/src/vm/core/region.rs
+++ b/src/vm/core/region.rs
@@ -380,6 +380,49 @@ impl VM {
             .and_then(|frame| frame.remove(&static_id.get()))
             .map(|m| m.region)
     }
+    /// Claim a spliced call's args array — the array the calling convention built
+    /// for this call and no binding of the program names
+    /// (docs/impl/region/mechanism.md § "A spliced call's arguments come out of
+    /// an array the convention owns").
+    ///
+    /// The claim is split from the free ([`Self::release_splice_args`]) because
+    /// the two answer to different moments. Taking the slot must happen BEFORE the
+    /// callee runs: a callee that suspends parks the continuation, and the park
+    /// SNAPSHOTS this activation's region map, so an entry still naming the array
+    /// would outlive the free and detonate the uncounted-borrow check when the
+    /// resume reads it (docs/impl/region/generations.md). Taking it first settles
+    /// the abandoned-frame walk in the same stroke — the slot is gone, so a callee
+    /// that raises leaves the walk nothing to run, and a frame abandoned BEFORE
+    /// the call still has it mapped and reclaims the array there.
+    ///
+    /// Shared by both dispatch tiers so the accounting is identical whichever runs
+    /// the caller (`handle_call_array`/`handle_tail_call_array`, and the JIT's
+    /// `elle_jit_call_array`/`elle_jit_tail_call_array`).
+    #[inline]
+    pub(crate) fn take_splice_args(&mut self, slot: StaticRegion) -> Option<RuntimeRegion> {
+        self.take_runtime_region_for_drop_slot(slot)
+    }
+
+    /// Free the region [`Self::take_splice_args`] claimed, once the callee holds
+    /// its own reference to every argument.
+    ///
+    /// The array counts one reference per element — `ArrayMutPush` /
+    /// `ArrayMutExtend` go through the store funnel — so this release runs their
+    /// cascade, and the callee's own references are what it must not be the last
+    /// of. The region cannot be recycled between the claim and here: it is held by
+    /// its own minting reference until this call.
+    #[inline]
+    pub(crate) fn release_splice_args(&mut self, region: Option<RuntimeRegion>) {
+        let Some(region) = region else {
+            return;
+        };
+        if crate::config::get().has_trace("rc") {
+            let rc = self.heap().region_rc(region);
+            eprintln!("[trace:rc] splice args released({region}) rc={rc}");
+        }
+        self.heap().decref_region(region);
+    }
+
     /// The interpreter's entry to the abandoned-frame walk: the tables come off
     /// the executing `Code`, and slot `s` lives on this activation's frame stack.
     pub(crate) fn release_abandoned_frame(&mut self, code: &crate::value::Code, payload: Value) {

--- a/src/vm/env.rs
+++ b/src/vm/env.rs
@@ -60,20 +60,24 @@ impl VM {
         Some(Rc::new(self.env_cache.clone()))
     }
 
-    /// Build a closure environment for a JIT TAIL call: a pure MOVE
-    /// (`own_params = false`), mirroring `tail_call_inner`'s closure path
-    /// (`src/vm/call.rs`). The caller's reference to each arg transfers to the
-    /// callee, which releases it at the param's last use — so no `CallArgument`
-    /// incref here. Uses `tail_call_env_cache` (it must not alias `env_cache`).
-    /// Returns `None` (error set on fiber) on bad keyword args.
+    /// Build a closure environment for a JIT TAIL call, mirroring
+    /// `tail_call_inner`'s closure path (`src/vm/call.rs`). Uses
+    /// `tail_call_env_cache` (it must not alias `env_cache`). Returns `None`
+    /// (error set on fiber) on bad keyword args.
     ///
-    /// The interpreter's own tail calls go through `tail_call_inner`, so the
-    /// JIT's array-call helper is the only caller.
+    /// `own_params` is what `tail_call_inner` decides from the same fact: an
+    /// ordinary tail call is a pure MOVE (`false` — the caller's reference to
+    /// each arg transfers to the callee, which releases it at the param's last
+    /// use, so no `CallArgument` incref here), while a SPLICED tail call has no
+    /// reference of the frame's to move and the callee mints one of its own
+    /// (`true`; docs/impl/region/mechanism.md § "A spliced call's arguments come
+    /// out of an array the convention owns").
     #[cfg(feature = "jit")]
     pub(crate) fn build_tail_call_env(
         &mut self,
         closure: &crate::value::Closure,
         args: &[Value],
+        own_params: bool,
     ) -> Option<Rc<Vec<Value>>> {
         if !Self::populate_env(
             &mut self.tail_call_env_cache,
@@ -81,7 +85,7 @@ impl VM {
             &mut self.fiber,
             closure,
             args,
-            false,
+            own_params,
         ) {
             return None;
         }

--- a/tests/elle/oracle.lisp
+++ b/tests/elle/oracle.lisp
@@ -147,16 +147,19 @@
 # fall-through owes, a signal exit owes too"). Its first stranded reference was the
 # aborted fiber's own value, which pinned the body closure and everything the parked
 # frame held behind it.
-# `denied-discard`'s rate is what is LEFT of the dead continuation once the frames'
-# own owed releases run. A frame abandoned by an error — and a parked one the fiber
-# can never re-enter — reaches none of its remaining instructions, so each release
-# among them runs off the value-route slots the emitter recorded
-# (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it still
-# owes"), gauged directly by `tests/elle/region-error-unwind.lisp`. What that walk
-# cannot NAME is a value with no binding of its own, so no route and no receipt:
-# the literal the denied call materialized straight into an argument, the rest list
-# the calling convention built for it, and a parameter released through an env slot,
-# which carries no nil stamp — so a release that ran reads like one that did not.
+# `denied-discard` is a CLOSED control now, and it stays declared under F2 so its
+# rate keeps reading against that root. What it measured was what is LEFT of a dead
+# continuation once the frames' own owed releases run: a frame abandoned by an
+# error — and a parked one the fiber can never re-enter — reaches none of its
+# remaining instructions, so each release among them runs off the value-route slots
+# the emitter recorded (docs/impl/region/mechanism.md § "An abandoned frame runs the
+# releases it still owes"), gauged directly by `tests/elle/region-error-unwind.lisp`.
+# What that walk could not NAME was a value with no binding of its own, and the one
+# this shape had is the ARGS ARRAY the denied `(println …)` builds for its
+# `(apply string args)`: no binding names it, so no emitted release could either.
+# The call that consumes an args array now reclaims it (mechanism.md § "A spliced
+# call's arguments come out of an array the convention owns"), gauged directly by
+# `tests/elle/region-splice-args.lisp`.
 # `spawn-join` is a CLOSED control now (undeclared, like `rest-array-copy`), so a
 # regression to open trips the completeness gate loudly rather than being absorbed
 # under F2 — which is not where it belonged: what it measured was the frame-held
@@ -259,7 +262,7 @@
   @{"fiber-nested" 0
     "multi-resume" 0
     "yield-discard" 0
-    "denied-discard" 2
+    "denied-discard" 0
     "abort-discard" 0
     "cancel-discard" 0
     "adopt-park-drop" 2
@@ -1383,7 +1386,7 @@
     (fn [j]
       (let [f (fiber/new (fn [] (println "blocked")) |:error :io| :deny |:io|)]
         (fiber/resume f)
-        (get (fiber/value f) :error))) 2]
+        (get (fiber/value f) :error))) 0]
    # The adopt-park family and its controls — the `ap-*` defns above hold the
    # attribution set. Open on both dimensions; the region pins live in
    # `@dual-read`.
@@ -1442,8 +1445,8 @@
    # exit consumes it itself (docs/impl/region/mechanism.md § "What the fall-through
    # owes, a signal exit owes too"). The stranded reference was the fiber's own, which
    # pinned the body closure and the parked frame's payload behind it. A CLOSED control
-   # now, beside `denied-discard`, whose residual is the DENIED call's own argument
-   # scratch and stays open under F2.
+   # now, beside `denied-discard`, whose residual was the args array the denied
+   # `(println …)` built for its own spliced call.
    ["abort-discard"
     (fn [j]
       (let [f (fiber/new (fn []
@@ -1630,10 +1633,9 @@
    # reaches — bound by the body, returned from tail position, and held across a
    # further park — beside `emit-resume-literal`, the control whose resume block
    # mints in bytecode and so is correct with no delivery mint at all. A parked
-   # CAPABILITY DENIAL is the fourth park of this shape and has no probe here on
-   # purpose: its rate is dominated by the denied call's own argument scratch,
-   # which `denied-discard` already declares under F2, so a probe there would
-   # count one root twice instead of gauging the delivery. Its soundness face is
+   # CAPABILITY DENIAL is the fourth park of this shape and has no probe here:
+   # `denied-discard` drives that shape under F2, and it never resumes the denied
+   # fiber, so no rate here would see the delivery at all. Its soundness face is
    # the `w-denied` witness under guardfree.
    ["primitive-resume-bind" (fn [j] (pr-bind j)) 0]
    ["primitive-resume-tail" (fn [j] (pr-tail j)) 0]

--- a/tests/elle/region-splice-args-uaf.lisp
+++ b/tests/elle/region-splice-args-uaf.lisp
@@ -1,0 +1,197 @@
+(elle/epoch 12)
+# Soundness complement of region-splice-args.lisp
+# (docs/impl/region/mechanism.md § "A spliced call's arguments come out of an
+# array the convention owns"). Run under `--trace=guardfree` by the subprocess
+# pin `region_splice_args_uaf` in tests/integration/elle_scripts.rs.
+#
+# The args array a spliced call builds holds one counted reference per element,
+# and the call reclaims the array once the callee holds what it needs. That
+# reclaim is a release on a path that ran none before, so it owes what any new
+# release owes: the reference it drops must be the array's own and no one
+# else's.
+#
+# Four faces have to survive it.
+#
+# 1. The ARGUMENT the callee still reads. The callee mints its own reference to
+#    every parameter, so the array's cascade must leave that one standing —
+#    including for a spliced TAIL call, where the frame that built the array is
+#    replaced before the callee runs a single instruction.
+# 2. The SOURCE the splice read. A spliced tail call moves nothing, so the
+#    frame's release of the source is relocated ahead of the frame replacement
+#    and now runs BEFORE the callee reads the elements. The array's own
+#    reference is what stands between the two.
+# 3. The RESULT handed back through the array's reclaim. A pass-through native
+#    returns a value living inside an argument, and the reclaim runs after the
+#    call — so the pass-through retain, not the array, must be what keeps it.
+# 4. An OUTER holder. The value the splice read is still named by the binding it
+#    came from, whose reference the reclaim must leave alone.
+#
+# Every read below happens AFTER the spliced call returned, so an over-release
+# faults at the deref (guardfree) or trips the generation check.
+
+(defn take-one [x]
+  (length x))
+(defn take-two [x y]
+  (%add (length x) (length y)))
+(defn take-rest [& rest]
+  (length rest))
+(defn hand-back [x]
+  x)
+
+# ── 1. the argument the callee reads, in tail position ────────────────────────
+# `(take-one ;args)` in tail position replaces this frame. The callee reads its
+# parameter after the array is gone, so the reference it minted must be live.
+
+(defn tail-closure [tag]
+  (let [args [(string "elem-" tag)]]
+    (take-one ;args)))
+
+(var i 0)
+(while (< i 40)
+  (assert (< 0 (tail-closure i))
+          "a spliced tail call's argument must survive the array's reclaim")
+  (assign i (+ i 1)))
+
+# ── 2. the source the splice read, released ahead of the frame replacement ────
+# Two elements from one source, so the source's own release — relocated ahead of
+# the tail call — drops a reference the array's edges must not be counted for.
+
+(defn tail-two-from-source [tag]
+  (let [args [(string "a-" tag) (string "b-" tag)]]
+    (take-two ;args)))
+
+(assign i 0)
+(while (< i 40)
+  (assert (< 0 (tail-two-from-source i))
+          "a spliced tail call's source may be released before the callee reads")
+  (assign i (+ i 1)))
+
+# ── 3. the result handed back out of an argument ──────────────────────────────
+# `hand-back` returns its parameter, so the value the caller reads lives in a
+# region the array also referenced. The caller's read happens after the reclaim.
+
+(defn tail-passthrough [tag]
+  (let [args [(string "through-" tag)]]
+    (hand-back ;args)))
+
+(assign i 0)
+(while (< i 40)
+  (assert (= (length (tail-passthrough i)) (length (string "through-" i)))
+          "a spliced call's pass-through result must survive the array's reclaim")
+  (assign i (+ i 1)))
+
+# ── 4. the outer holder, in call position ─────────────────────────────────────
+# A NON-tail splice: the frame keeps its own reference to the source and reads
+# it after the call, so the array's reclaim must drop only the array's.
+
+(defn nontail-then-read [tag]
+  (let [src (string "outer-" tag)]
+    (let [args [src]]
+      (let [n (take-one ;args)]
+        [n (length src) (length (get args 0))]))))
+
+(assign i 0)
+(while (< i 40)
+  (let [r (nontail-then-read i)]
+    (assert (= (get r 0) (get r 1))
+            "the splice source must still be readable after the call")
+    (assert (= (get r 1) (get r 2))
+            "the splice source's own array must still hold its element"))
+  (assign i (+ i 1)))
+
+# ── 5. the variadic callee: the rest list holds its own reference ─────────────
+# The collected rest list increfs each element, so the array's cascade and the
+# list's release name the same regions. Reading the list's elements inside the
+# callee proves neither ran twice.
+
+(defn rest-sum [& rest]
+  (var total 0)
+  (each x in rest
+    (assign total (%add total (length x))))
+  total)
+
+(defn tail-variadic [tag]
+  (let [args [(string "r1-" tag) (string "r2-" tag)]]
+    (rest-sum ;args)))
+
+(assign i 0)
+(while (< i 40)
+  (assert (< 0 (tail-variadic i))
+          "a spliced variadic call's rest elements must survive the reclaim")
+  (assign i (+ i 1)))
+
+# ── 6. `apply`, and a mutable source the callee keeps reading ─────────────────
+# The source is an `@array` the caller still owns; `apply` splices it into a
+# fresh args array, and both must be intact afterwards.
+
+(defn apply-then-read [tag]
+  (let [src @[(string "m-" tag)]]
+    (let [n (apply take-one src)]
+      [n (length (get src 0))])))
+
+(assign i 0)
+(while (< i 40)
+  (let [r (apply-then-read i)]
+    (assert (= (get r 0) (get r 1))
+            "an `apply` source must survive its args array's reclaim"))
+  (assign i (+ i 1)))
+
+# ── 7. a spliced call that RAISES before the array is consumed ────────────────
+# `ArrayMutExtend` over a non-sequence raises where the array exists and the
+# call has not run, so the abandoned frame reclaims it. The catcher's own values
+# must be untouched by that walk.
+
+(defn bad-splice [tag]
+  (let [keep (string "keep-" tag)]
+    (let [r (try
+              (take-one ;tag)
+              (catch e :caught))]
+      [r (length keep)])))
+
+(assign i 0)
+(while (< i 40)
+  (let [r (bad-splice i)]
+    (assert (= (get r 0) :caught) "a bad splice source must raise")
+    (assert (< 0 (get r 1)) "the catching frame's own value must survive"))
+  (assign i (+ i 1)))
+
+# ── 8. the callee SUSPENDS inside the spliced call ────────────────────────────
+# THE TRAP. A park SNAPSHOTS the activation's region map, and the resume checks
+# every slot in that snapshot against the region's generation. So the args
+# array's slot has to be claimed BEFORE the callee can park — a claim after it
+# clears only the live map, leaving the parked copy naming a region the reclaim
+# then frees, and the resume detonates the uncounted-borrow check.
+#
+# Both call positions park here: the `let`-bound call parks the splicing frame
+# itself, and the tail call parks the callee's, whose args came out of an array
+# the replaced frame built.
+
+(defn yield-then-count [x]
+  (yield x)
+  (length x))
+
+(defn nontail-splice-park [tag]
+  (let [args [(string "park-" tag)]]
+    (let [f (fiber/new (fn []
+                         (let [v (yield-then-count ;args)]
+                           (%add v 0))) |:yield|)]
+      (let [handed (fiber/resume f)]
+        [(length handed) (fiber/resume f)]))))
+
+(defn tail-splice-park [tag]
+  (let [args [(string "tpark-" tag)]]
+    (let [f (fiber/new (fn [] (yield-then-count ;args)) |:yield|)]
+      (let [handed (fiber/resume f)]
+        [(length handed) (fiber/resume f)]))))
+
+(assign i 0)
+(while (< i 40)
+  (let [r (nontail-splice-park i)]
+    (assert (= (get r 0) (get r 1))
+            "a spliced call's parked frame must resume onto a live argument"))
+  (let [r (tail-splice-park i)]
+    (assert (= (get r 0) (get r 1))
+            "a spliced tail call's parked callee must resume onto a live argument"))
+  (assign i (+ i 1)))
+
+(println "region-splice-args-uaf: ok")

--- a/tests/elle/region-splice-args.lisp
+++ b/tests/elle/region-splice-args.lisp
@@ -1,0 +1,180 @@
+(elle/epoch 12)
+# A spliced call's arguments come out of an array the convention owns
+# (docs/impl/region/mechanism.md § "A spliced call's arguments come out of an
+# array the convention owns").
+#
+# A call with a spliced argument — `(f ;args)`, and the `apply` it underlies —
+# cannot push its arguments onto the operand stack, because how many there are
+# is a runtime fact. The lowerer builds them into a fresh `@array` and hands
+# that array to `CallArrayMut`/`TailCallArrayMut`. No binding of the program
+# ever names that array, so nothing in the emitted code releases it: the array
+# is the calling convention's, and the call that consumes it releases it.
+#
+# THE TRAP the counts below guard. The array and the call are two allocations,
+# and a static region slot names ONE allocation execution between drops
+# (docs/impl/region/model.md § "The per-execution region model"). Giving the
+# array the CALL's slot leaves the array's physical region orphaned the moment
+# the call maps its own mint over the same slot — unreachable by the value route
+# (no binding names it) and by the abandoned-frame walk (the slot now maps
+# something else), so it survives to process teardown.
+#
+# THE COUNTER-FACTUAL a two-column reading catches. A spliced TAIL call to a
+# closure replaces the frame, so every release the lowerer emits after
+# `TailCallArrayMut` is dead. Reading the array's own reclaim as the whole
+# defect leaves those behind — one region per source the splice read, on top of
+# the array. That is why (d) and (g) below are separate subjects from (c): a
+# native tail callee keeps the frame and runs that block, so it reads bounded
+# even while a closure callee strands it.
+#
+# This file is the LEAK gauge — an `arena/region-count` delta over a fixed
+# window, BOUNDED for every subject. The soundness complement is
+# region-splice-args-uaf.lisp.
+
+(def window 400)
+
+(def shared (string "subject"))
+
+(defn measure [thunk warm window]
+  (var i 0)
+  (while (%lt i warm)
+    (thunk)
+    (assign i (%add i 1)))
+  (def before (arena/region-count))
+  (var j 0)
+  (while (%lt j window)
+    (thunk)
+    (assign j (%add j 1)))
+  (%sub (arena/region-count) before))
+
+(defn take-one [x]
+  (length x))
+(defn take-two [x y]
+  (%add (length x) (length y)))
+(defn take-rest [& rest]
+  (length rest))
+
+# subjects ─────────────────────────────────────────────────────────────────────
+
+# (a) NON-tail splice, native callee. The frame is never replaced, so the only
+# region with no release is the args array itself.
+(defn a-nontail-native []
+  (let [args [shared]]
+    (let [n (length ;args)]
+      (%add n 0))))
+
+# (b) NON-tail splice, closure callee. The callee mints its own reference to
+# each parameter, so the array's counted edge is surplus and its reclaim must
+# cascade exactly once.
+(defn b-nontail-closure []
+  (let [args [shared]]
+    (let [n (take-one ;args)]
+      (%add n 0))))
+
+# (c) TAIL splice, native callee. A native pushes no bytecode frame, so the
+# post-`TailCallArrayMut` block runs and carries the frame's own releases.
+(defn c-tail-native []
+  (let [args [shared]]
+    (length ;args)))
+
+# (d) TAIL splice, CLOSURE callee — the frame-replacing shape. The array is one
+# stranded region; the source the splice read is another, and only the
+# relocation ahead of the frame replacement reclaims it.
+(defn d-tail-closure []
+  (let [args [shared]]
+    (take-one ;args)))
+
+# (e) `apply`, which lowers to the same splice path.
+(defn e-apply []
+  (let [args [shared]]
+    (apply take-one args)))
+
+# (f) a splice whose source is built at the call — nothing outside the call ever
+# names the array OR its source.
+(defn f-tail-literal []
+  (take-one ;[shared]))
+
+# (g) a MIXED call: one plain argument beside a spliced one. The plain argument
+# is pushed into the same array, so its own reference and the array's must not
+# be counted for each other.
+(defn g-tail-mixed []
+  (let [args [shared]]
+    (take-two shared ;args)))
+
+# (h) a VARIADIC callee: the spliced arguments land in the rest parameter's
+# collected list, which takes an incref of its own. The array's reclaim and the
+# list's release name the same regions and must each run once.
+(defn h-tail-variadic []
+  (let [args [shared shared]]
+    (take-rest ;args)))
+
+# controls ─────────────────────────────────────────────────────────────────────
+
+# (i) the identical computation with no splice in it: the plain call path, whose
+# rate this file's subjects must reach.
+(defn i-plain []
+  (let [args [shared]]
+    (take-one (get args 0))))
+
+# (j) the array literal alone, with no call spliced from it — proves the source
+# collection is not what any subject's rate measures.
+(defn j-source-only []
+  (let [args [shared]]
+    (length args)))
+
+# measurement ──────────────────────────────────────────────────────────────────
+
+(def d-a (measure a-nontail-native 20 window))
+(def d-b (measure b-nontail-closure 20 window))
+(def d-c (measure c-tail-native 20 window))
+(def d-d (measure d-tail-closure 20 window))
+(def d-e (measure e-apply 20 window))
+(def d-f (measure f-tail-literal 20 window))
+(def d-g (measure g-tail-mixed 20 window))
+(def d-h (measure h-tail-variadic 20 window))
+(def d-i (measure i-plain 20 window))
+(def d-j (measure j-source-only 20 window))
+
+(println "region-splice-args over " window " iters (region deltas):")
+(println "  a nontail-native  " d-a)
+(println "  b nontail-closure " d-b)
+(println "  c tail-native     " d-c)
+(println "  d tail-closure    " d-d)
+(println "  e apply           " d-e)
+(println "  f tail-literal    " d-f)
+(println "  g tail-mixed      " d-g)
+(println "  h tail-variadic   " d-h)
+(println "  i plain           " d-i " (control)")
+(println "  j source-only     " d-j " (control)")
+
+(assert (%lt d-i 40)
+        (concat "control: the plain call path must be bounded, delta="
+                (number->string d-i)))
+(assert (%lt d-j 40)
+        (concat "control: the splice source alone must be bounded, delta="
+                (number->string d-j)))
+
+(assert (%lt d-a 40)
+        (concat "a non-tail spliced call strands its args array, delta="
+                (number->string d-a)))
+(assert (%lt d-b 40)
+        (concat "a non-tail spliced call to a closure strands its args array, "
+                "delta=" (number->string d-b)))
+(assert (%lt d-c 40)
+        (concat "a spliced tail call to a native strands its args array, delta="
+                (number->string d-c)))
+(assert (%lt d-d 40)
+        (concat "a spliced tail call to a closure strands its args array and "
+                "the source the splice read, delta=" (number->string d-d)))
+(assert (%lt d-e 40)
+        (concat "`apply` strands its args array, delta=" (number->string d-e)))
+(assert (%lt d-f 40)
+        (concat "a spliced tail call over a literal source strands it, delta="
+                (number->string d-f)))
+(assert (%lt d-g 40)
+        (concat "a mixed plain/spliced tail call strands its args array, delta="
+                (number->string d-g)))
+(assert (%lt d-h 40)
+        (concat "a spliced tail call to a variadic callee strands its args "
+                "array, delta=" (number->string d-h)))
+
+(println "region-splice-args: ok")

--- a/tests/elle/region-splice-tail-return.lisp
+++ b/tests/elle/region-splice-tail-return.lisp
@@ -10,19 +10,18 @@
 # native's single pass-through reference is drained by the caller's
 # `DecrefValueRegion`. The fix is in `lower_call`'s splice arm (src/lir/lower).
 #
-# WHY A CORRECTNESS GUARD, NOT A UAF WITNESS. Unlike the non-splice case, the
-# splice path cannot fault TODAY even with the retain missing: the freshly-built
-# splice args-array's region is never released (a separate, pre-existing leak,
-# shared with the non-tail `CallArrayMut` path — see the discarded-tail-return
-# leak the leak-suite canaries pin on this branch), and that live args-array keeps
-# the borrowed result alive. So under `--trace=guardfree` the value reads back
-# intact whether or not the retain is present — there is no deterministic fault
-# to assert on. This test therefore asserts the RESULT VALUE is correct: GREEN
-# now (the retain is present; and even without it the masking leak hid the bug),
-# and it BECOMES a real use-after-free guard the moment the args-array leak is
-# fixed — at which point a missing retain would free the result under the
-# caller's borrow and this assert would read torn bytes. Keeping the retain in
-# now means that future leak fix lands UAF-free. docs/impl/region/rules.md Rules 4/5/8.
+# THE TRAP the assertions guard. The args array is reclaimed by the call that
+# consumes it (docs/impl/region/mechanism.md § "A spliced call's arguments come
+# out of an array the convention owns"), so nothing outlives the call to keep a
+# borrowed result alive on the caller's behalf. Withhold the retain and the
+# native's single pass-through reference is drained by the caller's
+# `DecrefValueRegion`, and the reads below get torn bytes.
+#
+# THE COUNTER-FACTUAL. While the array's own region was still stranded, that live
+# array held the borrowed result and these same assertions passed with the retain
+# missing — the leak masked the defect. So this file is a witness only in company
+# with region-splice-args.lisp: a regression that re-strands the array would paint
+# it green again. docs/impl/region/rules.md Rules 4/5/8.
 #
 # Run under the guardfree oracle in tests/integration/elle_scripts.rs, mirroring
 # region-native-tail-return-uaf.

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -741,6 +741,24 @@ fn region_tail_signal_exit_uaf() {
     );
 }
 
+// Guard — a spliced call's args array is reclaimed by the call that consumes it
+// (docs/impl/region/mechanism.md § "A spliced call's arguments come out of an
+// array the convention owns"). The array counts one reference per element, so
+// that reclaim is a cascade on a path that ran none before, and four faces must
+// survive it: the ARGUMENT the callee still reads after the array is gone, the
+// SOURCE the splice read — released ahead of the frame replacement now that a
+// spliced tail call moves nothing — the pass-through RESULT handed back out of
+// an argument, and an OUTER holder in call position. Every read below happens
+// after the reclaim ran, so an over-release faults there — SIGSEGV under
+// guardfree. The leak face is `region-splice-args.lisp`.
+#[test]
+fn region_splice_args_uaf() {
+    run_elle_script_with_args(
+        "region-splice-args-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — a frame abandoned by an ERROR runs the releases it still owed, off
 // the value-route slots the emitter recorded (docs/impl/region/mechanism.md
 // § "An abandoned frame runs the releases it still owes"). Each is a release


### PR DESCRIPTION
## What was wrong

A spliced call — `(f ;args)`, and the `apply` it underlies — stranded a region
on every call: one per call to a native callee, two per call to a closure,
unbounded in a loop.

`lower_call`'s splice arm builds the arguments into a fresh `@array` with
`MakeArrayMut` / `ArrayMutPush` / `ArrayMutExtend` and hands that array to
`CallArrayMut` / `TailCallArrayMut`. Two things went wrong with it.

**The array shared the call's region slot.** A static region slot names one
allocation execution between drops (docs/impl/region/model.md § "The
per-execution region model"), and `runtime_region_for_alloc_slot` mints fresh and
overwrites the activation's mapping on every execution. So the array's physical
region was orphaned the moment the call mapped its own mint over the same slot —
unreachable by the value route, which needs a binding the array does not have,
and by the abandoned-frame walk, which reads a slot that by then maps something
else.

**The splice tail arm opened no relocation point.** A frame-replacing closure
callee never arrives at the block after `TailCallArrayMut`, so every release the
lowerer emitted there was dead. The non-splice arm carries those back ahead of
the call (`open_tail_exit_hoist`); the splice arm did not. That is the second
region: the source the splice read.

`(f a b)` and `(f ;[a b])` compute the same thing, so the gap read as a
differential — 800 iterations of `(take-one ;args)` grew the live-region count by
1601 where `(take-one (get args 0))` grew it by 1.

## What the change does

One rule, threaded through both dispatch tiers: **the args array is the operand
stack spelled as a heap value — the calling convention builds it, the call
consumes it, and no binding of the program ever names it**
(docs/impl/region/mechanism.md § "A spliced call's arguments come out of an array
the convention owns").

- **The array takes a managed slot of its own** (`fresh_managed_region`), so the
  call's own mint cannot orphan it.
- **The call releases it.** `CallArrayMut` / `TailCallArrayMut` carry that slot
  as a second region operand, and each dispatcher claims the slot before the
  callee runs and frees the region once it returns. Claiming first is
  load-bearing: a callee that suspends parks a *snapshot* of the activation's
  region map, and an entry still naming the array there outlives the free and
  detonates the uncounted-borrow check on resume. Claiming first also settles the
  abandoned-frame walk — a frame that reached the call leaves it nothing to run.
- **The callee mints its own reference to every argument.** The store funnel
  counts each `ArrayMutPush` / `ArrayMutExtend`, so the array holds one counted
  reference per element and a spliced call hands the callee nothing of the
  frame's: `own_params` is true in tail position as well as in call position. A
  spliced tail call therefore moves nothing, and the splice arm now opens the
  relocation point with no argument exempted.

The array's slot joins `frame_release_regions`, so a frame abandoned between the
array's construction and the call — an `ArrayMutExtend` over a source that is not
a sequence raises there — still reclaims it.

## How it was measured

`tests/elle/region-splice-args.lisp` reads `arena/region-count` growth over 400
iterations for eight subjects and two controls:

| subject | before | after |
|---|--:|--:|
| non-tail splice, native callee | 400 | 0 |
| non-tail splice, closure callee | 400 | 0 |
| tail splice, native callee | 400 | 0 |
| tail splice, closure callee | 800 | 0 |
| `apply` | 800 | 0 |
| tail splice over a literal source | 800 | 0 |
| mixed plain + spliced arguments | 800 | 0 |
| tail splice, variadic callee | 800 | 0 |
| plain call (control) | 0 | 0 |
| splice source alone (control) | 0 | 0 |

The issue's own measurement now reads 1 for all three of its shapes — the rate
its non-splice control already read.

`tests/elle/oracle.lisp` exits `oracle: ok`, and the `denied-discard` probe
closes with this change: its residual was the args array the denied `(println …)`
builds for its own `(apply string args)`. Its pins drop from 2 to 0 on both the
object and the region dimension, and the open-defect split goes from 8 to 6.

`cargo test -p elle --lib` (2315), `cargo test -p elle --test lib region_ --
--test-threads=1` (the guardfree UAF family, 95), `make smoke-elle` on the
release binary, `make qa` and `make fmt-check` all pass.

## What pins it

- `tests/elle/region-splice-args.lisp` — the leak gauge above. Every subject
  reads its old rate without this change.
- `tests/elle/region-splice-args-uaf.lisp` — the soundness complement under
  `--trace=guardfree`, registered as `region_splice_args_uaf`. Eight sections for
  what the array's reclaim must not reach: the argument the callee still reads,
  the source released ahead of the frame replacement, the pass-through result, an
  outer holder, the variadic rest list, an `apply`'d `@array`, the raising splice
  the abandoned frame walks, and the park. Claiming the slot after the call
  rather than before it fails that last section with the stale suspended-frame
  borrow panic.
- `src/lir/lower/tests/release/emission.rs` —
  `a_spliced_call_allocates_its_args_array_outside_the_call_region` pins the
  distinct slot, and `a_splice_args_array_is_owed_by_the_frame_until_the_call_takes_it`
  pins that the frame owes the release and emits no `DecrefRegion` for it.
- `tests/elle/region-splice-tail-return.lisp` becomes a real witness. Its comment
  recorded that the args-array leak was masking a missing `ReturnValue` retain by
  keeping the borrowed result alive; that mask is gone.

Closes #977.

