### PR TITLE
regions: a live pages-less owner node counts in the region gauge

### DIFF
--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -11,8 +11,17 @@ adoption is a debug-asserted bug, and the node's demise is one `free_region_set`
 transitive children (interior cycles reclaim with the set; the Shared frontier, read from the
 recorded `outgoing` tables, cascades once). **No new reclamation mode exists** — the node
 rides the same subtree drop a region root does; tearing down its own entry returns zero
-pages. Pinned by `regionstore::tests::forest::pages_less_owner_node_subtree_drops_members`
-and `…::interior_cycle_in_owner_node_reclaims`.
+pages.
+
+That entry is also the node's only trace on the gauges. The node holds no object and claims
+no page, so `arena/count`, `arena/bytes`, and `arena/page-claims` read flat across its whole
+life. `arena/region-count` alone can see it, because `active_region_count` counts entries
+rather than contents ([diagnostics.md](diagnostics.md)) — which is what makes the region
+gauge the dual reading of the object gauge rather than a coarser copy of it.
+
+Pinned by `regionstore::tests::forest::pages_less_owner_node_subtree_drops_members`,
+`…::pages_less_owner_node_counts_in_active_region_count`, and
+`…::interior_cycle_in_owner_node_reclaims`.
 
 **The channel is `AdoptIntoActivation { child }`** — value-resolved like `AdoptRegion` (the
 handler resolves the child's runtime region through `result_region_of`, unwrapping a capture

--- a/src/value/fiberheap/regionstore/tests/forest.rs
+++ b/src/value/fiberheap/regionstore/tests/forest.rs
@@ -322,6 +322,63 @@ fn pages_less_owner_node_subtree_drops_members() {
     );
 }
 
+/// The region gauge sees a LIVE owner node. `active_region_count` — the backend
+/// of `arena/region-count` — counts entries, so the node's `ensure`d entry is
+/// counted for exactly as long as the node lives, even though the node holds no
+/// object and claims no page (docs/impl/region/owner.md § "Owner nodes — an
+/// activation as a forest root"). That inclusion is what makes the region gauge
+/// the object gauge's dual: an activation's owner node is a strand
+/// `arena/count` cannot see at all.
+///
+/// The counter-factual is a filter on object count or on pages, which is
+/// representable and which every pin in this file survives: the drop pin
+/// (`pages_less_owner_node_subtree_drops_members`) reads the node after it is
+/// gone, and `reparent_degenerate_cases_are_noops` reads an id that never
+/// adopted and so has no entry under either reading. Measured, each filter
+/// detonates exactly one other test — the JIT helper's
+/// `adopt_into_activation_adopts_into_lazily_minted_node`, whose subject is the
+/// adopt rather than the gauge: it reads a release DELTA of 2 and blames a
+/// failed adopt for a 1, so a maintainer who narrowed the gauge would go
+/// hunting in the helper. Naming the reading here is what points at the gauge.
+///
+/// Each of the three assertions below is needed: the first fixes what the
+/// entry-less baseline is, the second is the live reading a filter would blind,
+/// and the third proves the reading tracks the node's demise rather than
+/// standing at a constant.
+#[test]
+fn pages_less_owner_node_counts_in_active_region_count() {
+    let mut store = RegionStore::default();
+    let base = store.active_region_count();
+    let node = store.new_runtime_region(); // never allocated into
+    let member = store.new_runtime_region();
+    store.alloc_obj(member, cons_obj());
+    assert_eq!(
+        store.active_region_count(),
+        base + 1,
+        "minting the node's id materializes no entry — only the member has one"
+    );
+
+    store.adopt_region(node, member);
+    assert_eq!(
+        store.region_obj_count(node),
+        0,
+        "the node owns no object of its own"
+    );
+    assert_eq!(
+        store.active_region_count(),
+        base + 2,
+        "the adopt's `ensure` mints the node's entry and the gauge counts it while \
+         both are LIVE: one entry for the member, one for the pages-less node"
+    );
+
+    store.decref(node); // rc 1→0 → subtree drop over node + member
+    assert_eq!(
+        store.active_region_count(),
+        base,
+        "the drop returns both entries, so the gauge tracks the node's whole life"
+    );
+}
+
 /// An interior reference cycle whose members are adopted by a pages-less owner
 /// node reclaims with the node's drop — the `(push a b)(push b a)` knot per-region
 /// RC cannot collect (region/rules.md Rule 8), rooted at an owner that owns no


### PR DESCRIPTION
`arena/region-count` reads `RegionStore::active_region_count`, which counts
region-table entries — a pages-less owner node's `ensure`d entry included. That
inclusion is what makes the region gauge the object gauge's dual: an
activation's owner node holds no object and claims no page, so `arena/count`,
`arena/bytes` and `arena/page-claims` read flat across its whole life.

No test named that reading while the node is LIVE. The forest pins read the node
after its drop (`pages_less_owner_node_subtree_drops_members`), or read an id
that never adopted and so has no entry at all
(`reparent_degenerate_cases_are_noops`); the runtime ownership tests read
baseline-vs-after deltas that return to zero either way. So filtering
`active_region_count` on pages or on object count was representable, and it
would blind the region gauge to the one strand the object gauge cannot see.

The close is one test beside the drop pin, and no production code. It mints a
node id, adopts a member into it, and asserts the count rose by exactly 2 while
both are live, with the node's own `region_obj_count` at 0. The node's drop then
returns the count to its baseline.

## How it was measured

Counter-factual, run twice: `active_region_count` filtered on object count, and
again filtered on pages. The new test fails at the live reading under both
(1, expected 2).

Each filter also detonates
`jit::dispatch::tests::adopt_into_activation_adopts_into_lazily_minted_node`,
so the gap is narrower than the issue states. That test's subject is the JIT
adopt helper rather than the gauge: it reads a release delta of 2 and blames a
failed adopt for a 1, which sends a maintainer hunting in the helper. Nothing
else in the lib suite moves under either filter, so the named store-level
reading is what points at the gauge.

Unfiltered: `cargo test -p elle --lib` green (2416 passed), `make qa` green.

## What pins it

`value::fiberheap::regionstore::tests::forest::pages_less_owner_node_counts_in_active_region_count`.
`docs/impl/region/owner.md` § "Owner nodes" states the inclusion and cites it.

Closes #987.