### PR TITLE
regions: a deferred tail-call release has the activation owner node's life

### DIFF
--- a/docs/impl/region/letrec.md
+++ b/docs/impl/region/letrec.md
@@ -234,7 +234,7 @@ channels and lets exactly one fire.
   descending into nested lambdas), `tail_callee_defers_release` returns true for such a callee
   (read through a **non-upvalue** reference only, so a nested closure in the body can
   never free the arena out from under a later use), and the `TailCall` carries
-  `DeferredReleases::callee = region_of(callee)` — the merged arena, because a member lives in it.
+  the callee channel's `region_of(callee)` — the merged arena, because a member lives in it.
   That consumer refuses a callee crossing the **fiber** frontier, and admits the return
   facet — the same reading, for the same reason, as the merge's own frontier gate above,
   and the return half of the argument the cell-free self-recursive deferral makes
@@ -259,9 +259,10 @@ channels and lets exactly one fire.
   (`compute_closure_cycle_merges` → `ClosureCycleMerge::tail_release_sites`), and the
   runtime resolves that slot through the executing activation's region map — the arena
   was minted during the letrec setup and its scope-exit drop is dead. If the callee
-  turns out a **closure**, the frame is replaced and `trampoline_loop`'s
-  `deferred_releases` frees the resolved arena once (deduped) at the recursion's
-  completion; if it turns out a **native**, the frame is not replaced, the slot is
+  turns out a **closure**, the frame is replaced and the activation's own deferred set
+  frees the resolved arena once (deduped) at whichever end that activation reaches
+  ([owner.md](owner.md) § "A deferred tail-call release has the node's life");
+  if it turns out a **native**, the frame is not replaced, the slot is
   never consumed, and the live scope-exit `DecrefRegion` frees the arena — mutually
   exclusive, exactly one release, the compiler having classified nothing.
 

--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1646,6 +1646,12 @@ function releases for is what keeps a caller's leftovers out: the map survives a
 frame-replacing tail call, and the references still in it are the callee's own machinery
 to answer for.
 
+The tables are not everything the exit runs. A release the frame took over from a
+frame-replacing tail call has no route and no receipt to record — the instruction that
+would have run it is the *caller's*, dead past the `TailCall` — so it is carried on the
+activation itself and discharged at the same exits, on the same `walk_abandoned` question
+([owner.md](owner.md) § "A deferred tail-call release has the node's life").
+
 **What the signal carries is not abandoned — unless the raise minted its delivery.**
 The error's payload leaves with the signal, and the catcher's read of it is funded by
 exactly one **delivery** reference. Where that reference comes from decides what the

--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -197,17 +197,61 @@ the funnel-recovered face; the refusal family) and at runtime by
 (bounded flag-on beside the leaking flag-off counterfactual, under the JIT too).
 
 **Lifecycle.** The node slot is per-activation state carried beside the region-remap frame:
-`Fiber::activation_owner_nodes` parallels `activation_region_maps`, pushed empty on every
+`Fiber::activation_dues` parallels `activation_region_maps`, pushed empty on every
 fresh activation entry (the interpreter's `saving_stack` push, the JIT prologue's
 `push_region_map`) and popped with it. The node is freed **implicitly at the activation's
 normal completion** — the interpreter trampoline's clean
 break and the compiled function's `Return` path
-(`elle_jit_release_activation_owner_node`) each take the slot and run one
+(`elle_jit_release_activation_dues`) each take the slot and run one
 `decref_region_if_present(node)`: rc 1→0, subtree drop — never by an emitted drop
 instruction (no single static site covers return + tail + yield + error + squelch). This is
 the same clean-break discipline as the trampoline's tail-call-adopted closure release, and a
 frame-replacing tail call likewise keeps the activation — and its node — alive to the
 recursion's completion.
+
+**A deferred tail-call release has the node's life, so it rides the node's slot.** A
+frame-replacing tail call strands the releases the lowerer emitted past the `TailCall`: the
+callee closure's own per-call region, and the merged closure-cycle arena a letrec body
+tail-calls out of ([letrec.md](letrec.md) § "The arena channel and the callee channel are
+independent"). The new activation takes each over and owes it one decref. That obligation
+answers to the same three moments the node's does — it must reach the activation's normal
+completion across however many parks the activation takes on the way, and it must be
+discharged where the activation is abandoned instead — so the two are **one** per-activation
+record (`ActivationDues`: the node plus the deferred set). One record means one move
+discipline: the slot is pushed and popped with the region-remap frame, MOVED into the parked
+`BytecodeFrame` at a suspend, restored by `restore_activation_region_map`, and released as a
+unit at the discard chokepoint and the terminal teardown. Splitting them into two carriers
+would let a park move one and drop the other, which is a leak on one side and a strand on the
+other, and nothing would fail on it.
+
+Held in the trampoline loop's own Rust local instead — where it was — the set is lost at
+every exit that is not the clean break, and the ordinary case is not the error exit but the
+**park**: the loop returns, the local dies, and the resumed body re-enters through a *fresh*
+loop with an empty set. So a fiber that yields once inside a tail-called closure stranded the
+callee's region even when it was resumed to completion. The record on the activation slot is
+also what carries the deferral to a tail call the interpreter trampoline never sees — the JIT
+sentinel arms and the top-level driver each consume the pending tail call themselves — so the
+deferral is recorded where the tail call is BUILT (`tail_call_inner`) rather than where it
+happens to be consumed.
+
+**What an abandoned frame owes, it owes the deferred set too.** The exits no resume can
+reach run the set rather than parking it: an **error** exit whose frame the entrant does not
+park — the same `walk_abandoned` question the release table's walk asks
+([mechanism.md](mechanism.md) § "An abandoned frame runs the releases it still owes") — and a
+**squelch** boundary, which turns the signal into an error the abandoned activation never
+catches. Both stand exactly where the clean break stands: nothing replays the frame, so the
+decref the activation took over is at its last chance to run.
+
+The signal's payload needs no exemption here, unlike the release table's own routes. A
+deferred region is a per-call closure region or a merged arena; a raise's payload is either a
+value the native built into its own fresh call region — nobody's argument, so it is in
+neither — or one of the call's arguments, whose delivery the raise mints
+(`mint_raised_argument_delivery`), which is precisely what lets the frame's own references
+go. The shape that looks like a counterexample is the one the defect was filed on: a payload
+the raiser reaches through the tail-called closure's **captured environment**, where the
+env's counted edge is the value's last holder once the frame-exit relocation has run the
+binding's own release ahead of the `TailCall`. Releasing the closure region cascades that
+edge away — and the value survives on the raise's mint, which is a reference no frame holds.
 
 **Park/unpark symmetry — what a park retains, and who releases it.** These rules keep a
 parked fiber's accounting symmetric with its unpark:
@@ -513,45 +557,48 @@ parked fiber's accounting symmetric with its unpark:
   (`tests/elle/async-error-propagation.lisp` § 4 is the pinning corpus shape; the
   `region-fiber-park-symmetry.lisp` restart face churns the mechanism).
 
-A park moves the activation's owner node into the suspended frame: a suspending exit — a
+A park moves the activation's dues into the suspended frame: a suspending exit — a
 yield, a suspending native, `fiber/resume`'s SIG_SWITCH handoff, a fuel pause, a capability
-denial — parks the activation's continuation as a `BytecodeFrame`; the frame **takes** the
-activation's node (`BytecodeFrame::activation_owner_node`, a parameter of
+denial — parks the activation's continuation as a `BytecodeFrame`; the frame **takes** what
+the activation owed (`BytecodeFrame::activation_dues`, a parameter of
 `BytecodeFrame::suspend` so every suspend site must decide it) exactly as it carries the
 activation's `activation_region_map`. The members stay Owned (RC frozen) across the park,
 so the node is the only route to them; losing it at the suspend would strand every adopted
 member. Where the park is built by the *caller* of the already-unwound activation (a fiber
 body's pause in `do_fiber_first_resume`, a callee interrupted mid-instruction in
-`call_inner`), the node rides out in `ExecResult::activation_owner_node`, captured by
+`call_inner`), the record rides out in `ExecResult::activation_dues`, captured by
 `execute_bytecode_saving_stack` beside the region map just before the frame pops.
-`resume_suspended` restores the parked node into the slot beside
-`restore_activation_region_map`, so the resumed body's normal completion frees it through
-the same trampoline clean break, and a body that parks again re-captures it (the yield
-handler's take, or the re-suspend frame built from the exec result). The node is **moved**
-at every step — taken from the slot into exactly one frame, restored from the frame into
-exactly one live slot, never cloned — so a second release path is unrepresentable by
-construction. Pinned by
+`resume_suspended` restores the parked record into the slot beside
+`restore_activation_region_map`, so the resumed body's normal completion discharges it
+through the same trampoline clean break, and a body that parks again re-captures it (the
+yield handler's take, or the re-suspend frame built from the exec result). The record is
+**moved** at every step — taken from the slot into exactly one frame, restored from the
+frame into exactly one live slot, never cloned — so a second release path is
+unrepresentable by construction. Pinned by
 `runtime::tests::ownership::activation_owner_node_survives_yield_resume_completion`,
 `…_survives_repeated_parks`, and `…_rides_exec_result_across_fuel_pause` (interpreter park /
 re-park / caller-built park), and `jit::suspend::tests::park` (the JIT yield side-exit
 parks the node; the interpreted resume completes and frees it).
 
-**A discard frees the parked node (squelch/abort = subtree drop).** Abandoning suspended
+**A discard frees the parked dues (squelch/abort = subtree drop).** Abandoning suspended
 work — a squelch/attune signal-violation, an abort — flows through one chokepoint,
 `VM::discard_suspended_frames` (reached from `enforce_squelch` on every tier: the
 interpreter trampoline, `compile/run-on`, and the JIT call paths). The discarded frames'
 continuations will never run, so the completion release above never fires for them; the
 chokepoint therefore runs it *at the discard*: each discarded `BytecodeFrame`'s parked node
 gets the same one tolerant decref — rc 1→0, subtree drop over node + adopted members, the
-Shared frontier cascading once from the recorded `outgoing` tables. This frees **only** the
-node: the regions named by the frame's `activation_region_map` are a borrowed view —
-possibly shared with an outer, non-discarded frame or the activation that catches the
-squelch — and releasing them here would over-release (the historical squelch double-free);
-a node's members, by contrast, are exactly the regions the inference proved externally
-unique and moved in through `AdoptIntoActivation`, so the discard release cannot touch a
-region any live frame still counts on. A frame dropped *outside* the chokepoint (an
-abandoned error park) still abandons its node — a bounded leak, never a double-free (the
-members have no count for any other release route to reach). Pinned by
+Shared frontier cascading once from the recorded `outgoing` tables — and each release the
+frame's activation took over from its own tail calls gets the plain decref its emitting
+instruction never ran. This frees **only** the dues: the regions named by the frame's
+`activation_region_map` are a borrowed view — possibly shared with an outer, non-discarded
+frame or the activation that catches the squelch — and releasing them here would
+over-release (the historical squelch double-free); a node's members, by contrast, are
+exactly the regions the inference proved externally unique and moved in through
+`AdoptIntoActivation`, and a deferred region is one the compiler itself named as this
+activation's to release, so the discard cannot touch a region any live frame still counts
+on. A frame dropped *outside* the chokepoint (an abandoned error park) still abandons its
+dues — a bounded leak, never a double-free (the members have no count for any other release
+route to reach). Pinned by
 `runtime::tests::ownership::discard_frees_parked_activation_owner_node` (single frame and
 multi-frame chains; the member's generation bumps at the discard, bounded across repeated
 park-discard cycles) with the full-stdlib squelch corpus under `--trace=guardfree` as the
@@ -588,9 +635,10 @@ the teardown below gathers every parked node under the fiber node for one set-dr
 **Fiber teardown frees everything the fiber owns.** The members a fiber owns are released
 at its **terminal** transitions, through one take-then-release pair
 (`take_fiber_owned` / `release_fiber_owned`, `src/vm/fiber.rs`): the taking empties the
-fiber's owned slots (each still-parked `BytecodeFrame`'s activation owner node, the fiber
-node, and — via `Fiber::take_parked_state` — the parked non-terminal signal whose park
-escape retain the resume path can no longer consume) under the fiber borrow; the releasing
+fiber's owned slots (each still-parked `BytecodeFrame`'s activation owner node and deferred
+tail-call releases, the fiber node, and — via `Fiber::take_parked_state` — the parked
+non-terminal signal whose park escape retain the resume path can no longer consume) under
+the fiber borrow; the releasing
 then runs against the heap with the borrow already dropped, so heap mutation never overlaps
 fiber access and a cascade that frees the fiber's own heap value cannot invalidate a live
 borrow. A hard kill takes BEFORE installing its terminal error, so the superseded parked
@@ -622,7 +670,8 @@ or capability-denied fiber nobody restarts — reaches no teardown call, so the 
 where its demise is actually observed: the region free. When a dying region's pages hold a
 `Fiber` object, `RegionStore::teardown_set` takes that fiber's parked state (the same
 `Fiber::take_parked_state` set the terminal teardown consumes: parked activation owner
-nodes, the fiber owner node, the parked non-terminal signal's escape retain, and each
+nodes and deferred tail-call releases, the fiber owner node, the parked non-terminal
+signal's escape retain, and each
 parked frame's own owed releases — read off its two release tables, with the signal
 payload's region exempted only where the raise did not mint the delivery itself,
 [mechanism.md](mechanism.md) § "An abandoned frame runs the releases it still owes") and feeds

--- a/docs/impl/selfrec.md
+++ b/docs/impl/selfrec.md
@@ -101,7 +101,7 @@ branches — `(begin (stmt …) (go k))`, `(if c go (go k))` — and the frame i
 the same. On the paths that take the tail call the scope end is dead and the
 deferral supplies it; on a path that falls through instead — a sibling arm, or a callee
 that turns out to be a native and keeps the frame — the scope-end `DecrefRegion` runs live
-and no deferral is recorded at all (`tail_call_inner` builds `DeferredReleases` only on
+and no deferral is recorded at all (`tail_call_inner` records one only on
 the closure arm). The two channels are exclusive per path by construction, so a body whose
 paths disagree needs no choice made for it.
 
@@ -166,10 +166,13 @@ cell-free case.
 In both stranded cases the runtime **deferred release** supplies it.
 `tail_callee_defers_release` (`lir/lower/control/call.rs`) returns true for every tail call to a
 `stranded_self_bindings` callee (§ "The deferral needs no escape gate"); the `TailCall` then
-carries `DeferredReleases::callee = region_of(callee)`, and `trampoline_loop` (`vm/execute.rs`)
-decrefs each deferred region exactly once on the recursion's **normal completion** (deduped — a
-tail-recursive `loop` re-enters with the same closure each iteration but carries one
-stranded decref).
+carries the callee channel's `region_of(callee)`, `tail_call_inner` records it on the
+activation, and the activation decrefs each deferred region exactly once when it ends
+(deduped — a tail-recursive `loop` re-enters with the same closure each iteration but carries
+one stranded decref). Which ends it takes — the recursion's normal completion, a park it is
+resumed out of, or an abandonment no resume reaches — is the activation owner node's question
+and is answered beside it ([region/owner.md](region/owner.md) § "A deferred tail-call release
+has the node's life").
 
 That marking is consulted **before** the predicate's demise reading, which asks whether some
 region's `decref_point` is this call node. The stranded binding's release is at its binder's
@@ -207,13 +210,13 @@ call:
 - any **container's**, taken by the store funnel when the closure is stored on the way out
   — the store facet, which never refused.
 
-The deferral runs at the recursion's **normal completion**: `trampoline_loop` breaks only
-once the final body has returned, so every `Return` mint on the taken path has already
-executed. The order over one call is: frame reference taken, callee mint, deferred release,
-caller's release — and between the mint and the caller's release the standing reference is
-the caller's. On a path that returns something *else* no mint fired and no one else holds
-the region, so the deferral's decref is the last reference and freeing there is exactly
-right.
+On the **normal completion** the order over one call is: frame reference taken, callee mint,
+deferred release, caller's release — the trampoline breaks only once the final body has
+returned, so every `Return` mint on the taken path has already executed, and between the mint
+and the caller's release the standing reference is the caller's. On a path that returns
+something *else* no mint fired and no one else holds the region, so the deferral's decref is
+the last reference and freeing there is exactly right. An **abandoned** exit is that second
+case: the callee never returned, so it minted nothing and handed the closure to nobody.
 
 This is the same "the retain on this node funds this release" argument the frame-exit
 relocation makes for a returned region ([region/mechanism.md](region/mechanism.md) § "The

--- a/src/jit/calls/callops/arraycall.rs
+++ b/src/jit/calls/callops/arraycall.rs
@@ -365,12 +365,13 @@ fn jit_tail_call_inner(
             env: new_env,
             closure: func,
             squelch_mask: closure.squelch_mask,
-            // JIT tail-call path: closure-callee adoption not yet wired here.
-            // Leaving the channels empty keeps the region held to the activation's
-            // own teardown — a bounded over-keep, never an over-free — until the
-            // adopt-and-release is extended to the JIT trampolines.
-            deferred: Default::default(),
         });
+        // A deferral this spliced JIT tail call strands is not recorded on the
+        // activation's dues: the callee-release and merged-arena channels are not
+        // wired on this path, so the region stays held to the activation's own
+        // teardown — a bounded over-keep, never an over-free — until they are
+        // (docs/impl/region/owner.md § "A deferred tail-call release has the
+        // node's life").
 
         return TAIL_CALL_SENTINEL;
     }

--- a/src/jit/compiler/tests.rs
+++ b/src/jit/compiler/tests.rs
@@ -132,7 +132,7 @@ fn make_adopt_into_activation_lir() -> LirFunction {
 /// `runtime::tests::ownership::activation_owner_node_frees_adopted_member_on_normal_completion`.
 /// The compiled body adopts its argument's region into the activation's
 /// lazily-minted owner node (`elle_jit_adopt_into_activation`); the compiled
-/// `Return` path must free the node (`elle_jit_release_activation_owner_node`),
+/// `Return` path must free the node (`elle_jit_release_activation_dues`),
 /// whose subtree drop reclaims the member — its generation bumps and the live
 /// region count stays bounded across 50 calls. The member is Owned (count
 /// consumed by the adopt), so if the Return-path release is not emitted, NOTHING

--- a/src/jit/dispatch/region.rs
+++ b/src/jit/dispatch/region.rs
@@ -297,14 +297,14 @@ pub extern "C" fn elle_jit_adopt_into_activation(child_tag: u64, child_payload: 
 
 /// Free the current activation's owner node at the compiled function's normal
 /// completion — the JIT twin of the interpreter trampoline's clean-break
-/// release (`VM::release_activation_owner_node`). Emitted on the `Return` path
+/// release (`VM::release_activation_dues`). Emitted on the `Return` path
 /// (before the region-map pop) of a function whose LIR carries
 /// `AdoptIntoActivation`; a function that cannot mint a node never pays the
 /// call.
 #[no_mangle]
-pub extern "C" fn elle_jit_release_activation_owner_node(vm: *mut ()) {
+pub extern "C" fn elle_jit_release_activation_dues(vm: *mut ()) {
     let vm = unsafe { &mut *(vm as *mut crate::vm::VM) };
-    vm.release_activation_owner_node();
+    vm.release_activation_dues();
 }
 
 /// Run the releases a COMPILED activation abandoned by an **error** still owed —

--- a/src/jit/dispatch/tests.rs
+++ b/src/jit/dispatch/tests.rs
@@ -405,7 +405,7 @@ fn adopt_region_freezes_child_and_subtree_drops_with_parent() {
 /// `handle_adopt_into_activation`: it resolves the child Value to its runtime
 /// region, lazily mints the current activation's pages-less owner node, and
 /// moves the child `Counted → Owned` (count consumed). Releasing the node
-/// (`VM::release_activation_owner_node`, the completion free both tiers share)
+/// (`VM::release_activation_dues`, the completion free both tiers share)
 /// then subtree-drops node + member as one unit. A no-op (broken) helper would
 /// leave the child `Counted(1)` and the release would reclaim nothing — both
 /// assertions catch it.
@@ -437,7 +437,7 @@ fn adopt_into_activation_adopts_into_lazily_minted_node() {
     // The node was lazily minted into the current (base) activation slot;
     // releasing it reclaims node + adopted member as one subtree.
     let before = unsafe { &*heap_ptr }.active_region_count();
-    vm.release_activation_owner_node();
+    vm.release_activation_dues();
     let after = unsafe { &*heap_ptr }.active_region_count();
     assert_eq!(
         before - after,
@@ -458,7 +458,7 @@ fn adopt_into_activation_immediate_child_mints_no_node() {
     let n = Value::int(42);
     elle_jit_adopt_into_activation(n.tag, n.payload, &mut vm as *mut VM as *mut ());
     assert!(
-        vm.take_activation_owner_node().is_none(),
+        vm.take_activation_dues().is_empty(),
         "an immediate child must not mint an owner node"
     );
     assert_eq!(

--- a/src/jit/suspend.rs
+++ b/src/jit/suspend.rs
@@ -198,11 +198,11 @@ pub extern "C" fn elle_jit_yield(
         let resume_ip = yield_meta.resume_ip;
         trace_park("jit-yield", closure, yield_index, resume_ip, &env, &stack);
         check_parked_frame("elle_jit_yield", closure, resume_ip, &env, &stack);
-        // MOVE the activation's owner node into the frame (its slot is
+        // MOVE what the activation owes into the frame (its slot is
         // likewise still on top) so it rides the park to the resumed body's
         // completion — the compiled twin of the interpreter yield park
         // (docs/impl/region/owner.md § "Owner nodes").
-        let activation_owner_node = vm.take_activation_owner_node();
+        let activation_dues = vm.take_activation_dues();
         // The yielding body's own closure — park it so a self-edge resolved after
         // resume (re-entering via the interpreter) names the right closure. The JIT
         // already threads it here for self-tail-call detection.
@@ -213,7 +213,7 @@ pub extern "C" fn elle_jit_yield(
             stack,
             true,
             activation_region_map,
-            activation_owner_node,
+            activation_dues,
             closure_val,
             vm.heap(),
         ));
@@ -320,9 +320,9 @@ pub extern "C" fn elle_jit_yield_through_call(
         &env,
         &stack,
     );
-    // MOVE the caller's owner node into its park — this compiled activation
+    // MOVE what the caller's activation owes into its park — this compiled activation
     // unwinds with the callee's suspending signal (see elle_jit_yield).
-    let activation_owner_node = vm.take_activation_owner_node();
+    let activation_dues = vm.take_activation_dues();
     // The caller body's own closure (see elle_jit_yield) — park it for the resume.
     let caller_frame = SuspendedFrame::Bytecode(BytecodeFrame::suspend(
         code,
@@ -331,7 +331,7 @@ pub extern "C" fn elle_jit_yield_through_call(
         stack,
         true,
         activation_region_map,
-        activation_owner_node,
+        activation_dues,
         closure_val,
         vm.heap(),
     ));

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -101,9 +101,17 @@ pub(crate) struct FunctionTranslator<'a> {
     /// Module's closure list for MakeClosure → ClosureId lookup.
     pub(crate) module_closures: Vec<crate::lir::LirFunction>,
     /// Whether this function's LIR carries an `AdoptIntoActivation` — computed
-    /// once at construction so the `Return` path emits the owner-node release
-    /// (`elle_jit_release_activation_owner_node`) only for a function that can
+    /// once at construction so the `Return` path emits the dues release
+    /// (`elle_jit_release_activation_dues`) only for a function that can
     /// have minted a node; the common path pays no extra helper call.
+    ///
+    /// The node is the whole of what a COMPILED activation can owe: the deferred
+    /// tail-call releases are recorded by the interpreter's `tail_call_inner`
+    /// alone, and the JIT's own tail-call path leaves both channels unwired
+    /// (`jit_tail_call_inner`). Wiring them means gating this on the deferral
+    /// too, or the release the compiled `Return` skips is the one nothing else
+    /// runs (docs/impl/region/owner.md § "A deferred tail-call release has the
+    /// node's life").
     pub(crate) uses_activation_owner_node: bool,
 }
 

--- a/src/jit/translate/terminator.rs
+++ b/src/jit/translate/terminator.rs
@@ -90,10 +90,9 @@ impl<'a> FunctionTranslator<'a> {
                     let vm = self.vm_ptr.ok_or_else(|| {
                         JitError::InvalidLir("owner-node release without vm pointer".to_string())
                     })?;
-                    let func_ref = self.module.declare_func_in_func(
-                        self.helpers.release_activation_owner_node,
-                        builder.func,
-                    );
+                    let func_ref = self
+                        .module
+                        .declare_func_in_func(self.helpers.release_activation_dues, builder.func);
                     builder.ins().call(func_ref, &[vm]);
                 }
                 self.emit_pop_then_return(builder, tag, payload)?;

--- a/src/jit/vtable.rs
+++ b/src/jit/vtable.rs
@@ -145,7 +145,7 @@ pub(crate) struct RuntimeHelpers {
     pub(crate) adopt_into_activation: FuncId,
     /// Free the current activation's owner node at the compiled `Return` path —
     /// the JIT twin of the interpreter trampoline's clean-break release.
-    pub(crate) release_activation_owner_node: FuncId,
+    pub(crate) release_activation_dues: FuncId,
     /// Run the releases this compiled activation still owed at an **error** exit
     /// — the compiled entry to the interpreter's abandoned-frame walk.
     pub(crate) release_abandoned_frame: FuncId,
@@ -449,8 +449,8 @@ pub(crate) fn register_symbols(builder: &mut JITBuilder) {
         dispatch::elle_jit_adopt_into_activation as *const u8,
     );
     builder.symbol(
-        "elle_jit_release_activation_owner_node",
-        dispatch::elle_jit_release_activation_owner_node as *const u8,
+        "elle_jit_release_activation_dues",
+        dispatch::elle_jit_release_activation_dues as *const u8,
     );
     builder.symbol(
         "elle_jit_release_abandoned_frame",

--- a/src/jit/vtable/helpers.rs
+++ b/src/jit/vtable/helpers.rs
@@ -245,11 +245,11 @@ pub(crate) fn declare_helpers(module: &mut JITModule) -> Result<RuntimeHelpers, 
             "elle_jit_adopt_into_activation",
             &make_sig(module, &[I64, I64, I64], &[]),
         )?,
-        // release_activation_owner_node: (vm) -> () — the compiled Return
+        // release_activation_dues: (vm) -> () — the compiled Return
         // path's owner-node free.
-        release_activation_owner_node: declare(
+        release_activation_dues: declare(
             module,
-            "elle_jit_release_activation_owner_node",
+            "elle_jit_release_activation_dues",
             &make_sig(module, &[I64], &[]),
         )?,
         // release_abandoned_frame: (vm, slots_ptr, num_slots, regions_ptr,

--- a/src/lir/lower/binding/let.rs
+++ b/src/lir/lower/binding/let.rs
@@ -304,15 +304,14 @@ impl<'a> Lowerer<'a> {
         // past the `TailCall`, so the decref never runs and the region leaks. Mark such
         // bindings stranded BEFORE lowering the body, so a tail call to one (`(loop k)`
         // here, or its own `(loop …)` self-call) defers the region's release — the
-        // runtime's
-        // `deferred_releases` supplies the stranded decref exactly once.
+        // activation's own dues supply the stranded decref exactly once.
         //
         // The premise is a tail call to THIS binding, not a body that is wholly one:
         // a body reaches its tail call through statements (`(begin (yield go) (go n))`)
         // and through branches, and the scope end is dead on exactly the paths that
         // take a tail call. A path that falls through instead — a sibling `if` arm, a
         // native callee that keeps the frame — runs the live scope-end decref and
-        // records no deferral (`tail_call_inner` builds `DeferredReleases` only on the
+        // records no deferral (`tail_call_inner` records one only on the
         // closure arm), so the two are mutually exclusive per path rather than
         // alternatives to choose between. Without the tail-call premise a body that
         // never replaces the frame would defer a decref that also fires live — a

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -285,8 +285,10 @@ pub struct Lowerer<'a> {
     /// so the closure's scope-end `DecrefRegion` is emitted as dead code past that
     /// frame-replacing `TailCall` and never runs — the per-call closure region would
     /// otherwise leak. `tail_callee_defers_release` routes a tail call to such a binding
-    /// through the runtime's `deferred_releases` release (`vm/execute.rs`), which frees
-    /// the region exactly once at the recursion's normal completion. Gating on the
+    /// through the activation's own deferred set (`ActivationDues`), which frees
+    /// the region exactly once at whichever end that activation reaches
+    /// (docs/impl/region/owner.md § "A deferred tail-call release has the node's
+    /// life"). Gating on the
     /// tail-call body is what keeps the deferral from double-freeing a self-recursive
     /// closure whose `DecrefRegion` instead fires live (a non-tail body) — the
     /// use-after-free that gate prevents.

--- a/src/lir/types/instr.rs
+++ b/src/lir/types/instr.rs
@@ -131,8 +131,8 @@ pub enum LirInstr {
         /// is dead past this frame-replacing `TailCall`, so when the callee turns
         /// out to be a **closure** at runtime (a redefined operator, a foreign
         /// fn) the new activation resolves this slot through its region map and
-        /// ADOPTS the arena — `deferred_releases` frees it once at the recursion's
-        /// completion. When the callee is a **native** (a `NativeFn` — a funnel
+        /// ADOPTS the arena onto its own dues, which free it once at whichever
+        /// end that activation reaches. When the callee is a **native** (a `NativeFn` — a funnel
         /// op like `%array-push`, or a rebound operator's value-position face) the
         /// frame is NOT replaced, this slot is never consumed, and the live
         /// scope-exit `DecrefRegion` frees the arena instead — the two paths are

--- a/src/runtime/tests/ownership/anode.rs
+++ b/src/runtime/tests/ownership/anode.rs
@@ -221,7 +221,7 @@ fn activation_owner_node_survives_repeated_parks() {
     );
 }
 
-/// The node rides `ExecResult::activation_owner_node` when the park is built by
+/// The node rides `ExecResult::activation_dues` when the park is built by
 /// the CALLER of the already-unwound activation — the fuel-pause channel
 /// (docs/impl/region/owner.md § "Owner nodes"). A fuel pause (unlike a yield)
 /// creates no suspended frame inside the dispatch loop: the activation unwinds
@@ -297,7 +297,7 @@ fn activation_owner_node_rides_exec_result_across_fuel_pause() {
             result.stack,
             !result.bits.intersects(crate::value::SIG_FUEL),
             result.activation_region_map,
-            result.activation_owner_node,
+            result.activation_dues,
             result.current_closure,
             vm.heap(),
         );

--- a/src/runtime/tests/ownership/fnode.rs
+++ b/src/runtime/tests/ownership/fnode.rs
@@ -152,7 +152,7 @@ fn fiber_owner_node_survives_parks_and_frees_at_completion() {
             vec![],
             true,
             rustc_hash::FxHashMap::default(),
-            Some(node_b),
+            crate::value::fiber::ActivationDues::with_owner_node(node_b),
             crate::value::Value::NIL,
             unsafe { &*heap_ptr },
         );
@@ -863,7 +863,7 @@ fn a_primitive_park_delivery_is_worth_one_retain() {
             vec![],
             true,
             rustc_hash::FxHashMap::default(),
-            None,
+            crate::value::fiber::ActivationDues::default(),
             crate::value::Value::NIL,
             unsafe { &*heap_ptr },
         );

--- a/src/value/AGENTS.md
+++ b/src/value/AGENTS.md
@@ -19,6 +19,7 @@ Runtime value representation using a tagged union.
 | `types.rs` | `Arity`, `SymbolId`, `NativeFn`, `TableKey`, sorted-struct helpers |
 | `closure.rs` | `Closure` (template + env + squelch mask), `ClosureTemplate`, `TemplateRef` |
 | `fiber.rs` | `Fiber`, `FiberHandle`, `WeakFiberHandle`, `SuspendedFrame`, `Frame`, `FiberStatus`; re-exports `SignalBits` (from `fiber/signalbits.rs`) and the `SIG_*` constants (from `crate::signals`) |
+| `fiber/dues.rs` | `ActivationDues` — what one activation owes the region system when it ends: its owner node and the releases it took over from frame-replacing tail calls, carried as one record so a park moves both or neither (docs/impl/region/owner.md § "A deferred tail-call release has the node's life") |
 | `fiber/delivery.rs` | `Delivery` — the delivery ledger: how the current park's delivery references are funded, with a method-only surface (docs/impl/region/owner.md § "A park names its funding in the delivery ledger") |
 | `error.rs` | `rich_error!` macro plus `error_val_in()`, `error_val_extra_in()`, `match_fail_error_in()`, and `format_error()` for region-coherent error structs (docs/impl/region/errors.md) |
 | `ffi.rs` | `LibHandle` for C interop |

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -21,6 +21,9 @@ pub use status::*;
 mod delivery;
 pub use delivery::Delivery;
 
+mod dues;
+pub use dues::ActivationDues;
+
 mod signalbits;
 pub use signalbits::SignalBits;
 
@@ -172,19 +175,21 @@ pub struct Fiber {
     /// covers the top level). Carried on the fiber so it survives yields.
     pub activation_region_maps: Vec<rustc_hash::FxHashMap<u32, crate::hir::region::MappedRegion>>,
 
-    /// The per-activation OWNER-NODE slots, parallel to `activation_region_maps`
-    /// (one entry per activation frame; pushed/popped only through
+    /// The per-activation DUES slots, parallel to `activation_region_maps` (one
+    /// entry per activation frame; pushed/popped only through
     /// `VM::push_activation_region_map` / `restore_activation_region_map` /
     /// `pop_activation_region_map`, which keep the two stacks in lockstep). An
-    /// entry holds the activation's pages-less owner-node region — the forest
-    /// root `AdoptIntoActivation` adopts members into (docs/impl/region/owner.md
-    /// § "Owner nodes — an activation as a forest root") — or `None` until the
-    /// activation's first adopt lazily mints it. Freed at the activation's
-    /// normal completion (`VM::release_activation_owner_node`); a suspend MOVES
-    /// the slot's node into the parked frame
-    /// ([`BytecodeFrame::activation_owner_node`]) and the resume restores it,
-    /// so the node reaches that completion across any number of parks.
-    pub activation_owner_nodes: Vec<Option<crate::hir::region::RuntimeRegion>>,
+    /// entry holds what the activation owes the region system when it ends: its
+    /// pages-less owner-node region — the forest root `AdoptIntoActivation`
+    /// adopts members into (docs/impl/region/owner.md § "Owner nodes — an
+    /// activation as a forest root") — and the releases it took over from
+    /// frame-replacing tail calls. Discharged at the activation's normal
+    /// completion (`VM::release_activation_dues`); a suspend MOVES the whole
+    /// record into the parked frame ([`BytecodeFrame::activation_dues`]) and the
+    /// resume restores it, so both reach that completion across any number of
+    /// parks (docs/impl/region/owner.md § "A deferred tail-call release has the
+    /// node's life").
+    pub activation_dues: Vec<ActivationDues>,
 
     /// The FIBER's own owner node — the pages-less forest root for a region whose
     /// owner is the fiber itself, outliving every single activation
@@ -278,6 +283,14 @@ pub struct ParkedState {
     /// can be stale (its value's release was emitted value-based, or died past a
     /// tail call), so a blanket map release double-frees a possibly-recycled id.
     pub nodes: Vec<crate::hir::region::RuntimeRegion>,
+    /// The releases each still-parked `BytecodeFrame`'s activation took over from
+    /// its own frame-replacing tail calls, in chain order. Kept apart from
+    /// [`Self::nodes`] because the two are freed differently: a node's members are
+    /// gathered under the fiber node before its subtree drop, while a deferred
+    /// region is `Counted` throughout and takes the plain decref its emitting
+    /// instruction never ran (docs/impl/region/owner.md § "A deferred tail-call
+    /// release has the node's life").
+    pub deferred: Vec<crate::hir::region::RuntimeRegion>,
     /// The parked NON-TERMINAL signal (a yielded value, a yielding io request, a
     /// capability-denial payload) — its park took exactly one escape retain
     /// (`EmitEscape` / `SuspendEscape`) whose symmetric release lives on the
@@ -348,6 +361,7 @@ impl Fiber {
     /// across two discharges.
     pub fn take_parked_state(&mut self) -> ParkedState {
         let mut nodes = Vec::new();
+        let mut deferred = Vec::new();
         let mut owed = Vec::new();
         let mut owed_regions = Vec::new();
         let mut owns_signal = false;
@@ -362,7 +376,8 @@ impl Fiber {
                 if i == 0 {
                     owns_signal = true;
                 }
-                nodes.extend(f.activation_owner_node);
+                nodes.extend(f.activation_dues.owner_node);
+                deferred.extend(f.activation_dues.deferred.iter().copied());
                 // The releases this frame still owed. Its locals sit at the base
                 // of the saved stack (the activation's own frame base, the stack
                 // having been emptied at entry), so the emitter's slot indexes
@@ -411,6 +426,7 @@ impl Fiber {
         }
         ParkedState {
             nodes,
+            deferred,
             signal,
             owed,
             owed_regions,
@@ -439,7 +455,7 @@ impl Fiber {
             delivery: Delivery::new(),
             suspended: None,
             activation_region_maps: vec![rustc_hash::FxHashMap::default()],
-            activation_owner_nodes: vec![None],
+            activation_dues: vec![ActivationDues::default()],
             fiber_owner_node: None,
             current_closure: Value::NIL,
             call_depth: 0,
@@ -475,7 +491,7 @@ impl Fiber {
             delivery: Delivery::new(),
             suspended: None,
             activation_region_maps: vec![rustc_hash::FxHashMap::default()],
-            activation_owner_nodes: vec![None],
+            activation_dues: vec![ActivationDues::default()],
             fiber_owner_node: None,
             current_closure: Value::NIL,
             call_depth: 0,

--- a/src/value/fiber/dues.rs
+++ b/src/value/fiber/dues.rs
@@ -1,0 +1,79 @@
+//! What one activation owes the region system when it ends.
+//!
+//! Two obligations, one life. The **owner node** is the pages-less forest root
+//! `AdoptIntoActivation` adopts members into; the **deferred set** is the
+//! releases a frame-replacing tail call stranded, which the new activation took
+//! over. Both must reach the activation's normal completion across however many
+//! parks it takes on the way, and both must be discharged where the activation
+//! is abandoned instead (docs/impl/region/owner.md § "A deferred tail-call
+//! release has the node's life").
+//!
+//! Carrying them as one record is what makes the move discipline enforceable:
+//! every site that takes the slot, parks it in a `BytecodeFrame`, restores it,
+//! or releases it handles both or neither. Split into two carriers, a park that
+//! moved one and dropped the other would be a leak on one side and a strand on
+//! the other, and nothing would fail on it.
+
+use crate::hir::region::RuntimeRegion;
+
+/// The region obligations of one activation, held in `Fiber::activation_dues`
+/// (one entry per activation frame, parallel to `activation_region_maps`) and
+/// MOVED into `BytecodeFrame::activation_dues` for the duration of a park.
+///
+/// `Clone` exists because `BytecodeFrame` is cloneable, and a clone duplicates
+/// obligations: two records naming one region release it twice. The clone sites
+/// are the frame-chain hand-offs that drop the original in the same breath
+/// (`resume_suspended` re-parking the frames it did not reach), never a way to
+/// hold the same dues in two live places.
+#[derive(Debug, Default, Clone)]
+pub struct ActivationDues {
+    /// The activation's owner node — the forest root minted lazily on the first
+    /// `AdoptIntoActivation`, whose single decref subtree-drops every member the
+    /// activation adopted. `None` for an activation that never adopted.
+    pub owner_node: Option<RuntimeRegion>,
+    /// The per-call regions this activation took over from frame-replacing tail
+    /// calls: the callee closure's own region, and the merged closure-cycle
+    /// arena a letrec body tail-called out of. Each is owed exactly ONE decref,
+    /// which is why [`Self::defer`] dedupes — a tail-recursive `go` re-enters
+    /// with the same closure every iteration and strands one release, not one
+    /// per step.
+    pub deferred: Vec<RuntimeRegion>,
+}
+
+impl ActivationDues {
+    /// The dues of an activation that adopted `node` and deferred nothing — the
+    /// shape a test builds a park from directly, where the production sites take
+    /// the whole record off the live slot.
+    pub fn with_owner_node(node: RuntimeRegion) -> Self {
+        ActivationDues {
+            owner_node: Some(node),
+            deferred: Vec::new(),
+        }
+    }
+
+    /// Whether this activation owes nothing at all.
+    pub fn is_empty(&self) -> bool {
+        self.owner_node.is_none() && self.deferred.is_empty()
+    }
+
+    /// Take over one stranded release, ignoring a region already owed. Called
+    /// where the tail call is BUILT (`tail_call_inner`), so the deferral is
+    /// recorded on the activation that owes it whether or not the interpreter
+    /// trampoline is the loop that consumes the pending call.
+    pub fn defer(&mut self, region: RuntimeRegion) {
+        if !self.deferred.contains(&region) {
+            self.deferred.push(region);
+        }
+    }
+
+    /// Take the deferred set alone, leaving the node in place. The abandoned
+    /// exits run these where the clean break would have; the node's own
+    /// disposal there is a separate question (it rides out to the caller that
+    /// may still park the frame).
+    pub fn take_deferred(&mut self) -> Vec<RuntimeRegion> {
+        std::mem::take(&mut self.deferred)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/value/fiber/dues/tests.rs
+++ b/src/value/fiber/dues/tests.rs
@@ -1,0 +1,66 @@
+//! What one activation's dues record owes, and what it refuses to owe twice.
+
+use super::*;
+
+/// The ledger never dereferences a region — it only records and compares ids —
+/// so any distinct real id serves. The trap: `RuntimeRegion::new` refuses the
+/// reserved low ids, so a test id must start above them.
+fn region(id: u32) -> RuntimeRegion {
+    RuntimeRegion::new(id).expect("test region ids are above the reserved range")
+}
+
+#[test]
+fn a_repeated_deferral_is_owed_once() {
+    // The trap: a tail-recursive `go` re-enters the activation with the SAME
+    // closure every iteration, so the same region is deferred once per step —
+    // but the frame took exactly one reference and owes exactly one decref.
+    // Counter-factual: pushing unconditionally releases N times for one
+    // reference, freeing the closure under the recursion still running in it.
+    let mut dues = ActivationDues::default();
+    dues.defer(region(7));
+    dues.defer(region(7));
+    dues.defer(region(7));
+    assert_eq!(
+        dues.deferred,
+        vec![region(7)],
+        "one reference, one release, however many tail calls named it",
+    );
+}
+
+#[test]
+fn distinct_deferrals_are_each_owed() {
+    // A single tail call can strand both channels — a merged closure-cycle
+    // arena and the callee closure's own region — and each names a reference
+    // the frame separately owns.
+    let mut dues = ActivationDues::default();
+    dues.defer(region(3));
+    dues.defer(region(4));
+    assert_eq!(dues.deferred, vec![region(3), region(4)]);
+}
+
+#[test]
+fn the_abandoned_take_leaves_the_node_standing() {
+    // An abandoned exit runs the deferred set and nothing else: the node rides
+    // out to the caller that may still park the frame.
+    let mut dues = ActivationDues::with_owner_node(region(9));
+    dues.defer(region(2));
+    assert_eq!(dues.take_deferred(), vec![region(2)]);
+    assert_eq!(
+        dues.owner_node,
+        Some(region(9)),
+        "the node is not the abandoned walk's to release",
+    );
+    assert!(
+        dues.take_deferred().is_empty(),
+        "a second take finds nothing — the release ran once",
+    );
+}
+
+#[test]
+fn an_activation_that_neither_adopted_nor_tail_called_owes_nothing() {
+    assert!(ActivationDues::default().is_empty());
+    assert!(!ActivationDues::with_owner_node(region(5)).is_empty());
+    let mut deferred_only = ActivationDues::default();
+    deferred_only.defer(region(6));
+    assert!(!deferred_only.is_empty());
+}

--- a/src/value/fiber/frame.rs
+++ b/src/value/fiber/frame.rs
@@ -48,17 +48,19 @@ pub struct BytecodeFrame {
     /// or — on a static-slot collision — a use-after-free). `resume_suspended`
     /// restores this as the activation's region frame before re-entering.
     pub activation_region_map: rustc_hash::FxHashMap<u32, crate::hir::region::MappedRegion>,
-    /// This activation's owner node at the moment of suspension — MOVED (taken,
-    /// never cloned) out of the activation's `Fiber::activation_owner_nodes`
-    /// slot by the suspend site, so the node lives in exactly one place: the
-    /// live slot or one parked frame (docs/impl/region/owner.md § "Owner nodes"
-    /// — "A park moves the node into the suspended frame"). Its members are
-    /// `Owned` (RC frozen) with no other release route, so the node must ride
-    /// the park to the resumed body's completion, where the trampoline's
-    /// clean-break release frees node + members. `resume_suspended` restores it
-    /// into the live slot beside `activation_region_map`. `None` for an
-    /// activation that never adopted (the node is minted lazily).
-    pub activation_owner_node: Option<crate::hir::region::RuntimeRegion>,
+    /// What this activation owed at the moment of suspension — MOVED (taken,
+    /// never cloned) out of the activation's `Fiber::activation_dues` slot by
+    /// the suspend site, so the record lives in exactly one place: the live slot
+    /// or one parked frame (docs/impl/region/owner.md § "Owner nodes" — "A park
+    /// moves the node into the suspended frame"). The owner node's members are
+    /// `Owned` (RC frozen) with no other release route, and the deferred set's
+    /// regions have no route at all — their emitting instruction died with the
+    /// frame the tail call replaced — so both must ride the park to the resumed
+    /// body's completion, where the trampoline's clean-break release runs them.
+    /// `resume_suspended` restores the record into the live slot beside
+    /// `activation_region_map`. Default (no node, nothing deferred) for an
+    /// activation that neither adopted nor tail-called.
+    pub activation_dues: crate::value::fiber::ActivationDues,
     /// The executing-closure register (`Fiber::current_closure`) at the moment this
     /// activation suspended. A yield unwinds the Rust call stack and restores the
     /// live register to the caller's value, so without parking it here a self-edge
@@ -103,7 +105,7 @@ impl BytecodeFrame {
         stack: Vec<Value>,
         push_resume_value: bool,
         activation_region_map: rustc_hash::FxHashMap<u32, crate::hir::region::MappedRegion>,
-        activation_owner_node: Option<crate::hir::region::RuntimeRegion>,
+        activation_dues: crate::value::fiber::ActivationDues,
         current_closure: Value,
         heap: &crate::value::fiberheap::FiberHeap,
     ) -> Self {
@@ -118,7 +120,7 @@ impl BytecodeFrame {
             stack,
             push_resume_value,
             activation_region_map,
-            activation_owner_node,
+            activation_dues,
             current_closure,
             #[cfg(debug_assertions)]
             region_borrows,

--- a/src/value/fiberheap/regionstore/free.rs
+++ b/src/value/fiberheap/regionstore/free.rs
@@ -280,6 +280,16 @@ impl RegionStore {
                     handle.try_with_mut(|fib| {
                         let parked = fib.take_parked_state();
                         discharged.extend(parked.nodes.iter().map(|r| r.get()));
+                        // The releases those activations took over from their own
+                        // frame-replacing tail calls (docs/impl/region/owner.md
+                        // § "A deferred tail-call release has the node's life").
+                        // The completion that would have run them is a
+                        // continuation this fiber can never re-enter. Unlike the
+                        // owed tables below, these name no value the payload could
+                        // be: a deferred region is the tail callee's own closure
+                        // region or a merged arena, and a raise's payload is
+                        // neither.
+                        discharged.extend(parked.deferred.iter().map(|r| r.get()));
                         if let Some(node) = fib.fiber_owner_node.take() {
                             discharged.push(node.get());
                         }

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -78,9 +78,12 @@ creating `SuspendedFrame`s or `TailCallInfo`.
 - `execute_bytecode` wraps raw slices in `Rc` once at the public boundary
 - `execute_bytecode_from_ip` / `execute_bytecode_saving_stack` take `&Rc`
 - `TailCallInfo` carries the tail callee's `Code`, env `Rc`, the callee closure
-  value (installed as `fiber.current_closure` on the frame replacement), its
-  squelch mask, and an optional adopt region — tail calls clone the `Rc`s (cheap),
-  not the `Vec`s (expensive)
+  value (installed as `fiber.current_closure` on the frame replacement), and its
+  squelch mask — tail calls clone the `Rc`s (cheap), not the `Vec`s (expensive).
+  The releases the call strands are NOT carried here: `tail_call_inner` records
+  them on the activation's own `ActivationDues`, which outlives whoever consumes
+  the pending call (docs/impl/region/owner.md § "A deferred tail-call release has
+  the node's life")
 - `closure_env` parameter is `&Rc<Vec<Value>>` (non-optional; empty Rc for no env)
 - `execute_closure_bytecode` takes `&Rc` params directly (no `.to_vec()` copy);
   used by JIT trampolines where the closure already owns Rc'd data

--- a/src/vm/call/inner.rs
+++ b/src/vm/call/inner.rs
@@ -19,7 +19,7 @@ impl VM {
     /// The `frames.is_empty()` guard leaves a deeper yield's already-parked chain
     /// untouched. `push_resume_value` is false for a fuel pause (the interrupted
     /// opcode re-executes from `ip`, injecting no extra value) and true otherwise.
-    /// The callee's region remap and owner node ride out in `result`, moved into
+    /// The callee's region remap and its activation's dues ride out in `result`, moved into
     /// the frame so the remap survives the yield (docs/impl/region/owner.md).
     pub(crate) fn park_suspended_callee_frame(
         &mut self,
@@ -35,7 +35,7 @@ impl VM {
                 result.stack,
                 !bits.intersects(SIG_FUEL),
                 result.activation_region_map,
-                result.activation_owner_node,
+                result.activation_dues,
                 result.current_closure,
                 self.heap(),
             );
@@ -274,10 +274,10 @@ impl VM {
                                 // instruction's result. The JIT callee runs without an
                                 // interpreter region frame; `caller_region_frame` (=
                                 // `activation_region_maps.last()`) is the caller's.
-                                // MOVE the caller's owner node into its park — this
+                                // MOVE what the caller's activation owes into its park — this
                                 // activation unwinds with the suspending signal
                                 // (docs/impl/region/owner.md § "Owner nodes").
-                                let caller_owner_node = self.take_activation_owner_node();
+                                let caller_dues = self.take_activation_dues();
                                 // The JIT callee suspended without entering an
                                 // interpreter activation, so `current_closure` is
                                 // still this caller's — park it for the continuation.
@@ -290,7 +290,7 @@ impl VM {
                                         caller_stack,
                                         true,
                                         caller_region_frame,
-                                        caller_owner_node,
+                                        caller_dues,
                                         caller_closure,
                                         self.heap(),
                                     ));
@@ -434,10 +434,10 @@ impl VM {
                         .last()
                         .cloned()
                         .unwrap_or_default();
-                    // MOVE the caller's owner node into its park — this activation
+                    // MOVE what the caller's activation owes into its park — this activation
                     // unwinds with the suspending signal
                     // (docs/impl/region/owner.md § "Owner nodes").
-                    let caller_owner_node = self.take_activation_owner_node();
+                    let caller_dues = self.take_activation_dues();
                     // `saving_stack` restored `current_closure` to this caller on the
                     // callee's suspending return, so park the caller's value here; the
                     // callee's value rode out in `result.current_closure` (below).
@@ -449,7 +449,7 @@ impl VM {
                         caller_stack,
                         true,
                         caller_region_frame,
-                        caller_owner_node,
+                        caller_dues,
                         caller_closure,
                         self.heap(),
                     ));

--- a/src/vm/call/inner/tail.rs
+++ b/src/vm/call/inner/tail.rs
@@ -291,14 +291,21 @@ impl VM {
 
             // Take over the callee closure's release when the compiler flagged it
             // as a per-call local closure whose release is dead past this
-            // `TailCall` (`lower_call`'s `defer_callee_release`). The new
-            // activation releases this
-            // region when it completes — the missing decref the frame replacement
-            // skipped. Recorded BEFORE `populate_env` (which copies the closure's
-            // env uncounted): the closure must stay alive through the callee's
-            // run, so the release is deferred to the trampoline-loop break, NOT
-            // done here. A program-root callee is never flagged, so its
-            // program-lifetime region is never released. See `TailCallInfo`.
+            // `TailCall` (`lower_call`'s `defer_callee_release`). The activation
+            // discharges this region when it ENDS — the missing decref the frame
+            // replacement skipped. Recorded BEFORE `populate_env` (which copies
+            // the closure's env uncounted): the closure must stay alive through
+            // the callee's run, so the release is deferred, NOT done here. A
+            // program-root callee is never flagged, so its program-lifetime
+            // region is never released.
+            //
+            // Recorded on the activation's own dues slot rather than carried on
+            // the `TailCallInfo`, because the obligation outlives whoever
+            // consumes the pending call: the interpreter trampoline is one such
+            // consumer, and a park unwinds it entirely
+            // (docs/impl/region/owner.md § "A deferred tail-call release has the
+            // node's life"). The current activation is still the CALLER's here,
+            // which is the activation the frame replacement hands it to.
             //
             // The arena channel: a letrec body tail-calling a NON-member out of a
             // closure-cycle merged arena carries the arena's static slot
@@ -322,13 +329,14 @@ impl VM {
             // name the same region — a merge MEMBER callee is absent from
             // `cycle_tail_release`, and `tail_callee_defers_release` refuses every
             // `closure_cycle_members` region.
-            let deferred = crate::vm::core::DeferredReleases {
-                arena: deferred_release_slot
-                    .and_then(|slot| self.runtime_region_for_release_slot(slot)),
-                callee: defer_callee_release
-                    .then(|| self.tail_callee_release_region(func))
-                    .flatten(),
-            };
+            let arena =
+                deferred_release_slot.and_then(|slot| self.runtime_region_for_release_slot(slot));
+            let callee = defer_callee_release
+                .then(|| self.tail_callee_release_region(func))
+                .flatten();
+            for region in arena.into_iter().chain(callee) {
+                self.defer_activation_release(region);
+            }
 
             // Build proper environment using cached vector. Each env value mints
             // its own fresh region inside `populate_env` (see `env_value_region`),
@@ -364,7 +372,6 @@ impl VM {
                 env: new_env_rc,
                 closure: func,
                 squelch_mask: closure.squelch_mask,
-                deferred,
             });
 
             self.fiber.signal = Some((SIG_OK, Value::NIL));

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -40,37 +40,6 @@ impl JitCacheEntry {
     }
 }
 
-/// The releases a frame-replacing tail call leaves behind, one per channel.
-///
-/// Everything the lowerer emits after a `TailCall` runs only on the native
-/// fall-through, so a closure callee strands every release the enclosing scopes
-/// put there. Two channels supply the strand, and a single tail call may need
-/// **both**: a letrec body that tail-calls a per-call local closure out of a
-/// closure-cycle merged arena strands the arena's binding-scope `DecrefRegion`
-/// *and* the callee closure's own. The channels name different regions by
-/// construction — a merge MEMBER callee is absent from `cycle_tail_release` and
-/// `tail_callee_defers_release` refuses every `closure_cycle_members` region —
-/// so neither can stand in for the other.
-#[derive(Default, Clone, Copy)]
-pub(crate) struct DeferredReleases {
-    /// The closure-cycle merged arena named by `TailCall::deferred_release_slot`,
-    /// resolved through this activation's region map.
-    pub arena: Option<RuntimeRegion>,
-    /// The callee closure's own per-call region, flagged by
-    /// `TailCall::defer_callee_release`.
-    pub callee: Option<RuntimeRegion>,
-}
-
-impl DeferredReleases {
-    /// The regions to release at the activation's normal completion, in the
-    /// order the channels were earned. Order is immaterial — each is a decref of
-    /// a `Counted` region, and where one holds a counted edge to the other the
-    /// cascade and the direct decref commute.
-    pub fn regions(self) -> impl Iterator<Item = RuntimeRegion> {
-        self.arena.into_iter().chain(self.callee)
-    }
-}
-
 pub(crate) struct TailCallInfo {
     pub code: crate::value::Code,
     pub env: Rc<Vec<Value>>,
@@ -84,25 +53,6 @@ pub(crate) struct TailCallInfo {
     /// always a real closure in practice).
     pub closure: Value,
     pub squelch_mask: SignalBits,
-    /// The releases this tail call stranded past the frame replacement, which the
-    /// new activation TAKES OVER and runs when it completes (the trampoline-loop
-    /// break). Each region stays `Counted` throughout: these are deferred
-    /// decrefs, never ownership-forest adoptions.
-    ///
-    /// The callee channel covers a per-call *local* closure whose
-    /// compiler-emitted `DecrefValueRegion` the lowerer put past the `TailCall`
-    /// (one such region per call through every higher-order stdlib fn:
-    /// `fold`/`map`/`filter`/…, whose recursion tail-calls a `letrec`-bound
-    /// `go`). It is empty for a callee that is NOT a per-call local closure — a
-    /// top-level `defn` (a program-root closure, region held for the program's
-    /// life: it has no per-call decref and tail-calling it never leaked) or a
-    /// native/parameter callee (no frame replacement). The discriminator is
-    /// `VM::tail_callee_release_region`: a local closure's region is recorded in
-    /// the CURRENT activation's region map (and, with its decref dead, never
-    /// cleared); a program-root closure's region was minted in a different,
-    /// popped activation. Releasing a program-root region would be a
-    /// use-after-free.
-    pub deferred: DeferredReleases,
 }
 
 /// Pending fiber resume for the trampoline.
@@ -421,30 +371,35 @@ impl VM {
     /// which also frees the fiber owner node this discard leaves alone — the
     /// fiber survives a squelch and may still own it).
     ///
-    /// Each discarded `BytecodeFrame` may carry its activation's parked owner
-    /// node ([`crate::value::BytecodeFrame::activation_owner_node`], MOVED in at
-    /// the suspend — the node's only home). Its members are `Owned` (count
-    /// consumed by the adopt) with no other release route, and the continuation
-    /// whose normal completion would have freed the node will never run — so the
-    /// discard runs that release here: one tolerant decref takes the node's rc
-    /// 1→0 and subtree-drops node + members (interior cycles reclaim with the
-    /// set; the Shared frontier cascades once). The move discipline makes this
-    /// the sole release path — the slot was emptied at the park, so no
-    /// completion or resume can free the node a second time.
+    /// Each discarded `BytecodeFrame` carries what its activation owed
+    /// ([`crate::value::BytecodeFrame::activation_dues`], MOVED in at the
+    /// suspend — the record's only home): the parked owner node, whose members
+    /// are `Owned` (count consumed by the adopt) with no other release route,
+    /// and the releases the activation took over from its own frame-replacing
+    /// tail calls, whose emitting instruction died with the frame the tail call
+    /// replaced. The continuation whose normal completion would have discharged
+    /// them will never run, so the discard runs them here: one tolerant decref
+    /// each — for the node, rc 1→0 and a subtree drop over node + members
+    /// (interior cycles reclaim with the set; the Shared frontier cascades
+    /// once). The move discipline makes this the sole release path — the slot
+    /// was emptied at the park, so no completion or resume can reach either a
+    /// second time.
     ///
-    /// The node is the ONLY thing released. The frame's `activation_region_map`
-    /// is a borrowed view: a region it names can still be live in an outer,
-    /// non-discarded frame or in the activation that catches the squelch, so a
-    /// per-slot release here over-frees live state. A node's members, by
-    /// contrast, are exactly the regions the inference proved externally unique
-    /// and moved in through `AdoptIntoActivation`, so freeing them cannot touch
-    /// a region any live frame still counts on. The map's regions stay leaked
-    /// on this path until an ownership cut adopts them (UAF-safe, bounded per
-    /// discard; docs/impl/region/owner.md § "Owner nodes").
+    /// The dues are the ONLY thing released. The frame's
+    /// `activation_region_map` is a borrowed view: a region it names can still
+    /// be live in an outer, non-discarded frame or in the activation that
+    /// catches the squelch, so a per-slot release here over-frees live state. A
+    /// node's members, by contrast, are exactly the regions the inference proved
+    /// externally unique and moved in through `AdoptIntoActivation`, and a
+    /// deferred region is one the compiler itself named as this activation's to
+    /// release — so neither can touch a region any live frame still counts on.
+    /// The map's regions stay leaked on this path until an ownership cut adopts
+    /// them (UAF-safe, bounded per discard; docs/impl/region/owner.md § "Owner
+    /// nodes").
     pub(crate) fn discard_suspended_frames(&mut self) {
         if let Some(frames) = self.fiber.suspended.take() {
-            for node in crate::vm::fiber::parked_owner_nodes(frames) {
-                self.heap().decref_region_if_present(node);
+            for region in crate::vm::fiber::parked_activation_dues(frames) {
+                self.heap().decref_region_if_present(region);
             }
         }
         // The abandoned park's funding has no consumer — the delivery funnel

--- a/src/vm/core/region.rs
+++ b/src/vm/core/region.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::fiber::ActivationDues;
 use crate::value::fiberheap::regionstore::RegionMint;
 
 /// Where the abandoned-frame walk reads a value route's slot
@@ -550,17 +551,17 @@ impl VM {
         }
     }
     /// Push a fresh region-remap frame on closure entry, with its (empty)
-    /// parallel owner-node slot (docs/impl/region/owner.md § "Owner nodes").
+    /// parallel dues slot (docs/impl/region/owner.md § "Owner nodes").
     #[inline]
     pub(crate) fn push_activation_region_map(&mut self) {
         self.fiber
             .activation_region_maps
             .push(rustc_hash::FxHashMap::default());
-        self.fiber.activation_owner_nodes.push(None);
+        self.fiber.activation_dues.push(ActivationDues::default());
         debug_assert_eq!(
             self.fiber.activation_region_maps.len(),
-            self.fiber.activation_owner_nodes.len(),
-            "the owner-node stack must parallel the region-remap stack (one slot \
+            self.fiber.activation_dues.len(),
+            "the dues stack must parallel the region-remap stack (one slot \
              per activation frame)",
         );
     }
@@ -568,88 +569,128 @@ impl VM {
     /// static→physical mapping on resume (`resume_suspended`). The map is
     /// re-owned by the live stack so the resumed body's allocs/decrefs mutate
     /// it in place; the matching `pop_activation_region_map` discards it afterward.
-    /// The parallel owner-node slot receives the node the suspend MOVED into the
-    /// parked frame (`BytecodeFrame::activation_owner_node`) — `None` when the
-    /// activation had not adopted — so the resumed body's normal completion
-    /// frees it through the trampoline's clean break
-    /// (docs/impl/region/owner.md § "Owner nodes").
+    /// The parallel dues slot receives the record the suspend MOVED into the
+    /// parked frame (`BytecodeFrame::activation_dues`) — the owner node and the
+    /// releases the activation took over from frame-replacing tail calls — so
+    /// the resumed body's normal completion discharges both through the
+    /// trampoline's clean break (docs/impl/region/owner.md § "Owner nodes",
+    /// § "A deferred tail-call release has the node's life").
     #[inline]
     pub(crate) fn restore_activation_region_map(
         &mut self,
         frame: rustc_hash::FxHashMap<u32, MappedRegion>,
-        owner_node: Option<RuntimeRegion>,
+        dues: ActivationDues,
     ) {
         self.fiber.activation_region_maps.push(frame);
-        self.fiber.activation_owner_nodes.push(owner_node);
+        self.fiber.activation_dues.push(dues);
     }
     /// The current activation's owner node — the pages-less forest root
     /// `AdoptIntoActivation` adopts members into (docs/impl/region/owner.md
     /// § "Owner nodes — an activation as a forest root") — minted lazily on
     /// first use so an activation that adopts nothing pays nothing. The slot
-    /// parallels the activation's region-remap frame
-    /// (`Fiber::activation_owner_nodes`); the node is freed at the activation's
-    /// normal completion via [`Self::release_activation_owner_node`].
+    /// parallels the activation's region-remap frame (`Fiber::activation_dues`);
+    /// the node is freed at the activation's normal completion via
+    /// [`Self::release_activation_dues`].
     #[inline]
     pub(crate) fn activation_owner_node(&mut self) -> RuntimeRegion {
-        if let Some(node) = self.fiber.activation_owner_nodes.last().copied().flatten() {
+        if let Some(node) = self.activation_dues().owner_node {
             return node;
         }
         let node = self.heap().new_runtime_region();
-        *self
-            .fiber
-            .activation_owner_nodes
-            .last_mut()
-            .expect("owner-node stack must be non-empty (a base slot covers the top level)") =
-            Some(node);
+        self.activation_dues().owner_node = Some(node);
         node
     }
-    /// Take the current activation's owner node, leaving the slot empty; `None`
-    /// if this activation never adopted (the node is minted lazily).
+    /// The current activation's dues slot. Always present — a base slot covers
+    /// the top level and every push/pop pair keeps the stack parallel to
+    /// `activation_region_maps`.
     #[inline]
-    pub(crate) fn take_activation_owner_node(&mut self) -> Option<RuntimeRegion> {
+    pub(crate) fn activation_dues(&mut self) -> &mut ActivationDues {
         self.fiber
-            .activation_owner_nodes
+            .activation_dues
             .last_mut()
-            .and_then(|slot| slot.take())
+            .expect("dues stack must be non-empty (a base slot covers the top level)")
     }
-    /// Free the current activation's owner node, if one was minted: one
-    /// tolerant decref takes the node's rc 1→0 and subtree-drops the node plus
-    /// every member the activation adopted (interior cycles reclaim with the
-    /// set; the Shared frontier cascades once). Runs at the activation's NORMAL
-    /// completion on every tier — the interpreter trampoline's clean break and
-    /// the compiled `Return` path (`elle_jit_release_activation_owner_node`) —
-    /// never from an emitted drop instruction
-    /// (docs/impl/region/owner.md § "Owner nodes").
-    pub(crate) fn release_activation_owner_node(&mut self) {
-        if let Some(node) = self.take_activation_owner_node() {
+    /// Take over one release a frame-replacing tail call stranded, recorded on
+    /// the activation that owes it (docs/impl/region/owner.md § "A deferred
+    /// tail-call release has the node's life"). Called from `tail_call_inner`,
+    /// where the current activation is still the caller's — which is the
+    /// activation the frame replacement hands the obligation to.
+    #[inline]
+    pub(crate) fn defer_activation_release(&mut self, region: RuntimeRegion) {
+        self.activation_dues().defer(region);
+    }
+    /// Take everything the current activation owes, leaving the slot empty: the
+    /// owner node (`None` if it never adopted) and the deferred set (empty if it
+    /// made no frame-replacing tail call). The MOVE that keeps the record in
+    /// exactly one place — the live slot, or one parked frame.
+    #[inline]
+    pub(crate) fn take_activation_dues(&mut self) -> ActivationDues {
+        std::mem::take(self.activation_dues())
+    }
+    /// Discharge everything the current activation owes. The owner node gets one
+    /// tolerant decref — rc 1→0, subtree drop over the node plus every member the
+    /// activation adopted (interior cycles reclaim with the set; the Shared
+    /// frontier cascades once). Each deferred region gets the decref its
+    /// emitting instruction would have run, had the tail call not replaced the
+    /// frame holding it. Runs at the activation's NORMAL completion on every
+    /// tier — the interpreter trampoline's clean break and the compiled `Return`
+    /// path (`elle_jit_release_activation_dues`) — never from an emitted
+    /// drop instruction (docs/impl/region/owner.md § "Owner nodes").
+    pub(crate) fn release_activation_dues(&mut self) {
+        let dues = self.take_activation_dues();
+        for region in dues.deferred {
+            self.heap().decref_region_if_present(region);
+        }
+        if let Some(node) = dues.owner_node {
             self.heap().decref_region_if_present(node);
         }
     }
+    /// Run the deferred releases of an activation the exit ABANDONS — an error
+    /// no restart replays, or a squelch boundary — leaving its owner node alone
+    /// (docs/impl/region/owner.md § "What an abandoned frame owes, it owes the
+    /// deferred set too"). Nothing replays the frame, so this is the last chance
+    /// the decref the activation took over has to run; the node's own disposal
+    /// there is a separate question, since it rides out to the caller that may
+    /// still park the frame.
+    pub(crate) fn release_abandoned_deferred(&mut self) {
+        for region in self.activation_dues().take_deferred() {
+            Self::freelog_abandoned("deferred tail call", 0, region);
+            self.heap().decref_region_if_present(region);
+        }
+    }
     /// The callee closure's runtime region, whose release the new activation
-    /// takes over (`DeferredReleases::callee`).
+    /// takes over — the CALLEE channel of the deferred set
+    /// ([`Self::defer_activation_release`]).
+    ///
     /// Called ONLY when the compiler flagged this tail call's callee as a
     /// per-call local closure whose release is dead past the `TailCall`
-    /// (`lower_call`'s `defer_callee_release`, plumbed through `TailCallInfo`). The
-    /// program-root-vs-local discrimination is made at compile time (the solver
-    /// knows whether the closure's region dies at the call), so this is just the
-    /// runtime region lookup. `None` for an immediate (no region). See
-    /// `TailCallInfo` and `tests/elle/region-tailcall-closure-callee-leak.lisp`.
+    /// (`lower_call`'s `defer_callee_release`). That covers one region per call
+    /// through every higher-order stdlib fn — `fold`/`map`/`filter`/…, whose
+    /// recursion tail-calls a `letrec`-bound `go`. It is NOT flagged for a
+    /// callee that is not a per-call local closure: a top-level `defn` is a
+    /// program-root closure whose region is held for the program's life and has
+    /// no per-call decref, and a native or parameter callee replaces no frame.
+    /// Releasing a program-root region would be a use-after-free, so the
+    /// discrimination is made at compile time (the solver knows whether the
+    /// closure's region dies at the call) and this is just the runtime region
+    /// lookup. `None` for an immediate (no region). See
+    /// `tests/elle/region-tailcall-closure-callee-leak.lisp`.
     #[inline]
     pub(crate) fn tail_callee_release_region(&self, func: Value) -> Option<RuntimeRegion> {
         crate::value::arena::region_of(unsafe { &mut *self.heap_ptr }, func)
     }
     /// Pop the current region-remap frame on normal closure return, with its
-    /// parallel owner-node slot. The base frame (top level) is never popped.
+    /// parallel dues slot. The base frame (top level) is never popped.
     #[inline]
     pub(crate) fn pop_activation_region_map(&mut self) {
         if self.fiber.activation_region_maps.len() > 1 {
             self.fiber.activation_region_maps.pop();
-            self.fiber.activation_owner_nodes.pop();
+            self.fiber.activation_dues.pop();
         }
         debug_assert_eq!(
             self.fiber.activation_region_maps.len(),
-            self.fiber.activation_owner_nodes.len(),
-            "the owner-node stack must parallel the region-remap stack (one slot \
+            self.fiber.activation_dues.len(),
+            "the dues stack must parallel the region-remap stack (one slot \
              per activation frame)",
         );
     }

--- a/src/vm/core/resume.rs
+++ b/src/vm/core/resume.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::fiber::ActivationDues;
 
 impl VM {
     /// Resume execution from suspended frames.
@@ -19,7 +20,7 @@ impl VM {
     /// Returns SignalBits. The result value is stored in `self.fiber.signal`.
     pub fn resume_suspended(
         &mut self,
-        frames: Vec<SuspendedFrame>,
+        mut frames: Vec<SuspendedFrame>,
         resume_value: Value,
     ) -> SignalBits {
         if frames.is_empty() {
@@ -33,6 +34,16 @@ impl VM {
         let mut current_value = resume_value;
 
         for i in 0..frames.len() {
+            // MOVE what the parked activation owed out of the frame before the
+            // shared borrow below: the record lives in exactly one place, and
+            // from the restore on it is the live slot's (docs/impl/region/owner.md
+            // § "A deferred tail-call release has the node's life"). A
+            // `FiberResume` frame owes nothing — its sub-fiber has its own
+            // lifecycle — and this arm returns before the restore anyway.
+            let parked_dues = match &mut frames[i] {
+                SuspendedFrame::Bytecode(f) => std::mem::take(&mut f.activation_dues),
+                SuspendedFrame::FiberResume { .. } => ActivationDues::default(),
+            };
             let frame = &frames[i];
 
             match frame {
@@ -201,16 +212,17 @@ impl VM {
                     // Restore this activation's static→physical region remap
                     // as the current frame before re-entering its body, so
                     // post-resume allocs/decrefs resolve in the same frame the
-                    // pre-yield allocations did (docs/impl/region/owner.md). The
-                    // parked owner node is restored with it, so the resumed
-                    // body's normal completion frees it through the trampoline's
-                    // clean break. The chain is
+                    // pre-yield allocations did (docs/impl/region/owner.md). What
+                    // the activation owed is restored with it — its owner node and
+                    // the releases it took over from its own frame-replacing tail
+                    // calls — so the resumed body's normal completion discharges
+                    // both through the trampoline's clean break. The chain is
                     // replayed sequentially (not Rust-nested), so each frame
                     // gets its own push/pop around its resumed execution.
                     // `from_ip` does not push/pop, so we manage it here.
                     self.restore_activation_region_map(
                         frame.activation_region_map.clone(),
-                        frame.activation_owner_node,
+                        parked_dues,
                     );
 
                     // Re-install the executing-closure register parked at suspend so
@@ -263,7 +275,7 @@ impl VM {
                                 .last()
                                 .cloned()
                                 .unwrap_or_default();
-                            let activation_owner_node = self.take_activation_owner_node();
+                            let activation_dues = self.take_activation_dues();
                             let re_suspend = BytecodeFrame::suspend(
                                 exec.code,
                                 exec.env,
@@ -271,7 +283,7 @@ impl VM {
                                 exec.stack,
                                 !exec.bits.intersects(SIG_FUEL),
                                 activation_region_map,
-                                activation_owner_node,
+                                activation_dues,
                                 exec.current_closure,
                                 self.heap(),
                             );

--- a/src/vm/dispatch.rs
+++ b/src/vm/dispatch.rs
@@ -92,11 +92,12 @@ impl VM {
                 .last()
                 .cloned()
                 .unwrap_or_default();
-            // MOVE the activation's owner node into the frame (its slot is
-            // likewise still on top): the members are Owned with no other
-            // release route, so the node must ride the park to the resumed
+            // MOVE what the activation owes into the frame (its slot is
+            // likewise still on top): a node's members are Owned with no other
+            // release route and a deferred tail-call release has no emitted
+            // instruction left at all, so both must ride the park to the resumed
             // body's completion (docs/impl/region/owner.md § "Owner nodes").
-            let activation_owner_node = self.take_activation_owner_node();
+            let activation_dues = self.take_activation_dues();
             // The yielding activation runs the current closure — park it so the
             // recursion resolves to the same closure after resume.
             let current_closure = self.fiber.current_closure;
@@ -107,7 +108,7 @@ impl VM {
                 saved_stack,
                 true,
                 activation_region_map,
-                activation_owner_node,
+                activation_dues,
                 current_closure,
                 self.heap(),
             ));

--- a/src/vm/execute.rs
+++ b/src/vm/execute.rs
@@ -90,6 +90,7 @@
 //!    so the `SIG_SWITCH` trampoline is driven inside your scope — see the
 //!    SIG_SWITCH section above.
 
+use crate::value::fiber::ActivationDues;
 use crate::value::{SignalBits, Value, SIG_ERROR};
 use std::rc::Rc;
 
@@ -129,17 +130,17 @@ pub(crate) struct ExecResult {
     /// so the remap survives the yield. Default (empty) for
     /// `execute_bytecode_from_ip`, whose caller manages frames itself.
     pub activation_region_map: rustc_hash::FxHashMap<u32, crate::hir::region::MappedRegion>,
-    /// This activation's owner node, TAKEN by `execute_bytecode_saving_stack`
+    /// What this activation owed, TAKEN by `execute_bytecode_saving_stack`
     /// beside `activation_region_map` on a non-OK exit — the channel that
-    /// carries the node out of the already-popped activation to the caller
-    /// that builds its park (`BytecodeFrame::activation_owner_node`): the
-    /// fiber body's pause in `do_fiber_first_resume`, the interrupted callee's
-    /// inner frame in `call_inner`. A suspend handler that parked the frame
-    /// itself (the yield path) already took the node, so this reads `None`
-    /// there — the move discipline holds. Always `None` for
+    /// carries the record out of the already-popped activation to the caller
+    /// that builds its park (`BytecodeFrame::activation_dues`): the fiber
+    /// body's pause in `do_fiber_first_resume`, the interrupted callee's inner
+    /// frame in `call_inner`. A suspend handler that parked the frame itself
+    /// (the yield path) already took the record, so this reads default there —
+    /// the move discipline holds. Always default for
     /// `execute_bytecode_from_ip` (`resume_suspended` manages the slot
     /// directly).
-    pub activation_owner_node: Option<crate::hir::region::RuntimeRegion>,
+    pub activation_dues: crate::value::fiber::ActivationDues,
     /// The executing-closure register (`fiber.current_closure`) at the moment the
     /// trampoline broke — the callee's value, possibly re-installed by tail calls
     /// in this activation. A caller building a `SuspendedFrame` from this returned
@@ -194,20 +195,6 @@ impl VM {
         let mut current_env = closure_env.clone();
         let mut current_ip = start_ip;
         let mut accumulated_squelch_mask = SignalBits::EMPTY;
-        // Releases taken over from frame-replacing tail calls in this activation
-        // (`TailCallInfo::deferred`, one entry per channel — a single tail call
-        // may hand over both a merged closure-cycle arena and its callee closure).
-        // Each is a per-call allocation whose compiler-emitted release is dead
-        // past the `TailCall`; this activation took over that release and runs it
-        // on NORMAL completion below. Deduped by region: a tail-recursive `go`
-        // re-enters with the SAME closure each iteration but carries one dead
-        // decref, so it must be released exactly once. Released only on the clean
-        // break — on a suspending/error/squelch exit the closures may still be
-        // needed (resume) and are left to leak, a bounded over-keep, never a
-        // double-free (unlike the activation owner node, these regions are
-        // `Counted` and not moved into the park, so no discard-time release can
-        // be sound without per-frame liveness).
-        let mut deferred_releases: Vec<crate::hir::region::RuntimeRegion> = Vec::new();
 
         loop {
             let (bits, ip) =
@@ -215,6 +202,14 @@ impl VM {
 
             if !bits.is_empty() {
                 if self.enforce_squelch(bits, accumulated_squelch_mask) {
+                    // The boundary turns the signal into an error this
+                    // activation never catches, so the frame is abandoned
+                    // exactly as an error exit's is and owes what it took over
+                    // from its tail calls (docs/impl/region/owner.md § "What an
+                    // abandoned frame owes, it owes the deferred set too").
+                    if walk_abandoned {
+                        self.release_abandoned_deferred();
+                    }
                     break ExecResult {
                         bits: SIG_ERROR,
                         ip,
@@ -222,18 +217,22 @@ impl VM {
                         env: current_env,
                         stack: vec![],
                         activation_region_map: rustc_hash::FxHashMap::default(),
-                        activation_owner_node: None,
+                        activation_dues: ActivationDues::default(),
                         current_closure: self.fiber.current_closure,
                     };
                 }
                 // The frame's locals are still on the stack, and an error leaves
                 // through the signal machinery without running the rest of its
                 // instructions — so the releases among them run here, before the
-                // locals travel out in `stack` below.
+                // locals travel out in `stack` below. The releases this
+                // activation took over from a frame-replacing tail call are owed
+                // on the same question and have no table to be read off, their
+                // emitting instruction having died with the replaced frame.
                 if walk_abandoned && bits.intersects(SIG_ERROR) {
                     let payload = self.fiber.signal.map(|(_, v)| v).unwrap_or(Value::NIL);
                     let exit_code = current_code.clone();
                     self.release_abandoned_frame(&exit_code, payload);
+                    self.release_abandoned_deferred();
                 }
                 let inner_stack = std::mem::take(&mut self.fiber.stack).into_vec();
                 break ExecResult {
@@ -243,18 +242,13 @@ impl VM {
                     env: current_env,
                     stack: inner_stack,
                     activation_region_map: rustc_hash::FxHashMap::default(),
-                    activation_owner_node: None,
+                    activation_dues: ActivationDues::default(),
                     current_closure: self.fiber.current_closure,
                 };
             }
 
             if let Some(tail) = self.pending_tail_call.take() {
                 accumulated_squelch_mask |= tail.squelch_mask;
-                for r in tail.deferred.regions() {
-                    if !deferred_releases.contains(&r) {
-                        deferred_releases.push(r);
-                    }
-                }
                 // The fresh-frame invariant (docs/impl/region/rules.md Rule 5):
                 // the callee's unwritten local slots must read NIL exactly as on
                 // a fresh activation — a branch-arm temp's scope-end release
@@ -275,19 +269,14 @@ impl VM {
                 current_env = tail.env;
                 current_ip = 0;
             } else {
-                // Normal completion: run the deferred closure-callee releases —
-                // the decrefs the frame-replacing tail calls left dead.
-                for &r in &deferred_releases {
-                    self.heap().decref_region_if_present(r);
-                }
-                // ... and free this activation's owner node, if an
-                // `AdoptIntoActivation` minted one: the node's single decref
-                // subtree-drops every member the activation adopted
-                // (docs/impl/region/owner.md § "Owner nodes"). The same
-                // clean-break discipline as the deferred callee releases above —
-                // a frame-replacing tail call keeps the activation (and its
-                // node) alive to the recursion's completion here.
-                self.release_activation_owner_node();
+                // Normal completion: discharge what this activation owes — the
+                // decrefs its frame-replacing tail calls left dead, and its
+                // owner node, whose single decref subtree-drops every member the
+                // activation adopted (docs/impl/region/owner.md § "Owner
+                // nodes"). One clean-break discipline for both: a
+                // frame-replacing tail call keeps the activation alive to the
+                // recursion's completion here, and so keeps everything it owes.
+                self.release_activation_dues();
                 break ExecResult {
                     bits,
                     ip,
@@ -295,7 +284,7 @@ impl VM {
                     env: current_env,
                     stack: vec![],
                     activation_region_map: rustc_hash::FxHashMap::default(),
-                    activation_owner_node: None,
+                    activation_dues: ActivationDues::default(),
                     current_closure: self.fiber.current_closure,
                 };
             }
@@ -381,12 +370,12 @@ impl VM {
                 .last()
                 .cloned()
                 .unwrap_or_default();
-            // MOVE the activation's owner node out with the map: a suspend
-            // handler that parked a frame already took it (this reads None),
+            // MOVE what the activation owes out with the map: a suspend
+            // handler that parked a frame already took it (this reads default),
             // but a pause with no frame of its own (fuel) leaves it here, and
             // the caller that builds the park from this result re-attaches it
             // (docs/impl/region/owner.md § "Owner nodes").
-            result.activation_owner_node = self.take_activation_owner_node();
+            result.activation_dues = self.take_activation_dues();
         }
         self.pop_activation_region_map();
         // Restore the caller's executing-closure register. On a suspending exit the

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -48,7 +48,7 @@ mod borrow_tests;
 // `crate::vm::fiber::<Item>` (external callers) or `super::<Item>` (sibling
 // submodules) still resolves unchanged. Visibility matches each item's original
 // `pub(crate)`/private declaration.
-pub(crate) use owned::{kill_fiber, parked_owner_nodes, release_fiber_owned, take_fiber_owned};
+pub(crate) use owned::{kill_fiber, parked_activation_dues, release_fiber_owned, take_fiber_owned};
 use refcount::{incref_signal_region, release_discarded_signal};
 pub(crate) use refcount::{
     is_terminal_signal, release_displaced_denial_payload, release_displaced_io_request,

--- a/src/vm/fiber/owned.rs
+++ b/src/vm/fiber/owned.rs
@@ -18,6 +18,11 @@ use crate::value::{FiberHandle, SignalBits, SuspendedFrame, Value, SIG_ERROR};
 pub(crate) struct FiberOwned {
     /// Each still-parked `BytecodeFrame`'s activation owner node, in chain order.
     parked_nodes: Vec<crate::hir::region::RuntimeRegion>,
+    /// The releases those activations took over from their own frame-replacing
+    /// tail calls (docs/impl/region/owner.md § "A deferred tail-call release has
+    /// the node's life"). A frame this fiber can never re-enter never reaches
+    /// the completion that would have run them.
+    parked_deferred: Vec<crate::hir::region::RuntimeRegion>,
     /// The parked non-terminal signal (a yielded value / io request / denial
     /// payload), whose one park escape retain is released on the resume path —
     /// which will never come for a terminal fiber (`release_discarded_signal`).
@@ -34,18 +39,28 @@ pub(crate) struct FiberOwned {
     fiber_node: Option<crate::hir::region::RuntimeRegion>,
 }
 
-/// The parked activation owner nodes of an abandoned frame chain. The frames'
-/// continuations will never run, so the completion release that would have freed
-/// each node never fires; the release belongs to whoever abandoned the chain —
-/// the discard chokepoint (`VM::discard_suspended_frames`) or the terminal-fiber
-/// teardown ([`take_fiber_owned`]). A `FiberResume` frame owns no node (its
-/// sub-fiber has its own lifecycle).
-pub(crate) fn parked_owner_nodes(
+/// What the activations of an abandoned frame chain still owed: each parked
+/// frame's owner node, and the releases it took over from its own
+/// frame-replacing tail calls. The frames' continuations will never run, so the
+/// completion release that would have discharged them never fires; it belongs to
+/// whoever abandoned the chain — the discard chokepoint
+/// (`VM::discard_suspended_frames`) or the terminal-fiber teardown
+/// ([`take_fiber_owned`]). A `FiberResume` frame owes nothing (its sub-fiber has
+/// its own lifecycle).
+/// Each region here takes one tolerant decref, node and deferred region alike:
+/// a node's rc goes 1→0 and subtree-drops its adopted members, and a deferred
+/// region's decref is the one its emitting instruction never ran. Order between
+/// them is immaterial — where one holds a counted edge to the other, the cascade
+/// and the direct decref commute.
+pub(crate) fn parked_activation_dues(
     frames: Vec<SuspendedFrame>,
 ) -> impl Iterator<Item = crate::hir::region::RuntimeRegion> {
-    frames.into_iter().filter_map(|frame| match frame {
-        SuspendedFrame::Bytecode(f) => f.activation_owner_node,
-        SuspendedFrame::FiberResume { .. } => None,
+    frames.into_iter().flat_map(|frame| match frame {
+        SuspendedFrame::Bytecode(f) => {
+            let dues = f.activation_dues;
+            dues.deferred.into_iter().chain(dues.owner_node)
+        }
+        SuspendedFrame::FiberResume { .. } => Vec::new().into_iter().chain(None),
     })
 }
 
@@ -64,6 +79,7 @@ pub(crate) fn take_fiber_owned(fiber: &mut crate::value::fiber::Fiber) -> FiberO
     let parked = fiber.take_parked_state();
     FiberOwned {
         parked_nodes: parked.nodes,
+        parked_deferred: parked.deferred,
         parked_signal: parked.signal,
         parked_owed: parked.owed,
         parked_owed_regions: parked.owed_regions,
@@ -85,6 +101,7 @@ pub(crate) fn release_fiber_owned(
 ) {
     let FiberOwned {
         parked_nodes,
+        parked_deferred,
         parked_signal,
         parked_owed,
         parked_owed_regions,
@@ -111,6 +128,13 @@ pub(crate) fn release_fiber_owned(
             continue;
         }
         heap.decref_region_if_present(m.region);
+    }
+    // The deferred releases run before the nodes, so a closure region a node's
+    // member still holds a counted edge to is not freed twice — the decref here
+    // drops this activation's reference and the member's edge keeps it standing
+    // until the subtree drop below cascades through.
+    for region in parked_deferred {
+        heap.decref_region_if_present(region);
     }
     for node in parked_nodes {
         if let Some(fnode) = fiber_node {

--- a/src/vm/fiber/resume.rs
+++ b/src/vm/fiber/resume.rs
@@ -267,8 +267,8 @@ impl VM {
             // (SIG_ERROR, user-defined, etc.): the instruction at result.ip expects
             // the signal's "return value" on the stack (e.g. Return needs a value to
             // pop), so push it.
-            // The body's owner node rode out of the popped activation in
-            // `result.activation_owner_node` (moved, beside the region map) —
+            // What the body's activation owed rode out of the popped activation in
+            // `result.activation_dues` (moved, beside the region map) —
             // park it so the resumed body's completion frees it.
             let frame = BytecodeFrame::suspend(
                 result.code,
@@ -277,7 +277,7 @@ impl VM {
                 result.stack,
                 !result.bits.intersects(SIG_FUEL),
                 result.activation_region_map,
-                result.activation_owner_node,
+                result.activation_dues,
                 result.current_closure,
                 self.heap(),
             );

--- a/src/vm/fiber/signal.rs
+++ b/src/vm/fiber/signal.rs
@@ -126,10 +126,10 @@ impl VM {
                 .last()
                 .cloned()
                 .unwrap_or_default();
-            // MOVE the caller's owner node into its continuation park — this
+            // MOVE what the caller's activation owes into its continuation park — this
             // activation unwinds with the SIG_SWITCH handoff
             // (docs/impl/region/owner.md § "Owner nodes").
-            let activation_owner_node = self.take_activation_owner_node();
+            let activation_dues = self.take_activation_dues();
             // The closure that called `fiber/resume` is the one to resume into.
             let current_closure = self.fiber.current_closure;
             let caller_frame = SuspendedFrame::Bytecode(BytecodeFrame::suspend(
@@ -139,7 +139,7 @@ impl VM {
                 caller_stack,
                 true,
                 activation_region_map,
-                activation_owner_node,
+                activation_dues,
                 current_closure,
                 self.heap(),
             ));
@@ -192,10 +192,10 @@ impl VM {
                         .last()
                         .cloned()
                         .unwrap_or_default();
-                    // MOVE the caller's owner node into its continuation park —
+                    // MOVE what the caller's activation owes into its continuation park —
                     // this activation unwinds with the child's suspending
                     // signal (docs/impl/region/owner.md § "Owner nodes").
-                    let activation_owner_node = self.take_activation_owner_node();
+                    let activation_dues = self.take_activation_dues();
                     // Caller activation's remap (the resumed sub-fiber runs
                     // on its own frame stack; this frame continues us).
                     let current_closure = self.fiber.current_closure;
@@ -206,7 +206,7 @@ impl VM {
                         caller_stack,
                         true,
                         activation_region_map,
-                        activation_owner_node,
+                        activation_dues,
                         current_closure,
                         self.heap(),
                     ));

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -207,13 +207,14 @@ impl VM {
         // Whether THIS invocation is the true root driver (the fiber's base
         // activation frame). A top-level body runs directly on the base slot —
         // this entry pushes no activation frame — so an `AdoptIntoActivation` it
-        // executes mints the owner node in the BASE slot, which no trampoline
-        // clean break ever releases; the root driver must release it itself at
-        // the program's completion (below). A RE-ENTRANT execute_code (a native
-        // loading a module mid-activation) runs in its caller's activation
-        // (depth > 1), whose node belongs to that caller's own completion
-        // release — it must not be touched here.
-        let at_root = self.fiber.activation_owner_nodes.len() == 1;
+        // executes mints the owner node in the BASE slot, and a top-level tail
+        // call records its deferred release there, neither of which any
+        // trampoline clean break ever reaches; the root driver discharges them
+        // itself at the program's completion (below). A RE-ENTRANT execute_code
+        // (a native loading a module mid-activation) runs in its caller's
+        // activation (depth > 1), whose dues belong to that caller's own
+        // completion release — they must not be touched here.
+        let at_root = self.fiber.activation_dues.len() == 1;
 
         // Initial execution with tail-call loop.
         // Scope-mark rotation: when a tail call is rotation-safe,
@@ -281,14 +282,15 @@ impl VM {
                 ));
             }
         };
-        // The root activation's clean break: release the base slot's owner node
-        // (one tolerant decref → subtree drop over node + adopted members) at the
+        // The root activation's clean break: discharge the base slot's dues —
+        // the owner node (one tolerant decref → subtree drop over node +
+        // adopted members) and whatever a top-level tail call deferred — at the
         // program's completion, the root counterpart of `trampoline_loop`'s
         // normal-break release (docs/impl/region/owner.md § "Owner nodes"). Runs
         // on every root exit — a finished program has no resumable state at this
         // boundary, so an error exit releases identically.
         if at_root {
-            self.release_activation_owner_node();
+            self.release_activation_dues();
         }
         self.fiber.current_closure = saved_closure;
         result

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -144,10 +144,10 @@ impl VM {
                     .last()
                     .cloned()
                     .unwrap_or_default();
-                // MOVE the activation's owner node into the frame (its slot is
+                // MOVE what the activation owes into the frame (its slot is
                 // likewise still on top) so it rides the park to the resumed
                 // body's completion (docs/impl/region/owner.md § "Owner nodes").
-                let activation_owner_node = self.take_activation_owner_node();
+                let activation_dues = self.take_activation_dues();
                 // Suspending primitive: this activation's remap is still on top
                 // (the wrapping `saving_stack` pops it after we return), and the
                 // current closure is this activation's — park it for the resume.
@@ -159,7 +159,7 @@ impl VM {
                     saved_stack,
                     true,
                     activation_region_map,
-                    activation_owner_node,
+                    activation_dues,
                     current_closure,
                     self.heap(),
                 ));
@@ -292,8 +292,8 @@ impl VM {
             .last()
             .cloned()
             .unwrap_or_default();
-        // MOVE the activation's owner node into the frame (see the Suspend arm).
-        let activation_owner_node = self.take_activation_owner_node();
+        // MOVE what the activation owes into the frame (see the Suspend arm).
+        let activation_dues = self.take_activation_dues();
         // Capability denial suspends the current activation; its remap is still on
         // top (the wrapping `saving_stack` pops it after return), and its closure
         // is the current one — park it for the resume.
@@ -305,7 +305,7 @@ impl VM {
             saved_stack,
             true,
             activation_region_map,
-            activation_owner_node,
+            activation_dues,
             current_closure,
             self.heap(),
         ));

--- a/tests/elle/region-tail-deferred-exits-uaf.lisp
+++ b/tests/elle/region-tail-deferred-exits-uaf.lisp
@@ -1,0 +1,169 @@
+(elle/epoch 12)
+# Soundness complement of region-tail-deferred-exits.lisp
+# (docs/impl/region/owner.md § "A deferred tail-call release has the node's
+# life"). Run under `--trace=guardfree` by the subprocess pin
+# `region_tail_deferred_exits_uaf` in tests/integration/elle_scripts.rs.
+#
+# The deferred release now runs on paths that never ran it: an abandoned error
+# exit, a squelch boundary, a park's discharge, and the completion of a body
+# resumed out of a park. Each is a decref the activation genuinely owed, so what
+# has to survive is every reference the activation does not own.
+#
+# Five faces.
+#
+# 1. The error PAYLOAD the raiser reached through the tail-called closure's
+#    captured environment. The frame-exit relocation already ran the binding's
+#    own release ahead of the `TailCall`, so the env's counted edge is the
+#    value's last holder — and the deferred release cascades that edge away. The
+#    payload survives on the reference the raise minted, and the catcher's read
+#    proves it.
+# 2. A closure that ESCAPES the frame that tail-called it. A container's counted
+#    store holds it, so the deferred decref must not be the last reference.
+# 3. A RESUMED body. The release belongs to the resumed body's completion, not
+#    to the park, so everything the continuation still reads must be whole.
+# 4. A DROPPED fiber's parked payload, released by the discharge. What
+#    `fiber/value` hands back must survive that.
+# 5. A tail-RECURSIVE loop, which re-enters with the same closure every
+#    iteration and owes it ONE release. Releasing per iteration frees the
+#    closure under the recursion still running in it.
+#
+# Every read below happens AFTER the exit ran, so an over-release faults at the
+# deref (guardfree) or trips the generation check.
+
+# ── 1. a payload reached through the tail callee's captured environment ───────
+
+(defn raise-from-capture [tag]
+  (let [[ok e] (protect (let [s (string "cap-" tag)]
+                          ((fn [] (error s)))))]
+    [ok (type-of e) (length e)]))
+
+(var i 0)
+(while (< i 40)
+  (let [r (raise-from-capture i)]
+    (assert (= (get r 0) false) "the tail-called closure must raise")
+    (assert (= (get r 1) :string) "the captured payload must survive the exit")
+    (assert (< 0 (get r 2)) "the captured payload's bytes must be whole"))
+  (assign i (+ i 1)))
+
+# ── 2. a tail-called closure a container still holds ──────────────────────────
+# `sink` takes a counted reference before the call, so the deferred release
+# drops the frame's own and no more. Reading the closure back after the raise —
+# and CALLING it — faults if the release was the last.
+
+(def sink @[])
+
+(defn escape-then-raise [tag]
+  (let [held (string "held-" tag)
+        f (fn [] (error held))]
+    (push sink f)
+    (f)))
+
+(assign i 0)
+(while (< i 40)
+  (protect (escape-then-raise i))
+  (assign i (+ i 1)))
+
+(assert (= (length sink) 40) "every escaping closure must have reached the sink")
+(var n 0)
+(while (< n (length sink))
+  (let [[ok e] (protect ((get sink n)))]
+    (assert (= ok false) "the stored closure must still be callable")
+    (assert (= (type-of e) :string)
+            "its capture must outlive the deferred release"))
+  (assign n (+ n 1)))
+
+# ── 3. a body resumed out of a park, running to completion ───────────────────
+# The release belongs to the resumed body's completion. Running it at the park
+# would free the closure the continuation is still executing in.
+
+(defn park-then-finish [tag]
+  (let [f (fiber/new (fn []
+                       (let [s (string "park-" tag)]
+                         ((fn []
+                            (emit :yield 1)
+                            (emit :yield 2)
+                            (string s "-done"))))) |:yield|)]
+    (fiber/resume f nil)
+    (fiber/resume f nil)
+    (fiber/resume f nil)
+    (fiber/value f)))
+
+(assign i 0)
+(while (< i 40)
+  (let [v (park-then-finish i)]
+    (assert (= (type-of v) :string)
+            "the resumed body's result must survive the deferred release")
+    (assert (< 4 (length v)) "and must be whole, not a freed page"))
+  (assign i (+ i 1)))
+
+# ── 4. a dropped fiber's parked payload ──────────────────────────────────────
+# Nothing resumes this fiber, so the discharge runs the deferred release. The
+# payload it parked is read after that.
+
+(defn park-then-drop [tag]
+  (let [f (fiber/new (fn []
+                       (let [s (string "drop-" tag)]
+                         ((fn []
+                            (begin
+                              (emit :yield s)
+                              s))))) |:yield|)]
+    (fiber/resume f nil)
+    (let [v (fiber/value f)]
+      [(type-of v) (length v)])))
+
+(assign i 0)
+(while (< i 40)
+  (let [r (park-then-drop i)]
+    (assert (= (get r 0) :string)
+            "the parked payload must survive the discharge")
+    (assert (< 0 (get r 1)) "and must be whole"))
+  (assign i (+ i 1)))
+
+# ── 5. a squelch boundary, and the error it hands the catcher ────────────────
+
+(def squelched
+  (squelch (fn []
+             (let [s (string "sq")]
+               ((fn []
+                  (begin
+                    (emit :yield 1)
+                    s))))) :yield))
+
+(assign i 0)
+(while (< i 40)
+  (let [[ok e] (protect (squelched))]
+    (assert (= ok false) "the squelch boundary must raise")
+    (assert (= (type-of e) :struct)
+            "the boundary's own error must survive the abandonment"))
+  (assign i (+ i 1)))
+
+# ── 6. one release per recursion, not one per iteration ──────────────────────
+# A tail-recursive local closure re-enters with the SAME closure every step, and
+# the activation owes it exactly one decref. A release per step frees the
+# closure the recursion is still running in.
+
+(defn count-down [n]
+  (letrec [go (fn [k acc] (if (%lt k 1) acc (go (%sub k 1) (%add acc k))))]
+    (go n 0)))
+
+(assign i 0)
+(while (< i 40)
+  (assert (= (count-down 50) 1275) "the recursion must complete on one release")
+  (assign i (+ i 1)))
+
+# ...and the same recursion abandoned partway by an error, so the activation
+# leaves through the walk while its deferred set names the one closure it
+# re-entered 20 times.
+(defn count-down-raising [n]
+  (letrec [go (fn [k acc]
+                (if (%lt k 30) (error acc) (go (%sub k 1) (%add acc k))))]
+    (go n 0)))
+
+(assign i 0)
+(while (< i 40)
+  (let [[ok e] (protect (count-down-raising 50))]
+    (assert (= ok false) "the recursion must raise")
+    (assert (= (type-of e) :integer) "and hand the catcher its accumulator"))
+  (assign i (+ i 1)))
+
+(println "region-tail-deferred-exits-uaf: ok")

--- a/tests/elle/region-tail-deferred-exits.lisp
+++ b/tests/elle/region-tail-deferred-exits.lisp
@@ -173,9 +173,10 @@
 # body that allocates nothing reads 0. It is the body's own pending value: the
 # squelch exit runs no abandoned-frame walk, so the release table's half of what
 # that frame owed stays owed (docs/impl/region/mechanism.md § "An abandoned frame
-# runs the releases it still owes" — a different mechanism, still open there).
-# So each subject is read against its own control rather than against 0, with one
-# window's slack for allocator noise.
+# runs the releases it still owes" — a different mechanism, open at that exit;
+# elle-lisp/elle#1027). So each subject is read against its own control rather
+# than against 0, with one window's slack for allocator noise. When #1027 closes,
+# the squelch control drops to 0 and this reading gets tighter, not wrong.
 (def slack 50)
 
 (assert (%lt d-clean slack)

--- a/tests/elle/region-tail-deferred-exits.lisp
+++ b/tests/elle/region-tail-deferred-exits.lisp
@@ -1,0 +1,200 @@
+(elle/epoch 12)
+# A deferred tail-call release has the activation owner node's life
+# (docs/impl/region/owner.md § "A deferred tail-call release has the node's
+# life").
+#
+# A frame-replacing tail call strands the release the lowerer emitted past the
+# `TailCall` — the callee closure's own per-call region — and the new activation
+# takes it over. That obligation has to reach the activation's end whichever end
+# it takes: the normal completion, a park it is resumed out of, or an
+# abandonment no resume reaches.
+#
+# Every subject below is a per-call local closure called in TAIL position out of
+# a body that then leaves by a signal. Its control is the same closure called in
+# STATEMENT position, where no frame replacement happens and the compiler's own
+# release runs — so the DIFFERENCE is the deferred release and nothing else.
+#
+# This file is the LEAK gauge — an `arena/count` delta over a fixed window. The
+# soundness complement is region-tail-deferred-exits-uaf.lisp.
+
+(def window 300)
+
+(defn measure [thunk warm window]
+  (var i 0)
+  (while (%lt i warm)
+    (thunk)
+    (assign i (%add i 1)))
+  (def before (arena/count))
+  (var j 0)
+  (while (%lt j window)
+    (thunk)
+    (assign j (%add j 1)))
+  (%sub (arena/count) before))
+
+(defn run-to-end [f]
+  (fiber/resume f nil)
+  (while (= (fiber/status f) :suspended) (fiber/resume f nil))
+  nil)
+
+# subjects ─────────────────────────────────────────────────────────────────────
+
+# (a) an ERROR exit. The raising body IS the tail-called closure, so the
+# activation that took the release over is the one the signal abandons.
+(defn err-tail []
+  (try
+    (let [s (string "x" 1)]
+      ((fn []
+         (begin
+           (error :boom)
+           s))))
+    (catch e nil)))
+
+# (b) a PARK the fiber is resumed out of, all the way to completion. The
+# ordinary case: no error anywhere, and the release still has to survive the
+# suspend that unwound the loop holding it.
+(defn park-resumed []
+  (run-to-end (fiber/new (fn []
+                           (let [s (string "x" 1)]
+                             ((fn []
+                                (begin
+                                  (emit :yield 1)
+                                  s))))) |:yield|)))
+
+# (c) a PARK nothing resumes: the fiber handle is dropped while suspended, so
+# the discharge is the release's last chance.
+(defn park-dropped []
+  (def f
+    (fiber/new (fn []
+                 (let [s (string "x" 1)]
+                   ((fn []
+                      (begin
+                        (emit :yield 1)
+                        s))))) |:yield|))
+  (fiber/resume f nil)
+  nil)
+
+# (d) a SQUELCH boundary: the yield violates the mask, so the boundary raises a
+# signal-violation the abandoned activation never catches.
+(def squelched-tail
+  (squelch (fn []
+             (let [s (string "x" 1)]
+               ((fn []
+                  (begin
+                    (emit :yield 1)
+                    s))))) :yield))
+
+(defn sq-tail []
+  (try
+    (squelched-tail)
+    (catch e nil)))
+
+# controls ─────────────────────────────────────────────────────────────────────
+
+# The same closures called in statement position: no frame replacement, so the
+# compiler's own release runs and nothing is deferred. A subject that reads like
+# its control is measuring the deferral and not the exit's other accounting.
+(defn err-nontail []
+  (try
+    (let [s (string "x" 1)]
+      (begin
+        ((fn []
+           (begin
+             (error :boom)
+             s)))
+        s))
+    (catch e nil)))
+
+(defn park-resumed-nontail []
+  (run-to-end (fiber/new (fn []
+                           (let [s (string "x" 1)]
+                             (begin
+                               ((fn []
+                                  (begin
+                                    (emit :yield 1)
+                                    s)))
+                               s))) |:yield|)))
+
+(defn park-dropped-nontail []
+  (def f
+    (fiber/new (fn []
+                 (let [s (string "x" 1)]
+                   (begin
+                     ((fn []
+                        (begin
+                          (emit :yield 1)
+                          s)))
+                     s))) |:yield|))
+  (fiber/resume f nil)
+  nil)
+
+(def squelched-nontail
+  (squelch (fn []
+             (let [s (string "x" 1)]
+               (begin
+                 ((fn []
+                    (begin
+                      (emit :yield 1)
+                      s)))
+                 s))) :yield))
+
+(defn sq-nontail []
+  (try
+    (squelched-nontail)
+    (catch e nil)))
+
+# (e) the clean break itself: the same tail call with no signal at all. Bounded
+# before this mechanism and after it — a regression here is the deferred release
+# failing to run where it always did.
+(defn clean-tail []
+  (let [s (string "x" 1)]
+    ((fn [] s))))
+
+# measurement ──────────────────────────────────────────────────────────────────
+
+(def d-err (measure err-tail 20 window))
+(def d-err-c (measure err-nontail 20 window))
+(def d-park (measure park-resumed 20 window))
+(def d-park-c (measure park-resumed-nontail 20 window))
+(def d-drop (measure park-dropped 20 window))
+(def d-drop-c (measure park-dropped-nontail 20 window))
+(def d-sq (measure sq-tail 20 window))
+(def d-sq-c (measure sq-nontail 20 window))
+(def d-clean (measure clean-tail 20 window))
+
+(println "region-tail-deferred-exits over " window " iters (object deltas):")
+(println "  error exit     " d-err " (control " d-err-c ")")
+(println "  park + resume  " d-park " (control " d-park-c ")")
+(println "  park + drop    " d-drop " (control " d-drop-c ")")
+(println "  squelch exit   " d-sq " (control " d-sq-c ")")
+(println "  clean break    " d-clean " (control)")
+
+# The trap: a control is not always 0. The squelch control reads one object per
+# op, and it is NOT the boundary's own signal-violation error — a squelch of a
+# body that allocates nothing reads 0. It is the body's own pending value: the
+# squelch exit runs no abandoned-frame walk, so the release table's half of what
+# that frame owed stays owed (docs/impl/region/mechanism.md § "An abandoned frame
+# runs the releases it still owes" — a different mechanism, still open there).
+# So each subject is read against its own control rather than against 0, with one
+# window's slack for allocator noise.
+(def slack 50)
+
+(assert (%lt d-clean slack)
+        (concat "control: the clean break must still run the deferred release, "
+                "delta=" (number->string d-clean)))
+
+(assert (%lt d-err (%add d-err-c slack))
+        (concat "an abandoned activation owes its deferred release, delta="
+                (number->string d-err) " control=" (number->string d-err-c)))
+(assert (%lt d-park (%add d-park-c slack))
+        (concat "a deferred release must survive a park the fiber is resumed "
+                "out of, delta=" (number->string d-park) " control="
+                (number->string d-park-c)))
+(assert (%lt d-drop (%add d-drop-c slack))
+        (concat "a park nothing resumes discharges its deferred release, delta="
+                (number->string d-drop) " control=" (number->string d-drop-c)))
+(assert (%lt d-sq (%add d-sq-c slack))
+        (concat "a squelch boundary abandons the activation, so it owes the "
+                "deferred release, delta=" (number->string d-sq) " control="
+                (number->string d-sq-c)))
+
+(println "region-tail-deferred-exits: ok")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -813,6 +813,25 @@ fn region_error_unwind_uaf() {
     );
 }
 
+// Guard — a deferred tail-call release runs at every end its activation can
+// reach, not only the clean break (docs/impl/region/owner.md § "A deferred
+// tail-call release has the node's life"). Each is a decref the activation
+// genuinely owed, now run where it never ran, so what must survive is every
+// reference the activation does not own: the error PAYLOAD the raiser reached
+// through the tail callee's captured environment, a closure a CONTAINER still
+// holds, the RESUMED body whose completion the release belongs to, a DROPPED
+// fiber's parked payload, and a tail RECURSION that re-enters with one closure
+// and owes it one release. Every read happens after the exit ran, so an
+// over-release faults there — SIGSEGV under guardfree. The leak face is
+// `region-tail-deferred-exits.lisp`.
+#[test]
+fn region_tail_deferred_exits_uaf() {
+    run_elle_script_with_args(
+        "region-tail-deferred-exits-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — an emit-raised error's payload keeps every frame-owed release: the
 // raise minted the delivery reference itself, so the walk and the parked
 // frame's discharge stop exempting the payload's region


### PR DESCRIPTION
Closes #918.

## The defect, as filed and as measured

The issue reproduces on `main` exactly as written — `+2` regions and `+3`
objects per raise:

```lisp
(try (let [s (string "x" 1)] ((fn [] (error s)))) (catch e nil))
```

Varying the scaffold before the op showed the error exit is one of three. Each
subject below is a per-call local closure called in TAIL position out of a body
that then leaves by a signal; each control is the same closure called in
STATEMENT position, so the difference is the deferred release and nothing else
(objects per op, `arena/count`):

| exit | subject before | subject after | control |
|---|---:|---:|---:|
| error | 3 | 0 | 0 |
| park, fiber resumed to completion | 3 | 0 | 0 |
| park, fiber dropped unresumed | 3 | 0 | 0 |
| squelch boundary | 3 | 0 | 1 |
| clean break (regression control) | 0 | 0 | — |

The **park** row is the one worth reading twice. It is not an error path at all:
`trampoline_loop` held the deferred set in a Rust local, a suspend returned out
of that loop, and the resumed body re-entered through a *fresh* loop with an
empty set. So a fiber that yielded once inside a tail-called closure stranded
the callee's region even when it ran to completion.

## The fix

The obligation is the activation owner node's, moment for moment: it must reach
the activation's normal completion across however many parks the activation
takes, and be discharged where the activation is abandoned instead. So the two
become one per-activation record, `ActivationDues` (`src/value/fiber/dues.rs`),
and every site that already moved the node moves both — the park into
`BytecodeFrame`, the resume's restore, the discard chokepoint, the terminal
fiber teardown, and the region free path's fiber discharge.

One record is what makes the move discipline enforceable. Split into two
carriers, a park that moved one and dropped the other is a leak on one side and
a strand on the other, and nothing fails on it.

The abandoned exits run the deferred set beside the release table's own walk, on
the same `walk_abandoned` question — so a frame the restarts system can replay
is left alone, exactly as it is for the table.

Recording also moves to where the tail call is **built** (`tail_call_inner`)
rather than where the pending call is consumed. The interpreter trampoline is
only one consumer of `pending_tail_call`; the top-level driver and the JIT
sentinel arms are others, and they dropped the set outright.

### Why the signal's payload needs no exemption

A deferred region is a per-call closure region or a merged closure-cycle arena.
A raise's payload is either a value the native built into its own fresh call
region — nobody's argument, so in neither — or one of the call's arguments,
whose delivery the raise mints (`mint_raised_argument_delivery`).

The shape that looks like a counterexample is the one the issue was filed on: a
payload the raiser reaches through the tail-called closure's **captured
environment**, where the env's counted edge is the value's last holder once the
frame-exit relocation has run the binding's own release ahead of the `TailCall`.
Releasing the closure region cascades that edge away — and the value survives on
the raise's mint, which is a reference no frame holds. `region-tail-deferred-exits-uaf.lisp`
face 1 is that shape, read after the exit.

## Gauges

- `tests/elle/region-tail-deferred-exits.lisp` — the leak gauge: four exits,
  each against its own control, plus the clean break as a regression control.
  Fails on `main` for the right reason on all four.
- `tests/elle/region-tail-deferred-exits-uaf.lisp` — the soundness pin, run
  under `--trace=guardfree` by `region_tail_deferred_exits_uaf`. Six faces:
  the captured-environment payload, a closure a container still holds, a resumed
  body, a dropped fiber's parked payload, a squelch boundary's error, and a tail
  recursion that re-enters with one closure and owes it one release.
- `src/value/fiber/dues/tests.rs` — the record's own contract (the dedup a
  tail-recursive `go` depends on; the abandoned take leaving the node standing).

All three project gauges run clean:

- `oracle.lisp` → `oracle: ok`, `open defects: 0 across 0 roots; by-design: 5`
- `cargo test -p elle --test lib region_` → 98 passed, 0 failed
- `make smoke-elle` (release, unpiped) → 1005 pass, 0 fail, 0 diverge, 0 timeout
- `cargo test -p elle --lib ownership` → 69 passed; clippy and `cargo fmt` clean

The new files also pass under `--jit=eager` and `--jit=off`.

## Deliberately out of scope

Measuring the squelch control turned up a **different** defect of the same
family, left untouched here and filed as **#1027**: the squelch exit runs no
abandoned-frame walk, so the release *table's* half of what that frame owed
stays owed — one object per pending value, which is the 1 in the control column
above. It is not the boundary's own error (a squelch of a body that allocates
nothing reads 0); it is the body's own pending value, and both the live
activation the boundary breaks out of and the parked frames the discard abandons
are affected. That is `docs/impl/region/mechanism.md` § "An abandoned frame runs
the releases it still owes" missing at a second exit, across six enforcement
sites, and it wants its own test and its own argument about what a walk may
release for a fiber that *survives* the boundary. This PR touches the same
break — it runs the deferred set there — so the two are neighbours, but the
claims are separate and #1027 carries the second one.

The JIT's own tail-call path still wires neither channel
(`jit_tail_call_inner`), so a compiled activation records no deferral — the
pre-existing bounded over-keep, now noted where the compiled `Return` decides
whether to emit the dues release.

