### PR TITLE
ci: the corpus job count comes from the runner, and a file's budget outlives its own deadline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,32 @@
 
 .DEFAULT_GOAL := all
 
+# The processors the box will schedule on.
+#
+# `nproc` first because it is the only one of the three that honours a CPU
+# affinity mask: a run pinned to a subset of the box gets the subset, not the
+# box. It is GNU coreutils, so it is absent on a stock macOS runner — and the
+# `brew install coreutils` the macOS job runs installs it as `gnproc`, not on
+# PATH under this name. `getconf` is the portable answer both platforms give.
+# The literal is reached only if a box has neither.
+CORES := $(shell nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
+
 ifdef GITHUB_ACTIONS
-  JOBS          ?= 4
+  # One corpus process per processor. GitHub gives the Linux runners four and
+  # the macOS runner three, and re-sizes them without notice, so this is read
+  # from the runner rather than written down — a constant fits the runner it was
+  # chosen on and over-subscribes the others. See docs/analysis/ci.md § "Runner
+  # capacity"; tests/integration/capacity.rs is the standing check.
+  JOBS          ?= $(CORES)
+  # Not $(CORES): the wasm pass is bounded by memory, not by processors. Each
+  # `--wasm=full` run compiles a whole module before it runs anything.
   WASM_JOBS     ?= 2
   ELLE          ?= ./target/release/elle
   CARGO_PROFILE := --release
 else
+  # Deliberately a constant, and deliberately not $(CORES): a development box
+  # shares its cores with everything else its owner is running, and its owner
+  # can pass JOBS= when that is wrong.
   JOBS          ?= 16
   WASM_JOBS     ?= 4
   ELLE          ?= ./target/debug/elle
@@ -50,11 +70,11 @@ define RUN_PLUMB
 		|| { echo "FAILED: plumb.lisp ($(1))"; exit 1; }
 endef
 
-# Two corpus files spend most of a per-file budget on work the case needs:
-# h2-load-volume drives 500 requests over one h2 session, and
+# Some corpus files spend most of a per-file budget on work the case needs: the
+# h2 families drive hundreds of requests or streams over one session, and
 # region-jit-io-suspend-uaf reads 20000 lines to drive one function hot enough
 # for the JIT to compile it. Cut either volume and the shape stops reaching the
-# state it pins. Both fit TIMEOUT with room on an idle box, and both have been
+# state it pins. They fit TIMEOUT with room on an idle box, and they have been
 # killed at it on CI, where the runner is shared and slower by an order of
 # magnitude. A killed file is exit 124 — no output, no assertion message — so it
 # reads as a flaky runner rather than as a budget that was never wide enough.
@@ -62,14 +82,24 @@ endef
 # per-file form: an override for the files that need it, so every other file
 # still fails fast on a hang. The pins are tests/integration/budget.rs.
 #
-# The wider budget is a BACKSTOP, not the deadline. h2-load-volume carries its
-# own deadline and reports which request stalled and how long it waited; that
-# message is the reason to run the file, and it only ever prints if the outer
-# kill lands after it. Keep this above any in-file deadline, and read both from
-# a timed run rather than from a number written here — remembering that a run
-# `timeout` killed reports the cap, not what the file would have cost.
-WIDE_TIMEOUT ?= 120s
-WIDE_FILES   := -e h2-load-volume.lisp -e region-jit-io-suspend-uaf.lisp
+# The wider budget is a BACKSTOP, not the deadline. Each of these files carries
+# its own `deadline` and reports which request stalled and how long it waited;
+# that message is the reason to run the file, and it only ever prints if the
+# outer kill lands after it. So WIDE_TIMEOUT must stay above the LARGEST
+# in-file deadline named here, which is 120 s. Read both from a timed run rather
+# than from a number written here — remembering that a run `timeout` killed
+# reports the cap, not what the file would have cost.
+#
+# The h2 entries are family prefixes, not file names. A deadline is a property
+# of the family: every h2-bidi case gets 120 s, every h2-load case 60 s, and a
+# new sibling copies its neighbour. Naming the prefix means the new file arrives
+# with a budget above the deadline it inherited, instead of arriving under a
+# 30 s one and going unnoticed until a runner is slow enough. h2 files that
+# declare no deadline (h2-rfc9113, h2-recycle-cleanup, h2-stress-scoped) are not
+# in a family named here and keep TIMEOUT.
+WIDE_TIMEOUT ?= 150s
+WIDE_FILES   := -e h2-bidi- -e h2-load- -e h2-stream- -e h2-timeout- \
+                -e region-jit-io-suspend-uaf.lisp
 
 # The budget for ONE corpus file: `parallel` substitutes the path into `{}` and
 # the pass's shell picks a budget, once per file. Every pass that runs the corpus
@@ -481,3 +511,10 @@ help:  ## Show this help
 	@grep -E '^[a-z].*:.*##' $(MAKEFILE_LIST) | \
 		sed 's/:.*##/\t/' | \
 		column -t -s '	'
+
+# One variable's value, as make expands it: `make print-JOBS`. Several of these
+# are conditional on the environment or computed by `$(shell …)`, so reading
+# the assignment is not reading the value. tests/integration/capacity.rs checks
+# the job count through this rule.
+print-%:
+	@echo '$($*)'

--- a/docs/analysis/ci.md
+++ b/docs/analysis/ci.md
@@ -49,6 +49,46 @@ Each job keeps its own `Swatinem/rust-cache` `shared-key`. The pair builds
 different profiles, so one shared key would make the two jobs overwrite each
 other's cache on alternating runs.
 
+### What each job builds
+
+Every job that drives the Makefile builds `--release` and runs
+`target/release/elle`, on every platform. The Makefile picks that under
+`ifdef GITHUB_ACTIONS`, which is set on all GitHub runners, so the macOS and
+AArch64 Smoke jobs are release runs exactly as the x86_64 ones are. The Rust
+Tests jobs build the dev profile, also on every platform, because `cargo test`
+does. No platform is quietly gated at a weaker optimization level.
+
+One job changes the release profile it builds. `macOS Smoke` sets
+`CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS`, because the panic that reads a
+scrubbed page is `#[cfg(debug_assertions)]` and `--trace=scrub` is worthless
+without it (docs/impl/region/diagnostics.md). Its binary is therefore a release
+build that also runs the debug-only checks, on the smallest runner in the
+workflow. Read a macOS corpus timing against that, not against a Linux one.
+
+### Runner capacity
+
+The corpus passes run one process per file, `parallel -j $(JOBS)`. On CI the
+Makefile reads that count from the runner — `nproc`, or `getconf
+_NPROCESSORS_ONLN` where `nproc` is absent, which is every macOS runner. It does
+not write a number down.
+
+GitHub does not give every runner the same machine, and it re-sizes them
+without notice. Today the Linux x86_64 and AArch64 runners report four
+processors and the macOS runner reports three. A constant chosen for one runner
+over-subscribes the other.
+
+Over-subscription does not fail the corpus, it stretches it. Every file still
+passes its assertions, and the ones nearest the per-file budget get killed on
+the way out. That failure is exit 124 with no output, which reads as a flaky
+runner rather than as a job count that never fit. `JOBS` remains an override
+for a job that needs a different number.
+
+Outside CI the default stays the constant 16. A development box is not sized by
+the runner, and its owner can pass `JOBS=`.
+
+`tests/integration/capacity.rs` is the standing check that the CI count still
+tracks the runner.
+
 ### Adding a job
 
 `All Checks Passed` is the only status check branch protection requires

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -189,6 +189,40 @@ pub fn eval_reuse(input: &str) -> Result<Value, String> {
     eval_with_cache(input, &FULL_CACHE, true)
 }
 
+/// One Makefile variable's value, as `make` itself expands it, or `None` if
+/// `make` could not be run.
+///
+/// Tests that check how CI dimensions the corpus — job counts, per-file
+/// budgets — have to read the value the pass will use, not the assignment's
+/// text. Those two differ: a variable can sit inside an `ifdef`, be computed by
+/// `$(shell …)`, be continued across lines with a backslash, or reference
+/// another variable. A test that parses the Makefile reimplements `make`, and
+/// the first thing such a parser does is disagree with it. This asks `make`.
+///
+/// `env` sets variables for the child, over a slate cleared of `GITHUB_ACTIONS`
+/// and `JOBS`: the answer must not depend on whether the suite itself is
+/// running under CI.
+///
+/// The Makefile's `print-%` rule is what this reads through.
+#[allow(dead_code)]
+pub fn make_var(name: &str, env: &[(&str, &str)]) -> Option<String> {
+    let mut command = std::process::Command::new("make");
+    command
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .arg("--no-print-directory")
+        .arg(format!("print-{name}"))
+        .env_remove("GITHUB_ACTIONS")
+        .env_remove("JOBS");
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let out = command.output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8(out.stdout).ok()?.trim().to_string())
+}
+
 /// Uniquely-named scratch directory under the platform temp root, removed
 /// recursively on drop — the panic path included, so a failing test leaves no
 /// litter in `$TMPDIR`. See `tests/AGENTS.md` § Scratch files.

--- a/tests/integration/budget.rs
+++ b/tests/integration/budget.rs
@@ -2,19 +2,20 @@
 //
 // `RUN_PER_FILE` runs every corpus file as its own process under `timeout`, and
 // a file that outlives its budget is killed: exit 124, no output, no assertion
-// message. That budget is a single number for the whole corpus, and two files
-// spend most of it on work they need — one drives 500 requests over one h2
-// session, the other reads 20000 lines to drive a function hot enough for the
-// JIT to compile it. On an idle box each finishes with seconds to spare; on a
-// loaded CI runner it does not, and the gate reports a kill rather than a
-// defect.
+// message. That budget is a single number for the whole corpus, and some files
+// spend most of it on work they need — the h2 families drive hundreds of
+// requests over one session, and one file reads 20000 lines to drive a function
+// hot enough for the JIT to compile it. On an idle box each finishes with
+// seconds to spare; on a loaded CI runner it does not, and the gate reports a
+// kill rather than a defect.
 //
-// So those two are named in the Makefile and given a wider budget. The names
-// are shell text, and both halves fail quietly: a renamed file stops matching
-// and silently drops back to the narrow budget, and a new pass that spells the
-// narrow budget directly gives it to every file. Nothing compiles either one.
-// These tests are the standing check, and they cost a read of the Makefile and
-// a few `sh` invocations.
+// So those are named in the Makefile and given a wider budget. The names are
+// shell text, and every half of that fails quietly: a renamed file stops
+// matching and silently drops back to the narrow budget, a new pass that spells
+// the narrow budget directly gives it to every file, and a file that grows its
+// own deadline is connected to none of it. Nothing compiles any of them. These
+// tests are the standing check, and they cost a read of the Makefile and a few
+// `sh` invocations.
 //
 // The trap, and why the selector is executed here rather than pattern-matched:
 // the shell that parses it is the platform's `/bin/sh`, and they do not agree.
@@ -22,7 +23,7 @@
 // it, so a construct that carries one — a `case` pattern — parses on the
 // development box and dies file by file on the macOS runner.
 
-use std::collections::BTreeMap;
+use crate::common::make_var;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -35,100 +36,77 @@ fn makefile() -> String {
     fs::read_to_string(repo_root().join("Makefile")).expect("read the Makefile")
 }
 
-/// Every simple variable assignment in the Makefile, by name.
+/// One Makefile variable, as `make` expands it.
 ///
-/// A definition opens at column zero and its operator is one of `:=`, `?=` or
-/// `=`. Rules (`target: prerequisite`) and recipe lines are not assignments and
-/// do not land here.
-fn assignments(text: &str) -> BTreeMap<String, String> {
-    let mut out = BTreeMap::new();
-    for line in text.lines() {
-        if line.starts_with([' ', '\t', '#']) {
-            continue;
-        }
-        let Some((head, value)) = line.split_once('=') else {
-            continue;
-        };
-        let name = head.trim_end_matches([':', '?', '+']).trim();
-        if name.is_empty() || !name.chars().all(|c| c.is_ascii_uppercase() || c == '_') {
-            continue;
-        }
-        out.insert(name.to_string(), value.trim().to_string());
-    }
-    out
+/// Asking `make` rather than parsing the assignment is the whole point: these
+/// tests measure what the corpus pass will actually run, and a parser that
+/// reimplements variable references, line continuations and `$(shell …)` is a
+/// second `make` that can disagree with the first.
+fn expand(name: &str) -> String {
+    make_var(name, &[]).unwrap_or_else(|| panic!("`make print-{name}` did not run"))
 }
 
-/// One Makefile variable, expanded.
+/// The patterns the Makefile gives the wider budget.
 ///
-/// Only `$(NAME)` references to other variables are resolved; a `$(...)` whose
-/// body is not a bare variable name — the shell substitution below is one — is
-/// left alone. `expanded_budget_selector` asserts that nothing unresolved
-/// remains, so a reference this cannot follow fails the test rather than
-/// reaching `sh` as literal text.
-fn expand(name: &str, vars: &BTreeMap<String, String>) -> String {
-    let mut text = vars
-        .get(name)
-        .unwrap_or_else(|| panic!("the Makefile defines {name}"))
-        .clone();
-    for _ in 0..8 {
-        let mut next = String::new();
-        let mut rest = text.as_str();
-        while let Some(at) = rest.find("$(") {
-            let (before, from) = rest.split_at(at);
-            next.push_str(before);
-            let body = &from[2..];
-            match body.split_once(')') {
-                Some((inner, after)) if vars.contains_key(inner) => {
-                    next.push_str(&vars[inner]);
-                    rest = after;
-                }
-                _ => {
-                    next.push_str("$(");
-                    rest = body;
-                }
-            }
-        }
-        next.push_str(rest);
-        if next == text {
-            return text;
-        }
-        text = next;
-    }
-    panic!("{name} expands without settling; a variable references itself");
-}
-
-/// The names the Makefile gives the wider budget, as corpus file names.
-///
-/// `WIDE_FILES` is a `grep` pattern list, `-e one.lisp -e two.lisp` — the shape
-/// the per-pass skip lists beside it already use.
-fn wide_file_names() -> Vec<String> {
-    let text = makefile();
-    let patterns = expand("WIDE_FILES", &assignments(&text));
+/// `WIDE_FILES` is a `grep` pattern list, `-e one -e two` — the shape the
+/// per-pass skip lists beside it already use. A pattern is a substring of a
+/// path, not a file name: a whole family of corpus files shares one deadline
+/// and one prefix, so the list names the prefix rather than every member.
+fn wide_patterns() -> Vec<String> {
+    let patterns = expand("WIDE_FILES");
     let names: Vec<String> = patterns
         .split_whitespace()
         .filter(|word| *word != "-e")
         .map(str::to_string)
         .collect();
     assert!(
-        !names.is_empty() && names.iter().all(|n| n.ends_with(".lisp")),
-        "WIDE_FILES does not read as a `grep` pattern list over corpus files: {patterns}"
+        !names.is_empty(),
+        "WIDE_FILES does not read as a `grep` pattern list: {patterns}"
     );
     names
 }
 
+/// Every corpus file the per-file passes run, as a repo-relative path.
+fn corpus_files() -> Vec<String> {
+    let mut paths: Vec<String> = fs::read_dir(repo_root().join("tests/elle"))
+        .expect("read tests/elle")
+        .map(|entry| entry.expect("a corpus directory entry").file_name())
+        .filter_map(|name| name.to_str().map(str::to_string))
+        .filter(|name| name.ends_with(".lisp"))
+        .map(|name| format!("tests/elle/{name}"))
+        .collect();
+    paths.sort();
+    assert!(paths.len() > 100, "the corpus did not read: {paths:?}");
+    paths
+}
+
+/// The deadline a corpus file gives itself, if it declares one.
+///
+/// A file that has to detect a stall carries `(def deadline N)` and reports
+/// through it — which request stalled, and how long it waited. That number is
+/// in seconds, and it is the only thing that knows what the file considers
+/// hung.
+fn declared_deadline(path: &str) -> Option<u64> {
+    let source = fs::read_to_string(repo_root().join(path)).expect("read a corpus file");
+    let (_, rest) = source.split_once("(def deadline ")?;
+    let digits = rest.split(')').next()?.trim();
+    Some(
+        digits
+            .parse()
+            .unwrap_or_else(|_| panic!("{path} declares a deadline this cannot read: {digits}")),
+    )
+}
+
 /// The Makefile's budget selector with `{}` replaced by `path`, ready for `sh`.
 fn expanded_budget_selector(path: &str) -> String {
-    let text = makefile();
-    let selector = expand("FILE_TIMEOUT", &assignments(&text)).replace("$$", "$");
-    // What survives expansion is shell. A `$(NAME)` still standing is a make
-    // reference this could not follow, and handing it to `sh` would measure
-    // something other than what the pass runs.
-    let unresolved = selector
-        .match_indices("$(")
-        .any(|(at, _)| selector[at + 2..].starts_with(|c: char| c.is_ascii_uppercase()));
+    let selector = expand("FILE_TIMEOUT");
+    // `{}` is where `parallel` puts the path. A selector without one is still
+    // valid shell and still prints a budget — the same budget for every file —
+    // so nothing downstream would notice, and every test here would measure a
+    // constant while believing it measured a choice.
     assert!(
-        !unresolved,
-        "the budget selector still carries a make variable: {selector}"
+        selector.contains("{}"),
+        "the budget selector never names the file `parallel` substitutes: {selector}"
     );
     selector.replace("{}", path)
 }
@@ -159,23 +137,20 @@ fn budget_for(path: &str) -> String {
     String::from_utf8(out.stdout).expect("the selector prints a budget")
 }
 
-// A file named in `WIDE_FILES` that no longer exists is not an error anywhere:
-// the `case` alternative simply stops matching, and the file it was written for
-// — under whatever name it now has — goes back to the narrow budget and starts
-// dying on exit 124 under load. The counter-factual: rename one of the two
-// heavy corpus files without touching the Makefile, and every gate still
-// passes until a runner is slow enough.
+// A `WIDE_FILES` pattern that matches nothing is not an error anywhere: `grep`
+// simply never fires it, and the file it was written for — under whatever name
+// it now has — goes back to the narrow budget and starts dying on exit 124
+// under load. The counter-factual: rename a heavy corpus file without touching
+// the Makefile, and every gate still passes until a runner is slow enough.
 #[test]
-fn every_file_named_for_the_wider_budget_is_a_corpus_file() {
-    let root = repo_root();
-    for name in wide_file_names() {
-        let path = root.join("tests/elle").join(&name);
+fn every_pattern_named_for_the_wider_budget_matches_a_corpus_file() {
+    let corpus = corpus_files();
+    for pattern in wide_patterns() {
         assert!(
-            path.exists(),
-            "the Makefile gives `{name}` the wider per-file budget, but \
-             {} does not exist. The `case` alternative matches nothing, so \
-             whatever that file is called now runs under TIMEOUT.",
-            path.display()
+            corpus.iter().any(|path| path.contains(&pattern)),
+            "the Makefile gives `{pattern}` the wider per-file budget, but no \
+             corpus file matches it. `grep` never fires the pattern, so \
+             whatever those files are called now run under TIMEOUT."
         );
     }
 }
@@ -187,22 +162,22 @@ fn every_file_named_for_the_wider_budget_is_a_corpus_file() {
 // heavy files quietly return to the narrow budget.
 #[test]
 fn the_selector_widens_the_named_files_and_nothing_else() {
-    let text = makefile();
-    let vars = assignments(&text);
-    let wide = expand("WIDE_TIMEOUT", &vars);
-    let narrow = expand("TIMEOUT", &vars);
+    let wide = expand("WIDE_TIMEOUT");
+    let narrow = expand("TIMEOUT");
     assert!(
         seconds(&wide) > seconds(&narrow),
         "WIDE_TIMEOUT is {wide}, which is not wider than TIMEOUT at {narrow}"
     );
 
-    for name in wide_file_names() {
-        let path = format!("tests/elle/{name}");
-        assert_eq!(
-            budget_for(&path),
-            wide,
-            "{path} is named in WIDE_FILES but the selector gives it {narrow}"
-        );
+    for pattern in wide_patterns() {
+        for path in corpus_files().iter().filter(|p| p.contains(&pattern)) {
+            assert_eq!(
+                budget_for(path),
+                wide,
+                "{path} matches the WIDE_FILES pattern `{pattern}` but the \
+                 selector gives it {narrow}"
+            );
+        }
     }
 
     // Ordinary corpus files keep the narrow budget: it is what makes a hang
@@ -266,43 +241,40 @@ fn no_corpus_pass_spells_the_narrow_budget_directly() {
     );
 }
 
-// The wider budget is a backstop, not the deadline. A file that carries its own
+// The outer budget is a backstop, not the deadline. A file that carries its own
 // `deadline` reports on it — which request stalled, how long it waited — and
 // that message is the reason to run the file at all. If the outer `timeout`
 // fires first the message is never printed: the process dies on a signal and
-// the gate reports exit 124. The counter-factual: set the wider budget below
-// the in-file deadline and a genuine h2 stall is indistinguishable from a busy
-// runner, which is the failure this whole mechanism exists to end.
+// the gate reports exit 124.
+//
+// This asks every corpus file, not only the ones already named in WIDE_FILES.
+// Naming is the half that rots: a file grows a deadline, or copies a sibling
+// that has one, and nothing connects that number to the budget the pass will
+// actually hand it. The counter-factual is what this found — thirteen h2 files
+// declaring deadlines of 60 s and 120 s while running under a 30 s budget, so
+// none of them could ever print the diagnostic they exist to print.
 #[test]
-fn the_wider_budget_outlives_the_in_file_deadline_it_backstops() {
-    let text = makefile();
-    let budget = seconds(&expand("WIDE_TIMEOUT", &assignments(&text)));
-    let root = repo_root();
+fn no_corpus_file_outlives_the_budget_before_its_own_deadline_fires() {
     let mut checked = 0;
-    for name in wide_file_names() {
-        let source = fs::read_to_string(root.join("tests/elle").join(&name))
-            .expect("read a file named for the wider budget");
-        let Some((_, rest)) = source.split_once("(def deadline ") else {
+    for path in corpus_files() {
+        let Some(deadline) = declared_deadline(&path) else {
             continue;
         };
-        let deadline: u64 = rest
-            .split(')')
-            .next()
-            .and_then(|n| n.trim().parse().ok())
-            .unwrap_or_else(|| panic!("{name} declares a deadline this cannot read"));
+        let budget = budget_for(&path);
         assert!(
-            budget > deadline,
-            "{name} gives itself {deadline} s to report a stall, and the pass \
-             kills it at {budget} s. The kill lands first, so the file's own \
-             diagnostic can never print."
+            seconds(&budget) > deadline,
+            "{path} gives itself {deadline} s to report a stall, and the pass \
+             kills it at {budget}. The kill lands first, so the file's own \
+             diagnostic can never print — the gate reports exit 124 with no \
+             output, which reads as a flaky runner. Either name the file in \
+             WIDE_FILES or lower the deadline below TIMEOUT."
         );
         checked += 1;
     }
     assert!(
         checked > 0,
-        "no file named for the wider budget declares a deadline. Either the \
-         declaration changed shape or the argument no longer applies — teach \
-         this test the new shape rather than letting it pass by matching \
-         nothing."
+        "no corpus file declares a deadline. Either the declaration changed \
+         shape or the argument no longer applies — teach this test the new \
+         shape rather than letting it pass by matching nothing."
     );
 }

--- a/tests/integration/capacity.rs
+++ b/tests/integration/capacity.rs
@@ -1,0 +1,116 @@
+// The number of corpus processes a CI runner is asked to run at once.
+//
+// The per-file passes run one process per file through `parallel -j $(JOBS)`.
+// GitHub does not give every runner the same machine and re-sizes them without
+// notice, so a constant written into the Makefile fits whichever runner it was
+// measured on and over-subscribes the rest. The argument, and what
+// over-subscription costs, is in docs/analysis/ci.md § "Runner capacity".
+//
+// Nothing else checks it. A wrong job count does not fail the corpus, it
+// stretches it: every file still passes its assertions and the ones nearest the
+// per-file budget get killed on the way out, reported as exit 124 with no
+// output. That reads as a flaky runner, so the number can be wrong for months.
+//
+// The expectation here is independent of the Makefile's own arithmetic: the
+// Makefile asks the shell, this asks Rust. Two different counts mean the
+// Makefile is reading something other than the machine it runs on.
+//
+// The trap in that independence: the two agree on a GitHub runner and on a bare
+// box, and can disagree under a cgroup CPU quota. `available_parallelism`
+// honours a quota; `nproc` and `getconf` report the processors that exist. A
+// container with `--cpus=2` on a 32-way host fails the first test below — which
+// is the right answer, because the Makefile really would ask that container for
+// 32 corpus processes.
+
+use crate::common::make_var;
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The environment a CI runner presents to the Makefile.
+const CI: &[(&str, &str)] = &[("GITHUB_ACTIONS", "true")];
+
+/// The processors this box will actually schedule on, asked of the platform
+/// rather than of the Makefile.
+fn processors() -> usize {
+    std::thread::available_parallelism()
+        .expect("the platform reports its parallelism")
+        .get()
+}
+
+// The CI job count tracks the runner. The counter-factual is the defect this
+// replaced: `JOBS ?= 4`, which matched the four-processor Linux runners exactly
+// and asked the three-processor macOS runner for a third more work than it had.
+// A constant passes every gate on the box it was chosen for.
+#[test]
+fn the_ci_job_count_is_read_from_the_runner() {
+    let Some(jobs) = make_var("JOBS", CI) else {
+        eprintln!("SKIPPED: `make print-JOBS` did not run");
+        return;
+    };
+    assert_eq!(
+        jobs,
+        processors().to_string(),
+        "under GITHUB_ACTIONS the Makefile runs {jobs} corpus processes at \
+         once, and this box has {} processors. A job count that does not \
+         track the runner over-subscribes whichever runner it was not chosen \
+         for; see docs/analysis/ci.md § \"Runner capacity\".",
+        processors()
+    );
+}
+
+// An override has to survive the detection, or a job that needs a different
+// number has no way to ask for one — and the wasm pass, which is bounded by
+// memory rather than by processors, is exactly such a job.
+#[test]
+fn an_explicit_job_count_overrides_the_detection() {
+    let Some(jobs) = make_var("JOBS", &[("GITHUB_ACTIONS", "true"), ("JOBS", "3")]) else {
+        eprintln!("SKIPPED: `make print-JOBS` did not run");
+        return;
+    };
+    assert_eq!(
+        jobs, "3",
+        "JOBS=3 in the environment did not reach the corpus passes. The \
+         assignment must stay `?=`, or a runner that needs a smaller number \
+         cannot ask for one."
+    );
+}
+
+// Outside CI the default is deliberately a constant, not the box's processor
+// count: a development box is not sized by the runner and shares its cores with
+// everything else its owner is running. This pins the distinction, so a change
+// that makes CI adaptive does not silently take the local default with it.
+#[test]
+fn the_local_default_stays_a_constant() {
+    let Some(jobs) = make_var("JOBS", &[]) else {
+        eprintln!("SKIPPED: `make print-JOBS` did not run");
+        return;
+    };
+    assert!(
+        jobs.parse::<usize>().is_ok_and(|n| n > 0),
+        "the local JOBS default is not a positive number: {jobs}"
+    );
+    assert_eq!(
+        jobs, "16",
+        "the local default job count changed to {jobs}. That is a choice about \
+         development boxes, not about CI runners — make it deliberately and \
+         update docs/analysis/ci.md § \"Runner capacity\", which records 16."
+    );
+}
+
+// The rule the other tests read through. A `print-%` that stops existing takes
+// every assertion above it with it: `make` fails, each test prints SKIPPED, and
+// the job count goes unchecked on every platform at once.
+#[test]
+fn the_makefile_keeps_the_rule_these_tests_read_variables_through() {
+    let text = fs::read_to_string(repo_root().join("Makefile")).expect("read the Makefile");
+    assert!(
+        text.contains("print-%:"),
+        "the Makefile no longer defines `print-%`. Every test in this file \
+         reads a variable through it and skips without it, so the job count \
+         would stop being checked with nothing reporting that."
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -174,6 +174,9 @@ mod workflows {
 mod budget {
     include!("budget.rs");
 }
+mod capacity {
+    include!("capacity.rs");
+}
 mod doctest {
     include!("doctest.rs");
 }


### PR DESCRIPTION
`JOBS ?= 4` was written for the Linux runners. GitHub gives those four
processors and the macOS runner three, so macOS ran a third more corpus
processes than it had cores. This reads the count from the runner instead:
`nproc`, or `getconf _NPROCESSORS_ONLN` where `nproc` is absent, which is every
macOS runner. The local default stays the constant 16 — that is a choice about
development boxes, not about runners.

Over-subscription does not fail the corpus, it stretches it, and the files
nearest the per-file budget get killed on the way out. Chasing that turned up
the second half.

## A file's own deadline could never fire

Thirteen h2 corpus files declare `(def deadline 60)` or `(def deadline 120)` and
ran under a 30 s budget. The outer `timeout` always landed first, so the stall
diagnostic each file exists to print — which request stalled, how long it waited
— could never print. The gate reported exit 124 with no output, which reads as a
flaky runner rather than as a budget that was never wide enough.

The Makefile already owned the rule ("the wider budget is a BACKSTOP, not the
deadline"), but only two files were named, and nothing connected a file's
declared deadline to the budget it would actually get.

`WIDE_FILES` now names family prefixes rather than two file names. A deadline is
a property of the family — every `h2-bidi` case gets 120 s, every `h2-load` case
60 s — and a new sibling copies its neighbour, so naming the prefix means the new
file arrives with a budget above the deadline it inherited. `WIDE_TIMEOUT` rises
to 150 s to clear the largest declared deadline.

## Tests

- `tests/integration/capacity.rs` (new) pins the job count. The Makefile asks the
  shell, the test asks Rust (`available_parallelism`), and they must agree.
  Against the old constant it failed `left: "4", right: "32"`.
- `budget.rs`'s deadline test now walks every corpus file, not only the ones
  already named in `WIDE_FILES` — naming is the half that rots. It failed on
  `h2-bidi-messages` before this change.
- `budget.rs` loses its hand-rolled Makefile parser, which had just disagreed
  with `make` about a line continuation. That is the one thing a test measuring
  what CI runs must never do. Both test files now read values through a new
  `print-%` rule via a shared `make_var` helper.

`docs/analysis/ci.md` gains "Runner capacity" and "What each job builds". The
second exists because the release question came up: every Makefile-driven CI job
builds `--release` on every platform, and `macOS Smoke` is the only job that adds
`CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS`, so its timings are not comparable to a
Linux runner's.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and
the budget/capacity/workflows/paths/doctest tests are green on this branch. All
21 `h2-*` corpus files pass on the release binary locally, 0.6–4.2 s each.

I have no macOS box, so I cannot confirm three jobs plus the wider budget is
enough headroom there — only that the budget can no longer be silently wrong.

Separately, and not fixed here: `h2-bidi-recycle` was killed *after* printing its
success line, in process teardown. The wider budget stops that failing the gate;
it does not explain why teardown cost five seconds.
