### PR TITLE
epochs: read every source under the lexicon its own epoch selects

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -39,6 +39,7 @@ Design documents, language references, and contributor guides for Elle.
 | File | Description |
 |------|-------------|
 | `impl/reader.md` | Lexer, parser, source locations, markdown literate mode |
+| `impl/lexicon.md` | Epoch-aware lexing design: the epoch prescan and the `Lexicon` rule set |
 | `impl/hir.md` | Binding resolution, signal inference |
 | `impl/lir.md` | SSA form, virtual registers, basic blocks |
 | `impl/bytecode.md` | Instruction set and encoding |

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ Focused files covering one topic each, all runnable via `elle docs/<file>.md`.
 
 | Directory | Content |
 |-----------|---------|
-| [impl/](impl/) | Reader, HIR, LIR, bytecode, VM, JIT, WASM, MLIR, SPIR-V, GPU, values, symbols, stdlib cache |
+| [impl/](impl/) | Reader, lexicon, HIR, LIR, bytecode, VM, JIT, WASM, MLIR, SPIR-V, GPU, values, symbols, stdlib cache |
 
 ## Reference
 

--- a/docs/epochs.md
+++ b/docs/epochs.md
@@ -44,6 +44,10 @@ compiler applies all migration rules from epoch N+1 through the current epoch
 to the parsed syntax tree. This is transparent — old-epoch code compiles and
 runs exactly as if it had been written using current-epoch syntax.
 
+Because migration operates on parsed trees, it cannot express changes to
+tokenization itself. [`impl/lexicon.md`](impl/lexicon.md) is the design for
+extending epochs to lexical changes (not yet implemented).
+
 ## Migration rule types
 
 Each epoch bump defines a set of migration rules. The `MigrationRule` enum in

--- a/docs/epochs.md
+++ b/docs/epochs.md
@@ -36,7 +36,8 @@ See [`compile-time.md`](compile-time.md) and [`strings.md`](strings.md).
 The epoch migration pass runs after parsing and before macro expansion:
 
 ```
-Source → Reader → [Epoch Migration] → Expander → HIR → LIR → Bytecode
+Source → [epoch prescan] → Reader → [Epoch Migration] → Expander → HIR → LIR
+       → Bytecode
 ```
 
 If a file declares `(elle/epoch N)` where N is older than the current epoch, the
@@ -45,8 +46,10 @@ to the parsed syntax tree. This is transparent — old-epoch code compiles and
 runs exactly as if it had been written using current-epoch syntax.
 
 Because migration operates on parsed trees, it cannot express changes to
-tokenization itself. [`impl/lexicon.md`](impl/lexicon.md) is the design for
-extending epochs to lexical changes (not yet implemented).
+tokenization itself. The reader therefore reads the declaration before it
+lexes, with a frozen micro-grammar, and tokenizes under the lexer rules that
+epoch selects — see [`impl/lexicon.md`](impl/lexicon.md). Every epoch
+registered today shares one set of rules, so no file lexes differently yet.
 
 ## Migration rule types
 
@@ -112,10 +115,16 @@ directly (preserving comments, whitespace, and formatting) and updates the
 elle rewrite [OPTIONS] <file...>
 ```
 
+It reads each file under the lexicon that file's own epoch selects, so a file
+written before a token-level change still tokenizes the way its author meant
+(see [`impl/lexicon.md`](impl/lexicon.md)). Tokens whose spelling changed are
+rewritten in place alongside the tree rules.
+
 **Options:**
 - `--check` — Report files that need changes (exit 1 if any). Does not modify files.
 - `--dry-run` — Show what would change without writing.
-- `--list-rules` — Print all migration rules for the current epoch.
+- `--list-rules` — Print all migration rules for the current epoch, tree rules
+  and lexical changes alike.
 
 **Example workflow:**
 
@@ -139,7 +148,9 @@ To make a breaking change to Elle:
 
 1. Bump `CURRENT_EPOCH` in `src/epoch/rules.rs`.
 2. Add a `Migration` entry to the `MIGRATIONS` array with the new epoch number,
-   a summary, and the rules describing the change.
+   a summary, and the rules describing the change. A change to tokenization
+   also flips a `Lexicon` field in `Lexicon::for_epoch` and names itself in the
+   entry's `lexical` list — see [`impl/lexicon.md`](impl/lexicon.md).
 3. Update `(elle/epoch N)` in `stdlib.lisp` to the new epoch. The WASM backend
    strips stdlib's epoch tag and concatenates the body as-is — it does not run
    migration on stdlib, so stdlib must already use current-epoch syntax.

--- a/docs/impl/lexicon.md
+++ b/docs/impl/lexicon.md
@@ -1,7 +1,9 @@
 # Lexicon: epoch-aware lexing
 
-Status: design — not yet implemented; tracked in issue #1020. The first
-client is the comment/splice swap proposed in issue #983.
+Status: the prescan (`prescan_epoch`) and the `Lexicon` seam are implemented
+and tested; the reader entry points do not consult them yet. Issue #1020
+tracks the remaining wiring. The first client is the comment/splice swap
+proposed in issue #983.
 
 Epochs rewrite parsed syntax trees (see [../epochs.md](../epochs.md)). This
 document extends the epoch system down one level, to the lexer, so that an
@@ -57,8 +59,9 @@ a fixed micro-grammar that no future epoch may change:
 1. If the source starts with `#!`, skip the first line (the reader already
    strips shebangs before lexing).
 2. Skip whitespace.
-3. Match the literal shape `(elle/epoch <digits>)`: the characters `(`, the
-   symbol `elle/epoch`, whitespace, decimal digits, optional whitespace, `)`.
+3. Match the literal shape `(elle/epoch <digits>)`: the character `(`,
+   optional whitespace, the symbol `elle/epoch`, whitespace, decimal digits,
+   optional whitespace, `)`.
 4. On a match, the digits name the epoch. On anything else — including a
    comment in either style — the source targets `CURRENT_EPOCH`.
 
@@ -173,16 +176,20 @@ before the body, that selects the reader for the rest of the file.
 
 ## Landing order
 
-Documentation, then tests, then code:
+Documentation, then tests, then code. The prescan
+(`src/epoch/mod.rs::prescan_epoch`), the `Lexicon` seam
+(`src/epoch/rules.rs`), and the lexer's consultation of its lexicon are in
+place, with tests pinning the prescan edges and the token-stream divergence.
+What remains, in order:
 
-1. This document, cross-referenced from [../epochs.md](../epochs.md) and
-   [reader.md](reader.md).
-2. Tests: prescan unit tests (shebang, whitespace, absent, malformed,
-   too-new, negative, declaration-below-comment), the lexicon-mismatch
-   error, and the silent-divergence example pinned as producing different
-   trees under two lexicons that differ.
-3. The `Lexicon` seam with identical rules for all epochs ≤ 12 — a pure
-   refactor — plus the prescan and the mismatch check.
-4. The `elle rewrite` token-level pass.
+1. Wire the prescan into the reader entry points (`read_str` and `lex_all`
+   in `src/reader/mod.rs`): prescan the original source, then lex with
+   `Lexer::with_lexicon(input, Lexicon::for_epoch(n))`.
+2. The mismatch check after `extract_epoch` in `src/pipeline/compile.rs`:
+   reject the file when the declared and prescanned epochs select
+   different lexicons.
+3. Update `detect_epoch_in_source` (`src/epoch/mod.rs`) to lex under the
+   prescanned lexicon instead of the current one.
+4. The `elle rewrite` token-level pass (`src/rewrite/`).
 5. The first real lexical epoch (#983) exercises the mechanism end to end
    and lands with its own migration tests.

--- a/docs/impl/lexicon.md
+++ b/docs/impl/lexicon.md
@@ -1,9 +1,8 @@
 # Lexicon: epoch-aware lexing
 
-Status: the prescan (`prescan_epoch`) and the `Lexicon` seam are implemented
-and tested; the reader entry points do not consult them yet. Issue #1020
-tracks the remaining wiring. The first client is the comment/splice swap
-proposed in issue #983.
+Status: implemented. Every registered epoch shares one lexicon, so no file
+lexes differently yet. The first client is the comment/splice swap proposed
+in issue #983.
 
 Epochs rewrite parsed syntax trees (see [../epochs.md](../epochs.md)). This
 document extends the epoch system down one level, to the lexer, so that an
@@ -27,7 +26,7 @@ promise stops at the token boundary.
 The failure can be silent. This text is legal under both a splice-`;` grammar
 and a comment-`;` grammar, with different values:
 
-```lisp
+```text
 [1 ;xs
  2]
 ```
@@ -78,13 +77,19 @@ and rejects duplicates. The prescan only selects the lexicon. The two must
 agree where it matters:
 
 - If `Lexicon::for_epoch(declared) == Lexicon::for_epoch(prescanned)`, any
-  disagreement is harmless and allowed. All epochs ≤ 12 share one lexicon, so
-  every existing file — including a file with comments above its declaration
-  — keeps working unchanged.
+  disagreement is harmless and allowed. Every registered epoch shares one
+  lexicon, so every existing file — including a file with comments above its
+  declaration — keeps working unchanged.
 - If the two lexicons differ, compilation fails with an error telling the
   author to move the declaration above everything except the shebang. A
   declaration the prescan cannot see cannot have selected the lexer that read
   it, so the file's reading is unreliable by construction.
+
+The pipeline runs this check immediately after the read, while it still holds
+both the source text and the tree read from it (`src/pipeline/compile.rs` and
+`src/pipeline/compile/frontend.rs`). The comparison is over lexicons, never
+over epoch numbers: comparing the numbers would reject every file that carries
+a comment above its declaration.
 
 ## The Lexicon
 
@@ -100,10 +105,18 @@ affected match arms instead of hard-coding the rules. A lexical change
 touches exactly two places: the `Lexicon` field that names the behavior, and
 the `for_epoch` table that flips it.
 
+`Lexicon::respell` reads the same fields in the other direction: given a
+token lexed under one lexicon, it returns the text that spells the same
+token under another, or nothing when the two spell it alike. That single
+method is what `elle rewrite` migrates tokens with, so the rules and the
+rewrite of the rules cannot drift apart.
+
 Each lexical change also gets a `LexicalChange` descriptor (a name and a
 summary) in the epoch's `Migration` entry, so `elle rewrite --list-rules` and
 the epoch history in [../epochs.md](../epochs.md) can enumerate token-level
-changes alongside tree rules.
+changes alongside tree rules. A test pins the pairing in both directions: an
+epoch declares a `LexicalChange` exactly when its lexicon differs from its
+predecessor's.
 
 ## Scope
 
@@ -115,7 +128,7 @@ unit. The declaration sits above everything except a shebang and whitespace.
 | `.lisp` file | prescan |
 | Literate `.md` | prescan of the stripped text; the declaration is the first form of the first fence |
 | stdin program | prescan |
-| REPL input | always current epoch |
+| REPL input | always current epoch (`read_syntax_all_current`) |
 | `eval` / `read` of a string | prescan (a data string without a declaration is current-epoch) |
 | stdlib / prelude | must be current-epoch text (unchanged rule; the WASM backend concatenates stdlib without migration) |
 | `.lua`, `.js`, `.py` syntax modes | out of scope — those lexers do not consult the lexicon |
@@ -125,21 +138,33 @@ with the current lexicon, as today.
 
 ## Tooling
 
-**`elle rewrite`** gains a token-level pass that runs before the tree rules:
-re-lex the file under its source-epoch lexicon, rewrite each changed token in
-place by byte span, then apply tree rules and bump the tag. Token spans make
-this formatting-preserving by construction, matching the tool's existing
+**`elle rewrite`** lexes a file under its own epoch's lexicon — every pass it
+runs, not only the new one — and applies a token-level pass alongside the
+tree rules. `Lexicon::respell` gives each token its current-epoch spelling,
+and the rewriter applies the difference in place by byte span. Token spans
+make this formatting-preserving by construction, matching the tool's existing
 contract. `--check`, `--dry-run`, and `--list-rules` cover lexical changes
 the same way they cover tree rules.
 
-**`elle fmt`** lexes under the file's declared epoch and re-emits under the
-same epoch. Formatting never migrates; only `elle rewrite` does.
+Two shapes fall outside a respelling. A token the current lexicon cannot
+spell at all is not a byte-span rewrite; the rewriter stops and names the
+position, and the epoch that removes the shape carries a tree rule for it.
+And the shebang line is not Elle text, so no token inside it is respelled,
+however the lexer happened to tokenize it.
+
+**`elle fmt`** runs the epoch rewrite before it formats, unless `--no-epoch`
+skips it (`src/formatter/run.rs`), so the file it writes is current-epoch text
+under a current tag. It lexes its input under the epoch that input declares,
+exactly as `elle rewrite` does. It emits comment text verbatim, so a file
+formatted with `--no-epoch` keeps the spelling it arrived with.
 
 **Diagnostics.** When lexing or parsing fails at a token whose rule differs
-in an older lexicon, the error appends: "if this file targets epoch ≤ N, add
-`(elle/epoch N)` as its first form, or run `elle rewrite`". This is the
+in an older lexicon, the error should append: "if this file targets epoch ≤ N,
+add `(elle/epoch N)` as its first form, or run `elle rewrite`". This is the
 loud path for un-tagged old files; the declaration requirement exists for the
-silent ones.
+silent ones. No token's rule differs yet, so the hint has nothing to fire on;
+it lands with the first lexical epoch, which is the first epoch that can test
+it.
 
 ## Alternatives considered
 
@@ -173,23 +198,27 @@ before the body, that selects the reader for the rest of the file.
   lexicons differ, compilation fails.
 - All lexical differences between epochs live in `Lexicon::for_epoch`. The
   lexer contains no bare epoch comparisons.
+- A source unit's lexicon comes from its own text. The REPL is the single
+  exception: prompt input is always current-epoch, so a pasted declaration
+  cannot change how the prompt lexes.
 
-## Landing order
+## Where the pieces live
 
-Documentation, then tests, then code. The prescan
-(`src/epoch/mod.rs::prescan_epoch`), the `Lexicon` seam
-(`src/epoch/rules.rs`), and the lexer's consultation of its lexicon are in
-place, with tests pinning the prescan edges and the token-stream divergence.
-What remains, in order:
+| Piece | Home |
+|-------|------|
+| The prescan | `src/epoch/mod.rs::prescan_epoch` |
+| The lexicon and its `respell` | `src/epoch/rules.rs` |
+| The lexer's consultation of it | `src/reader/lexer.rs::in_lexicon` |
+| Reader entry points that prescan | `src/reader/mod.rs` |
+| The REPL's current-epoch entry point | `src/reader/mod.rs::read_syntax_all_current` |
+| The mismatch check | `src/epoch/mod.rs::check_lexicon_agreement` |
+| The token-level rewrite pass | `src/rewrite/run.rs::collect_lexical_edits` |
 
-1. Wire the prescan into the reader entry points (`read_str` and `lex_all`
-   in `src/reader/mod.rs`): prescan the original source, then lex with
-   `Lexer::with_lexicon(input, Lexicon::for_epoch(n))`.
-2. The mismatch check after `extract_epoch` in `src/pipeline/compile.rs`:
-   reject the file when the declared and prescanned epochs select
-   different lexicons.
-3. Update `detect_epoch_in_source` (`src/epoch/mod.rs`) to lex under the
-   prescanned lexicon instead of the current one.
-4. The `elle rewrite` token-level pass (`src/rewrite/`).
-5. The first real lexical epoch (#983) exercises the mechanism end to end
-   and lands with its own migration tests.
+Every registered epoch shares one lexicon, so the paths that act on a
+difference cannot be reached through `Lexicon::for_epoch`. Tests build the
+differing pair directly — `Lexicon::divergent`, `Lexicon::no_semicolon` —
+rather than leave those paths to run for the first time on the epoch that
+needs them.
+
+The first real lexical epoch (#983) exercises the mechanism end to end and
+lands with its own migration tests.

--- a/docs/impl/lexicon.md
+++ b/docs/impl/lexicon.md
@@ -1,0 +1,188 @@
+# Lexicon: epoch-aware lexing
+
+Status: design — not yet implemented; tracked in issue #1020. The first
+client is the comment/splice swap proposed in issue #983.
+
+Epochs rewrite parsed syntax trees (see [../epochs.md](../epochs.md)). This
+document extends the epoch system down one level, to the lexer, so that an
+epoch bump can change tokenization itself. It owns the argument for the
+mechanism and the alternatives it beat.
+
+## Problem
+
+The migration pass runs after the reader:
+
+```
+Source → Reader → [epoch migration] → Expander → HIR → LIR → Bytecode
+```
+
+Every `MigrationRule` operates on `Syntax` trees, so the current lexer must
+tokenize a file before the file's epoch can help it. A lexical change — a
+different comment character, a removed reader token — breaks that assumption.
+An old file misreads before migration ever runs, and the `(elle/epoch N)`
+promise stops at the token boundary.
+
+The failure can be silent. This text is legal under both a splice-`;` grammar
+and a comment-`;` grammar, with different values:
+
+```lisp
+[1 ;xs
+ 2]
+```
+
+Under splice, `xs` spreads into the array. Under comment, the rest of the
+line disappears. No error fires in either reading. The epoch must therefore
+be *declared*, never inferred from whether the file happens to parse.
+
+## Design
+
+Two additions: a frozen **epoch prescan** that finds the declaration before
+lexing, and a **`Lexicon`** value that carries the epoch-gated lexer rules.
+
+```
+Source → [shebang strip] → [epoch prescan] → Lexer(Lexicon) → Parser
+       → [epoch tree migration] → Expander → …
+```
+
+The reader entry points in `src/reader/mod.rs` (`read_str`, `lex_all`, and
+everything built on them) prescan internally and build the lexicon
+themselves. The public reader API does not change; the formatter, LSP, lint,
+`elle rewrite`, and embedders keep their current signatures.
+
+## The epoch prescan
+
+The prescan answers one question — which lexicon tokenizes this source — with
+a fixed micro-grammar that no future epoch may change:
+
+1. If the source starts with `#!`, skip the first line (the reader already
+   strips shebangs before lexing).
+2. Skip whitespace.
+3. Match the literal shape `(elle/epoch <digits>)`: the characters `(`, the
+   symbol `elle/epoch`, whitespace, decimal digits, optional whitespace, `)`.
+4. On a match, the digits name the epoch. On anything else — including a
+   comment in either style — the source targets `CURRENT_EPOCH`.
+
+The frozen subset is the whole trick. The declaration form contains only
+characters whose lexical meaning is identical in every epoch, past and
+future, so the prescan needs no epoch to read it. This invariant binds all
+future epochs: no epoch may change the meaning of `(`, `)`, whitespace,
+decimal digits, or the constituent characters of the symbol `elle/epoch` in
+the positions the prescan examines.
+
+`extract_epoch` (`src/epoch/mod.rs`) stays the authority for the epoch
+number: it still validates the declaration on the parsed tree, consumes it,
+and rejects duplicates. The prescan only selects the lexicon. The two must
+agree where it matters:
+
+- If `Lexicon::for_epoch(declared) == Lexicon::for_epoch(prescanned)`, any
+  disagreement is harmless and allowed. All epochs ≤ 12 share one lexicon, so
+  every existing file — including a file with comments above its declaration
+  — keeps working unchanged.
+- If the two lexicons differ, compilation fails with an error telling the
+  author to move the declaration above everything except the shebang. A
+  declaration the prescan cannot see cannot have selected the lexer that read
+  it, so the file's reading is unreliable by construction.
+
+## The Lexicon
+
+`Lexicon` is a struct of the epoch-gated lexer rules — the comment
+introducer, whether `;` lexes as `Splice`, whether `,;` fuses into
+`UnquoteSplicing`, the dispatch table behind `#`, and whatever later epochs
+add. `Lexicon::for_epoch(n)` builds it, and it lives in `src/epoch/rules.rs`
+next to the `MigrationRule` tables, so one file describes everything an epoch
+changed.
+
+The lexer (`src/reader/lexer.rs`) holds a `Lexicon` and consults it in the
+affected match arms instead of hard-coding the rules. A lexical change
+touches exactly two places: the `Lexicon` field that names the behavior, and
+the `for_epoch` table that flips it.
+
+Each lexical change also gets a `LexicalChange` descriptor (a name and a
+summary) in the epoch's `Migration` entry, so `elle rewrite --list-rules` and
+the epoch history in [../epochs.md](../epochs.md) can enumerate token-level
+changes alongside tree rules.
+
+## Scope
+
+One source unit, one epoch: the prescanned epoch governs every byte of the
+unit. The declaration sits above everything except a shebang and whitespace.
+
+| Source | Epoch resolution |
+|--------|------------------|
+| `.lisp` file | prescan |
+| Literate `.md` | prescan of the stripped text; the declaration is the first form of the first fence |
+| stdin program | prescan |
+| REPL input | always current epoch |
+| `eval` / `read` of a string | prescan (a data string without a declaration is current-epoch) |
+| stdlib / prelude | must be current-epoch text (unchanged rule; the WASM backend concatenates stdlib without migration) |
+| `.lua`, `.js`, `.py` syntax modes | out of scope — those lexers do not consult the lexicon |
+
+`MigrationRule::Replace` templates are current-epoch syntax and are lexed
+with the current lexicon, as today.
+
+## Tooling
+
+**`elle rewrite`** gains a token-level pass that runs before the tree rules:
+re-lex the file under its source-epoch lexicon, rewrite each changed token in
+place by byte span, then apply tree rules and bump the tag. Token spans make
+this formatting-preserving by construction, matching the tool's existing
+contract. `--check`, `--dry-run`, and `--list-rules` cover lexical changes
+the same way they cover tree rules.
+
+**`elle fmt`** lexes under the file's declared epoch and re-emits under the
+same epoch. Formatting never migrates; only `elle rewrite` does.
+
+**Diagnostics.** When lexing or parsing fails at a token whose rule differs
+in an older lexicon, the error appends: "if this file targets epoch ≤ N, add
+`(elle/epoch N)` as its first form, or run `elle rewrite`". This is the
+loud path for un-tagged old files; the declaration requirement exists for the
+silent ones.
+
+## Alternatives considered
+
+**Infer the grammar (try current, retry older on failure).** Beaten by the
+silent-divergence example above: both grammars accept overlapping texts with
+different meanings, so failure is not a reliable signal. Rejected outright.
+
+**A superset lexer that defers the decision to the parser.** Tokenization
+cannot be deferred: a comment consumes to end of line during lexing, so the
+two grammars produce different token streams, not one stream with two
+readings.
+
+**Out-of-band declaration (file extension, manifest).** Elle files must be
+self-describing: `elle script.lisp` has no manifest, and files travel through
+pipes, fences, and transcripts without their directory. Rust editions live in
+`Cargo.toml` because cargo owns every build; Elle has no such owner.
+
+**Flag day with a converter, no compatibility.** Breaks the epoch promise
+for external corpora, and the promise is the epoch system's whole point.
+
+Prior art: Racket's `#lang` line is the same shape — a frozen prefix, read
+before the body, that selects the reader for the rest of the file.
+
+## Invariants
+
+- The prescan micro-grammar never changes. The characters it examines keep
+  their lexical meaning in every epoch.
+- One declaration per source unit, above everything except a shebang and
+  whitespace, when the unit crosses a lexical boundary.
+- The prescan selects the lexicon; `extract_epoch` owns the number. If their
+  lexicons differ, compilation fails.
+- All lexical differences between epochs live in `Lexicon::for_epoch`. The
+  lexer contains no bare epoch comparisons.
+
+## Landing order
+
+Documentation, then tests, then code:
+
+1. This document, cross-referenced from [../epochs.md](../epochs.md) and
+   [reader.md](reader.md).
+2. Tests: prescan unit tests (shebang, whitespace, absent, malformed,
+   too-new, negative, declaration-below-comment), the lexicon-mismatch
+   error, and the silent-divergence example pinned as producing different
+   trees under two lexicons that differ.
+3. The `Lexicon` seam with identical rules for all epochs ≤ 12 — a pure
+   refactor — plus the prescan and the mismatch check.
+4. The `elle rewrite` token-level pass.
+5. The first real lexical epoch (#983) exercises the mechanism end to end
+   and lands with its own migration tests.

--- a/docs/impl/reader.md
+++ b/docs/impl/reader.md
@@ -63,4 +63,5 @@ reporting.
 ## See also
 
 - [impl/hir.md](hir.md) — analysis phase after reading
+- [impl/lexicon.md](lexicon.md) — epoch-aware lexing design (not yet implemented)
 - [syntax.md](../syntax.md) — user-facing syntax reference

--- a/docs/impl/reader.md
+++ b/docs/impl/reader.md
@@ -7,8 +7,16 @@ markdown (`.md`).
 ## Pipeline
 
 ```text
-Source text → Lexer → Tokens → Parser → Vec<Syntax>
+Source text → [shebang strip] → [epoch prescan] → Lexer(Lexicon) → Tokens
+            → Parser → Vec<Syntax>
 ```
+
+The entry points in `src/reader/mod.rs` prescan the source for its
+`(elle/epoch N)` declaration and lex under the lexicon that epoch selects
+(see [impl/lexicon.md](lexicon.md)). A declaration naming an epoch this
+compiler does not know is a read error: no lexicon exists to tokenize it.
+`read_syntax_all_current` skips the prescan and lexes under the current
+epoch; the REPL is its one caller.
 
 ## Lexer
 
@@ -63,5 +71,5 @@ reporting.
 ## See also
 
 - [impl/hir.md](hir.md) — analysis phase after reading
-- [impl/lexicon.md](lexicon.md) — epoch-aware lexing design (not yet implemented)
+- [impl/lexicon.md](lexicon.md) — epoch-aware lexing: the prescan and the `Lexicon`
 - [syntax.md](../syntax.md) — user-facing syntax reference

--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -8,7 +8,7 @@
 //! # File format
 //!
 //! ```lisp
-//! (elle 42)
+//! (elle/epoch 12)
 //! (def x 10)
 //! ```
 //!
@@ -18,10 +18,13 @@
 //!
 //! # Pipeline integration
 //!
-//! The epoch pass runs after parsing and before macro expansion:
+//! The reader prescans the declaration to choose the lexicon it tokenizes
+//! under (docs/impl/lexicon.md). The migration pass then runs after parsing
+//! and before macro expansion:
 //!
 //! ```text
-//! Source → Reader → [epoch migration] → Expander → HIR → LIR → Bytecode
+//! Source → [epoch prescan] → Reader → [epoch migration] → Expander → HIR
+//!        → LIR → Bytecode
 //! ```
 
 pub mod rules;
@@ -38,46 +41,54 @@ use crate::syntax::{Syntax, SyntaxKind};
 /// the list and returns the epoch number. If absent, returns `None`
 /// (the file targets the current epoch).
 pub fn extract_epoch(forms: &mut Vec<Syntax>) -> Result<Option<u64>, String> {
-    if forms.is_empty() {
+    let Some(n) = forms.first().and_then(epoch_declaration) else {
         return Ok(None);
+    };
+    if n < 0 {
+        return Err(format!(
+            "invalid epoch at {}: {} (must be non-negative)",
+            forms[0].span, n
+        ));
     }
+    let epoch = n as u64;
+    if epoch > CURRENT_EPOCH {
+        return Err(format!(
+            "file at {} targets epoch {} but this compiler only supports up to epoch {}",
+            forms[0].span, epoch, CURRENT_EPOCH
+        ));
+    }
+    forms.remove(0);
 
-    if let SyntaxKind::List(items) = &forms[0].kind {
-        if items.len() == 2 && items[0].is_symbol("elle/epoch") {
-            if let SyntaxKind::Int(n) = items[1].kind {
-                if n < 0 {
-                    return Err(format!(
-                        "invalid epoch at {}: {} (must be non-negative)",
-                        forms[0].span, n
-                    ));
-                }
-                let epoch = n as u64;
-                if epoch > CURRENT_EPOCH {
-                    return Err(format!(
-                        "file at {} targets epoch {} but this compiler only supports up to epoch {}",
-                        forms[0].span, epoch, CURRENT_EPOCH
-                    ));
-                }
-                forms.remove(0);
-
-                // Reject duplicate epoch declarations.
-                for form in forms.iter() {
-                    if let SyntaxKind::List(items) = &form.kind {
-                        if items.len() == 2 && items[0].is_symbol("elle/epoch") {
-                            return Err(format!(
-                                "duplicate (elle/epoch) at {}; only one epoch declaration is allowed per file",
-                                form.span
-                            ));
-                        }
-                    }
-                }
-
-                return Ok(Some(epoch));
+    // Reject duplicate epoch declarations. This matches the form's shape
+    // rather than a usable number, which `epoch_declaration` requires:
+    // `(elle/epoch x)` further down the file is still a second declaration.
+    for form in forms.iter() {
+        if let SyntaxKind::List(items) = &form.kind {
+            if items.len() == 2 && items[0].is_symbol("elle/epoch") {
+                return Err(format!(
+                    "duplicate (elle/epoch) at {}; only one epoch declaration is allowed per file",
+                    form.span
+                ));
             }
         }
     }
 
-    Ok(None)
+    Ok(Some(epoch))
+}
+
+/// The number in an `(elle/epoch N)` form, or `None` when `form` is not
+/// one. The number is unvalidated: callers decide what they can act on.
+fn epoch_declaration(form: &Syntax) -> Option<i64> {
+    let SyntaxKind::List(items) = &form.kind else {
+        return None;
+    };
+    if items.len() != 2 || !items[0].is_symbol("elle/epoch") {
+        return None;
+    }
+    match items[1].kind {
+        SyntaxKind::Int(n) => Some(n),
+        _ => None,
+    }
 }
 
 /// The epoch whose lexicon tokenizes this source (docs/impl/lexicon.md).
@@ -92,13 +103,7 @@ pub fn extract_epoch(forms: &mut Vec<Syntax>) -> Result<Option<u64>, String> {
 /// for tree migration, and the reader rejects the file only when the two
 /// epochs select different lexicons.
 pub fn prescan_epoch(source: &str) -> Result<u64, String> {
-    let rest = match source.strip_prefix("#!") {
-        Some(after) => match after.find('\n') {
-            Some(i) => &after[i + 1..],
-            None => "",
-        },
-        None => source,
-    };
+    let rest = &source[crate::reader::shebang_len(source)..];
     let Some(rest) = rest.trim_start().strip_prefix('(') else {
         return Ok(CURRENT_EPOCH);
     };
@@ -126,6 +131,97 @@ pub fn prescan_epoch(source: &str) -> Result<u64, String> {
     }
 }
 
+/// An epoch paired with the lexicon it selects.
+///
+/// The mismatch check compares two of these. Carrying the lexicon beside
+/// its epoch lets a test build a pair no registered epoch can produce:
+/// every registered epoch shares one lexicon today, so the refusal below
+/// is otherwise unreachable and would ship untested.
+#[derive(Clone, Copy)]
+struct EpochLexicon {
+    epoch: u64,
+    lexicon: rules::Lexicon,
+}
+
+impl EpochLexicon {
+    /// The pair a real epoch number produces.
+    fn of(epoch: u64) -> Self {
+        EpochLexicon {
+            epoch,
+            lexicon: rules::Lexicon::for_epoch(epoch),
+        }
+    }
+
+    /// A pair no registered epoch produces, for reaching the refusal path.
+    #[cfg(test)]
+    fn with_lexicon(epoch: u64, lexicon: rules::Lexicon) -> Self {
+        EpochLexicon { epoch, lexicon }
+    }
+}
+
+/// Reject a source whose declaration could not have chosen the lexer that
+/// read it (docs/impl/lexicon.md).
+fn refuse_mismatch(
+    declared: EpochLexicon,
+    prescanned: EpochLexicon,
+    source_name: &str,
+) -> Result<(), String> {
+    // Lexicons, never epoch numbers. A declaration the prescan could not
+    // see still tokenized correctly when both epochs lex alike, which is
+    // every file today and every file that carries a comment above its
+    // declaration.
+    if declared.lexicon == prescanned.lexicon {
+        return Ok(());
+    }
+    Err(format!(
+        "{}: this file declares (elle/epoch {}), but the reader tokenized it \
+         as epoch {}. The two epochs do not lex alike. Move the declaration \
+         above everything except a shebang line.",
+        source_name, declared.epoch, prescanned.epoch
+    ))
+}
+
+/// The epoch this tree declares, when the declaration is one the lexicon
+/// tables can answer for.
+///
+/// [`extract_epoch`] is the authority: it validates the number, consumes
+/// the form, and reports a negative or unknown epoch. This only looks, so
+/// the lexicon check can run before it.
+fn declared_epoch(forms: &[Syntax]) -> Option<u64> {
+    let n = epoch_declaration(forms.first()?)?;
+    u64::try_from(n).ok().filter(|e| *e <= CURRENT_EPOCH)
+}
+
+/// Reject a file whose epoch declaration the prescan could not see, when
+/// the declaration and the prescan select different lexicons
+/// (docs/impl/lexicon.md). Pass the source as the reader received it.
+pub fn check_lexicon_agreement(
+    forms: &[Syntax],
+    source: &str,
+    source_name: &str,
+) -> Result<(), String> {
+    match declared_epoch(forms) {
+        Some(declared) => check_declared_lexicon(declared, source, source_name),
+        None => Ok(()),
+    }
+}
+
+/// The same check for a caller that already knows the declared epoch and
+/// has no parsed tree — `elle rewrite`, which reads the declaration out of
+/// the source text.
+pub fn check_declared_lexicon(
+    declared: u64,
+    source: &str,
+    source_name: &str,
+) -> Result<(), String> {
+    let prescanned = crate::reader::prescanned_epoch_for(source, source_name)?;
+    refuse_mismatch(
+        EpochLexicon::of(declared),
+        EpochLexicon::of(prescanned),
+        source_name,
+    )
+}
+
 /// Info about an epoch declaration found in source text.
 pub struct EpochInfo {
     /// The declared epoch number.
@@ -141,44 +237,35 @@ pub struct EpochInfo {
 /// Parses just enough to find `(elle/epoch N)` at the start. Returns `None`
 /// if no epoch declaration is present. Used by the CLI rewriter to
 /// build per-file rules without modifying the syntax tree.
+///
+/// The read goes through [`read_syntax_all`], so the source is tokenized
+/// under the lexicon its own prescan selects (docs/impl/lexicon.md) — the
+/// spans below name bytes of the file as its author wrote it.
 pub fn detect_epoch_in_source(source: &str) -> Result<Option<EpochInfo>, String> {
     // The reader strips shebang lines before parsing, so syntax spans are
     // relative to the post-strip input.  Compute the offset so we can
     // translate back to original-source byte positions.
-    let shebang_offset = if source.starts_with("#!") {
-        source.find('\n').map(|i| i + 1).unwrap_or(source.len())
-    } else {
-        0
-    };
+    let shebang_offset = crate::reader::shebang_len(source);
 
     let syntaxes = read_syntax_all(source, "<detect-epoch>")?;
-    if syntaxes.is_empty() {
+    let Some(n) = syntaxes.first().and_then(epoch_declaration) else {
         return Ok(None);
+    };
+    if n < 0 {
+        return Err(format!("invalid epoch: {} (must be non-negative)", n));
     }
-
-    if let SyntaxKind::List(items) = &syntaxes[0].kind {
-        if items.len() == 2 && items[0].is_symbol("elle/epoch") {
-            if let SyntaxKind::Int(n) = items[1].kind {
-                if n < 0 {
-                    return Err(format!("invalid epoch: {} (must be non-negative)", n));
-                }
-                let epoch = n as u64;
-                if epoch > CURRENT_EPOCH {
-                    return Err(format!(
-                        "file targets epoch {} but this compiler only supports up to epoch {}",
-                        epoch, CURRENT_EPOCH
-                    ));
-                }
-                return Ok(Some(EpochInfo {
-                    epoch,
-                    byte_start: syntaxes[0].span.start + shebang_offset,
-                    byte_end: syntaxes[0].span.end + shebang_offset,
-                }));
-            }
-        }
+    let epoch = n as u64;
+    if epoch > CURRENT_EPOCH {
+        return Err(format!(
+            "file targets epoch {} but this compiler only supports up to epoch {}",
+            epoch, CURRENT_EPOCH
+        ));
     }
-
-    Ok(None)
+    Ok(Some(EpochInfo {
+        epoch,
+        byte_start: syntaxes[0].span.start + shebang_offset,
+        byte_end: syntaxes[0].span.end + shebang_offset,
+    }))
 }
 
 /// Migrate forms from a source epoch to the current epoch.

--- a/src/epoch/mod.rs
+++ b/src/epoch/mod.rs
@@ -80,6 +80,52 @@ pub fn extract_epoch(forms: &mut Vec<Syntax>) -> Result<Option<u64>, String> {
     Ok(None)
 }
 
+/// The epoch whose lexicon tokenizes this source (docs/impl/lexicon.md).
+///
+/// Scans a frozen micro-grammar that no epoch may change: an optional
+/// shebang line, whitespace, then the literal shape `(elle/epoch N)`.
+/// Anything else means the source targets [`CURRENT_EPOCH`].
+///
+/// Comment syntax is epoch-dependent, so the prescan cannot skip a
+/// comment without the answer it is computing. A declaration below a
+/// comment is therefore invisible here — `extract_epoch` still sees it
+/// for tree migration, and the reader rejects the file only when the two
+/// epochs select different lexicons.
+pub fn prescan_epoch(source: &str) -> Result<u64, String> {
+    let rest = match source.strip_prefix("#!") {
+        Some(after) => match after.find('\n') {
+            Some(i) => &after[i + 1..],
+            None => "",
+        },
+        None => source,
+    };
+    let Some(rest) = rest.trim_start().strip_prefix('(') else {
+        return Ok(CURRENT_EPOCH);
+    };
+    let Some(rest) = rest.trim_start().strip_prefix("elle/epoch") else {
+        return Ok(CURRENT_EPOCH);
+    };
+    // The symbol must end here: `elle/epochs` is a different name.
+    if !rest.starts_with(|c: char| c.is_whitespace()) {
+        return Ok(CURRENT_EPOCH);
+    }
+    let rest = rest.trim_start();
+    let digits = &rest[..rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len())];
+    if digits.is_empty() || !rest[digits.len()..].trim_start().starts_with(')') {
+        return Ok(CURRENT_EPOCH);
+    }
+    match digits.parse::<u64>() {
+        Ok(epoch) if epoch <= CURRENT_EPOCH => Ok(epoch),
+        // Also the overflow case: an epoch too large for u64 is too new.
+        _ => Err(format!(
+            "file targets epoch {} but this compiler only supports up to epoch {}",
+            digits, CURRENT_EPOCH
+        )),
+    }
+}
+
 /// Info about an epoch declaration found in source text.
 pub struct EpochInfo {
     /// The declared epoch number.

--- a/src/epoch/rules.rs
+++ b/src/epoch/rules.rs
@@ -10,6 +10,64 @@ use std::collections::HashMap;
 /// and add a corresponding entry to `MIGRATIONS`.
 pub const CURRENT_EPOCH: u64 = 12;
 
+/// The epoch-gated lexer rules (docs/impl/lexicon.md). The lexer consults
+/// a `Lexicon` instead of hard-coding these, so an epoch bump can change
+/// tokenization itself. All registered epochs currently share one lexicon;
+/// the first lexical epoch introduces the first divergence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Lexicon {
+    /// The character that starts a comment running to end of line.
+    pub(crate) comment_char: char,
+    /// Whether `;` lexes as the splice token. The comment character is
+    /// checked first, so a lexicon whose `comment_char` is `;` never
+    /// consults this flag; with both off, `;` is a lex error.
+    pub(crate) semicolon_splices: bool,
+    /// Whether `,;` fuses into the unquote-splicing token.
+    pub(crate) comma_semicolon_fuses: bool,
+}
+
+impl Lexicon {
+    /// The lexicon for the given epoch. Callers validate the epoch number
+    /// first: the prescan and `extract_epoch` both reject epochs above
+    /// [`CURRENT_EPOCH`].
+    pub fn for_epoch(epoch: u64) -> Lexicon {
+        debug_assert!(epoch <= CURRENT_EPOCH, "unregistered epoch {epoch}");
+        Lexicon {
+            comment_char: '#',
+            semicolon_splices: true,
+            comma_semicolon_fuses: true,
+        }
+    }
+
+    /// The current epoch's lexicon.
+    pub fn current() -> Lexicon {
+        Lexicon::for_epoch(CURRENT_EPOCH)
+    }
+}
+
+/// Lexicons that match no registered epoch. Tests lex under them to prove
+/// the lexer consults its lexicon rather than hard-coding the rules.
+#[cfg(test)]
+impl Lexicon {
+    /// `;` comments, nothing splices — the shape issue #983 proposes.
+    pub(crate) fn divergent() -> Lexicon {
+        Lexicon {
+            comment_char: ';',
+            semicolon_splices: false,
+            comma_semicolon_fuses: false,
+        }
+    }
+
+    /// `;` has no meaning at all: not a comment, not a splice.
+    pub(crate) fn no_semicolon() -> Lexicon {
+        Lexicon {
+            semicolon_splices: false,
+            comma_semicolon_fuses: false,
+            ..Lexicon::current()
+        }
+    }
+}
+
 /// A set of changes introduced at a given epoch.
 #[derive(Debug, Clone)]
 pub struct Migration {

--- a/src/epoch/rules.rs
+++ b/src/epoch/rules.rs
@@ -4,6 +4,7 @@
 //! migration rules here. Rules are pure data so they can be consumed
 //! by both the in-pipeline transformer and the `elle rewrite` CLI tool.
 
+use crate::reader::Token;
 use std::collections::HashMap;
 
 /// Current language epoch. Bump this when making a breaking change
@@ -43,6 +44,51 @@ impl Lexicon {
     pub fn current() -> Lexicon {
         Lexicon::for_epoch(CURRENT_EPOCH)
     }
+
+    /// The text that spells `token` — read under `self` — with its meaning
+    /// intact under `target`. `None` when both lexicons spell it alike,
+    /// which is every token whose rules did not move.
+    ///
+    /// This is the only place a token crosses between two lexicons, so
+    /// `elle rewrite` and the lexer read the same fields and cannot drift
+    /// apart (docs/impl/lexicon.md).
+    ///
+    /// A token `target` cannot spell at all is an error, not an unchanged
+    /// token: leaving those bytes in place would keep a file that parses
+    /// and means something else.
+    pub(crate) fn respell(
+        &self,
+        token: &Token<'_>,
+        target: &Lexicon,
+    ) -> Result<Option<String>, String> {
+        match token {
+            // A comment is its introducer and the rest of the line. Only the
+            // introducer belongs to the lexicon; the rest is the author's.
+            Token::Comment(text) if self.comment_char != target.comment_char => {
+                let body = text.strip_prefix(self.comment_char).unwrap_or(text);
+                Ok(Some(format!("{}{}", target.comment_char, body)))
+            }
+            Token::Splice if self.semicolon_splices && !target.semicolon_splices => {
+                Err(no_spelling("`;` splice"))
+            }
+            Token::UnquoteSplicing
+                if self.comma_semicolon_fuses && !target.comma_semicolon_fuses =>
+            {
+                Err(no_spelling("`,;` unquote-splicing"))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+/// The refusal shared by every token shape that survives a lexical change
+/// only as a different form, never as different bytes.
+fn no_spelling(lexeme: &str) -> String {
+    format!(
+        "{} has no spelling under the target lexicon; the epoch that removed \
+         the shape migrates it with a tree rule, not a token rewrite",
+        lexeme
+    )
 }
 
 /// Lexicons that match no registered epoch. Tests lex under them to prove
@@ -68,6 +114,19 @@ impl Lexicon {
     }
 }
 
+/// A token-level change an epoch made, for the reader of a changelog.
+///
+/// The rewrite itself comes from `Lexicon::respell`; this only names the
+/// change so `elle rewrite --list-rules` and the epoch history can show it
+/// beside the tree rules (docs/impl/lexicon.md).
+#[derive(Debug, Clone)]
+pub struct LexicalChange {
+    /// Short name, in the shape of a rule name: `comment-char`, `splice`.
+    pub name: &'static str,
+    /// Human-readable summary for changelogs and error messages.
+    pub summary: &'static str,
+}
+
 /// A set of changes introduced at a given epoch.
 #[derive(Debug, Clone)]
 pub struct Migration {
@@ -77,6 +136,10 @@ pub struct Migration {
     pub summary: &'static str,
     /// The individual rules in this migration.
     pub rules: &'static [MigrationRule],
+    /// The token-level changes in this migration. Non-empty exactly when
+    /// this epoch's [`Lexicon`] differs from its predecessor's; a test
+    /// pins the pairing.
+    pub lexical: &'static [LexicalChange],
 }
 
 /// A single mechanical transformation.
@@ -182,6 +245,7 @@ static MIGRATIONS: &[Migration] = &[
                 template: "(let [[ok? err] (protect ($1))] (assert (not ok?) $3) (assert (= (get err :error) $2) $3))",
             },
         ],
+        lexical: &[],
     },
     Migration {
         epoch: 2,
@@ -200,6 +264,7 @@ static MIGRATIONS: &[Migration] = &[
                 message: "use (pp ...) for literal form or (port/write port data) for port I/O",
             },
         ],
+        lexical: &[],
     },
     Migration {
         epoch: 3,
@@ -210,6 +275,7 @@ static MIGRATIONS: &[Migration] = &[
                 new: "print",
             },
         ],
+        lexical: &[],
     },
     Migration {
         epoch: 4,
@@ -236,6 +302,7 @@ static MIGRATIONS: &[Migration] = &[
                 new: "port/flush",
             },
         ],
+        lexical: &[],
     },
     Migration {
         epoch: 5,
@@ -255,6 +322,7 @@ static MIGRATIONS: &[Migration] = &[
                 new: "has?",
             },
         ],
+        lexical: &[],
     },
     Migration {
         epoch: 6,
@@ -263,6 +331,7 @@ static MIGRATIONS: &[Migration] = &[
             symbol: "ev/run",
             message: "user code already runs in the async scheduler; remove the ev/run wrapper",
         }],
+        lexical: &[],
     },
     Migration {
         epoch: 7,
@@ -270,6 +339,7 @@ static MIGRATIONS: &[Migration] = &[
         rules: &[MigrationRule::FlattenBindings {
             symbols: &["let", "letrec", "let*", "if-let", "when-let", "when-ok"],
         }],
+        lexical: &[],
     },
     Migration {
         epoch: 8,
@@ -279,6 +349,7 @@ static MIGRATIONS: &[Migration] = &[
             arity: 2,
             template: "(def @$1 $2)",
         }],
+        lexical: &[],
     },
     Migration {
         epoch: 9,
@@ -293,6 +364,7 @@ static MIGRATIONS: &[Migration] = &[
                 skip: 1,
             },
         ],
+        lexical: &[],
     },
     Migration {
         epoch: 10,
@@ -302,6 +374,7 @@ static MIGRATIONS: &[Migration] = &[
             MigrationRule::Rename { old: "car", new: "first" },
             MigrationRule::Rename { old: "cdr", new: "rest" },
         ],
+        lexical: &[],
     },
     Migration {
         epoch: 11,
@@ -327,6 +400,7 @@ static MIGRATIONS: &[Migration] = &[
             MigrationRule::Rename { old: "sys/spawn", new: "sys/spawn-vm" },
             MigrationRule::Rename { old: "os/spawn", new: "os/spawn-vm" },
         ],
+        lexical: &[],
     },
     Migration {
         epoch: 12,
@@ -372,6 +446,7 @@ static MIGRATIONS: &[Migration] = &[
                 message: "use (fiber/resume f) instead of (coroutine-next f)",
             },
         ],
+        lexical: &[],
     },
 ];
 
@@ -380,6 +455,14 @@ pub fn migrations_in_range(from: u64, to: u64) -> impl Iterator<Item = &'static 
     MIGRATIONS
         .iter()
         .filter(move |m| m.epoch > from && m.epoch <= to)
+}
+
+/// Every token-level change made in the range (from, to].
+pub fn lexical_changes_in_range(
+    from: u64,
+    to: u64,
+) -> impl Iterator<Item = &'static LexicalChange> {
+    migrations_in_range(from, to).flat_map(|m| m.lexical.iter())
 }
 
 /// Collapse all renames in a range into a single lookup table.

--- a/src/epoch/rules/tests.rs
+++ b/src/epoch/rules/tests.rs
@@ -106,3 +106,60 @@ fn test_rename_chaining() {
     assert_eq!(table.get("A"), Some(&"C"));
     assert!(!table.contains_key("B"));
 }
+
+// --- token-level respelling (docs/impl/lexicon.md) ---
+
+/// The current lexicon's spelling of `token`, read under `from`.
+fn into_current(from: Lexicon, token: Token<'_>) -> Result<Option<String>, String> {
+    from.respell(&token, &Lexicon::current())
+}
+
+#[test]
+fn a_comment_keeps_its_spelling_when_the_introducer_is_unchanged() {
+    assert_eq!(
+        into_current(Lexicon::current(), Token::Comment("# c\n".to_string())).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn a_comment_takes_the_introducer_of_the_target_lexicon() {
+    // `divergent` comments with `;`; the current lexicon comments with `#`.
+    // Only the introducer moves — the rest of the line is the author's text.
+    assert_eq!(
+        into_current(Lexicon::divergent(), Token::Comment("; c\n".to_string())).unwrap(),
+        Some("# c\n".to_string())
+    );
+}
+
+#[test]
+fn a_token_the_target_cannot_spell_is_refused_not_left_alone() {
+    // `;` splices under one lexicon and starts a comment under the other,
+    // so there is no text to put in its place. Answering "unchanged" would
+    // leave the byte where it is and silently change what the file means.
+    let err = Lexicon::current()
+        .respell(&Token::Splice, &Lexicon::divergent())
+        .unwrap_err();
+    assert!(err.contains(';'), "{err}");
+}
+
+#[test]
+fn a_fused_unquote_splice_the_target_cannot_spell_is_refused() {
+    let err = Lexicon::current()
+        .respell(&Token::UnquoteSplicing, &Lexicon::no_semicolon())
+        .unwrap_err();
+    assert!(err.contains(",;"), "{err}");
+}
+
+#[test]
+fn an_epoch_declares_a_lexical_change_exactly_when_its_lexicon_moves() {
+    // The descriptor is what `--list-rules` and the epoch history read. A
+    // lexicon that moves without one is a breaking change nothing tells the
+    // author about; a descriptor without a moved lexicon describes a change
+    // that did not happen.
+    for epoch in 1..=CURRENT_EPOCH {
+        let moved = Lexicon::for_epoch(epoch) != Lexicon::for_epoch(epoch - 1);
+        let declared = lexical_changes_in_range(epoch - 1, epoch).next().is_some();
+        assert_eq!(moved, declared, "epoch {epoch}");
+    }
+}

--- a/src/epoch/tests.rs
+++ b/src/epoch/tests.rs
@@ -80,3 +80,92 @@ fn test_migrate_forms_current_epoch() {
     let count = migrate_forms(&mut forms, CURRENT_EPOCH).unwrap();
     assert_eq!(count, 0);
 }
+
+// --- prescan_epoch: the frozen micro-grammar (docs/impl/lexicon.md) ---
+
+#[test]
+fn test_prescan_bare_declaration() {
+    assert_eq!(prescan_epoch("(elle/epoch 3)\n(def x 1)").unwrap(), 3);
+}
+
+#[test]
+fn test_prescan_after_shebang() {
+    assert_eq!(
+        prescan_epoch("#!/usr/bin/env elle\n(elle/epoch 5)\n(def x 1)").unwrap(),
+        5
+    );
+}
+
+#[test]
+fn test_prescan_leading_whitespace() {
+    assert_eq!(prescan_epoch("\n\n  (elle/epoch 0)").unwrap(), 0);
+}
+
+#[test]
+fn test_prescan_inner_whitespace() {
+    assert_eq!(prescan_epoch("( elle/epoch  7 )").unwrap(), 7);
+}
+
+#[test]
+fn test_prescan_absent_targets_current() {
+    assert_eq!(prescan_epoch("(def x 1)").unwrap(), CURRENT_EPOCH);
+}
+
+#[test]
+fn test_prescan_empty_and_shebang_only() {
+    assert_eq!(prescan_epoch("").unwrap(), CURRENT_EPOCH);
+    assert_eq!(prescan_epoch("#!/usr/bin/env elle").unwrap(), CURRENT_EPOCH);
+}
+
+#[test]
+fn test_prescan_declaration_below_comment_is_invisible() {
+    // Comment syntax is epoch-dependent, so the prescan cannot skip a
+    // comment without the answer it is computing. Skipping `#`-comments
+    // here would have looked right — and silently pinned `#` as a comment
+    // character in every future epoch.
+    assert_eq!(prescan_epoch("# c\n(elle/epoch 3)").unwrap(), CURRENT_EPOCH);
+}
+
+#[test]
+fn test_prescan_not_first_form() {
+    assert_eq!(
+        prescan_epoch("(def y 2) (elle/epoch 3)").unwrap(),
+        CURRENT_EPOCH
+    );
+}
+
+#[test]
+fn test_prescan_too_new_is_an_error() {
+    let err = prescan_epoch(&format!("(elle/epoch {})", CURRENT_EPOCH + 1)).unwrap_err();
+    assert!(err.contains("only supports up to"));
+    // An epoch too large for u64 is the same refusal, not a silent miss.
+    let err = prescan_epoch("(elle/epoch 99999999999999999999)").unwrap_err();
+    assert!(err.contains("only supports up to"));
+}
+
+#[test]
+fn test_prescan_negative_is_not_a_match() {
+    // Digits only: `-1` is no declaration to the prescan. extract_epoch
+    // still rejects it on the parsed tree with "must be non-negative".
+    assert_eq!(prescan_epoch("(elle/epoch -1)").unwrap(), CURRENT_EPOCH);
+}
+
+#[test]
+fn test_prescan_malformed_is_not_a_match() {
+    assert_eq!(prescan_epoch("(elle/epoch x)").unwrap(), CURRENT_EPOCH);
+    assert_eq!(prescan_epoch("(elle/epoch 3 4)").unwrap(), CURRENT_EPOCH);
+    assert_eq!(prescan_epoch("(elle/epoch 3").unwrap(), CURRENT_EPOCH);
+    // The symbol must end exactly: a longer name is a different name.
+    assert_eq!(prescan_epoch("(elle/epochs 3)").unwrap(), CURRENT_EPOCH);
+    assert_eq!(prescan_epoch("(elle/epoch3)").unwrap(), CURRENT_EPOCH);
+}
+
+#[test]
+fn test_lexicon_identical_across_all_registered_epochs() {
+    // The seam landed before any lexical epoch: every registered epoch
+    // shares one lexicon. The first lexical epoch deletes this test and
+    // replaces it with one pinning the divergence.
+    for epoch in 0..=CURRENT_EPOCH {
+        assert_eq!(rules::Lexicon::for_epoch(epoch), rules::Lexicon::current());
+    }
+}

--- a/src/epoch/tests.rs
+++ b/src/epoch/tests.rs
@@ -169,3 +169,64 @@ fn test_lexicon_identical_across_all_registered_epochs() {
         assert_eq!(rules::Lexicon::for_epoch(epoch), rules::Lexicon::current());
     }
 }
+
+// --- the mismatch check (docs/impl/lexicon.md) ---
+
+/// The forms of `source`, read the way the pipeline reads them.
+fn forms_of(source: &str) -> Vec<Syntax> {
+    read_syntax_all(source, "t.lisp").unwrap()
+}
+
+#[test]
+fn a_declaration_below_a_comment_is_allowed_when_the_lexicons_agree() {
+    // The prescan cannot see this declaration, so the two epochs differ:
+    // prescanned is CURRENT_EPOCH, declared is 3. Comparing the NUMBERS
+    // rejects this file, and with it every existing file that carries a
+    // comment above its epoch line. The rule compares lexicons.
+    let source = "# what this file is\n(elle/epoch 3)\n(def x 1)";
+    assert_eq!(prescan_epoch(source).unwrap(), CURRENT_EPOCH);
+    check_lexicon_agreement(&forms_of(source), source, "t.lisp").unwrap();
+}
+
+#[test]
+fn a_source_without_a_declaration_needs_no_agreement() {
+    let source = "(def x 1)";
+    check_lexicon_agreement(&forms_of(source), source, "t.lisp").unwrap();
+}
+
+#[test]
+fn a_declaration_this_compiler_cannot_act_on_is_left_to_extract_epoch() {
+    // A negative epoch is not a lexicon the check could look up. It stays
+    // extract_epoch's error to report, so the check must pass it through
+    // rather than panic looking the number up.
+    let source = "(elle/epoch -1)\n(def x 1)";
+    check_lexicon_agreement(&forms_of(source), source, "t.lisp").unwrap();
+    assert!(extract_epoch(&mut forms_of(source)).is_err());
+}
+
+#[test]
+fn agreeing_lexicons_accept_any_pair_of_epochs() {
+    refuse_mismatch(
+        EpochLexicon::of(3),
+        EpochLexicon::of(CURRENT_EPOCH),
+        "t.lisp",
+    )
+    .unwrap();
+}
+
+#[test]
+fn differing_lexicons_refuse_the_file_and_name_the_fix() {
+    // Unreachable through for_epoch until a lexical epoch exists, so the
+    // pair is built directly. Without this the refusal would ship untested
+    // and first run on the epoch that needs it.
+    let err = refuse_mismatch(
+        EpochLexicon::with_lexicon(3, rules::Lexicon::divergent()),
+        EpochLexicon::of(CURRENT_EPOCH),
+        "t.lisp",
+    )
+    .unwrap_err();
+    assert!(err.contains("t.lisp"), "{err}");
+    assert!(err.contains("(elle/epoch 3)"), "{err}");
+    assert!(err.contains(&format!("epoch {}", CURRENT_EPOCH)), "{err}");
+    assert!(err.contains("shebang"), "{err}");
+}

--- a/src/formatter/AGENTS.md
+++ b/src/formatter/AGENTS.md
@@ -20,7 +20,8 @@ Does NOT:
 ## Architecture
 
 ```
-Source → strip shebang → lex_for_format (separate tokens + comments)
+Source → strip shebang → epoch prescan
+       → lex_for_format (separate tokens + comments)
        → parse to Syntax → collect trivia → attach trivia
        → generate Doc → render → strip leading newline
        → prepend shebang + trailing newline
@@ -148,7 +149,12 @@ or arguments.
 
 3. **Shebang is stripped once.** `strip_shebang()` produces a single stripped
    source that both the parser and trivia collector use, keeping byte offsets
-   consistent.
+   consistent. It measures the line with `reader::shebang_len`, so it agrees
+   with the reader and the rewriter about where Elle's text begins.
+   `format_code` then prescans that stripped source and hands
+   `lex_for_format` the rules of the epoch it declares
+   (`docs/impl/lexicon.md`). Comment text is emitted verbatim, so the
+   spelling that arrived is the spelling that leaves.
 
 4. **String literals are source-sliced.** `SyntaxKind::String(s)` stores the
    unescaped value. The formatter slices `source[span.start..span.end]` to

--- a/src/formatter/comments.rs
+++ b/src/formatter/comments.rs
@@ -7,6 +7,7 @@
 //! annotate.
 
 use super::pos::{ByteOffset, ColNum, LineNum};
+use crate::epoch::rules::Lexicon;
 use crate::reader::{Lexer, OwnedToken, SourceLoc, Token};
 
 /// A source comment with its position and text.
@@ -43,33 +44,10 @@ pub struct CommentMap {
 }
 
 impl CommentMap {
-    /// Build a CommentMap from a source string.
-    /// Lexes the source and collects all comment tokens.
+    /// Build a CommentMap from a source string under the current epoch's
+    /// lexicon. Lexes the source and collects all comment tokens.
     pub fn collect(source: &str, source_name: &str) -> Result<Self, String> {
-        let mut lexer = Lexer::with_file(source, source_name);
-        let mut comments = Vec::new();
-
-        loop {
-            match lexer.next_token_with_loc() {
-                Ok(Some(twl)) => {
-                    if let Token::Comment(text) = &twl.token {
-                        // Strip trailing newline — the lexer includes it
-                        // but the formatter handles line breaks itself.
-                        let trimmed = text.trim_end_matches('\n').to_string();
-                        comments.push(SourceComment::new(
-                            trimmed,
-                            twl.byte_offset,
-                            twl.loc.line as u32,
-                            twl.loc.col as u32,
-                        ));
-                    }
-                }
-                Ok(None) => break,
-                Err(e) => return Err(e),
-            }
-        }
-
-        Ok(CommentMap { comments })
+        Ok(lex_for_format(source, source_name, Lexicon::current())?.comment_map)
     }
 
     /// An empty comment map.
@@ -150,25 +128,27 @@ pub struct LexedForFormat {
 /// Returns (stripped_source, shebang_line).
 /// The shebang_line includes the trailing newline, or is empty if none.
 pub fn strip_shebang(source: &str) -> (&str, &str) {
-    if source.starts_with("#!") {
-        match source.find('\n') {
-            Some(pos) => (&source[pos + 1..], &source[..pos + 1]),
-            None => ("", source),
-        }
-    } else {
-        (source, "")
-    }
+    let len = crate::reader::shebang_len(source);
+    (&source[len..], &source[..len])
 }
 
-/// Lex source for formatting: produces regular tokens for the parser
-/// and collects comment tokens into a CommentMap.
+/// Lex source for formatting under `lexicon`: produces regular tokens for
+/// the parser and collects comment tokens into a CommentMap.
+///
+/// The caller picks the lexicon from the epoch the source declares
+/// (docs/impl/lexicon.md), so a file written before a token-level change
+/// formats as its author wrote it.
 ///
 /// IMPORTANT: `source` must already have its shebang stripped (if any).
 /// Use `strip_shebang()` before calling this function. This ensures
 /// byte offsets in the token stream agree with byte offsets in the
 /// source string passed to `collect_trivia`.
-pub fn lex_for_format(source: &str, source_name: &str) -> Result<LexedForFormat, String> {
-    let mut lexer = Lexer::with_file(source, source_name);
+pub fn lex_for_format(
+    source: &str,
+    source_name: &str,
+    lexicon: Lexicon,
+) -> Result<LexedForFormat, String> {
+    let mut lexer = Lexer::with_file(source, source_name).in_lexicon(lexicon);
     let mut tokens = Vec::new();
     let mut locations = Vec::new();
     let mut lengths = Vec::new();

--- a/src/formatter/comments/tests.rs
+++ b/src/formatter/comments/tests.rs
@@ -59,7 +59,7 @@ fn test_take_trailing() {
 
 #[test]
 fn test_lex_for_format() {
-    let result = lex_for_format("# comment\n(+ 1 2)", "<test>").unwrap();
+    let result = lex_for_format("# comment\n(+ 1 2)", "<test>", Lexicon::current()).unwrap();
     // Regular tokens: (, +, 1, 2, )
     assert_eq!(result.tokens.len(), 5);
     // Comment map has 1 comment
@@ -84,7 +84,7 @@ fn test_strip_no_shebang() {
 fn test_lex_for_format_shebang() {
     // lex_for_format receives already-stripped source
     let (stripped, _shebang) = strip_shebang("#!/usr/bin/env elle\n(+ 1 2)");
-    let result = lex_for_format(stripped, "<test>").unwrap();
+    let result = lex_for_format(stripped, "<test>", Lexicon::current()).unwrap();
     assert_eq!(result.tokens.len(), 5);
     assert!(result.comment_map.is_empty());
 }

--- a/src/formatter/core.rs
+++ b/src/formatter/core.rs
@@ -3,7 +3,7 @@
 //! Implements the full formatting pipeline:
 //!
 //! ```text
-//! Source → strip shebang → lex (separate tokens + comments)
+//! Source → strip shebang → epoch prescan → lex (separate tokens + comments)
 //!       → parse to Syntax → collect trivia → attach trivia
 //!       → generate Doc → render → prepend shebang + trailing newline
 //! ```
@@ -13,7 +13,7 @@ use super::config::FormatterConfig;
 use super::format::format_forms;
 use super::render::render;
 use super::trivia::{collect_trivia, AnnotatedSyntax, CommentInfo};
-use crate::reader::SyntaxReader;
+use crate::reader::{lexicon_for, SyntaxReader};
 
 /// Format Elle source code with the given configuration.
 ///
@@ -22,8 +22,9 @@ pub fn format_code(source: &str, config: &FormatterConfig) -> Result<String, Str
     // 1. Strip shebang (single strip point for consistent byte offsets)
     let (stripped, shebang) = strip_shebang(source);
 
-    // 2. Lex: separate regular tokens from comment tokens
-    let lexed = lex_for_format(stripped, "<format>")?;
+    // 2. Lex: separate regular tokens from comment tokens, under the rules
+    //    this source's own epoch declares (docs/impl/lexicon.md)
+    let lexed = lex_for_format(stripped, "<format>", lexicon_for(stripped)?)?;
 
     // 3. Parse regular tokens to Syntax tree
     let forms = if lexed.tokens.is_empty() {

--- a/src/formatter/core/tests/basics.rs
+++ b/src/formatter/core/tests/basics.rs
@@ -217,3 +217,17 @@ nil
     let second = format_code(&formatted, &config).unwrap();
     assert_eq!(formatted, second, "full file must be idempotent");
 }
+
+#[test]
+fn formatting_refuses_a_declaration_it_has_no_lexicon_for() {
+    // The formatter lexes under the epoch its input declares
+    // (docs/impl/lexicon.md). An unregistered epoch names no lexicon, so
+    // there are no rules to tokenize the file with — including under
+    // `--no-epoch`, which formats the text exactly as it arrived.
+    let src = format!(
+        "(elle/epoch {})\n(def x 1)\n",
+        crate::epoch::CURRENT_EPOCH + 1
+    );
+    let err = format_code(&src, &FormatterConfig::default()).unwrap_err();
+    assert!(err.contains("only supports up to"), "{err}");
+}

--- a/src/pipeline/AGENTS.md
+++ b/src/pipeline/AGENTS.md
@@ -43,6 +43,11 @@ Reader (read_syntax / read_syntax_all)
     ▼
 Syntax (one or many)
     │
+    ├─► check_lexicon_agreement (the declaration matches the lexer that
+    │   read it — docs/impl/lexicon.md)
+    │
+    ├─► extract_epoch + migrate_forms (old-epoch syntax → current)
+    │
     ▼
 Expander (macro expansion, cached VM)
     │

--- a/src/pipeline/compile.rs
+++ b/src/pipeline/compile.rs
@@ -145,6 +145,7 @@ fn compile_file_to_lir_inner(
     epoch_skip: usize,
 ) -> Result<crate::lir::LirModule, String> {
     let mut syntaxes = read_syntax_all_for(source, source_name)?;
+    crate::epoch::check_lexicon_agreement(&syntaxes, source, source_name)?;
 
     let source_epoch = crate::epoch::extract_epoch(&mut syntaxes)?;
     if let Some(epoch) = source_epoch {

--- a/src/pipeline/compile/frontend.rs
+++ b/src/pipeline/compile/frontend.rs
@@ -58,6 +58,7 @@ pub(super) fn compile_file_frontend_xform(
             &format!("{} read", source_name),
             t,
         );
+        crate::epoch::check_lexicon_agreement(&syntaxes, source, source_name)?;
         compile_syntaxes_frontend_xform_inner(syntaxes, symbols, cctx, source_name, xform)
     })
 }

--- a/src/reader/AGENTS.md
+++ b/src/reader/AGENTS.md
@@ -18,7 +18,7 @@ Does NOT:
 
 | Type | Purpose |
 |------|---------|
-| `Lexer` | Tokenizes input string |
+| `Lexer` | Tokenizes input string under a `Lexicon` (epoch-gated rules, `docs/impl/lexicon.md`) |
 | `Token` | Token variants (LParen, Int, Symbol, Pipe, AtPipe, etc.) |
 | `SourceLoc` | Line/column position |
 | `Reader` | Parses tokens to `Value` |

--- a/src/reader/AGENTS.md
+++ b/src/reader/AGENTS.md
@@ -31,19 +31,36 @@ Does NOT:
 let value = read_str(source, runtime.heap(), &mut symbols)?;
 
 // Parse to Syntax (preferred)
-let syntax = read_syntax(source)?;
+let syntax = read_syntax(source, source_name)?;
 
 // Parse multiple forms
-let forms = read_syntax_all(source)?;
+let forms = read_syntax_all(source, source_name)?;
+
+// Parse multiple forms under the current epoch, whatever the text declares
+let forms = read_syntax_all_current(source, source_name)?;
 ```
+
+Each entry point prescans the source for its `(elle/epoch N)` declaration
+and lexes under `Lexicon::for_epoch(N)` (`docs/impl/lexicon.md`).
+`prescanned_epoch_for` reports that choice without reading, so the pipeline
+can check it against the declaration in the tree.
+`read_syntax_all_current` is the one exception, and the REPL is its one
+caller: prompt input is always current-epoch, so a pasted declaration
+cannot change how the prompt lexes.
+
+`shebang_len` gives the byte length of a leading `#!` line. Everything that
+translates between original-source offsets and lexer offsets measures it
+here.
 
 ## Data flow
 
 ```
 Source string
     │
+    ├─► prescan_epoch() → Lexicon::for_epoch(n)
+    │
     ▼
-Lexer::new(source)
+Lexer::with_file(source, name).in_lexicon(lexicon)
     │
     ├─► next_token_with_loc() → Token + SourceLoc
     │
@@ -126,7 +143,12 @@ The `@` in `:@name` is consumed by the lexer and prepended to the keyword name.
 7. **`:@name` keywords are valid.** The lexer recognizes `:@` as a keyword
    prefix variant. The `@` is consumed and prepended to the keyword name.
 
-8. **Comments are tokens.** `#` line comments are emitted as `Token::Comment(String)`
+8. **The epoch declaration selects the lexicon.** `(elle/epoch N)` at the top
+   of a source unit decides how that unit tokenizes, before any token is
+   produced (`docs/impl/lexicon.md`). An epoch this compiler has no lexicon
+   for is a read error, not a parse that guesses.
+
+9. **Comments are tokens.** `#` line comments are emitted as `Token::Comment(String)`
    by the lexer. Both `SyntaxReader` and `Reader` skip comment tokens during
    parsing — they do not appear in the output tree. The formatter collects
    them separately via `lex_with_comments()` for comment preservation.

--- a/src/reader/README.md
+++ b/src/reader/README.md
@@ -11,7 +11,7 @@ source locations and supports hygienic macro expansion.
 ```rust
 use elle::reader::read_syntax;
 
-let syntax = read_syntax("(+ 1 2)")?;
+let syntax = read_syntax("(+ 1 2)", "example.lisp")?;
 // syntax.span contains line/column info
 // syntax.kind is SyntaxKind::List(...)
 ```
@@ -28,7 +28,10 @@ let value = read_str("(+ 1 2)", runtime.heap(), &mut symbols)?;
 
 ## Lexer
 
-The lexer tokenizes input character by character:
+The lexer tokenizes input character by character, under the `Lexicon` its
+epoch selects (`docs/impl/lexicon.md`). The entry points above prescan the
+source for `(elle/epoch N)` and hand the lexer that epoch's rules; a lexer
+built directly uses the current epoch's.
 
 ```rust
 let mut lexer = Lexer::new("(+ 1 2)");
@@ -62,7 +65,7 @@ Error at 5:12: undefined variable 'foo'
 To parse a file with multiple top-level expressions:
 
 ```rust
-let forms = read_syntax_all(source)?;
+let forms = read_syntax_all(source, source_name)?;
 for form in forms {
     // Process each form
 }

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -1,4 +1,5 @@
 use super::token::{SourceLoc, Token, TokenWithLoc, UNKNOWN_FILE};
+use crate::epoch::rules::Lexicon;
 
 /// Fast delimiter check - O(1) instead of string contains O(n)
 /// Checks if a character is a Lisp delimiter
@@ -24,6 +25,7 @@ pub struct Lexer<'a> {
     line: usize,
     col: usize,
     file: String,
+    lexicon: Lexicon,
 }
 
 impl<'a> Lexer<'a> {
@@ -39,6 +41,16 @@ impl<'a> Lexer<'a> {
             line: 1,
             col: 1,
             file: file.into(),
+            lexicon: Lexicon::current(),
+        }
+    }
+
+    /// Lex under an explicit lexicon instead of the current epoch's
+    /// (docs/impl/lexicon.md). The epoch prescan picks the lexicon.
+    pub fn with_lexicon(input: &'a str, lexicon: Lexicon) -> Self {
+        Lexer {
+            lexicon,
+            ..Lexer::new(input)
         }
     }
 
@@ -112,12 +124,12 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    /// Read a comment starting at the current `#` character.
-    /// Returns the full comment text including the `#` prefix.
+    /// Read a comment starting at the current comment character.
+    /// Returns the full comment text including its prefix character.
     /// Leaves the lexer positioned after the newline (or at EOF).
     fn read_comment(&mut self) -> String {
         let mut text = String::new();
-        // The caller guarantees current() == Some('#')
+        // The caller guarantees current() == Some(self.lexicon.comment_char)
         while let Some(c) = self.advance() {
             text.push(c);
             if c == '\n' {
@@ -190,7 +202,9 @@ impl<'a> Lexer<'a> {
 
         match self.current() {
             None => Ok(None),
-            Some('#') => {
+            // Checked before every other arm: a lexicon whose comment
+            // character is `;` shadows the splice arm below.
+            Some(c) if c == self.lexicon.comment_char => {
                 let text = self.read_comment();
                 Ok(Some(self.spanned(Token::Comment(text), loc, start_pos)))
             }
@@ -228,7 +242,7 @@ impl<'a> Lexer<'a> {
             }
             Some(',') => {
                 self.advance();
-                if self.current() == Some(';') {
+                if self.lexicon.comma_semicolon_fuses && self.current() == Some(';') {
                     self.advance();
                     Ok(Some(self.spanned(Token::UnquoteSplicing, loc, start_pos)))
                 } else {
@@ -236,6 +250,15 @@ impl<'a> Lexer<'a> {
                 }
             }
             Some(';') => {
+                if !self.lexicon.semicolon_splices {
+                    // Refuse rather than fall through: the symbol reader
+                    // stops at `;` (a delimiter) without advancing, so
+                    // falling through would loop forever on empty symbols.
+                    return Err(format!(
+                        "unexpected ';' at {}:{}:{}",
+                        self.file, self.line, self.col
+                    ));
+                }
                 self.advance();
                 Ok(Some(self.spanned(Token::Splice, loc, start_pos)))
             }

--- a/src/reader/lexer.rs
+++ b/src/reader/lexer.rs
@@ -45,13 +45,13 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    /// Lex under an explicit lexicon instead of the current epoch's
-    /// (docs/impl/lexicon.md). The epoch prescan picks the lexicon.
-    pub fn with_lexicon(input: &'a str, lexicon: Lexicon) -> Self {
-        Lexer {
-            lexicon,
-            ..Lexer::new(input)
-        }
+    /// Lex under `lexicon` instead of the current epoch's
+    /// (docs/impl/lexicon.md). The reader's epoch prescan picks it. This
+    /// is a builder rather than a third constructor so that a caller who
+    /// also needs a file name (`with_file`) can have both.
+    pub fn in_lexicon(mut self, lexicon: Lexicon) -> Self {
+        self.lexicon = lexicon;
+        self
     }
 
     fn get_loc(&self) -> SourceLoc {

--- a/src/reader/lexer/tests.rs
+++ b/src/reader/lexer/tests.rs
@@ -136,7 +136,7 @@ use crate::epoch::rules::Lexicon;
 
 /// All tokens of `input` under `lexicon`.
 fn tokens_under(input: &str, lexicon: Lexicon) -> Vec<Token<'_>> {
-    let mut lexer = Lexer::with_lexicon(input, lexicon);
+    let mut lexer = Lexer::new(input).in_lexicon(lexicon);
     let mut tokens = Vec::new();
     while let Some(t) = lexer.next_token().unwrap() {
         tokens.push(t);
@@ -205,7 +205,7 @@ fn a_meaningless_semicolon_is_a_lex_error_not_a_silent_symbol() {
     // Under a lexicon where `;` neither splices nor comments, falling
     // through to the symbol reader would yield an empty symbol without
     // advancing — an infinite loop. The refusal must be explicit.
-    let mut lexer = Lexer::with_lexicon("(f ;xs)", Lexicon::no_semicolon());
+    let mut lexer = Lexer::new("(f ;xs)").in_lexicon(Lexicon::no_semicolon());
     let mut result = Ok(None);
     for _ in 0..8 {
         result = lexer.next_token();

--- a/src/reader/lexer/tests.rs
+++ b/src/reader/lexer/tests.rs
@@ -129,3 +129,89 @@ fn comment_with_special_chars() {
     let tok = lexer.next_token().unwrap().unwrap();
     assert!(matches!(tok, Token::Comment(s) if s.contains("(parens)")));
 }
+
+// --- The lexicon seam (docs/impl/lexicon.md) ---
+
+use crate::epoch::rules::Lexicon;
+
+/// All tokens of `input` under `lexicon`.
+fn tokens_under(input: &str, lexicon: Lexicon) -> Vec<Token<'_>> {
+    let mut lexer = Lexer::with_lexicon(input, lexicon);
+    let mut tokens = Vec::new();
+    while let Some(t) = lexer.next_token().unwrap() {
+        tokens.push(t);
+    }
+    tokens
+}
+
+#[test]
+fn the_lexicon_decides_whether_semicolon_splices_or_comments() {
+    // Both lexicons accept this text and produce different programs — the
+    // silent divergence that makes the epoch declaration mandatory. A
+    // lexer that hard-codes `;` as splice passes the current-lexicon half
+    // and fails the divergent half; equality of the two streams would
+    // mean the seam carries nothing.
+    let src = "[1 ;xs\n 2]";
+    assert_eq!(
+        tokens_under(src, Lexicon::current()),
+        vec![
+            Token::LeftBracket,
+            Token::Integer(1),
+            Token::Splice,
+            Token::Symbol("xs"),
+            Token::Integer(2),
+            Token::RightBracket,
+        ]
+    );
+    assert_eq!(
+        tokens_under(src, Lexicon::divergent()),
+        vec![
+            Token::LeftBracket,
+            Token::Integer(1),
+            Token::Comment(";xs\n".to_string()),
+            Token::Integer(2),
+            Token::RightBracket,
+        ]
+    );
+}
+
+#[test]
+fn the_lexicon_decides_the_comment_character() {
+    assert_eq!(
+        tokens_under("# c\n42", Lexicon::current()),
+        vec![Token::Comment("# c\n".to_string()), Token::Integer(42)]
+    );
+    assert_eq!(
+        tokens_under("; c\n42", Lexicon::divergent()),
+        vec![Token::Comment("; c\n".to_string()), Token::Integer(42)]
+    );
+}
+
+#[test]
+fn the_lexicon_decides_whether_comma_semicolon_fuses() {
+    assert_eq!(
+        tokens_under(",;x", Lexicon::current()),
+        vec![Token::UnquoteSplicing, Token::Symbol("x")]
+    );
+    // Without fusion the comma is a plain unquote and `;` starts a comment.
+    assert_eq!(
+        tokens_under(",;x", Lexicon::divergent()),
+        vec![Token::Unquote, Token::Comment(";x".to_string())]
+    );
+}
+
+#[test]
+fn a_meaningless_semicolon_is_a_lex_error_not_a_silent_symbol() {
+    // Under a lexicon where `;` neither splices nor comments, falling
+    // through to the symbol reader would yield an empty symbol without
+    // advancing — an infinite loop. The refusal must be explicit.
+    let mut lexer = Lexer::with_lexicon("(f ;xs)", Lexicon::no_semicolon());
+    let mut result = Ok(None);
+    for _ in 0..8 {
+        result = lexer.next_token();
+        if result.is_err() {
+            break;
+        }
+    }
+    assert!(result.unwrap_err().contains(";"));
+}

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -20,9 +20,41 @@ pub use parser::Reader;
 pub use syntax::SyntaxReader;
 pub use token::{OwnedToken, SourceLoc, Token, TokenWithLoc, UNKNOWN_FILE};
 
+use std::borrow::Cow;
+
+use crate::epoch::rules::Lexicon;
 use crate::symbol::SymbolTable;
 use crate::syntax::Syntax;
 use crate::value::Value;
+
+/// The byte length of a leading shebang line, including its newline.
+///
+/// A shebang (`#!/usr/bin/env elle`) belongs to the operating system, not to
+/// Elle, so it never reaches the lexer. Everything that translates between
+/// original-source offsets and lexer offsets — the reader, the prescan, the
+/// epoch detector, the rewriter, the formatter — measures the gap with this,
+/// so they cannot disagree about where Elle's text begins.
+pub fn shebang_len(input: &str) -> usize {
+    if input.starts_with("#!") {
+        input.find('\n').map(|i| i + 1).unwrap_or(input.len())
+    } else {
+        0
+    }
+}
+
+/// The source the lexer sees: everything after a shebang line.
+fn strip_shebang(input: &str) -> &str {
+    &input[shebang_len(input)..]
+}
+
+/// The lexicon that tokenizes `input` (docs/impl/lexicon.md).
+///
+/// Pass the original source: the prescan skips a shebang itself, and it
+/// must read the declaration before any rule the declaration selects has
+/// been applied to the text.
+pub(crate) fn lexicon_for(input: &str) -> Result<Lexicon, String> {
+    Ok(Lexicon::for_epoch(crate::epoch::prescan_epoch(input)?))
+}
 
 /// Main public entry point for reading Lisp code from a string. The result is
 /// born in a fresh region on `heap` (the caller's instance heap — an embedder
@@ -32,15 +64,8 @@ pub fn read_str(
     heap: &mut crate::value::fiberheap::FiberHeap,
     symbols: &mut SymbolTable,
 ) -> Result<Value, String> {
-    // Strip shebang if present (e.g., #!/usr/bin/env elle)
-    let input_owned = if input.starts_with("#!") {
-        // Find the end of the first line and skip it
-        input.lines().skip(1).collect::<Vec<_>>().join("\n")
-    } else {
-        input.to_string()
-    };
-
-    let mut lexer = Lexer::new(&input_owned);
+    let lexicon = lexicon_for(input)?;
+    let mut lexer = Lexer::new(strip_shebang(input)).in_lexicon(lexicon);
     let mut tokens = Vec::new();
     let mut locations = Vec::new();
 
@@ -71,16 +96,16 @@ struct LexedTokens {
     byte_offsets: Vec<usize>,
 }
 
-/// Lex source into tokens with source locations and byte offsets.
+/// Lex source into tokens with source locations and byte offsets, under the
+/// lexicon its own epoch declaration selects.
 fn lex_all(input: &str, source_name: &str) -> Result<LexedTokens, String> {
-    // Strip shebang if present
-    let input_owned = if input.starts_with("#!") {
-        input.lines().skip(1).collect::<Vec<_>>().join("\n")
-    } else {
-        input.to_string()
-    };
+    lex_all_under(input, source_name, lexicon_for(input)?)
+}
 
-    let mut lexer = Lexer::with_file(&input_owned, source_name);
+/// Lex source into tokens with source locations and byte offsets, under an
+/// explicit lexicon.
+fn lex_all_under(input: &str, source_name: &str, lexicon: Lexicon) -> Result<LexedTokens, String> {
+    let mut lexer = Lexer::with_file(strip_shebang(input), source_name).in_lexicon(lexicon);
     let mut tokens = Vec::new();
     let mut locations = Vec::new();
     let mut lengths = Vec::new();
@@ -122,8 +147,20 @@ pub fn read_syntax(input: &str, source_name: &str) -> Result<Syntax, String> {
 
 /// Parse source code into multiple Syntax trees
 pub fn read_syntax_all(input: &str, source_name: &str) -> Result<Vec<Syntax>, String> {
-    let lex = lex_all(input, source_name)?;
+    parse_all(lex_all(input, source_name)?)
+}
 
+/// Parse source code into multiple Syntax trees under the current epoch's
+/// lexicon, whatever the text declares (docs/impl/lexicon.md).
+///
+/// The REPL reads this way. A declaration pasted at the prompt is a form in
+/// the session, not a choice of lexer for the prompt that follows it.
+pub fn read_syntax_all_current(input: &str, source_name: &str) -> Result<Vec<Syntax>, String> {
+    parse_all(lex_all_under(input, source_name, Lexicon::current())?)
+}
+
+/// Parse a lexed token stream into every form it holds.
+fn parse_all(lex: LexedTokens) -> Result<Vec<Syntax>, String> {
     if lex.tokens.is_empty() {
         return Ok(Vec::new());
     }
@@ -156,6 +193,28 @@ pub fn strip_markdown(source: &str) -> String {
     out
 }
 
+/// The s-expression text inside `input`: a literate document contributes
+/// only its fenced code, everything else contributes itself. One home for
+/// the rule, so the epoch prescan reads exactly the bytes the lexer will.
+fn sexp_text<'a>(input: &'a str, source_name: &str) -> Cow<'a, str> {
+    if source_name.ends_with(".md") {
+        Cow::Owned(strip_markdown(input))
+    } else {
+        Cow::Borrowed(input)
+    }
+}
+
+/// The epoch whose lexicon tokenizes `input` under `source_name` — the same
+/// choice [`read_syntax_all_for`] makes (docs/impl/lexicon.md).
+///
+/// The pipeline compares this against the declaration in the parsed tree.
+/// The other syntax modes have no lexicon to select, so this answers for
+/// them as though they were s-expressions; the comparison never reaches
+/// them, because their trees carry no `(elle/epoch N)` first form.
+pub fn prescanned_epoch_for(input: &str, source_name: &str) -> Result<u64, String> {
+    crate::epoch::prescan_epoch(&sexp_text(input, source_name))
+}
+
 /// Parse source, dispatching by file extension:
 /// `.lua` → Lua reader, `.js` → JavaScript reader, `.py` → Python reader,
 /// `.md` → markdown code-block extraction, anything else → s-expressions.
@@ -166,12 +225,12 @@ pub fn read_syntax_all_for(input: &str, source_name: &str) -> Result<Vec<Syntax>
         js_parser::parse_js_file(input, source_name)
     } else if source_name.ends_with(".py") {
         py_parser::parse_py_file(input, source_name)
-    } else if source_name.ends_with(".md") {
-        let stripped = strip_markdown(input);
-        read_syntax_all(&stripped, source_name)
     } else {
-        read_syntax_all(input, source_name)
+        read_syntax_all(&sexp_text(input, source_name), source_name)
     }
 }
 
 // Tests migrated to tests/elle/reader.lisp
+
+#[cfg(test)]
+mod tests;

--- a/src/reader/tests.rs
+++ b/src/reader/tests.rs
@@ -1,0 +1,127 @@
+//! Unit tests (`super` is the parent impl module).
+
+use super::*;
+use crate::epoch::rules::Lexicon;
+use crate::epoch::CURRENT_EPOCH;
+
+/// A declaration one epoch past what this compiler knows. No lexicon
+/// exists for it, so every reader entry point must refuse the source.
+fn too_new() -> String {
+    format!("(elle/epoch {})", CURRENT_EPOCH + 1)
+}
+
+#[test]
+fn a_declaration_from_the_future_stops_the_reader() {
+    // The reader picks a lexicon before it tokenizes, and it has no rules
+    // for an unregistered epoch. Without the prescan the text lexes fine
+    // and only the pipeline's extract_epoch objects — long after the
+    // reader produced tokens it had no rules to produce.
+    let src = format!("{}\n(def x 1)", too_new());
+    let err = read_syntax_all(&src, "t.lisp").unwrap_err();
+    assert!(err.contains("only supports up to"), "{err}");
+}
+
+#[test]
+fn a_shebang_does_not_hide_the_declaration_from_the_reader() {
+    let src = format!("#!/usr/bin/env elle\n{}\n(def x 1)", too_new());
+    let err = read_syntax_all(&src, "t.lisp").unwrap_err();
+    assert!(err.contains("only supports up to"), "{err}");
+}
+
+#[test]
+fn a_literate_document_prescans_the_stripped_text() {
+    // Prose is not Elle: the declaration is the first form of the first
+    // fence. Prescanning the raw markdown reaches the `#` heading first
+    // and reports "no declaration", which reads the file under the wrong
+    // lexicon instead of refusing it.
+    let src = format!(
+        "# Title\n\nProse.\n\n```lisp\n{}\n(def x 1)\n```\n",
+        too_new()
+    );
+    let err = read_syntax_all_for(&src, "t.md").unwrap_err();
+    assert!(err.contains("only supports up to"), "{err}");
+}
+
+#[test]
+fn read_str_stops_on_a_declaration_from_the_future() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let mut symbols = SymbolTable::new();
+    let src = format!("{}\n(def x 1)", too_new());
+    let err = read_str(&src, &mut heap, &mut symbols).unwrap_err();
+    assert!(err.contains("only supports up to"), "{err}");
+}
+
+#[test]
+fn a_supported_declaration_reads_as_an_ordinary_form() {
+    // The prescan only picks the lexicon. The declaration stays in the
+    // tree for extract_epoch to consume.
+    let forms = read_syntax_all("(elle/epoch 3)\n(def x 1)", "t.lisp").unwrap();
+    assert_eq!(forms.len(), 2);
+}
+
+#[test]
+fn an_undeclared_source_reads_under_the_current_lexicon() {
+    let forms = read_syntax_all("# c\n(def x 1)", "t.lisp").unwrap();
+    assert_eq!(forms.len(), 1);
+}
+
+#[test]
+fn a_literate_document_reports_the_epoch_of_its_first_fence() {
+    // The pipeline asks which epoch tokenized a file so it can compare that
+    // answer against the declaration in the tree. For a literate document
+    // the answer must come from the stripped text, as the lexer's did.
+    let md = "# Title\n\nProse.\n\n```lisp\n(elle/epoch 3)\n(def x 1)\n```\n";
+    assert_eq!(prescanned_epoch_for(md, "t.md").unwrap(), 3);
+    // Prescanning the raw markdown reaches the heading and reports "none".
+    assert_eq!(crate::epoch::prescan_epoch(md).unwrap(), CURRENT_EPOCH);
+}
+
+#[test]
+fn a_plain_source_reports_the_epoch_it_declares() {
+    assert_eq!(
+        prescanned_epoch_for("(elle/epoch 3)\n(def x 1)", "t.lisp").unwrap(),
+        3
+    );
+    assert_eq!(
+        prescanned_epoch_for("(def x 1)", "t.lisp").unwrap(),
+        CURRENT_EPOCH
+    );
+}
+
+#[test]
+fn lex_all_tokenizes_under_the_lexicon_it_is_given() {
+    // The same three bytes, two token streams. This pins that the choice
+    // reaches the tokens through lex_all's own body, not only through a
+    // Lexer a test builds by hand.
+    let current = lex_all(";xs", "t.lisp").unwrap();
+    assert_eq!(
+        current.tokens,
+        vec![OwnedToken::Splice, OwnedToken::Symbol("xs".to_string())]
+    );
+    let divergent = lex_all_under(";xs", "t.lisp", Lexicon::divergent()).unwrap();
+    assert_eq!(
+        divergent.tokens,
+        vec![OwnedToken::Comment(";xs".to_string())]
+    );
+}
+
+#[test]
+fn the_current_lexicon_entry_point_ignores_a_declaration() {
+    // Prompt input is always current-epoch (docs/impl/lexicon.md). A pasted
+    // declaration is an ordinary form there, not a choice of lexer, so the
+    // text the prescanning entry point refuses must still read.
+    let src = format!("{}\n(def x 1)", too_new());
+    assert!(read_syntax_all(&src, "<repl>").is_err());
+    let forms = read_syntax_all_current(&src, "<repl>").unwrap();
+    assert_eq!(forms.len(), 2);
+}
+
+#[test]
+fn the_shebang_length_is_the_bytes_the_lexer_never_sees() {
+    // Four callers translate between original-source offsets and lexer
+    // offsets with this number; they must all get the same one.
+    assert_eq!(shebang_len("(def x 1)"), 0);
+    assert_eq!(shebang_len("#!/usr/bin/env elle\n(def x 1)"), 20);
+    // A shebang with no newline is the whole file.
+    assert_eq!(shebang_len("#!/usr/bin/env elle"), 19);
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -12,7 +12,7 @@
 //! letrec unit.
 
 use crate::pipeline::{compile_file_repl, CompileCtx};
-use crate::reader::read_syntax_all;
+use crate::reader::read_syntax_all_current;
 use crate::signals::Signal;
 use crate::symbol::SymbolTable;
 use crate::syntax::{Syntax, SyntaxKind};
@@ -418,13 +418,17 @@ struct DefBinding {
 }
 
 /// Try to parse source into complete forms.
+///
+/// Prompt input is always current-epoch (docs/impl/lexicon.md): a pasted
+/// `(elle/epoch N)` is a form the session evaluates, never a choice of
+/// lexer for the text around it.
 fn try_read(source: &str) -> ReadResult {
     let trimmed = source.trim();
     if trimmed.is_empty() {
         return ReadResult::Incomplete;
     }
 
-    match read_syntax_all(trimmed, "<repl>") {
+    match read_syntax_all_current(trimmed, "<repl>") {
         Ok(syntaxes) if syntaxes.is_empty() => ReadResult::Incomplete,
         Ok(syntaxes) => {
             let forms = syntaxes

--- a/src/rewrite/AGENTS.md
+++ b/src/rewrite/AGENTS.md
@@ -5,8 +5,9 @@ whitespace, and formatting.
 
 ## Responsibility
 
-- Lex source to tokens with byte offsets
+- Lex source to tokens with byte offsets, under the file's own epoch
 - Apply rewrite rules to tokens, producing edits
+- Respell tokens whose lexical rules changed since the file's epoch
 - Apply edits back-to-front to preserve byte offsets
 - CLI interface for batch rewriting files
 
@@ -21,8 +22,10 @@ Does NOT:
 |-----------------|---------|
 | `Edit` | Byte-range replacement: offset, length, new text |
 | `apply_edits` | Apply edits to source (sorts back-to-front, panics on overlap) |
+| `SourceText` | Source text, its name, and the lexicon that tokenizes it |
 | `RewriteRule` | Trait: examine a token, optionally produce an Edit |
 | `RenameSymbol` | Data-driven symbol rename from HashMap |
+| `collect_lexical_edits` | Respell tokens between two lexicons, by byte span |
 | `rewrite_source` | Core: lex + apply rules + produce (new_source, edits) |
 | `run` | CLI entry point for `elle rewrite` |
 
@@ -31,14 +34,21 @@ Does NOT:
 ```
 Source string
     │
-    ▼
-Lexer::new(source)
-    │
-    ├─► next_token_with_loc() → TokenWithLoc (with byte_offset)
+    ├─► detect_epoch_in_source() → the epoch the file declares
     │
     ▼
-For each token, apply rules → collect Vec<Edit>
+SourceText { text, name, Lexicon::for_epoch(epoch) }
+    │
+    ├─► tokens() / code_tokens() → TokenWithLoc (with byte_offset)
+    │
+    ▼
+For each token, apply rules and respell → collect Vec<Edit>
     │
     ▼
 apply_edits(source, edits) → new source string
 ```
+
+Every pass reads its tokens through `SourceText`, never through a bare
+`Lexer`. A file written before a token-level change tokenizes under its own
+epoch's rules, and one pass reaching for the current epoch's would silently
+disagree with the others (`docs/impl/lexicon.md`).

--- a/src/rewrite/README.md
+++ b/src/rewrite/README.md
@@ -33,6 +33,14 @@ Rewriting is implemented via:
 3. **Transformation**: Apply rewrite rules to the tree
 4. **Emission**: Convert back to source code
 
+## Epochs
+
+`elle rewrite` migrates a file from the epoch it declares to the current one.
+It reads the file under that epoch's lexicon, so a file written before a
+token-level change tokenizes the way its author meant, and respells the
+tokens whose spelling changed. See
+[`docs/impl/lexicon.md`](../../docs/impl/lexicon.md).
+
 ## See Also
 
 - [AGENTS.md](AGENTS.md) - technical reference for LLM agents

--- a/src/rewrite/engine.rs
+++ b/src/rewrite/engine.rs
@@ -4,32 +4,31 @@
 use super::edit::apply_edits;
 use super::edit::Edit;
 use super::rule::RewriteRule;
-use crate::reader::Lexer;
+use super::text::SourceText;
+#[cfg(test)]
+use crate::epoch::rules::Lexicon;
 
 /// Lex source and collect edits from rules without applying them.
-pub(crate) fn collect_edits(source: &str, rules: &[&dyn RewriteRule]) -> Result<Vec<Edit>, String> {
-    let mut lexer = Lexer::new(source);
+pub(crate) fn collect_edits(
+    source: SourceText<'_>,
+    rules: &[&dyn RewriteRule],
+) -> Result<Vec<Edit>, String> {
     let mut edits = Vec::new();
 
-    loop {
-        match lexer.next_token_with_loc() {
-            Ok(Some(token)) => {
-                for rule in rules {
-                    if let Some(edit) = rule.apply(&token) {
-                        edits.push(edit);
-                        break; // first matching rule wins per token
-                    }
-                }
+    for token in source.tokens()? {
+        for rule in rules {
+            if let Some(edit) = rule.apply(&token) {
+                edits.push(edit);
+                break; // first matching rule wins per token
             }
-            Ok(None) => break,
-            Err(e) => return Err(e.to_string()),
         }
     }
 
     Ok(edits)
 }
 
-/// Rewrite source text by applying rules to each token.
+/// Rewrite source text by applying rules to each token, under the current
+/// epoch's lexicon.
 /// Returns (new_source, edits_applied). If no rules match, returns (original_source, empty_vec).
 /// Returns Err if lexing fails.
 #[cfg(test)]
@@ -37,7 +36,8 @@ pub(crate) fn rewrite_source(
     source: &str,
     rules: &[&dyn RewriteRule],
 ) -> Result<(String, Vec<Edit>), String> {
-    let mut edits = collect_edits(source, rules)?;
+    let text = SourceText::new(source, "<rewrite>", Lexicon::current());
+    let mut edits = collect_edits(text, rules)?;
 
     if edits.is_empty() {
         return Ok((source.to_string(), Vec::new()));

--- a/src/rewrite/engine/tests.rs
+++ b/src/rewrite/engine/tests.rs
@@ -72,3 +72,28 @@ fn test_multibyte_utf8() {
     assert!(result.contains("\"λ\"")); // multi-byte string preserved
     assert!(result.contains("(path-join x)"));
 }
+
+#[test]
+fn the_engine_lexes_under_the_lexicon_it_is_given() {
+    // `; cons` splices the symbol `cons` under the current lexicon and is a
+    // comment under a `;`-commenting one. A rename that fires on the symbol
+    // must not fire on the same bytes when they spell a comment.
+    let source = "; cons\n(pair a b)\n";
+    let mut renames = HashMap::new();
+    renames.insert("cons".to_string(), "pair".to_string());
+    let rule = RenameSymbol::new("t", renames);
+    let rules: Vec<&dyn RewriteRule> = vec![&rule];
+
+    let spliced = collect_edits(
+        SourceText::new(source, "t.lisp", Lexicon::current()),
+        &rules,
+    )
+    .unwrap();
+    assert_eq!(spliced.len(), 1);
+    let commented = collect_edits(
+        SourceText::new(source, "t.lisp", Lexicon::divergent()),
+        &rules,
+    )
+    .unwrap();
+    assert!(commented.is_empty());
+}

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -7,3 +7,4 @@ pub mod edit;
 pub mod engine;
 pub mod rule;
 pub mod run;
+pub mod text;

--- a/src/rewrite/run.rs
+++ b/src/rewrite/run.rs
@@ -3,33 +3,42 @@
 use super::edit::{apply_edits, Edit};
 use super::engine::collect_edits;
 use super::rule::{RenameSymbol, RewriteRule};
-use crate::epoch::detect_epoch_in_source;
+use super::text::SourceText;
 use crate::epoch::rules::{
-    collapsed_renames, flatten_clause_rules_in_range, flatten_rules_in_range, removals_in_range,
-    replace_rules_in_range, unwrap_rules_in_range, CURRENT_EPOCH,
+    collapsed_renames, flatten_clause_rules_in_range, flatten_rules_in_range,
+    lexical_changes_in_range, removals_in_range, replace_rules_in_range, unwrap_rules_in_range,
+    Lexicon, CURRENT_EPOCH,
 };
-use crate::reader::{Lexer, Token};
+use crate::epoch::{check_declared_lexicon, detect_epoch_in_source};
+use crate::reader::{shebang_len, Token};
 use std::collections::HashMap;
 
-/// Lex source into tokens, filtering out comment tokens.
-/// The rewrite engine uses positional token matching that assumes
-/// no comment tokens in the stream (they were invisible before the
-/// formatter needed them).
-fn lex_tokens_no_comments(source: &str) -> Result<Vec<(Token<'_>, usize, usize)>, String> {
-    let mut lexer = Lexer::new(source);
-    let mut tokens = Vec::new();
-    loop {
-        match lexer.next_token_with_loc() {
-            Ok(Some(t)) => {
-                if !matches!(t.token, Token::Comment(_)) {
-                    tokens.push((t.token, t.byte_offset, t.len));
-                }
-            }
-            Ok(None) => break,
-            Err(e) => return Err(e.to_string()),
+/// Collect edits that respell every token whose spelling differs between
+/// `source`'s lexicon and `target` (docs/impl/lexicon.md).
+pub(crate) fn collect_lexical_edits(
+    source: SourceText<'_>,
+    target: Lexicon,
+) -> Result<Vec<Edit>, String> {
+    let mut edits = Vec::new();
+
+    for token in source.tokens()? {
+        if source.in_shebang(&token) {
+            continue;
+        }
+        let replacement = source
+            .lexicon
+            .respell(&token.token, &target)
+            .map_err(|e| format!("{}: {}", token.loc.position(), e))?;
+        if let Some(replacement) = replacement {
+            edits.push(Edit {
+                byte_offset: token.byte_offset,
+                byte_len: token.len,
+                replacement,
+            });
         }
     }
-    Ok(tokens)
+
+    Ok(edits)
 }
 
 /// Run the rewrite tool. Returns exit code.
@@ -97,6 +106,9 @@ pub fn run(args: &[String]) -> i32 {
                     "  flatten-clauses: {} (parenthesized → flat pairs)",
                     names.join(", ")
                 );
+            }
+            for change in lexical_changes_in_range(0, CURRENT_EPOCH) {
+                println!("  lexical: {} ({})", change.name, change.summary);
             }
         }
         return 0;
@@ -169,11 +181,23 @@ pub(crate) fn rewrite_file(
 
     let file_epoch = epoch_info.as_ref().map(|info| info.epoch);
 
+    // The rules that read this file. A declaration the prescan cannot see
+    // did not choose the lexer that tokenized the file, so when the two
+    // disagree about the rules there is nothing safe to rewrite.
+    if let Some(epoch) = file_epoch {
+        check_declared_lexicon(epoch, source, file_path)?;
+    }
+    let text = SourceText::new(
+        source,
+        file_path,
+        Lexicon::for_epoch(file_epoch.unwrap_or(CURRENT_EPOCH)),
+    );
+
     // Check for removed symbols before doing any rewrites
     if let Some(epoch) = file_epoch {
         let removals = removals_in_range(epoch, CURRENT_EPOCH);
         if !removals.is_empty() {
-            check_removals(source, &removals, file_path)?;
+            check_removals(text, &removals)?;
         }
     }
 
@@ -183,7 +207,7 @@ pub(crate) fn rewrite_file(
         if unwraps.is_empty() {
             Vec::new()
         } else {
-            collect_unwrap_edits(source, &unwraps, file_path)?
+            collect_unwrap_edits(text, &unwraps)?
         }
     } else {
         Vec::new()
@@ -195,7 +219,7 @@ pub(crate) fn rewrite_file(
         if flattens.is_empty() {
             Vec::new()
         } else {
-            collect_flatten_edits(source, &flattens)?
+            collect_flatten_edits(text, &flattens)?
         }
     } else {
         Vec::new()
@@ -207,7 +231,7 @@ pub(crate) fn rewrite_file(
         if flatten_clauses.is_empty() {
             Vec::new()
         } else {
-            collect_flatten_clause_edits(source, &flatten_clauses)?
+            collect_flatten_clause_edits(text, &flatten_clauses)?
         }
     } else {
         Vec::new()
@@ -216,7 +240,7 @@ pub(crate) fn rewrite_file(
     // Normalize paren-delimited binding vectors to brackets:
     // (let (name val) ...) → (let [name val] ...)
     let binding_forms = &["let", "letrec", "let*", "if-let", "when-let", "when-ok"];
-    let bracket_edits = collect_bracket_edits(source, binding_forms)?;
+    let bracket_edits = collect_bracket_edits(text, binding_forms)?;
 
     // Collect replace edits (syntax-level, whole-form rewrites)
     let replace_edits = if let Some(epoch) = file_epoch {
@@ -224,7 +248,7 @@ pub(crate) fn rewrite_file(
         if replaces.is_empty() {
             Vec::new()
         } else {
-            collect_replace_edits(source, &replaces)?
+            collect_replace_edits(text, &replaces)?
         }
     } else {
         Vec::new()
@@ -245,7 +269,12 @@ pub(crate) fn rewrite_file(
 
     // Collect rename edits (token-level)
     let rules: Vec<&dyn RewriteRule> = rename_rule.iter().map(|r| r as &dyn RewriteRule).collect();
-    let mut edits = collect_edits(source, &rules)?;
+    let mut edits = collect_edits(text, &rules)?;
+
+    // Respell tokens whose lexical rules moved between the file's epoch and
+    // this one. Token-level like the renames above, so the structural filter
+    // below governs both (docs/impl/lexicon.md).
+    edits.extend(collect_lexical_edits(text, Lexicon::current())?);
 
     // Merge all structural edits (unwrap + replace + flatten), filtering out
     // rename edits that fall within their spans.
@@ -290,13 +319,8 @@ pub(crate) fn rewrite_file(
             });
         }
         // Insert current epoch as the first form, after the shebang if present.
-        let insert_offset = if source.starts_with("#!") {
-            source.find('\n').map(|i| i + 1).unwrap_or(source.len())
-        } else {
-            0
-        };
         edits.push(Edit {
-            byte_offset: insert_offset,
+            byte_offset: shebang_len(source),
             byte_len: 0,
             replacement: format!("(elle/epoch {})\n", CURRENT_EPOCH),
         });

--- a/src/rewrite/run/edits.rs
+++ b/src/rewrite/run/edits.rs
@@ -2,11 +2,10 @@ use super::*;
 
 /// Scan source for removed symbols and return an error listing them.
 pub(super) fn check_removals(
-    source: &str,
+    src: SourceText<'_>,
     removals: &HashMap<&str, &str>,
-    file_path: &str,
 ) -> Result<(), String> {
-    let tokens = lex_tokens_no_comments(source)?;
+    let tokens = src.code_tokens()?;
 
     let mut errors = Vec::new();
     for (token, _, _) in &tokens {
@@ -22,7 +21,7 @@ pub(super) fn check_removals(
     } else {
         Err(format!(
             "{}: removed symbols found:\n{}",
-            file_path,
+            src.name,
             errors.join("\n")
         ))
     }
@@ -32,16 +31,15 @@ pub(super) fn check_removals(
 /// Matches `(symbol (fn [] body...))` or `(symbol (fn () body...))` and
 /// replaces the entire form with just the body.
 pub(super) fn collect_unwrap_edits(
-    source: &str,
+    src: SourceText<'_>,
     unwraps: &HashMap<&str, &str>,
-    file_path: &str,
 ) -> Result<Vec<Edit>, String> {
-    let tokens = lex_tokens_no_comments(source)?;
+    let tokens = src.code_tokens()?;
 
     let mut edits = Vec::new();
     let mut i = 0;
     while i < tokens.len() {
-        if let Some(edit) = try_match_unwrap(source, &tokens, i, unwraps) {
+        if let Some(edit) = try_match_unwrap(src.text, &tokens, i, unwraps) {
             i = skip_balanced_form(&tokens, i);
             edits.push(edit);
         } else {
@@ -52,7 +50,7 @@ pub(super) fn collect_unwrap_edits(
                     if i > 0 && matches!(tokens[i - 1].0, Token::LeftParen) {
                         return Err(format!(
                             "{}: `{}` cannot be automatically unwrapped — {}",
-                            file_path, name, msg
+                            src.name, name, msg
                         ));
                     }
                 }
@@ -148,15 +146,15 @@ pub(super) fn try_match_unwrap<'a>(
 /// Lex source and collect edits for forms matching replace rules.
 /// Works at the token level using byte offsets from the lexer.
 pub(super) fn collect_replace_edits(
-    source: &str,
+    src: SourceText<'_>,
     replaces: &[(&str, usize, &str)],
 ) -> Result<Vec<Edit>, String> {
-    let tokens = lex_tokens_no_comments(source)?;
+    let tokens = src.code_tokens()?;
 
     let mut edits = Vec::new();
     let mut i = 0;
     while i < tokens.len() {
-        if let Some(edit) = try_match_replace(source, &tokens, i, replaces) {
+        if let Some(edit) = try_match_replace(src.text, &tokens, i, replaces) {
             // Skip past the matched form
             i = skip_balanced_form(&tokens, i);
             edits.push(edit);

--- a/src/rewrite/run/edits/flatten.rs
+++ b/src/rewrite/run/edits/flatten.rs
@@ -6,10 +6,10 @@ use super::*;
 /// Matches `( let|letrec [ [p1 v1] [p2 v2] ... ] body... )` and deletes
 /// the inner `[`/`]` (or `(`/`)`) delimiters, leaving the contents flat.
 pub(crate) fn collect_flatten_edits(
-    source: &str,
+    src: SourceText<'_>,
     flatten_syms: &[&str],
 ) -> Result<Vec<Edit>, String> {
-    let tokens = lex_tokens_no_comments(source)?;
+    let tokens = src.code_tokens()?;
 
     let mut edits = Vec::new();
     let mut i = 0;
@@ -18,7 +18,7 @@ pub(crate) fn collect_flatten_edits(
         if matches!(tokens.get(i), Some((Token::LeftParen, _, _))) {
             if let Some((Token::Symbol(s), _, _)) = tokens.get(i + 1) {
                 if flatten_syms.contains(s) {
-                    if let Some(new_edits) = try_match_flatten(source, &tokens, i) {
+                    if let Some(new_edits) = try_match_flatten(src.text, &tokens, i) {
                         edits.extend(new_edits);
                         // Don't skip the whole form — advance past `(` and symbol
                         // so nested let/letrec forms in the body are still visited.
@@ -135,10 +135,10 @@ pub(super) fn try_match_flatten(
 /// Matches `(let|letrec|let*|if-let|when-let|when-ok (bindings...) body...)`
 /// where the bindings container uses `(...)` and replaces with `[...]`.
 pub(crate) fn collect_bracket_edits(
-    source: &str,
+    src: SourceText<'_>,
     binding_forms: &[&str],
 ) -> Result<Vec<Edit>, String> {
-    let tokens = lex_tokens_no_comments(source)?;
+    let tokens = src.code_tokens()?;
 
     let mut edits = Vec::new();
     let mut i = 0;
@@ -179,18 +179,16 @@ pub(crate) fn collect_bracket_edits(
 /// Matches `(cond (test body) ...)` or `(match val (pat body) ...)` and
 /// removes the inner clause delimiters, wrapping multi-body arms in `(begin ...)`.
 pub(crate) fn collect_flatten_clause_edits(
-    source: &str,
+    src: SourceText<'_>,
     flatten_clauses: &[(&str, usize)],
 ) -> Result<Vec<Edit>, String> {
-    let mut lexer = Lexer::new(source);
-    let mut tokens: Vec<(Token<'_>, usize, usize)> = Vec::new();
-    loop {
-        match lexer.next_token_with_loc() {
-            Ok(Some(t)) => tokens.push((t.token, t.byte_offset, t.len)),
-            Ok(None) => break,
-            Err(e) => return Err(e.to_string()),
-        }
-    }
+    // Comments stay in this stream: a clause walk that counts them as
+    // children is what the pinned rewrites of `cond` and `match` expect.
+    let tokens: Vec<(Token<'_>, usize, usize)> = src
+        .tokens()?
+        .into_iter()
+        .map(|t| (t.token, t.byte_offset, t.len))
+        .collect();
 
     let mut edits = Vec::new();
     let mut i = 0;
@@ -199,7 +197,7 @@ pub(crate) fn collect_flatten_clause_edits(
         if matches!(tokens.get(i), Some((Token::LeftParen, _, _))) {
             if let Some((Token::Symbol(s), _, _)) = tokens.get(i + 1) {
                 if let Some(&(_, skip)) = flatten_clauses.iter().find(|(sym, _)| sym == s) {
-                    if let Some(new_edits) = try_match_flatten_clauses(source, &tokens, i, skip) {
+                    if let Some(new_edits) = try_match_flatten_clauses(src.text, &tokens, i, skip) {
                         edits.extend(new_edits);
                         // Don't skip the whole form — advance past head symbol
                         // so nested forms in the body are still visited.

--- a/src/rewrite/run/tests.rs
+++ b/src/rewrite/run/tests.rs
@@ -65,3 +65,58 @@ fn test_rewrite_no_epoch_tag_injects_one() {
         &new_source[..new_source.len().min(80)]
     );
 }
+
+// --- the token-level pass (docs/impl/lexicon.md) ---
+
+/// The source `edits` produce when applied.
+fn applied(source: &str, mut edits: Vec<Edit>) -> String {
+    apply_edits(source, &mut edits).unwrap()
+}
+
+/// `source` as a file read under `lexicon`.
+fn read_under(source: &str, lexicon: Lexicon) -> SourceText<'_> {
+    SourceText::new(source, "t.lisp", lexicon)
+}
+
+#[test]
+fn a_comment_is_respelled_into_the_target_lexicon() {
+    // Read under a lexicon that comments with `;`, written back out under
+    // one that comments with `#`. The comment's own text is untouched.
+    let source = "; note\n(def x 1)\n";
+    let edits = collect_lexical_edits(read_under(source, Lexicon::divergent()), Lexicon::current())
+        .unwrap();
+    assert_eq!(applied(source, edits), "# note\n(def x 1)\n");
+}
+
+#[test]
+fn a_shebang_line_is_never_respelled() {
+    // `#!/usr/bin/env elle` lexes as a comment under every lexicon that
+    // comments with `#`, so the pass sees it as ordinary Elle trivia. It is
+    // the operating system's line: respelling its first byte produces a file
+    // the kernel will not run.
+    let source = "#!/usr/bin/env elle\n# note\n(def x 1)\n";
+    let edits = collect_lexical_edits(read_under(source, Lexicon::current()), Lexicon::divergent())
+        .unwrap();
+    assert_eq!(
+        applied(source, edits),
+        "#!/usr/bin/env elle\n; note\n(def x 1)\n"
+    );
+}
+
+#[test]
+fn a_token_with_no_spelling_in_the_target_names_its_position() {
+    let source = "(def x 1)\n(f ;xs)\n";
+    let err = collect_lexical_edits(read_under(source, Lexicon::current()), Lexicon::divergent())
+        .unwrap_err();
+    assert!(err.contains("t.lisp:2:4"), "{err}");
+}
+
+#[test]
+fn a_file_under_one_lexicon_needs_no_lexical_edits() {
+    // Every registered epoch shares one lexicon, so this is the only case
+    // the tool can reach today: the pass must add nothing to the rewrite.
+    let source = "# note\n(def x 1)\n";
+    let edits =
+        collect_lexical_edits(read_under(source, Lexicon::current()), Lexicon::current()).unwrap();
+    assert!(edits.is_empty());
+}

--- a/src/rewrite/text.rs
+++ b/src/rewrite/text.rs
@@ -1,0 +1,62 @@
+//! The text a rewrite reads, paired with the rules that tokenize it.
+
+use crate::epoch::rules::Lexicon;
+use crate::reader::{Lexer, Token, TokenWithLoc};
+
+/// Source text, its name, and the lexicon that tokenizes it.
+///
+/// Every pass in the rewriter lexes the same bytes, and they must all lex
+/// them the same way: a file written before a token-level change tokenizes
+/// under its own epoch's rules, not the current ones (docs/impl/lexicon.md).
+/// Passing the three together is what keeps a pass from reaching for
+/// `Lexer::new` and getting the current epoch by habit.
+#[derive(Clone, Copy)]
+pub(crate) struct SourceText<'a> {
+    /// The bytes, exactly as the file holds them. Edits index into these.
+    pub text: &'a str,
+    /// The file name, for error messages.
+    pub name: &'a str,
+    /// The rules these bytes were written under.
+    pub lexicon: Lexicon,
+}
+
+impl<'a> SourceText<'a> {
+    pub(crate) fn new(text: &'a str, name: &'a str, lexicon: Lexicon) -> Self {
+        SourceText {
+            text,
+            name,
+            lexicon,
+        }
+    }
+
+    /// Whether `token` is part of the shebang line. That line is the
+    /// operating system's, not Elle's, however a lexicon happens to
+    /// tokenize it — a `#`-commenting one makes it a comment, another
+    /// makes it symbols. No rewrite may touch either reading.
+    pub(crate) fn in_shebang(&self, token: &TokenWithLoc<'_>) -> bool {
+        token.byte_offset < crate::reader::shebang_len(self.text)
+    }
+
+    /// Every token, comments included, with its span.
+    pub(crate) fn tokens(&self) -> Result<Vec<TokenWithLoc<'a>>, String> {
+        let mut lexer = Lexer::with_file(self.text, self.name).in_lexicon(self.lexicon);
+        let mut tokens = Vec::new();
+        while let Some(token) = lexer.next_token_with_loc()? {
+            tokens.push(token);
+        }
+        Ok(tokens)
+    }
+
+    /// Every token but the comments, as `(token, byte_offset, len)`.
+    ///
+    /// The passes built on this match forms by token position and count, so
+    /// a comment in the stream would shift every index after it.
+    pub(crate) fn code_tokens(&self) -> Result<Vec<(Token<'a>, usize, usize)>, String> {
+        Ok(self
+            .tokens()?
+            .into_iter()
+            .filter(|t| !matches!(t.token, Token::Comment(_)))
+            .map(|t| (t.token, t.byte_offset, t.len))
+            .collect())
+    }
+}

--- a/tests/elle/reader.lisp
+++ b/tests/elle/reader.lisp
@@ -196,3 +196,18 @@
   (assert (= (type-of m) :@struct) "eval of read @{...} produces @struct")
   (put m :b 2)
   (assert (= (get m :b) 2) "eval of read @{...} is mutable"))
+
+# ──────────────────────────────────────────────────────────────────────────────
+# epoch declaration — the read text names the token rules it is read under
+# ──────────────────────────────────────────────────────────────────────────────
+
+(assert (= (read-all "(elle/epoch 3) 1") (list '(elle/epoch 3) 1))
+        "a supported epoch declaration reads as an ordinary form")
+
+# The number comes from (elle/epoch) so the case stays "one past the end"
+# after every epoch bump.
+(let [future (string "(elle/epoch " (+ 1 (elle/epoch)) ") (def x 1)")]
+  (let [[ok? err] (protect (read-all future))]
+    (assert (not ok?) "reading an epoch with no token rules fails")
+    (assert (has? (get err :message) "only supports up to")
+            "the failure names the epoch ceiling")))


### PR DESCRIPTION
Closes #1020.

## What was wrong

The epoch system rewrites parsed trees, so migration runs after the reader and
cannot express a change to tokenization itself. A file written before such a
change misreads before migration ever runs, and the `(elle/epoch N)` promise
stops at the token boundary. The failure is silent, not loud: `[1 ;xs\n 2]` is
legal under both a splice-`;` and a comment-`;` grammar with different values,
so no mechanism that guesses the grammar can be trusted.

Two commits already on this branch landed the design (`docs/impl/lexicon.md`),
the frozen epoch prescan, and the `Lexicon` seam. This commit finishes the
wiring.

`elle rewrite` also had a defect reachable the moment a lexicon diverges: it
lexed every pass with `Lexer::new`, which is the current epoch's rules, while
rewriting a file that declares an older one.

## What this does

**Reading.** The reader entry points prescan for the declaration and lex under
`Lexicon::for_epoch(N)`. The pipeline then checks, after the read, that the
declaration in the tree and the one the prescan saw select the same lexicon.
The comparison is over lexicons, never epoch numbers — comparing numbers would
reject every file that carries a comment above its declaration.

**Rewriting.** `SourceText` carries the text, its name, and the lexicon
together; all eight rewrite passes read tokens through it, so no pass can reach
for the current epoch by habit. A token-level pass runs alongside the tree
rules: `Lexicon::respell` gives each token its current-epoch spelling and the
rewriter applies the difference by byte span, which is formatting-preserving by
construction. A token the current lexicon cannot spell at all stops the rewrite
and names the position rather than leaving bytes that mean something else. The
shebang line is skipped — a `#`-commenting lexicon tokenizes it as a comment,
and respelling its first byte leaves a file the kernel cannot run. Each epoch's
`LexicalChange` entries appear in `--list-rules`.

**Formatting and the REPL.** `elle fmt` lexes its input under the epoch that
input declares. The REPL reads through `read_syntax_all_current`, so a pasted
declaration cannot change how the prompt lexes.

**One measure of the shebang.** `reader::shebang_len` replaces four copies
across the reader, prescan, epoch detector, rewriter, and formatter.
`strip_shebang` now slices instead of rejoining `lines()`, so a CRLF file's
byte offsets no longer shift under the lexer.

Every registered epoch shares one lexicon, so no file lexes differently yet and
no existing behavior changes.

## How it was measured

The paths that act on a lexical difference are unreachable through
`Lexicon::for_epoch` until the first lexical epoch exists, so tests build the
differing pair directly (`Lexicon::divergent`, `Lexicon::no_semicolon`) rather
than leave those paths to run for the first time on the epoch that needs them.

Each behavior was checked counter-factually: `respell`, the shebang skip, the
lexicon threading, the REPL entry point, the formatter prescan, and the
change/lexicon pairing were each disabled in turn, and the corresponding tests
were confirmed red before the implementation was restored.

`make qa`, `make smoke`, `make smoke-nouring`, `make crosscheck`,
`cargo test --workspace --lib --all-features` (2356 tests), and
`cargo test --test '*'` all pass.

## Tests that pin it

| Claim | Test |
|-------|------|
| A comment takes the target lexicon's introducer | `epoch::rules::tests::a_comment_takes_the_introducer_of_the_target_lexicon` |
| A token the target cannot spell is refused, not left alone | `epoch::rules::tests::a_token_the_target_cannot_spell_is_refused_not_left_alone` |
| An epoch declares a `LexicalChange` exactly when its lexicon moves | `epoch::rules::tests::an_epoch_declares_a_lexical_change_exactly_when_its_lexicon_moves` |
| The shebang line is never respelled | `rewrite::run::tests::a_shebang_line_is_never_respelled` |
| The refusal names the position | `rewrite::run::tests::a_token_with_no_spelling_in_the_target_names_its_position` |
| The engine lexes under the lexicon it is given | `rewrite::engine::tests::the_engine_lexes_under_the_lexicon_it_is_given` |
| The reader refuses an epoch it has no lexicon for | `reader::tests::a_declaration_from_the_future_stops_the_reader` |
| A literate document prescans its stripped text | `reader::tests::a_literate_document_prescans_the_stripped_text` |
| The REPL entry point ignores a declaration | `reader::tests::the_current_lexicon_entry_point_ignores_a_declaration` |
| The formatter refuses an epoch it has no lexicon for | `formatter::core::tests::basics::formatting_refuses_a_declaration_it_has_no_lexicon_for` |
| A declaration below a comment is allowed when the lexicons agree | `epoch::tests::a_declaration_below_a_comment_is_allowed_when_the_lexicons_agree` |
| Differing lexicons refuse the file and name the fix | `epoch::tests::differing_lexicons_refuse_the_file_and_name_the_fix` |

Blocks #983, which is the first real lexical epoch and exercises the mechanism
end to end with its own migration tests.
