### PR TITLE
plugin: the ABI version names a calling convention, so it can be checked

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -262,20 +262,27 @@ jobs:
         with:
           shared-key: plugins
       # Two plugins in the portable set are not pure Rust, and neither says so
-      # in its own Cargo.toml — the system libraries arrive several crates deep.
-      # Read the set off the built artifacts, not off the manifests: `ldd
-      # target/release/libelle_*.so` after a local `make plugins` names every
-      # library the build actually linked.
+      # in its own Cargo.toml — the dependencies arrive several crates deep.
+      # elle-plotters reaches font-kit, which wants fontconfig through
+      # pkg-config; libfontconfig1-dev brings the freetype, expat and png
+      # headers behind it. elle-oxigraph reaches oxrocksdb-sys, which runs
+      # bindgen over vendored RocksDB.
       #
-      # elle-oxigraph pulls oxrocksdb-sys, which runs bindgen over vendored
-      # RocksDB and needs libclang. elle-plotters pulls font-kit, which needs
-      # fontconfig through pkg-config; libfontconfig1-dev brings the freetype,
-      # expat and png headers the same chain wants.
+      # See docs/analysis/ci.md § "What the runner has to install" for how to
+      # find this set, which is not by reading manifests.
       - name: Install GNU parallel and the plugin build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y parallel clang libclang-dev \
                                   pkg-config libfontconfig1-dev
+          # bindgen dlopens libclang by soname, and libclang-dev installs it
+          # under /usr/lib/llvm-<N>/lib, which is not on the loader's search
+          # path — so clang-sys has to be pointed at it. The <N> moves with the
+          # runner image, so find the file rather than write a version down, and
+          # fail here rather than let an empty LIBCLANG_PATH reach bindgen.
+          lib=$(find /usr/lib -name 'libclang.so*' -print -quit)
+          [ -n "$lib" ] || { echo "no libclang after installing libclang-dev"; exit 1; }
+          echo "LIBCLANG_PATH=$(dirname "$lib")" >> "$GITHUB_ENV"
       - name: make elle
         run: make elle
       - name: make plugins

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       source: ${{ steps.filter.outputs.source }}
+      plugins: ${{ steps.filter.outputs.plugins }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,9 +32,20 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED"
           if echo "$CHANGED" | grep -qE '\.(rs|lisp)$|^Cargo\.|^Makefile$|^\.cargo/'; then
-            echo "source=true" >> "$GITHUB_OUTPUT"
+            SOURCE=true
           else
-            echo "source=false" >> "$GITHUB_OUTPUT"
+            SOURCE=false
+          fi
+          echo "source=$SOURCE" >> "$GITHUB_OUTPUT"
+          # The submodule's recorded pointer is the bare path `plugins` with no
+          # extension, so the pattern above never matches a pointer bump — and a
+          # pointer bump changes exactly what the plugins job compiles. It gets
+          # its own output rather than widening `source`, which would run the
+          # whole matrix, macOS included, for a one-line gitlink move.
+          if [ "$SOURCE" = true ] || echo "$CHANGED" | grep -qx 'plugins'; then
+            echo "plugins=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "plugins=false" >> "$GITHUB_OUTPUT"
           fi
 
   qa:
@@ -217,6 +229,52 @@ jobs:
       # parallel install it needs) when the tier is brought back up.
       - name: make check-wasm
         run: make check-wasm
+
+  # The `plugins/` submodule is a separate cargo workspace whose crates take
+  # `elle-plugin` by path, so an `elle_api!` change moves the SDK and the plugin
+  # together and the workspace either compiles or does not. Nothing in CI
+  # checked it out until this job: #997 changed six declarations, stopped 17
+  # plugins from compiling at about 90 call sites, and every gate stayed green
+  # (#1023). The ABI version guard cannot stand in — it compares `ABI_VERSION`
+  # at load time, and a source break never reaches a load.
+  #
+  # Checking out at the recorded pointer is also what keeps the pointer fresh: a
+  # pointer left behind an ABI change names plugins that no longer compile.
+  #
+  # `make plugins` builds; `make smoke-plugins` asserts every artifact and then
+  # runs the corpus. Without the assertion the corpus reports success over a
+  # plugin that never built — see docs/analysis/ci.md § "Why the job asserts its
+  # build output".
+  plugins:
+    name: Plugin Tests
+    needs: changes
+    runs-on: ubuntu-latest
+    if: needs.changes.outputs.plugins == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      # Named, not `submodules: true`: that would also fetch `mcp`, which this
+      # job never builds — and an unreachable `mcp` pointer would then fail the
+      # one job that reports on the plugins.
+      - name: Check out the plugins submodule
+        run: git submodule update --init plugins
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: plugins
+      # clang and libclang for bindgen: elle-oxigraph pulls oxrocksdb-sys, which
+      # generates its bindings and compiles vendored RocksDB. Everything else in
+      # the portable set is pure Rust (elle-tls takes rustls over ring, not
+      # OpenSSL), so no other system library is needed.
+      - name: Install GNU parallel and bindgen's toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y parallel clang libclang-dev
+      - name: make elle
+        run: make elle
+      - name: make plugins
+        run: make plugins
+      - name: make smoke-plugins
+        run: make smoke-plugins
 
   # The corpus half of the AArch64 tier. Its Rust half is `aarch64-tests`
   # below, running at the same time on its own runner — the two share no build
@@ -439,7 +497,7 @@ jobs:
 
   all-checks:
     name: All Checks Passed
-    needs: [changes, qa, docs, tests-combined, tests, nouring, wasm, mlir, aarch64, aarch64-tests, aarch64-noffi, android, macos, macos-tests]
+    needs: [changes, qa, docs, tests-combined, tests, nouring, wasm, mlir, plugins, aarch64, aarch64-tests, aarch64-noffi, android, macos, macos-tests]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -464,6 +522,12 @@ jobs:
       # longer compiles or the tier no longer boots — that blocks.
       - name: Check WASM
         if: needs.wasm.result == 'failure'
+        run: exit 1
+      # The only job that compiles the `plugins/` submodule. A failure here is
+      # either a plugin the current `elle_api!` no longer accepts, or a recorded
+      # submodule pointer left behind an ABI change — both block.
+      - name: Check plugins
+        if: needs.plugins.result == 'failure'
         run: exit 1
       - name: Check documentation build
         if: needs.docs.result == 'failure'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -261,14 +261,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: plugins
-      # clang and libclang for bindgen: elle-oxigraph pulls oxrocksdb-sys, which
-      # generates its bindings and compiles vendored RocksDB. Everything else in
-      # the portable set is pure Rust (elle-tls takes rustls over ring, not
-      # OpenSSL), so no other system library is needed.
-      - name: Install GNU parallel and bindgen's toolchain
+      # Two plugins in the portable set are not pure Rust, and neither says so
+      # in its own Cargo.toml — the system libraries arrive several crates deep.
+      # Read the set off the built artifacts, not off the manifests: `ldd
+      # target/release/libelle_*.so` after a local `make plugins` names every
+      # library the build actually linked.
+      #
+      # elle-oxigraph pulls oxrocksdb-sys, which runs bindgen over vendored
+      # RocksDB and needs libclang. elle-plotters pulls font-kit, which needs
+      # fontconfig through pkg-config; libfontconfig1-dev brings the freetype,
+      # expat and png headers the same chain wants.
+      - name: Install GNU parallel and the plugin build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y parallel clang libclang-dev
+          sudo apt-get install -y parallel clang libclang-dev \
+                                  pkg-config libfontconfig1-dev
       - name: make elle
         run: make elle
       - name: make plugins

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,7 @@ dependencies = [
  "cranelift-native",
  "criterion",
  "crossbeam-channel",
+ "elle-plugin",
  "io-uring",
  "libc",
  "libffi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ repository = "https://github.com/elle-lisp/elle"
 authors = ["Andy Davidoff"]
 
 [dependencies]
+# The plugin SDK, for the one constant the host and a plugin must agree on:
+# ABI_VERSION. The types crossing that boundary stay duplicated in
+# `src/plugin_api.rs` as `#[repr(C)]` layouts, because the host side of each
+# one holds elle-internal types the SDK cannot name.
+elle-plugin = { path = "elle-plugin" }
 bumpalo = "3"
 rustc-hash = "2.0"
 smallvec = "1.11"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all elle docs docgen smoke test qa crosscheck clean space help \
        smoke-elle smoke-vm smoke-noffi smoke-jit smoke-nouring smoke-wasm smoke-mlir \
-       doctest myplugin elle-wasm check-wasm elle-mlir elle-noffi plugins plugins-all mcp embedding \
+       doctest myplugin elle-wasm check-wasm elle-mlir elle-noffi plugins plugins-all \
+       plugins-verify smoke-plugins mcp embedding \
        fmt fmt-check
 
 .DEFAULT_GOAL := all
@@ -161,6 +162,51 @@ plugins-all:  ## Build all plugins including system-dep ones (vulkan, egui, etc.
 mcp: elle  ## Build elle + MCP plugins (oxigraph, syn)
 	$(MAKE) -C plugins mcp
 
+# The portable plugin set has ONE home: `PORTABLE` in plugins/Makefile. This
+# reads that variable back out of the submodule's own make instead of repeating
+# the list, so a plugin added there is demanded here with no second edit, and a
+# plugin dropped there stops being demanded. The submodule carries no `print-%`
+# rule, so one is supplied for the read.
+#
+# Recursively expanded (`=`, not `:=`): the read runs `make -C plugins`, and
+# every invocation of this Makefile would pay for it under `:=` — including the
+# ones on a tree where the submodule was never checked out.
+#
+# A package's cdylib is `lib<package with - as _>.so`, because no plugin crate
+# overrides `[lib] name`. tests/integration/plugins.rs pins that mapping against
+# the crates the submodule actually contains.
+PORTABLE_PKGS = $(filter-out -p,$(shell $(MAKE) -s -C plugins --eval='print-portable:; @echo $$(PORTABLE)' print-portable))
+PORTABLE_SO   = $(foreach p,$(PORTABLE_PKGS),target/release/lib$(subst -,_,$(p)).so)
+
+# Every portable plugin produced its artifact.
+#
+# This is what makes the plugin corpus's self-gating harmless. Each
+# plugins/tests/*.lisp imports its `.so` under `protect` and exits 0 when the
+# import fails, so a plugin that did not build makes its own test report
+# success. Asserting the build output separately means the tests never have to
+# be the thing that detects a missing plugin. See docs/analysis/ci.md § "The
+# plugins job".
+#
+# The empty list is a failure, not a vacuous pass: it is what a tree whose
+# `plugins/` submodule was never checked out looks like.
+#
+# No prerequisite on `plugins`: the assertion is about what is on disk, and
+# keeping it free of a build is what lets tests/integration/plugins.rs drive it
+# both ways in a second.
+plugins-verify:  ## Assert every portable plugin built its artifact
+	@[ -n "$(PORTABLE_SO)" ] || { \
+		echo "FAILED: no portable plugins named — run: git submodule update --init plugins"; \
+		exit 1; }
+	@missing=""; for so in $(PORTABLE_SO); do \
+		[ -f "$$so" ] || missing="$$missing $$so"; \
+	done; \
+	[ -z "$$missing" ] || { \
+		echo "FAILED: the plugins build produced no artifact for:$$missing"; \
+		echo "  Each plugins/tests/*.lisp exits 0 when its import fails, so the"; \
+		echo "  corpus would report success without them. Run: make plugins"; \
+		exit 1; }
+	@echo "=== plugins: $(words $(PORTABLE_SO)) portable artifacts present ==="
+
 # ── Docs ────────────────────────────────────────────────────────────
 
 docs: docs/pipeline.svg  ## Generate documentation assets
@@ -196,6 +242,12 @@ fmt-check: elle  ## Check Elle formatting (exit 1 on diff)
 # `make test` exists to predict the PR gate, so it runs what the gate runs. A
 # target the workflow requires and `make test` skips is a failure a branch can
 # only discover in CI.
+#
+# `smoke-plugins` is the one exception, and it is deliberate. It needs the
+# `plugins/` submodule checked out, and the submodule is optional for building
+# elle (INSTALL.md), so folding it in here would fail every tree that never
+# initialized it. Run it by hand after `make plugins` when a change touches
+# `elle_api!`; the `Plugin Tests` job runs it on every pull request.
 #
 # The default-build elle scripts get TWO corpus passes, because they are two
 # different tests of the same files:
@@ -430,8 +482,8 @@ DOCTEST_TIMEOUT ?= 180s
 # authoring guide and demos/myplugin is the crate it walks through, so the
 # document's own test imports it as `plugin/myplugin`; docs/testing.md gates its
 # example on the same import. Nothing else in the tree builds it — the
-# `plugins/` submodule is a separate workspace, and it is not even checked out
-# in CI — so without this every form below either import is dead: the guide
+# `plugins/` submodule is a separate workspace, checked out by one CI job that
+# runs no doctest — so without this every form below either import is dead: the guide
 # fails its import, the gating example gates itself out, and `doctest` reports
 # both as passing. tests/integration/doctest.rs pins the agreement.
 myplugin:  ## Build the plugin the literate documents load
@@ -443,6 +495,28 @@ doctest: myplugin  ## Test code examples in documentation (literate mode)
 		parallel -j $(JOBS) --tag \
 			'timeout $(DOCTEST_TIMEOUT) $(ELLE) {}' \
 		|| { echo "FAILED: doctest"; exit 1; }
+
+# A plugin test drives a whole library through one long program — the oxigraph
+# file loads an RDF store, the tree-sitter file parses a grammar — so the corpus
+# TIMEOUT is too narrow for it. Same shape as DOCTEST_TIMEOUT: a wider per-file
+# budget, so every file still fails fast on a hang. Read the budget from a timed
+# run, never from a number written here.
+PLUGIN_TIMEOUT ?= 120s
+
+# The plugin corpus: one process per file, against the release binary and the
+# artifacts `plugins-verify` just asserted. Each file's `import-file` path is
+# relative to the repository root, so the run has to start here rather than in
+# the submodule.
+#
+# `plugins-verify` is a prerequisite rather than a step of the CI job, so that a
+# `make smoke-plugins` on a tree where `make plugins` was never run fails loud
+# instead of reporting a corpus that imported nothing.
+smoke-plugins: elle plugins-verify  ## Run the plugin corpus (needs `make plugins` first)
+	@echo "=== plugin tests ==="
+	@printf '%s\n' plugins/tests/*.lisp | \
+		parallel -j $(JOBS) --tag \
+			'timeout $(PLUGIN_TIMEOUT) $(ELLE) {}' \
+		|| { echo "FAILED: plugin tests"; exit 1; }
 
 EMBED_TARGET_DIR = $(CURDIR)/target/$(if $(findstring --release,$(CARGO_PROFILE)),release,debug)
 

--- a/docs/analysis/ci.md
+++ b/docs/analysis/ci.md
@@ -19,6 +19,7 @@ renamed heading breaks the site generator.
 | Thread-Pool I/O Tests | ubuntu | The corpus on the thread-pool I/O backend | — |
 | MLIR Tests | ubuntu | `smoke-mlir` | — |
 | WASM Build | ubuntu | `check-wasm` — the feature compiles, the tier boots | — |
+| Plugin Tests | ubuntu | Builds the `plugins/` submodule, asserts its artifacts, runs its corpus | — |
 | AArch64 Smoke | ubuntu-arm | `make smoke` | — |
 | AArch64 Rust Tests | ubuntu-arm | Integration tests, then property tests | 8 |
 | AArch64 No-Features | ubuntu-arm | `smoke-noffi` | — |
@@ -88,6 +89,49 @@ the runner, and its owner can pass `JOBS=`.
 
 `tests/integration/capacity.rs` is the standing check that the CI count still
 tracks the runner.
+
+### The plugins job
+
+The `plugins/` submodule is a separate cargo workspace. Every plugin in it
+takes `elle-plugin` by path, so a rebuild moves the plugin and the SDK
+together: a changed `elle_api!` declaration either compiles at every call site
+or does not. #997 changed six declarations and stopped 17 plugins from
+compiling, at about 90 call sites, and nothing went red. No job checked the
+submodule out.
+
+The ABI version guard does not close that hole. It compares `ABI_VERSION` when
+a plugin loads, so it catches a stale `.so` built against an older SDK. A
+source break never reaches a load. Only a job that compiles the submodule sees
+one.
+
+So `Plugin Tests` checks the submodule out at its recorded pointer, builds the
+portable plugins, asserts the artifacts, and runs `plugins/tests/*.lisp`
+against the release binary. Building at the recorded pointer is also what keeps
+the pointer fresh: a pointer left behind an ABI change names plugins that no
+longer compile, and the job fails on them.
+
+#### Why the job asserts its build output
+
+Each `plugins/tests/*.lisp` imports its `.so` under `protect` and exits 0 when
+the import fails. That is deliberate, because the file has to run on a tree
+where the submodule was never built. It also means a plugin that did not build
+makes its own test report success: run from a directory where the paths did not
+resolve, 13 of 19 files reported `ok` having executed nothing.
+
+`make plugins-verify` asserts the build output separately. Every package in
+`plugins/Makefile`'s `PORTABLE` list must have produced its cdylib under
+`target/release`. The list is read back out of the submodule's own make rather
+than copied, so a plugin added there is demanded here with no second edit. With
+the artifacts asserted, the self-gating is harmless — the tests never have to be
+the thing that detects a missing plugin. `make smoke-plugins` runs the
+assertion before the corpus for the same reason.
+
+The assertion names the portable set, not every plugin. `elle-polars` does not
+build on the current toolchain: its `ethnum` dependency fails a
+`mem::transmute` size check under this rustc, unrelated to elle. `elle-arrow`
+carries heavy optional dependencies, and `elle-vulkan`, `elle-egui` and
+`elle-wayland` need a GPU or a display to exercise. The tests for those plugins
+gate themselves out of the run.
 
 ### Adding a job
 

--- a/docs/analysis/ci.md
+++ b/docs/analysis/ci.md
@@ -119,11 +119,24 @@ RocksDB and needs libclang; `elle-plotters` reaches `font-kit`, which needs
 fontconfig through pkg-config and pulls the freetype, expat and png headers
 behind it.
 
-Read that set off the built artifacts, not off the manifests. After a local
-`make plugins`, `ldd target/release/libelle_*.so` names every library the build
-actually linked, and which plugin linked it. A manifest scan misses all of
-them, which is how the job's first run failed on a fontconfig nobody had
-declared.
+A manifest scan finds none of that, which is how the job's first run failed on
+a fontconfig nobody had declared. Two other readings do find it, and they
+answer different questions.
+
+For what the plugins **link**, read the built artifacts. After a local `make
+plugins`, `ldd target/release/libelle_*.so` names every shared library and
+which plugin needs it. Today that is `libfontconfig`, `libfreetype`,
+`libexpat`, `libpng16` and their compression chain under
+`libelle_plotters.so`, plus `libstdc++` under `libelle_oxigraph.so`, and
+nothing under any other portable plugin.
+
+For what the plugins **build with**, `ldd` says nothing: a build-time tool
+leaves no trace in the artifact. `oxrocksdb-sys` runs bindgen, which dlopens
+libclang at build time and links none of it — the job's second run failed
+there, one layer past the first. That class shows up only in a build on a bare
+runner, so read it out of the failure and set the variable the tool asks for.
+The job locates `libclang.so` rather than naming an LLVM version, because the
+version moves with the runner image.
 
 #### Why the job asserts its build output
 

--- a/docs/analysis/ci.md
+++ b/docs/analysis/ci.md
@@ -110,6 +110,21 @@ against the release binary. Building at the recorded pointer is also what keeps
 the pointer fresh: a pointer left behind an ABI change names plugins that no
 longer compile, and the job fails on them.
 
+#### What the runner has to install
+
+Two plugins in the portable set are not pure Rust, and neither says so in its
+own `Cargo.toml`. The system libraries arrive several crates deep:
+`elle-oxigraph` reaches `oxrocksdb-sys`, which runs bindgen over vendored
+RocksDB and needs libclang; `elle-plotters` reaches `font-kit`, which needs
+fontconfig through pkg-config and pulls the freetype, expat and png headers
+behind it.
+
+Read that set off the built artifacts, not off the manifests. After a local
+`make plugins`, `ldd target/release/libelle_*.so` names every library the build
+actually linked, and which plugin linked it. A manifest scan misses all of
+them, which is how the job's first run failed on a fontconfig nobody had
+declared.
+
 #### Why the job asserts its build output
 
 Each `plugins/tests/*.lisp` imports its `.so` under `protect` and exits 0 when

--- a/docs/cookbook/plugins.md
+++ b/docs/cookbook/plugins.md
@@ -115,10 +115,11 @@ dependency, so the document has to go red for it.
 
 ### API reference
 
-The `api()` function returns a reference to the resolved `Api` struct. The
-constructors that allocate take the call's `ctx` first; the ones that do not
-allocate — integers, floats, booleans, nil, and keywords, which are immediate
-or interned — do not. Common methods:
+The `api()` function returns a reference to the resolved `Api` struct. A
+method takes the call's `ctx` first when it allocates, and also when it reads
+or writes a name: a symbol or keyword is a bare hash, and the spelling behind
+that hash lives in the calling instance's memo, which `ctx` is the way to
+reach (see [`docs/impl/symbol.md`](../impl/symbol.md)). Common methods:
 
 ```rust
 let a = api();
@@ -128,11 +129,11 @@ a.int(42)                       // i64 → ElleValue
 a.float(3.14)                   // f64 → ElleValue
 a.boolean(true)                 // bool → ElleValue
 a.nil()                         // nil
-a.keyword("error")              // &str → ElleValue (keyword)
 
-// Constructors that allocate, and so take ctx
+// Constructors that allocate or name, and so take ctx
 a.string(ctx, "hello")          // &str → ElleValue
 a.bytes(ctx, &[1, 2, 3])        // &[u8] → ElleValue
+a.keyword(ctx, "error")         // &str → ElleValue (keyword)
 a.array(ctx, &[v1, v2])         // &[ElleValue] → ElleValue
 a.set(ctx, &[v1, v2])           // &[ElleValue] → ElleValue
 a.build_struct(ctx, &[("key", val)])  // &[(&str, ElleValue)] → ElleValue
@@ -145,6 +146,12 @@ a.get_string(v)                 // Option<&str>
 a.get_bytes(v)                  // Option<&[u8]>
 a.get_bool(v)                   // Option<bool>
 a.get_external::<T>(v, "name")  // Option<&T>
+
+// Accessors that read a spelling back, and so take ctx
+a.get_keyword_name(ctx, v)      // Option<&str>
+a.get_struct_key(ctx, v, i)     // Option<&str>
+a.struct_entries(ctx, v)        // Vec<(&str, ElleValue)>
+a.kw_name(ctx, hash)            // Option<&str>
 
 // Results
 a.ok(value)                     // ElleResult with SIG_OK

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -6,16 +6,47 @@ use `import` with the `std/` prefix and require no compilation.
 
 ## Stable ABI
 
-Plugins depend on the `elle-plugin` crate — not on `elle` itself. This
-provides a stable ABI: plugins can be compiled independently from elle
-and loaded at runtime without version matching. The ABI uses a named
-function lookup pattern (like `vkGetInstanceProcAddr`). Adding API
-functions to elle never breaks existing plugins.
+Plugins depend on the `elle-plugin` crate — not on `elle` itself, so a
+plugin compiles independently and loads at runtime. The ABI uses a named
+function lookup pattern (like `vkGetInstanceProcAddr`): the plugin asks
+the host for each API function by name at init time. Adding API functions
+to elle never breaks an existing plugin, because a plugin only asks for
+the names it was written against.
 
 Plugins live in a [separate repository](https://github.com/elle-lisp/plugins),
 available as a git submodule at `plugins/`.
 See [`docs/cookbook/plugins.md`](cookbook/plugins.md) for a step-by-step
 guide to writing a plugin.
+
+### The ABI version
+
+Name lookup carries the name, not the calling convention. A plugin that
+resolves `struct_key` gets whatever the host has under that name. It then
+calls that pointer through the argument list it was compiled with. A
+changed signature is therefore a corrupt call, not a failed lookup.
+`ABI_VERSION` names the current calling convention, and it is the only
+thing that tells those two cases apart.
+
+The host advertises its version in `ElleApiLoader::version`, and
+`define_plugin!`'s init returns `-2` when that differs from the
+`ABI_VERSION` the plugin was built against. The load fails cleanly and the
+`import` reports it.
+
+| Version | What it named |
+|---------|---------------|
+| 2 | Primitives took `(args, nargs)`. |
+| 3 | Primitives take a leading opaque `*mut ElleCtx`, and thread it into the allocating constructors. |
+| 4 | The keyword and struct-key name readers take the `ctx` too: a spelling comes from the calling instance's memo. |
+
+Bump `ABI_VERSION` whenever an existing declaration in `elle_api!` changes
+its arguments or return type, whenever a declaration is removed, and
+whenever the primitive calling convention itself changes. Adding a new
+declaration needs no bump.
+
+`elle-plugin`'s tests pin the signature of every function the current
+version names. Changing one fails the build until the pin and the version
+move together, because an unbumped signature change is the one breakage
+the load guard cannot see.
 
 ## Building plugins
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -81,6 +81,23 @@ unless you move the `.so` files or use `--path` (see below).
 The plugins submodule's own Makefile handles this automatically when it
 detects it's inside the elle repo, so `cd plugins && make` also works.
 
+## Testing plugins
+
+Each plugin has an integration test under `plugins/tests/`. Run the whole set
+against the elle binary from the repo root:
+
+```bash
+make plugins          # build the portable plugins first
+make smoke-plugins    # assert the artifacts, then run plugins/tests/*.lisp
+```
+
+`smoke-plugins` runs `plugins-verify` first, which fails when a portable plugin
+produced no `.so`. That assertion is not decoration. Every test file imports its
+`.so` under `protect` and exits 0 when the import fails, so a plugin that did
+not build makes its own test report success. The reasoning, and the CI job that
+runs these targets, are in
+[`docs/analysis/ci.md`](analysis/ci.md) § "The plugins job".
+
 ## Usage pattern
 
 ```text

--- a/elle-plugin/AGENTS.md
+++ b/elle-plugin/AGENTS.md
@@ -14,6 +14,12 @@ Single resolve function — same pattern as `vkGetInstanceProcAddr`.
 Plugins look up API functions by name at init time. Adding functions
 to elle never breaks existing plugins.
 
+A lookup carries the name, not the argument list, so a changed signature
+resolves and then miscalls. `ABI_VERSION` names the current calling
+convention; the host advertises its own in `ElleApiLoader::version` and
+init returns `-2` on a mismatch. See `docs/plugins.md` § "The ABI version"
+for the history and the rule for bumping it.
+
 ## Key Types
 
 | Type | Purpose |
@@ -44,3 +50,7 @@ to elle never breaks existing plugins.
 2. All types are `#[repr(C)]` for ABI stability.
 3. `ElleValue` is never inspected — always accessed through `Api`.
 4. Plugin .so is never unloaded — string pointers from rodata are static.
+5. `ABI_VERSION` is written once, here; the host reads it rather than
+   copying it.
+6. `tests.rs` pins the signature of every function the current version
+   names, so a changed argument list cannot ship under the old number.

--- a/elle-plugin/src/lib.rs
+++ b/elle-plugin/src/lib.rs
@@ -19,9 +19,19 @@ mod accessors;
 /// host whose version differs, turning an incompatible calling convention into a
 /// clean load failure instead of undefined behaviour.
 ///
+/// Name lookup carries the name and not the argument list, so a changed
+/// signature resolves and then miscalls. This number is what separates that
+/// from a name the plugin simply never asked for. Bump it whenever a
+/// declaration in `elle_api!` changes or disappears, and whenever the primitive
+/// calling convention changes; adding a declaration needs no bump. The version
+/// history and the rule are in `docs/plugins.md` § "The ABI version", and
+/// `tests.rs` pins the signature set this number names.
+///
 /// v3 added a leading opaque `*mut ElleCtx` (per-call region + heap capability)
-/// to every primitive and to the allocating constructors.
-pub const ABI_VERSION: u32 = 3;
+/// to every primitive and to the allocating constructors. v4 extends it to the
+/// keyword and struct-key name readers, whose spellings come from the calling
+/// instance's memo.
+pub const ABI_VERSION: u32 = 4;
 
 // ── Signal constants ──────────────────────────────────────────────────
 
@@ -141,6 +151,8 @@ pub type PluginInitFn = extern "C" fn(loader: &ElleApiLoader, ctx: &mut EllePlug
 /// This macro generates:
 /// - `Api` struct with one function pointer field per declared function
 /// - `Api::load()` that resolves all function pointers from the loader
+/// - `ABI_FUNCTIONS`, the declared name and signature of each, for the test
+///   that pins what `ABI_VERSION` names
 macro_rules! elle_api {
     ($(fn $name:ident($($arg:ty),*) -> $ret:ty;)*) => {
         /// Resolved function pointer cache. Built once at plugin init.
@@ -150,6 +162,16 @@ macro_rules! elle_api {
         pub struct Api {
             $(pub $name: extern "C" fn($($arg),*) -> $ret,)*
         }
+
+        /// Every declared API function, as `(name, signature)`, in declaration
+        /// order. The signature is the argument types and return type as
+        /// written, which is what a plugin compiles its call against.
+        pub const ABI_FUNCTIONS: &[(&str, &str)] = &[
+            $((
+                stringify!($name),
+                concat!("(", $(stringify!($arg), ",",)* ")->", stringify!($ret)),
+            ),)*
+        ];
 
         impl Api {
             /// Resolve all functions from the loader.
@@ -546,3 +568,6 @@ impl EllePrimDef {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/elle-plugin/src/tests.rs
+++ b/elle-plugin/src/tests.rs
@@ -1,0 +1,216 @@
+use super::*;
+use std::ffi::c_void;
+use std::ptr;
+
+// ── What version 4 names ──────────────────────────────────────────────
+
+/// Every API function version 4 declares, with the signature a v4 plugin
+/// compiles its call against.
+///
+/// This is a transcription of the `elle_api!` block, not a derivation from it:
+/// the two are written separately so that changing one and not the other is a
+/// failing build. The trap it guards is that `Api::load` resolves by name and
+/// then transmutes, so a host that renamed nothing but changed an argument list
+/// hands back a pointer the plugin calls with the wrong arguments — a resolve
+/// that succeeds into a call that corrupts. Nothing at load time can see that;
+/// only `ABI_VERSION` can, and only if it moves.
+const V4_FUNCTIONS: &[(&str, &str)] = &[
+    ("make_int", "(i64,)->ElleValue"),
+    ("make_float", "(f64,)->ElleValue"),
+    ("make_bool", "(bool,)->ElleValue"),
+    ("make_nil", "()->ElleValue"),
+    ("make_string", "(*mut ElleCtx,*const u8,usize,)->ElleValue"),
+    ("make_bytes", "(*mut ElleCtx,*const u8,usize,)->ElleValue"),
+    ("make_keyword", "(*mut ElleCtx,*const u8,usize,)->ElleValue"),
+    ("make_array", "(*mut ElleCtx,*const ElleValue,usize,)->ElleValue"),
+    ("make_struct", "(*mut ElleCtx,*const ElleKV,usize,)->ElleValue"),
+    ("make_set", "(*mut ElleCtx,*const ElleValue,usize,)->ElleValue"),
+    (
+        "make_error",
+        "(*mut ElleCtx,*const u8,usize,*const u8,usize,)->ElleValue",
+    ),
+    (
+        "make_external",
+        "(*mut ElleCtx,*const u8,usize,*mut c_void,Option<extern \"C\" fn(*mut c_void)>,)->ElleValue",
+    ),
+    ("as_external", "(ElleValue,*const u8,usize,)->*mut c_void"),
+    ("as_int", "(ElleValue,*mut i64,)->bool"),
+    ("as_float", "(ElleValue,*mut f64,)->bool"),
+    ("as_bool", "(ElleValue,)->i32"),
+    ("is_nil", "(ElleValue,)->bool"),
+    ("is_truthy", "(ElleValue,)->bool"),
+    ("as_string", "(ElleValue,*mut usize,)->*const u8"),
+    ("as_bytes", "(ElleValue,*mut usize,)->*const u8"),
+    ("type_name_of", "(ElleValue,*mut usize,)->*const u8"),
+    ("is_string", "(ElleValue,)->bool"),
+    ("is_keyword", "(ElleValue,)->bool"),
+    ("is_bytes", "(ElleValue,)->bool"),
+    ("is_array", "(ElleValue,)->bool"),
+    ("is_struct", "(ElleValue,)->bool"),
+    ("is_int", "(ElleValue,)->bool"),
+    ("is_float", "(ElleValue,)->bool"),
+    ("is_bool_val", "(ElleValue,)->bool"),
+    ("is_external", "(ElleValue,)->bool"),
+    (
+        "as_keyword_name",
+        "(*mut ElleCtx,ElleValue,*mut usize,)->*const u8",
+    ),
+    ("struct_get", "(ElleValue,*const u8,usize,)->ElleValue"),
+    ("struct_len", "(ElleValue,)->isize"),
+    (
+        "struct_key",
+        "(*mut ElleCtx,ElleValue,usize,*mut usize,)->*const u8",
+    ),
+    ("struct_value", "(ElleValue,usize,)->ElleValue"),
+    ("array_len", "(ElleValue,)->isize"),
+    ("array_get", "(ElleValue,usize,)->ElleValue"),
+    ("list_to_array", "(*mut ElleCtx,ElleValue,)->ElleValue"),
+    ("value_eq", "(ElleValue,ElleValue,)->bool"),
+    ("make_poll_fd", "(*mut ElleCtx,i32,u32,)->ElleValue"),
+    ("intern_keyword", "(*const u8,usize,)->u64"),
+    ("keyword_name", "(*mut ElleCtx,u64,*mut usize,)->*const u8"),
+];
+
+// The counter-factual: on the tree that changed `make_keyword`,
+// `as_keyword_name`, `struct_key` and `keyword_name` to take the per-call ctx
+// and left `ABI_VERSION` at 3, this test is the only thing in either repository
+// that fails. Every plugin still compiled, because plugins take `elle-plugin` by
+// path and were rebuilt against the new signatures; a plugin `.so` built before
+// the change kept loading, because the number the guard compares had not moved.
+#[test]
+fn every_declared_api_function_has_the_signature_version_4_pinned_it_with() {
+    assert_eq!(
+        ABI_VERSION, 4,
+        "the pin below is version 4's. Move both together, or the number stops \
+         naming anything."
+    );
+
+    for (name, declared) in ABI_FUNCTIONS {
+        let Some((_, pinned)) = V4_FUNCTIONS.iter().find(|(pinned, _)| pinned == name) else {
+            panic!(
+                "`{name}` is declared in `elle_api!` but is not pinned here. \
+                 Adding a function is compatible — a plugin never resolves a name \
+                 it was not compiled against — so add the row and leave \
+                 ABI_VERSION alone."
+            );
+        };
+        assert_eq!(
+            declared, pinned,
+            "`{name}` is declared `{declared}`, and version 4 pinned \
+             `{pinned}`. A v4 plugin resolves this name and calls it through the \
+             pinned argument list, so the load guard sees nothing and the call is \
+             wrong. Bump ABI_VERSION, re-pin the set, and add the row to \
+             docs/plugins.md § \"The ABI version\"."
+        );
+    }
+
+    for (name, _) in V4_FUNCTIONS {
+        assert!(
+            ABI_FUNCTIONS.iter().any(|(declared, _)| declared == name),
+            "`{name}` is pinned by version 4 and is no longer declared. A v4 \
+             plugin resolves it to null and fails to load with -1, which reads as \
+             a corrupt install rather than a version it cannot speak. Bump \
+             ABI_VERSION and re-pin."
+        );
+    }
+}
+
+// ── The load guard ────────────────────────────────────────────────────
+
+extern "C" fn unreachable_prim(
+    _ctx: *mut ElleCtx,
+    _args: *const ElleValue,
+    _nargs: usize,
+) -> ElleResult {
+    unreachable!("these tests never call the registered primitive")
+}
+
+static PRIMITIVES: [EllePrimDef; 1] = [EllePrimDef::exact(
+    "test/noop",
+    unreachable_prim,
+    SIG_OK,
+    0,
+    "doc",
+    "test",
+    "(test/noop)",
+)];
+
+define_plugin!("test/", &PRIMITIVES);
+
+/// Stands in for every API function. `Api::load` only checks for null and
+/// transmutes, so one non-null address resolves the whole table.
+extern "C" fn stub() {}
+
+extern "C" fn resolve_everything(_name: *const u8, _len: usize) -> *const c_void {
+    stub as *const c_void
+}
+
+extern "C" fn resolve_nothing(_name: *const u8, _len: usize) -> *const c_void {
+    ptr::null()
+}
+
+extern "C" fn count_registration(ctx: *mut EllePluginCtx, _def: *const EllePrimDef) {
+    let registered = unsafe { (*ctx)._opaque as *mut usize };
+    unsafe { *registered += 1 };
+}
+
+/// Run `elle_plugin_init` against a host and report `(return code, primitives
+/// registered)`.
+fn init_against(
+    version: u32,
+    resolve: extern "C" fn(*const u8, usize) -> *const c_void,
+) -> (i32, usize) {
+    let loader = ElleApiLoader { version, resolve };
+    let mut registered: usize = 0;
+    let mut ctx = EllePluginCtx {
+        register: count_registration,
+        _opaque: &mut registered as *mut usize as *mut c_void,
+    };
+    let code = elle_plugin_init(&loader, &mut ctx);
+    (code, registered)
+}
+
+#[test]
+fn a_host_one_version_ahead_is_refused_before_a_single_pointer_is_bound() {
+    let (code, registered) = init_against(ABI_VERSION + 1, resolve_everything);
+    assert_eq!(
+        code, -2,
+        "a newer host must fail the load, not be called into"
+    );
+    assert_eq!(
+        registered, 0,
+        "the guard has to run before registration: a primitive registered here \
+         is one elle will call through the wrong convention later."
+    );
+}
+
+#[test]
+fn a_host_one_version_behind_is_refused() {
+    let (code, _) = init_against(ABI_VERSION - 1, resolve_everything);
+    assert_eq!(
+        code, -2,
+        "an older host is as unusable as a newer one — the convention differs \
+         in both directions."
+    );
+}
+
+#[test]
+fn a_host_on_the_matching_version_loads_and_binds_the_api() {
+    let (code, registered) = init_against(ABI_VERSION, resolve_everything);
+    assert_eq!(code, 0, "the version the SDK speaks must load");
+    assert_eq!(registered, PRIMITIVES.len());
+    // `api()` panics when init returned before `API.set`, so reaching this
+    // proves the guard let the resolve through rather than short-circuiting.
+    let _ = api();
+}
+
+#[test]
+fn a_host_on_the_matching_version_that_resolves_nothing_is_refused_distinctly() {
+    let (code, registered) = init_against(ABI_VERSION, resolve_nothing);
+    assert_eq!(
+        code, -1,
+        "a missing name is -1 and a wrong version is -2; collapsing them would \
+         report an unspeakable ABI as a corrupt install."
+    );
+    assert_eq!(registered, 0);
+}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -5,8 +5,10 @@
 //! receives an `ElleApiLoader` + `EllePluginCtx`, resolves API functions
 //! by name, and registers primitives.
 //!
-//! The ABI is stable: plugins can be compiled separately from elle and
-//! loaded at runtime without version matching.
+//! The ABI is stable: a plugin compiles separately from elle and loads at
+//! runtime. Stable does not mean unversioned — a lookup carries the name and
+//! not the argument list, so the loader advertises `ABI_VERSION` and the
+//! plugin refuses a host it cannot call (docs/plugins.md § "The ABI version").
 
 use crate::error::{LError, LResult};
 use crate::plugin_api::{self, ApiLoader, PrimDefRaw};

--- a/src/plugin_api.rs
+++ b/src/plugin_api.rs
@@ -183,13 +183,13 @@ extern "C" fn api_resolve(name_ptr: *const u8, name_len: usize) -> *const c_void
 /// Construct the `ElleApiLoader` for plugin initialization.
 pub(crate) fn build_api_loader() -> ApiLoader {
     ApiLoader {
-        // ABI version 3: plugin primitives receive an opaque per-call ctx (region
-        // + heap) as their leading argument and thread it into the allocating
-        // constructors (docs/impl/region/ctx.md "Plugins"). This changed the
-        // primitive calling convention, so a v2 plugin (no ctx arg) is incompatible
-        // and must be recompiled; the SDK's version guard turns the mismatch into a
-        // clean load failure rather than a corrupt call.
-        version: 3,
+        // Read from the SDK rather than written again here. The number is what a
+        // plugin compares itself against, so a second copy of it can disagree
+        // with the first, and the disagreement is invisible: every name still
+        // resolves, and every call is made through the wrong argument list.
+        // What the current version names, and when to bump it, is in
+        // docs/plugins.md § "The ABI version".
+        version: elle_plugin::ABI_VERSION,
         resolve: api_resolve,
     }
 }

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -106,7 +106,8 @@ Tests are organized by feature area in separate files:
 | `elle_scripts.rs` | Process-global runtime-mode pins (guardfree/no-uring/mlir-off); the corpus itself runs via `elle test` |
 | `paths.rs` | The paths and URLs the Makefile and the doc generator name in text, checked against the tree |
 | `bytecode_doc.rs` | The instruction names and source paths the bytecode documents spell, checked against the `Instruction` enum |
-| `workflows.rs` | The PR workflow's merge gate: every job needed and enforced by `all-checks`, no job serializing the corpus and the Rust suite, no shared cache key |
+| `workflows.rs` | The PR workflow's merge gate: every job needed and enforced by `all-checks`, a job that builds the `plugins/` submodule, no job serializing the corpus and the Rust suite, no shared cache key |
+| `plugins.rs` | The plugin artifacts the Makefile demands, checked against the submodule's crates, and the assertion that fails when one is missing |
 | `budget.rs` | The wall-clock budget the Makefile's per-file corpus passes give one file |
 | `doctest.rs` | The plugins the literate documents load, checked against what the Makefile's `doctest` target builds |
 | `environment.rs` | Environment variables |

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -183,6 +183,9 @@ mod bytecode_doc {
 mod workflows {
     include!("workflows.rs");
 }
+mod plugins {
+    include!("plugins.rs");
+}
 mod budget {
     include!("budget.rs");
 }

--- a/tests/integration/plugins.rs
+++ b/tests/integration/plugins.rs
@@ -1,0 +1,175 @@
+// The gate that keeps the `plugins/` submodule compiling against this tree.
+//
+// The submodule is a separate cargo workspace whose crates take `elle-plugin`
+// by path, so a changed `elle_api!` declaration moves the SDK and the plugin
+// together and the workspace either compiles or does not. Until the `Plugin
+// Tests` job existed, nothing in CI checked the submodule out: #997 changed six
+// declarations, stopped 17 plugins from compiling at about 90 call sites, and
+// every gate stayed green (#1023). The argument, and why the ABI version guard
+// cannot stand in for the job, are in docs/analysis/ci.md § "The plugins job".
+//
+// These tests cover the two halves the job cannot check for itself: that the
+// list of artifacts it demands still describes the submodule, and that the
+// demand actually fails when an artifact is absent.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Run one Makefile target with variable overrides, returning (success, output).
+/// A command-line assignment beats the Makefile's own, which is what lets the
+/// artifact assertion be driven both ways without a plugin build.
+fn run_make(target: &str, overrides: &[&str]) -> (bool, String) {
+    let out = Command::new("make")
+        .current_dir(repo_root())
+        .arg("--no-print-directory")
+        .arg(target)
+        .args(overrides)
+        .env_remove("GITHUB_ACTIONS")
+        .output()
+        .unwrap_or_else(|e| panic!("run `make {target}`: {e}"));
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&out.stderr));
+    (out.status.success(), text)
+}
+
+/// The plugins the assertion must not demand: `elle-polars` fails to build on
+/// the current toolchain, `elle-arrow` carries heavy optional dependencies, and
+/// the last three need a GPU or a display. docs/analysis/ci.md § "The plugins
+/// job" owns the reasons.
+const NOT_PORTABLE: &[&str] = &["polars", "arrow", "vulkan", "egui", "wayland"];
+
+/// The package name a plugin directory declares, or `None` when the directory
+/// holds no crate.
+fn package_name(dir: &str) -> Option<String> {
+    let text = fs::read_to_string(repo_root().join("plugins").join(dir).join("Cargo.toml")).ok()?;
+    let line = text.lines().find(|l| l.trim_start().starts_with("name = "))?;
+    Some(line.split('"').nth(1)?.to_string())
+}
+
+// The artifact list is derived, not written down: the Makefile reads `PORTABLE`
+// back out of the submodule's own make and turns each package into the cdylib
+// name cargo emits for it. That derivation has two ways to go wrong quietly —
+// the read can return nothing, and the name mapping can stop matching the
+// crates — and either one makes the assertion pass while demanding nothing.
+//
+// The counter-factual: a plugin crate that sets `[lib] name` produces a `.so`
+// under a name this mapping never predicts. The assertion then demands a file
+// that is never built and fails every run, which is loud; the mapping breaking
+// the other way, on a package the list stops naming, is the silent half this
+// test catches.
+#[test]
+fn the_demanded_artifacts_describe_the_submodule() {
+    if !repo_root().join("plugins/Makefile").exists() {
+        eprintln!("SKIPPED: the `plugins/` submodule is not checked out");
+        return;
+    }
+
+    let (ok, listed) = run_make("print-PORTABLE_SO", &[]);
+    assert!(ok, "`make print-PORTABLE_SO` failed:\n{listed}");
+    let artifacts: Vec<&str> = listed.split_whitespace().collect();
+
+    // A read that returned nothing would assert nothing. The portable set has
+    // held around twenty plugins since the submodule was split out.
+    assert!(
+        artifacts.len() > 10,
+        "the Makefile demands only {} plugin artifacts; the read of \
+         `PORTABLE` out of plugins/Makefile is broken, not the submodule: {listed}",
+        artifacts.len()
+    );
+
+    for artifact in &artifacts {
+        let stem = artifact
+            .strip_prefix("target/release/libelle_")
+            .and_then(|s| s.strip_suffix(".so"))
+            .unwrap_or_else(|| {
+                panic!("`{artifact}` is not a `target/release/libelle_*.so` path")
+            });
+
+        // Cargo names a cdylib after the package, with `-` as `_`, unless the
+        // crate overrides it with `[lib] name`. The directory is the package
+        // name without the `elle-` prefix.
+        let dir = stem.replace('_', "-");
+        let package = package_name(&dir).unwrap_or_else(|| {
+            panic!("`{artifact}` names plugins/{dir}, which declares no package")
+        });
+        assert_eq!(
+            package.replace('-', "_"),
+            format!("elle_{stem}"),
+            "plugins/{dir} is package `{package}`, which cargo builds as \
+             something other than `{artifact}`"
+        );
+
+        let manifest =
+            fs::read_to_string(repo_root().join("plugins").join(&dir).join("Cargo.toml")).unwrap();
+        assert!(
+            manifest.contains("crate-type = [\"cdylib\"]"),
+            "plugins/{dir} is not a cdylib, so it produces no `{artifact}`"
+        );
+        assert!(
+            !manifest.contains("[lib]\nname = "),
+            "plugins/{dir} overrides its lib name, so `{artifact}` is a guess"
+        );
+    }
+
+    for excluded in NOT_PORTABLE {
+        let path = format!("target/release/libelle_{}.so", excluded.replace('-', "_"));
+        assert!(
+            !artifacts.contains(&path.as_str()),
+            "the assertion demands `{path}`, which the portable build does not \
+             produce; see docs/analysis/ci.md § \"The plugins job\""
+        );
+    }
+}
+
+// The assertion has to fail on a missing artifact, because nothing downstream
+// of it will. Every plugins/tests/*.lisp imports its `.so` under `protect` and
+// exits 0 when the import fails, so a plugin that did not build makes its own
+// test report success — run from a directory where the paths did not resolve,
+// 13 of 19 files reported `ok` having executed nothing.
+//
+// The counter-factual this replaces: `make plugins` followed by the corpus, and
+// nothing between them. A plugin dropped from the build took its test's
+// coverage with it and the job stayed green.
+#[test]
+fn the_artifact_assertion_fails_on_a_missing_plugin() {
+    let (ok, output) = run_make(
+        "plugins-verify",
+        &["PORTABLE_SO=target/release/libelle_never_built.so"],
+    );
+    assert!(
+        !ok,
+        "`plugins-verify` passed with an artifact that does not exist:\n{output}"
+    );
+    assert!(
+        output.contains("libelle_never_built.so"),
+        "the failure does not name the missing artifact, so the reader has to \
+         bisect the plugin set to find it:\n{output}"
+    );
+
+    // The same target over a file that is present must pass, or the test above
+    // proves only that the target always fails.
+    let (ok, output) = run_make("plugins-verify", &["PORTABLE_SO=Makefile"]);
+    assert!(
+        ok,
+        "`plugins-verify` failed over an artifact that exists:\n{output}"
+    );
+}
+
+// An empty list satisfies "every artifact is present" vacuously, and that is
+// exactly the state of a tree whose submodule was never checked out: the read
+// of `PORTABLE` returns nothing and the assertion greens. The gate has to
+// report the un-checked-out submodule instead of passing over it.
+#[test]
+fn the_artifact_assertion_rejects_an_empty_set() {
+    let (ok, output) = run_make("plugins-verify", &["PORTABLE_SO="]);
+    assert!(
+        !ok,
+        "`plugins-verify` passed while demanding no artifacts at all, which is \
+         what a missing `plugins/` checkout looks like:\n{output}"
+    );
+}

--- a/tests/integration/workflows.rs
+++ b/tests/integration/workflows.rs
@@ -200,6 +200,44 @@ fn no_job_serializes_the_corpus_and_the_rust_suite() {
     );
 }
 
+// The `plugins/` submodule is a separate workspace, and until this job existed
+// no CI job checked it out. #997 changed six `elle_api!` signatures and stopped
+// 17 plugins from compiling, at about 90 call sites, and every gate stayed
+// green — the break was found by hand (#1023). Plugins take `elle-plugin` by
+// path, so a source break never reaches a load and the ABI version guard cannot
+// see it; only a job that compiles the submodule can. The argument is in
+// docs/analysis/ci.md § "The plugins job".
+//
+// The counter-factual: this is the state main was in. Delete the job, or leave
+// it building a `plugins/` it never checked out, and an ABI change breaks every
+// plugin with nothing going red.
+#[test]
+fn a_job_builds_the_plugins_submodule() {
+    let text = workflow_text();
+
+    let building: Vec<(String, String)> = jobs(&text)
+        .into_iter()
+        .filter(|(_, body)| body.contains("make plugins") && body.contains("make smoke-plugins"))
+        .collect();
+    assert!(
+        !building.is_empty(),
+        "no job in {} runs both `make plugins` and `make smoke-plugins`, so \
+         nothing in CI compiles the `plugins/` workspace against this tree's \
+         `elle-plugin`",
+        workflow_path().display()
+    );
+
+    // Without a checkout the submodule directory is empty, `make plugins`
+    // builds nothing, and `plugins-verify` is the step that says so.
+    for (name, body) in &building {
+        assert!(
+            body.contains("submodule"),
+            "job `{name}` builds the plugins but never checks the submodule \
+             out, so it runs over an empty directory"
+        );
+    }
+}
+
 // A split pair that shares one `Swatinem/rust-cache` `shared-key` is worse than
 // no cache: the Smoke job populates the key with release artifacts, the Rust
 // Tests job restores those and saves dev-profile ones over them, and the two


### PR DESCRIPTION
## What was wrong

#997 changed six `elle_api!` declarations to thread the per-call `ctx` —
`make_keyword`, `as_keyword_name`, `struct_key` and `keyword_name` among them —
and left `ABI_VERSION` at 3. Nothing failed. Every plugin in the submodule takes
`elle-plugin` by path, so a rebuild moved plugin and SDK together; a plugin
`.so` built before the change kept loading, because the guard in
`define_plugin!` compares a number that had not moved, and then called through
an argument list that had.

That is the shape of the hole. A lookup resolves a name, and a name carries no
argument list, so a changed signature resolves and then miscalls. The version is
the only thing separating that from a name the plugin simply never asked for,
and two things kept it from working.

**The number had two homes.** `plugin_api.rs` advertised a hand-written
`version: 3` next to the SDK's own `ABI_VERSION: u32 = 3`. Two copies of a
constant that must agree, with nothing making them.

**Nothing pinned what the number named.** No test anywhere related the version
to the signatures it stands for, so the version could only ever move when
somebody remembered.

## What the change does

The host now depends on `elle-plugin` and reads `ABI_VERSION` from it.
`elle-plugin` keeps its zero dependencies and is where the number lives.

`elle_api!` also emits `ABI_FUNCTIONS` — the declared name and signature of each
function — and `elle-plugin/src/tests.rs` pins the set that version 4 names. A
changed argument list fails that test with the instruction to bump. A new
declaration is compatible, so it asks only for a row.

`ABI_VERSION` is 4.

## Tests

`elle-plugin/src/tests.rs`: the pin, and the load guard's three answers — `-2`
for a host one version ahead and one behind, `0` for a match, and `-1` for a
matching host that resolves nothing, so an unspeakable ABI never reports as a
corrupt install. The ahead case also asserts that no primitive was registered,
since the guard has to run before `Api::load`.

Counter-factuals, each run:

- `ABI_VERSION` back to 3 — the pin is the only failure in either repository,
  which is exactly what the unbumped tree looked like.
- `is_nil` given a leading `ctx`, declaration and wrapper together, version left
  at 4 — the pin names the function, both signatures, and the bump.
- the guard deleted — the two mismatch tests fail and nothing else does.

## Measured

`cargo test -p elle --lib` (2368), `cargo test --test lib` (1267), `make qa`,
`make doctest`, and `make smoke-elle` against the release binary — 21 corpus
passes, every one 0 fail, 0 diverge, 0 timeout.

End to end: a plugin built against the ABI-3 SDK now fails to load into this
binary with `init failed with code -2`, instead of being called through the
wrong convention.

The plugin corpus runs against a release binary and the rebuilt plugins: 20 of
21 files pass, and `plugins/tests/vulkan.lisp` gates itself out because this
build carries no MLIR.

## Plugins

The submodule is fixed for the v4 signatures in elle-lisp/plugins@7a5571a:
`ctx` threaded through 17 plugins, and new `tests/jiff.lisp` and
`tests/arrow.lisp` covering the two plugins whose changed lines were otherwise
untested and that need no display. Both new tests fail against a null `ctx`,
which is the mistake threading `ctx` by hand can make.

The second commit moves the recorded submodule pointer onto that commit. The old
one names plugins that do not compile against this `elle-plugin`, so `git
submodule update --init plugins && make plugins` from this branch now works.
`cargo check` over the pinned workspace is clean for every plugin but
`elle-polars`, which needs no change here and does not build on this toolchain.
