### PR TITLE
regions: a squelch boundary abandons frames the same way an error does

### DIFF
--- a/docs/impl/region/diagnostics.md
+++ b/docs/impl/region/diagnostics.md
@@ -223,20 +223,26 @@ above so its growth is not mistaken for a gauge artifact.
 
 Abandoning suspended work routes through one chokepoint, `VM::discard_suspended_frames`
 (src/vm/core.rs), on every tier — the interpreter's `enforce_squelch`, `compile/run-on`'s
-squelch enforcement, and the JIT call paths. The chokepoint subtree-drops each discarded
-frame's parked activation owner node
-([owner.md](owner.md) § "Owner nodes") and releases nothing else: the
-frame's `activation_region_map` is a borrowed view of regions that may be shared with an
-outer, non-discarded frame or with the activation that catches the squelch, so a per-slot
-release there over-frees (the historical squelch double-free — a non-unwinding abort in
-scheduler-heavy programs); the node's members are exactly the regions adoption moved in,
-so their release at the discard is sound by construction. The pin is two-sided:
-`runtime::tests::ownership::discard_frees_parked_activation_owner_node` proves the node
-and its members ARE freed at the discard (bounded, generation bump), and the squelch
-corpus (`region-squelch-nested.lisp`, `region-loop-capture-squelch.lisp`, and the
-redis-driven `redis.lisp` scheduler shape when a live Redis is present) under
-`--trace=guardfree` with the full stdlib proves the discard frees nothing more
-(panic-clean).
+squelch enforcement, and the JIT call paths. The chokepoint runs everything a discarded
+frame chain owed and nothing else ([owner.md](owner.md) § "A discard runs what the
+abandoned frames owed"): each frame's parked activation owner node, the releases its
+activation took over from its own frame-replacing tail calls, and the releases its two
+emitter-recorded tables name. What stays refused is the rest of the frame's
+`activation_region_map` — a borrowed view of regions that may be shared with an outer,
+non-discarded frame or with the activation that catches the squelch, so a blanket
+per-slot release there over-frees (the historical squelch double-free — a non-unwinding
+abort in scheduler-heavy programs). The three the chokepoint does run each carry their
+own warrant: the node's members are exactly the regions adoption moved in, a deferred
+region is one the compiler named as this activation's, and a table entry carries a
+receipt that says the release did not run. The pin is two-sided:
+`runtime::tests::ownership::discard_frees_parked_activation_owner_node` and
+`…::discard_runs_the_abandoned_frames_release_tables` prove the set IS freed at the
+discard (bounded, generation bump), and the squelch corpus
+(`region-squelch-unwind-uaf.lisp`, `region-squelch-nested.lisp`,
+`region-loop-capture-squelch.lisp`, and the redis-driven `redis.lisp` scheduler shape
+when a live Redis is present) under `--trace=guardfree` with the full stdlib proves the
+discard frees nothing more (panic-clean). The rate the tables carry is gauged by
+`tests/elle/region-squelch-unwind.lisp`.
 
 ## The terminal-fiber teardown
 

--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1698,6 +1698,43 @@ own discharge reads the same two tables off each parked `BytecodeFrame`, its sav
 locals and its saved activation map standing in for the live ones
 ([owner.md](owner.md) § "The bounded residual").
 
+**A squelch boundary abandons frames the same way, so it runs the same walk.** A
+`squelch`/`attune` boundary raises a `signal-violation` the activation it breaks out of
+never catches (`VM::enforce_squelch`), so that activation reaches none of its remaining
+instructions either. The exit **is** the error exit, and the trampoline writes it as
+one: the squelch arm turns the bits into `SIG_ERROR` and falls through to the walk
+below it. One arm is what keeps the two exits from drifting, and it hands the frame's
+operand stack out exactly as an error's does — a fiber body's first run parks that
+frame, and what a parked frame owes runs at its discharge.
+
+The boundary abandons a whole chain rather than one frame. Every frame parked between
+the emitting site and the boundary is discarded at one chokepoint,
+`VM::discard_suspended_frames`, which each enforcement site reaches through
+`squelch_violation`. So the discard reads each discarded `BytecodeFrame`'s two tables
+off its own `Code` — the reading `Fiber::take_parked_state` already makes for a fiber
+that can never run again, with the frame's saved locals and saved activation map
+standing in for the live ones ([owner.md](owner.md) § "A discard runs what the
+abandoned frames owed").
+
+The fiber **survives** a squelch, and that is what the reading has to answer for: an
+outer, non-discarded frame and the activation that catches the violation both run on.
+The tables answer it, and the fiber's survival never enters the argument. A discarded
+frame's saved stack and its map were taken and cloned at that frame's own park, and the
+activation they came from returned before the boundary was reached, so no live frame
+reads either. Within them, each route names only the executing function's own slots and
+carries its own receipt, so a slot still holding a heap value, or still mapped, is a
+release that frame genuinely owed and did not run. The rest of the parked map stays
+untouched for the opposite reason: a blanket release of it has no receipt at all, and
+the regions it names may be an outer frame's.
+
+**What the boundary raises exempts nothing, and neither does what it displaces.** The
+`signal-violation` is built by `escaping_error` in a fresh region of its own and records
+no delivery mint, so no frame's reference funds its delivery and every release the
+tables name runs. The signal the boundary displaces is not the exemption's subject
+either: a squelched park's payload is delivered to nobody, and the park's own escape
+retain holds it independently of any frame, so a frame's reference to it is that
+frame's to release like any other.
+
 **The compiled tier runs the same walk.** A compiled frame leaves by an error at two
 points, and each runs the walk before its activation's region-map pop: the check after
 a call, which finds the callee's raise, and an `Emit` of `SIG_ERROR`, which parks no
@@ -1764,7 +1801,16 @@ and `tests/elle/region-error-unwind-uaf.lisp` (the
 soundness complement — the payload the raising native builds while the frame holds its
 argument, a value the frame stored into a container that outlives it, a parked frame the
 restarts system replays, and a catching frame's own values, all under
-`--trace=guardfree`).
+`--trace=guardfree`). The squelch face carries the same pair —
+`tests/elle/region-squelch-unwind.lisp` (the leak gauge: a pending value in the emitting
+frame, two of them, an enclosing frame's, and the same under an `attune` boundary, each
+bounded beside a violation that has nothing pending) and
+`tests/elle/region-squelch-unwind-uaf.lisp` (the soundness complement: what the catching
+activation, an outer non-discarded frame, and a longer-lived container still read after
+the discard ran) — with
+`runtime::tests::ownership::discard_runs_the_abandoned_frames_release_tables` driving the
+chokepoint directly, where both routes and the untabled slot beside each are visible
+without a program that allocates into them.
 
 ## Compile-time region selection (coalescing)
 

--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -243,13 +243,15 @@ sentinel arms and the top-level driver each consume the pending tail call themse
 deferral is recorded where the tail call is BUILT (`tail_call_inner`) rather than where it
 happens to be consumed.
 
-**What an abandoned frame owes, it owes the deferred set too.** The exits no resume can
-reach run the set rather than parking it: an **error** exit whose frame the entrant does not
-park — the same `walk_abandoned` question the release table's walk asks
-([mechanism.md](mechanism.md) § "An abandoned frame runs the releases it still owes") — and a
-**squelch** boundary, which turns the signal into an error the abandoned activation never
-catches. Both stand exactly where the clean break stands: nothing replays the frame, so the
-decref the activation took over is at its last chance to run.
+**What an abandoned frame owes, it owes the deferred set too.** The exit no resume can
+reach runs the set rather than parking it: an **error** exit whose frame the entrant does
+not park — the same `walk_abandoned` question the release table's walk asks
+([mechanism.md](mechanism.md) § "An abandoned frame runs the releases it still owes"). A
+**squelch** boundary is that exit rather than a second one: it turns the signal into an
+error the abandoned activation never catches, and the trampoline writes the two as one arm
+([mechanism.md](mechanism.md) § "A squelch boundary abandons frames the same way, so it
+runs the same walk"). The exit stands exactly where the clean break stands: nothing replays
+the frame, so the decref the activation took over is at its last chance to run.
 
 The signal's payload needs no exemption here, unlike the release table's own routes. A
 deferred region is a per-call closure region or a merged arena; a raise's payload is either a
@@ -589,29 +591,47 @@ unrepresentable by construction. Pinned by
 re-park / caller-built park), and `jit::suspend::tests::park` (the JIT yield side-exit
 parks the node; the interpreted resume completes and frees it).
 
-**A discard frees the parked dues (squelch/abort = subtree drop).** Abandoning suspended
+**A discard runs what the abandoned frames owed (squelch/abort).** Abandoning suspended
 work — a squelch/attune signal-violation, an abort — flows through one chokepoint,
 `VM::discard_suspended_frames` (reached from `enforce_squelch` on every tier: the
 interpreter trampoline, `compile/run-on`, and the JIT call paths). The discarded frames'
-continuations will never run, so the completion release above never fires for them; the
-chokepoint therefore runs it *at the discard*: each discarded `BytecodeFrame`'s parked node
-gets the same one tolerant decref — rc 1→0, subtree drop over node + adopted members, the
-Shared frontier cascading once from the recorded `outgoing` tables — and each release the
-frame's activation took over from its own tail calls gets the plain decref its emitting
-instruction never ran. This frees **only** the dues: the regions named by the frame's
-`activation_region_map` are a borrowed view — possibly shared with an outer, non-discarded
-frame or the activation that catches the squelch — and releasing them here would
-over-release (the historical squelch double-free); a node's members, by contrast, are
-exactly the regions the inference proved externally unique and moved in through
-`AdoptIntoActivation`, and a deferred region is one the compiler itself named as this
-activation's to release, so the discard cannot touch a region any live frame still counts
-on. A frame dropped *outside* the chokepoint (an abandoned error park) still abandons its
-dues — a bounded leak, never a double-free (the members have no count for any other release
-route to reach). Pinned by
+continuations will never run, so every release that lived in one is at its last chance
+here, and the chokepoint runs the whole set a frame chain can owe — the same set
+`Fiber::take_parked_state` hands the terminal teardown and the free-path discharge, read
+the same way (`ParkedDues::of`). Three readings:
+
+- each frame's parked **owner node**, one tolerant decref — rc 1→0, subtree drop over
+  node + adopted members, the Shared frontier cascading once from the recorded `outgoing`
+  tables;
+- each release the frame's activation took over from its own **frame-replacing tail
+  calls**, the plain decref its emitting instruction never ran;
+- the releases the frame still owed off its **two release tables**, read against its
+  saved locals and its saved activation map ([mechanism.md](mechanism.md) § "An abandoned
+  frame runs the releases it still owes").
+
+Each reading names regions the discard is entitled to release, and none of them names a
+region a live frame still counts on. A node's members are exactly the regions the
+inference proved externally unique and moved in through `AdoptIntoActivation`. A deferred
+region is one the compiler itself named as this activation's to release. A table entry is
+a release the *executing function* emitted for its own slot, with a receipt that says it
+did not run — the value route's nil stamp, and the mapping the slot route takes. The
+frame's saved stack and saved map were taken and cloned at that frame's own park and its
+activation returned before the boundary was reached, so the receipts are read against
+state no live frame shares.
+
+What stays refused is the rest of the parked `activation_region_map`: a blanket per-slot
+release of it carries no receipt, and the regions it names may be an outer, non-discarded
+frame's or the catching activation's — the historical squelch double-free. A frame
+dropped *outside* the chokepoint (an abandoned error park) still abandons its dues — a
+bounded leak, never a double-free (the members have no count for any other release route
+to reach). Pinned by
 `runtime::tests::ownership::discard_frees_parked_activation_owner_node` (single frame and
 multi-frame chains; the member's generation bumps at the discard, bounded across repeated
-park-discard cycles) with the full-stdlib squelch corpus under `--trace=guardfree` as the
-panic-clean gate.
+park-discard cycles), `…::discard_runs_the_abandoned_frames_release_tables` (both routes,
+against a frame whose slot the emitter never recorded), and the leak gauge
+`tests/elle/region-squelch-unwind.lisp`, with
+`tests/elle/region-squelch-unwind-uaf.lisp` and the full-stdlib squelch corpus under
+`--trace=guardfree` as the panic-clean gate.
 
 **Exactly one reclamation path (the double-free invariant, positively).** A node member is
 `Owned`: it has no count for any other release route to reach, the inference that emits its

--- a/src/jit/calls/callops.rs
+++ b/src/jit/calls/callops.rs
@@ -166,8 +166,10 @@ pub extern "C" fn elle_jit_call(
                     // predicate the interpreter's `enforce_squelch` asks.
                     let squelched = crate::signals::squelched_bits(sig, closure_squelch_mask);
                     if !squelched.is_empty() {
-                        // `squelch_violation` is the discard chokepoint — it frees
-                        // each parked frame's owner node before handing back the error.
+                        // `squelch_violation` is the discard chokepoint — it runs
+                        // what each parked frame owed before handing back the error
+                        // (docs/impl/region/owner.md § "A discard runs what the
+                        // abandoned frames owed").
                         let err = vm.squelch_violation(squelched);
                         vm.fiber.signal = Some((SIG_ERROR, err));
                         return JitValue::nil();

--- a/src/runtime/tests/ownership/fnode.rs
+++ b/src/runtime/tests/ownership/fnode.rs
@@ -444,7 +444,7 @@ fn discard_frees_parked_activation_owner_node() {
             "the body parks at the yield"
         );
 
-        vm.discard_suspended_frames();
+        vm.discard_suspended_frames(crate::value::Value::NIL);
         assert!(
             vm.fiber.suspended.is_none(),
             "the discard consumed the parked chain"
@@ -457,7 +457,7 @@ fn discard_frees_parked_activation_owner_node() {
              (gen {gen_before} -> {gen_after})",
         );
         // A second discard finds nothing — the release ran exactly once.
-        vm.discard_suspended_frames();
+        vm.discard_suspended_frames(crate::value::Value::NIL);
     }
 
     // ── multi-frame chain: two parked activations, one discard frees both ──
@@ -476,7 +476,7 @@ fn discard_frees_parked_activation_owner_node() {
         chain.extend(vm.fiber.suspended.take().expect("second park"));
 
         vm.fiber.suspended = Some(chain);
-        vm.discard_suspended_frames();
+        vm.discard_suspended_frames(crate::value::Value::NIL);
         let bumped_a = unsafe { &*heap_ptr }.generation_raw(rid_a.get()) > gen_a;
         let bumped_b = unsafe { &*heap_ptr }.generation_raw(rid_b.get()) > gen_b;
         assert!(
@@ -492,6 +492,142 @@ fn discard_frees_parked_activation_owner_node() {
         "node + member must be reclaimed at each discard — live region count \
          must not grow (baseline={baseline}, after 100 park-discard cycles={after})",
     );
+}
+
+/// A squelch/abort DISCARD also runs the releases each abandoned frame still
+/// owed, off the two tables its own `Code` records
+/// (docs/impl/region/owner.md § "A discard runs what the abandoned frames
+/// owed"). The frame is hand-built so both routes are present and each has a
+/// neighbour the emitter did NOT record: slot 1 is a value route and slot 0 is
+/// not, static region slot 9 is a slot route and slot 8 is not. The discard must
+/// release exactly the two the tables name — running the untabled ones would
+/// free a region whose release the frame's own machinery still answers for,
+/// which is what a blanket release of the parked stack or the parked activation
+/// map does.
+///
+/// The second half is the payload exemption: the value the exit leaves with
+/// funds its reader's delivery out of the frame's own reference, so a table
+/// entry naming its region stays owed.
+#[test]
+fn discard_runs_the_abandoned_frames_release_tables() {
+    use crate::hir::region::{MappedRegion, RuntimeRegion};
+    use crate::value::code::CodeTables;
+    use crate::value::{BytecodeFrame, SuspendedFrame, Value};
+    use std::rc::Rc;
+
+    /// A frame whose function releases value-route slot 1 and slot route 9, and
+    /// nothing else.
+    fn tabled_code() -> crate::value::Code {
+        crate::value::Code::new(
+            Rc::new(vec![]),
+            Rc::new(vec![]),
+            Rc::new(crate::error::LocationMap::new()),
+            Rc::new(vec![]),
+        )
+        .with_tables(CodeTables {
+            frame_release_slots: Rc::new(vec![1]),
+            frame_release_regions: Rc::new(vec![9]),
+            ..CodeTables::default()
+        })
+    }
+
+    /// Park one frame holding `stack`, with `mapped` as its activation's
+    /// static→physical remap.
+    fn park(vm: &mut crate::vm::VM, stack: Vec<Value>, mapped: &[(u32, RuntimeRegion)]) {
+        let map = mapped
+            .iter()
+            .map(|(slot, region)| {
+                let gen = vm.heap().generation_raw(region.get());
+                (*slot, MappedRegion::new(*region, gen))
+            })
+            .collect();
+        let frame = BytecodeFrame::suspend(
+            tabled_code(),
+            Rc::new(vec![]),
+            0,
+            stack,
+            true,
+            map,
+            crate::value::fiber::ActivationDues::default(),
+            Value::NIL,
+            vm.heap(),
+        );
+        vm.fiber.suspended = Some(vec![SuspendedFrame::Bytecode(frame)]);
+    }
+
+    let mut vm = crate::vm::VM::new();
+    let heap_ptr = vm.heap_ptr;
+
+    // ── both routes run, and only for the slots the tables name ──
+    {
+        let (untabled, untabled_rid) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
+        let (owed, owed_rid) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
+        // Each slot-route region holds one object, so its birth reference is the
+        // one the abandoned `DecrefRegion` would have dropped.
+        let (_, mapped_rid) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
+        let (_, unmapped_rid) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
+        park(
+            &mut vm,
+            vec![untabled, owed],
+            &[(9, mapped_rid), (8, unmapped_rid)],
+        );
+
+        vm.discard_suspended_frames(Value::NIL);
+
+        assert_eq!(
+            vm.heap().region_rc(owed_rid),
+            0,
+            "the value route slot 1 names is a release the frame still owed",
+        );
+        assert_eq!(
+            vm.heap().region_rc(mapped_rid),
+            0,
+            "the slot route static slot 9 names is one too — its receipt is the \
+             mapping the release would have taken",
+        );
+        assert_eq!(
+            vm.heap().region_rc(untabled_rid),
+            1,
+            "slot 0 is not in the value-route table, so the frame's reference to \
+             what it holds stays standing",
+        );
+        assert_eq!(
+            vm.heap().region_rc(unmapped_rid),
+            1,
+            "static slot 8 is not in the slot-route table, so its mapping is a \
+             borrowed view the discard must not release",
+        );
+    }
+
+    // ── the payload the exit leaves with is exempt ──
+    {
+        let (payload, payload_rid) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
+        park(&mut vm, vec![Value::NIL, payload], &[]);
+
+        vm.discard_suspended_frames(payload);
+
+        assert_eq!(
+            vm.heap().region_rc(payload_rid),
+            1,
+            "the skipped release is the delivery the payload's reader consumes",
+        );
+    }
+
+    // ── unless the raise minted the delivery itself ──
+    {
+        let (payload, payload_rid) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
+        park(&mut vm, vec![Value::NIL, payload], &[]);
+        vm.fiber.delivery.record_mint(payload);
+
+        vm.discard_suspended_frames(payload);
+
+        assert_eq!(
+            vm.heap().region_rc(payload_rid),
+            0,
+            "a recorded mint funds the delivery, so the frame's own reference is \
+             reclaimed at the discard too",
+        );
+    }
 }
 
 /// A parked fiber whose last counted reference DROPS — no terminal transition

--- a/src/value/fiber.rs
+++ b/src/value/fiber.rs
@@ -270,27 +270,95 @@ fn noop_closure() -> Rc<Closure> {
     })
 }
 
-/// The parked region state a fiber that can never run again strands, TAKEN out
-/// of the fiber so exactly one release path reaches it: the parked chain's
-/// activation owner nodes, and the park escape retain on the parked signal's
-/// value (otherwise released only on the resume path). Consumed by the
-/// terminal-fiber teardown (`vm::fiber::release_fiber_owned`) and by the region
-/// free path's fiber discharge (`RegionStore::teardown_set`)
-/// (docs/impl/region/owner.md § "Park/unpark symmetry").
-pub struct ParkedState {
-    /// Each still-parked `BytecodeFrame`'s activation owner node, in chain order.
-    /// The activation-map regions are deliberately NOT collected: a mapped slot
-    /// can be stale (its value's release was emitted value-based, or died past a
-    /// tail call), so a blanket map release double-frees a possibly-recycled id.
+/// Everything the activations of a parked frame chain still owe, read off the
+/// frames themselves (docs/impl/region/owner.md § "A discard runs what the
+/// abandoned frames owed").
+///
+/// One reading serves every site that abandons a chain — the squelch/abort
+/// discard chokepoint (`VM::discard_suspended_frames`), the terminal-fiber
+/// teardown, and the region free path's fiber discharge — because what makes a
+/// release owed is a property of the FRAME, not of the fiber: the frame's saved
+/// stack and saved activation map were taken and cloned at its own park, and its
+/// activation returned before any of those sites was reached. So a fiber that
+/// survives the abandonment (the squelch case) changes nothing here.
+#[derive(Default)]
+pub struct ParkedDues {
+    /// Each `BytecodeFrame`'s activation owner node, in chain order.
     pub nodes: Vec<crate::hir::region::RuntimeRegion>,
-    /// The releases each still-parked `BytecodeFrame`'s activation took over from
-    /// its own frame-replacing tail calls, in chain order. Kept apart from
+    /// The releases each `BytecodeFrame`'s activation took over from its own
+    /// frame-replacing tail calls, in chain order. Kept apart from
     /// [`Self::nodes`] because the two are freed differently: a node's members are
     /// gathered under the fiber node before its subtree drop, while a deferred
     /// region is `Counted` throughout and takes the plain decref its emitting
     /// instruction never ran (docs/impl/region/owner.md § "A deferred tail-call
     /// release has the node's life").
     pub deferred: Vec<crate::hir::region::RuntimeRegion>,
+    /// The values each `BytecodeFrame` owes a release for — read out of its saved
+    /// locals at the slots its own `Code::frame_release_slots` names
+    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    /// still owes"). A frame nothing can re-enter never reaches the
+    /// `LoadLocal s; DecrefValueRegion; StoreLocal s nil` route that would have
+    /// released them, so the one release each is owed runs at the abandonment.
+    ///
+    /// This is the compiler's own release table, not the activation map: a mapped
+    /// slot can be stale, which is why the map contributes only through
+    /// [`Self::owed_regions`] below, while a value-route slot carries its own
+    /// receipt — the route stamps it nil, so a slot still holding a heap value is
+    /// a release that did not run.
+    pub owed: Vec<Value>,
+    /// The same for the frames' **slot-routed** releases: a static region slot
+    /// still mapped in a parked activation is a `DecrefRegion` that did not run.
+    /// Carried with its establishing generation so a consumer can tell a live
+    /// mapping from a leftover the frame's own release already answered for.
+    pub owed_regions: Vec<crate::hir::region::MappedRegion>,
+}
+
+impl ParkedDues {
+    /// Read a parked chain, innermost frame first. A `FiberResume` frame owes
+    /// nothing — its sub-fiber has a lifecycle of its own.
+    pub fn of(frames: impl IntoIterator<Item = SuspendedFrame>) -> Self {
+        let mut dues = ParkedDues::default();
+        for frame in frames {
+            let SuspendedFrame::Bytecode(f) = frame else {
+                continue;
+            };
+            dues.nodes.extend(f.activation_dues.owner_node);
+            dues.deferred
+                .extend(f.activation_dues.deferred.iter().copied());
+            // The releases this frame still owed. Its locals sit at the base of
+            // the saved stack (the activation's own frame base, the stack having
+            // been emptied at entry), so the emitter's slot indexes address them
+            // directly.
+            for slot in f.code.frame_release_slots.iter() {
+                match f.stack.get(*slot as usize) {
+                    Some(v) if v.as_heap_ptr().is_some() => dues.owed.push(*v),
+                    _ => {}
+                }
+            }
+            // The slot-routed half: a static region slot still mapped in the
+            // parked activation is a `DecrefRegion` that did not run, the release
+            // having taken the mapping wherever it did. Named by the frame's own
+            // function so a caller's leftovers past a tail call stay out.
+            for slot in f.code.frame_release_regions.iter() {
+                if let Some(m) = f.activation_region_map.get(slot) {
+                    dues.owed_regions.push(*m);
+                }
+            }
+        }
+        dues
+    }
+}
+
+/// The parked region state a fiber that can never run again strands, TAKEN out
+/// of the fiber so exactly one release path reaches it: everything its parked
+/// frames owe ([`ParkedDues`]), and the park escape retain on the parked
+/// signal's value (otherwise released only on the resume path). Consumed by the
+/// terminal-fiber teardown (`vm::fiber::release_fiber_owned`) and by the region
+/// free path's fiber discharge (`RegionStore::teardown_set`)
+/// (docs/impl/region/owner.md § "Park/unpark symmetry").
+pub struct ParkedState {
+    /// What the parked frames owed.
+    pub dues: ParkedDues,
     /// The parked NON-TERMINAL signal (a yielded value, a yielding io request, a
     /// capability-denial payload) — its park took exactly one escape retain
     /// (`EmitEscape` / `SuspendEscape`) whose symmetric release lives on the
@@ -311,30 +379,9 @@ pub struct ParkedState {
     /// record matches, and the frames' owed-release tables carry the reference
     /// with their own receipts.
     pub signal: Option<(SignalBits, Value)>,
-    /// The values each still-parked `BytecodeFrame` owes a release for — read out
-    /// of its saved locals at the slots its own `Code::frame_release_slots` names
-    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
-    /// still owes"). A frame this fiber can never re-enter never reaches the
-    /// `LoadLocal s; DecrefValueRegion; StoreLocal s nil` route that would have
-    /// released them, so the one release each is owed runs at the discharge.
-    ///
-    /// This is the compiler's own release table, not the activation map: a mapped
-    /// slot can be stale, which is why `nodes` above collects none of it, while a
-    /// value-route slot carries its own receipt — the route stamps it nil, so a
-    /// slot still holding a heap value is a release that did not run.
-    ///
-    /// The parked `signal`'s own value is excluded: a terminal payload is the
-    /// fiber's result, read through `fiber/value`, and the free-time signal scan
-    /// answers for it.
-    pub owed: Vec<Value>,
-    /// The same for the parked frames' **slot-routed** releases: a static region
-    /// slot still mapped in a parked activation is a `DecrefRegion` that did not
-    /// run. Carried with its establishing generation so a consumer can tell a live
-    /// mapping from a leftover the frame's own release already answered for.
-    pub owed_regions: Vec<crate::hir::region::MappedRegion>,
     /// The value the fiber's signal carries, if any — the payload a discharge
-    /// must leave standing. A consumer skips an [`Self::owed`] entry living in
-    /// this value's region: a terminal payload is the fiber's result and a
+    /// must leave standing. A consumer skips a [`ParkedDues::owed`] entry living
+    /// in this value's region: a terminal payload is the fiber's result and a
     /// non-terminal one is the [`Self::signal`] discharge's own, and a frame may
     /// well hold the very value the payload names.
     ///
@@ -360,46 +407,9 @@ impl Fiber {
     /// retain, and releasing the view too would double-free the one retain
     /// across two discharges.
     pub fn take_parked_state(&mut self) -> ParkedState {
-        let mut nodes = Vec::new();
-        let mut deferred = Vec::new();
-        let mut owed = Vec::new();
-        let mut owed_regions = Vec::new();
-        let mut owns_signal = false;
-        for (i, frame) in self
-            .suspended
-            .take()
-            .unwrap_or_default()
-            .into_iter()
-            .enumerate()
-        {
-            if let SuspendedFrame::Bytecode(f) = frame {
-                if i == 0 {
-                    owns_signal = true;
-                }
-                nodes.extend(f.activation_dues.owner_node);
-                deferred.extend(f.activation_dues.deferred.iter().copied());
-                // The releases this frame still owed. Its locals sit at the base
-                // of the saved stack (the activation's own frame base, the stack
-                // having been emptied at entry), so the emitter's slot indexes
-                // address them directly.
-                for slot in f.code.frame_release_slots.iter() {
-                    match f.stack.get(*slot as usize) {
-                        Some(v) if v.as_heap_ptr().is_some() => owed.push(*v),
-                        _ => {}
-                    }
-                }
-                // The slot-routed half: a static region slot still mapped in the
-                // parked activation is a `DecrefRegion` that did not run, the
-                // release having taken the mapping wherever it did. Named by the
-                // frame's own function so a caller's leftovers past a tail call
-                // stay out.
-                for slot in f.code.frame_release_regions.iter() {
-                    if let Some(m) = f.activation_region_map.get(slot) {
-                        owed_regions.push(*m);
-                    }
-                }
-            }
-        }
+        let frames = self.suspended.take().unwrap_or_default();
+        let owns_signal = matches!(frames.first(), Some(SuspendedFrame::Bytecode(_)));
+        let dues = ParkedDues::of(frames);
         let signal = match self.signal {
             Some((bits, _)) if owns_signal && !crate::vm::fiber::is_terminal_signal(bits) => {
                 self.signal.take()
@@ -425,11 +435,8 @@ impl Fiber {
             self.delivery.discharge();
         }
         ParkedState {
-            nodes,
-            deferred,
+            dues,
             signal,
-            owed,
-            owed_regions,
             protect,
         }
     }

--- a/src/value/fiberheap/regionstore/free.rs
+++ b/src/value/fiberheap/regionstore/free.rs
@@ -279,7 +279,7 @@ impl RegionStore {
                     };
                     handle.try_with_mut(|fib| {
                         let parked = fib.take_parked_state();
-                        discharged.extend(parked.nodes.iter().map(|r| r.get()));
+                        discharged.extend(parked.dues.nodes.iter().map(|r| r.get()));
                         // The releases those activations took over from their own
                         // frame-replacing tail calls (docs/impl/region/owner.md
                         // § "A deferred tail-call release has the node's life").
@@ -289,7 +289,7 @@ impl RegionStore {
                         // be: a deferred region is the tail callee's own closure
                         // region or a merged arena, and a raise's payload is
                         // neither.
-                        discharged.extend(parked.deferred.iter().map(|r| r.get()));
+                        discharged.extend(parked.dues.deferred.iter().map(|r| r.get()));
                         if let Some(node) = fib.fiber_owner_node.take() {
                             discharged.push(node.get());
                         }
@@ -308,7 +308,7 @@ impl RegionStore {
                                 )
                             })
                         });
-                        for v in &parked.owed {
+                        for v in &parked.dues.owed {
                             let Some(ptr) = v.as_heap_ptr() else {
                                 continue;
                             };
@@ -330,7 +330,7 @@ impl RegionStore {
                         // checked first: a mapping whose region has since been
                         // freed and recycled is a leftover the frame's own release
                         // already answered for.
-                        for m in &parked.owed_regions {
+                        for m in &parked.dues.owed_regions {
                             let rid = m.region.get();
                             let live = self.generation_raw(rid) == m.gen
                                 && self.regions.get(rid as usize).is_some_and(|s| s.is_some());

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -359,48 +359,59 @@ impl VM {
             "signal-violation",
             format!("squelch: signal {} caught at boundary", squelched_str),
         );
-        self.discard_suspended_frames();
+        // The error the boundary raises is what leaves with the signal, so it is
+        // the payload the discard's own releases must leave standing — built in a
+        // fresh region of its own, so in practice it exempts nothing and the
+        // abandoned frames' tables run in full.
+        self.discard_suspended_frames(err);
         err
     }
 
     /// Discard the LIVE fiber's suspended frames (squelch / abort) — the
     /// chokepoint for abandoning suspended work while the fiber runs on, the
-    /// discard counterpart of `resume_suspended` (docs/impl/region/diagnostics.md
-    /// § "The squelch/abort discard"; a fiber reaching a TERMINAL state instead
-    /// releases through `vm::fiber::take_fiber_owned`/`release_fiber_owned`,
-    /// which also frees the fiber owner node this discard leaves alone — the
-    /// fiber survives a squelch and may still own it).
+    /// discard counterpart of `resume_suspended` (docs/impl/region/owner.md
+    /// § "A discard runs what the abandoned frames owed"; a fiber reaching a
+    /// TERMINAL state instead releases through
+    /// `vm::fiber::take_fiber_owned`/`release_fiber_owned`, which also frees the
+    /// fiber owner node this discard leaves alone — the fiber survives a squelch
+    /// and may still own it).
     ///
-    /// Each discarded `BytecodeFrame` carries what its activation owed
-    /// ([`crate::value::BytecodeFrame::activation_dues`], MOVED in at the
-    /// suspend — the record's only home): the parked owner node, whose members
-    /// are `Owned` (count consumed by the adopt) with no other release route,
-    /// and the releases the activation took over from its own frame-replacing
-    /// tail calls, whose emitting instruction died with the frame the tail call
-    /// replaced. The continuation whose normal completion would have discharged
-    /// them will never run, so the discard runs them here: one tolerant decref
-    /// each — for the node, rc 1→0 and a subtree drop over node + members
-    /// (interior cycles reclaim with the set; the Shared frontier cascades
-    /// once). The move discipline makes this the sole release path — the slot
-    /// was emptied at the park, so no completion or resume can reach either a
-    /// second time.
+    /// The discarded frames' continuations will never run, so every release that
+    /// lived in one is at its last chance here. What each frame owes it carries
+    /// itself, in three readings [`crate::value::fiber::ParkedDues`] collects
+    /// together: its parked owner node and the releases its activation took over
+    /// from its own frame-replacing tail calls (both MOVED into the frame at the
+    /// suspend — the record's only home, so no completion or resume can reach
+    /// them a second time), and the releases its two emitter-recorded tables name,
+    /// read against its saved locals and its saved activation map.
     ///
-    /// The dues are the ONLY thing released. The frame's
-    /// `activation_region_map` is a borrowed view: a region it names can still
-    /// be live in an outer, non-discarded frame or in the activation that
-    /// catches the squelch, so a per-slot release here over-frees live state. A
-    /// node's members, by contrast, are exactly the regions the inference proved
-    /// externally unique and moved in through `AdoptIntoActivation`, and a
-    /// deferred region is one the compiler itself named as this activation's to
-    /// release — so neither can touch a region any live frame still counts on.
-    /// The map's regions stay leaked on this path until an ownership cut adopts
-    /// them (UAF-safe, bounded per discard; docs/impl/region/owner.md § "Owner
-    /// nodes").
-    pub(crate) fn discard_suspended_frames(&mut self) {
+    /// Each reading names regions this chokepoint is entitled to release: a
+    /// node's members are exactly the regions the inference proved externally
+    /// unique and moved in through `AdoptIntoActivation`, a deferred region is one
+    /// the compiler itself named as this activation's to release, and a table
+    /// entry is a release the executing function emitted for its own slot with a
+    /// receipt that says it did not run. The fiber's survival is not part of that
+    /// reading: a frame's saved stack and saved map were taken and cloned at its
+    /// own park, and its activation returned before this point, so no live frame
+    /// shares the state the receipts are read against.
+    ///
+    /// What stays refused is a blanket release of the rest of the frame's
+    /// `activation_region_map`. It is a borrowed view carrying no receipt, and a
+    /// region it names can still be live in an outer, non-discarded frame or in
+    /// the activation that catches the squelch. Those regions stay leaked on this
+    /// path until an ownership cut adopts them (UAF-safe, bounded per discard).
+    ///
+    /// `payload` is the value the exit leaves with — the boundary's own
+    /// `signal-violation` error — whose region no release here may take, on the
+    /// same reading the abandoned-frame walk makes
+    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    /// still owes").
+    pub(crate) fn discard_suspended_frames(&mut self, payload: Value) {
         if let Some(frames) = self.fiber.suspended.take() {
-            for region in crate::vm::fiber::parked_activation_dues(frames) {
-                self.heap().decref_region_if_present(region);
-            }
+            let dues = crate::value::fiber::ParkedDues::of(frames);
+            let protect = Some(payload).filter(|v| !self.fiber.delivery.mint_names(*v));
+            let heap = unsafe { &mut *self.heap_ptr };
+            crate::vm::fiber::release_parked_dues(heap, dues, protect, None);
         }
         // The abandoned park's funding has no consumer — the delivery funnel
         // that would have taken it will never run for these frames.

--- a/src/vm/execute.rs
+++ b/src/vm/execute.rs
@@ -201,33 +201,26 @@ impl VM {
                 self.execute_bytecode_inner_impl(&current_code, &current_env, current_ip);
 
             if !bits.is_empty() {
-                if self.enforce_squelch(bits, accumulated_squelch_mask) {
-                    // The boundary turns the signal into an error this
-                    // activation never catches, so the frame is abandoned
-                    // exactly as an error exit's is and owes what it took over
-                    // from its tail calls (docs/impl/region/owner.md § "What an
-                    // abandoned frame owes, it owes the deferred set too").
-                    if walk_abandoned {
-                        self.release_abandoned_deferred();
-                    }
-                    break ExecResult {
-                        bits: SIG_ERROR,
-                        ip,
-                        code: current_code,
-                        env: current_env,
-                        stack: vec![],
-                        activation_region_map: rustc_hash::FxHashMap::default(),
-                        activation_dues: ActivationDues::default(),
-                        current_closure: self.fiber.current_closure,
-                    };
-                }
+                // A squelch/attune boundary turns the signal into an error this
+                // activation never catches, so this exit IS the error exit and is
+                // written as one — a second arm would be a second place to keep
+                // the abandonment accounting in step (docs/impl/region/mechanism.md
+                // § "A squelch boundary abandons frames the same way, so it runs
+                // the same walk").
+                let bits = if self.enforce_squelch(bits, accumulated_squelch_mask) {
+                    SIG_ERROR
+                } else {
+                    bits
+                };
                 // The frame's locals are still on the stack, and an error leaves
                 // through the signal machinery without running the rest of its
                 // instructions — so the releases among them run here, before the
                 // locals travel out in `stack` below. The releases this
                 // activation took over from a frame-replacing tail call are owed
                 // on the same question and have no table to be read off, their
-                // emitting instruction having died with the replaced frame.
+                // emitting instruction having died with the replaced frame
+                // (docs/impl/region/owner.md § "What an abandoned frame owes, it
+                // owes the deferred set too").
                 if walk_abandoned && bits.intersects(SIG_ERROR) {
                     let payload = self.fiber.signal.map(|(_, v)| v).unwrap_or(Value::NIL);
                     let exit_code = current_code.clone();

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -48,7 +48,7 @@ mod borrow_tests;
 // `crate::vm::fiber::<Item>` (external callers) or `super::<Item>` (sibling
 // submodules) still resolves unchanged. Visibility matches each item's original
 // `pub(crate)`/private declaration.
-pub(crate) use owned::{kill_fiber, parked_activation_dues, release_fiber_owned, take_fiber_owned};
+pub(crate) use owned::{kill_fiber, release_fiber_owned, release_parked_dues, take_fiber_owned};
 use refcount::{incref_signal_region, release_discarded_signal};
 pub(crate) use refcount::{
     is_terminal_signal, release_displaced_denial_payload, release_displaced_io_request,

--- a/src/vm/fiber/owned.rs
+++ b/src/vm/fiber/owned.rs
@@ -1,13 +1,22 @@
-//! Owner-node teardown for terminal fibers. A fiber owns state through the
-//! ownership forest (its parked chain's activation nodes and its own fiber
-//! node); when it can never run again, that state must be freed exactly once.
-//! The take/release split keeps heap mutation disjoint from fiber access: the
-//! take empties the fiber's slots under its borrow, and the release — run after
-//! the borrow is dropped — can cascade-free the fiber's own heap value without
-//! invalidating a live borrow (docs/impl/region/owner.md § "Owner nodes").
+//! What an abandoned frame chain owed, and the teardown of a terminal fiber.
+//!
+//! [`release_parked_dues`] is the shared half: a chain nothing can re-enter owes
+//! its activation owner nodes, the releases those activations took over from
+//! their own frame-replacing tail calls, and the two release tables each frame's
+//! `Code` records. A squelch/abort discard and a terminal teardown run the same
+//! set, because what makes each release owed is a property of the frame rather
+//! than of the fiber (docs/impl/region/owner.md § "A discard runs what the
+//! abandoned frames owed").
+//!
+//! A TERMINAL fiber owes more — its own fiber node, and the escape retain on a
+//! parked non-terminal signal — and the take/release split keeps heap mutation
+//! disjoint from fiber access there: the take empties the fiber's slots under
+//! its borrow, and the release, run after the borrow is dropped, can
+//! cascade-free the fiber's own heap value without invalidating a live borrow
+//! (docs/impl/region/owner.md § "Owner nodes").
 
-use crate::value::fiber::FiberStatus;
-use crate::value::{FiberHandle, SignalBits, SuspendedFrame, Value, SIG_ERROR};
+use crate::value::fiber::{FiberStatus, ParkedDues};
+use crate::value::{FiberHandle, SignalBits, Value, SIG_ERROR};
 
 /// Everything a fiber owns through the ownership forest, TAKEN out of the fiber
 /// (its slots emptied) so the release can run after the fiber borrow is dropped
@@ -16,52 +25,73 @@ use crate::value::{FiberHandle, SignalBits, SuspendedFrame, Value, SIG_ERROR};
 /// disjoint from fiber access: the release's cascades can free the fiber's own
 /// heap value without invalidating a live borrow.
 pub(crate) struct FiberOwned {
-    /// Each still-parked `BytecodeFrame`'s activation owner node, in chain order.
-    parked_nodes: Vec<crate::hir::region::RuntimeRegion>,
-    /// The releases those activations took over from their own frame-replacing
-    /// tail calls (docs/impl/region/owner.md § "A deferred tail-call release has
-    /// the node's life"). A frame this fiber can never re-enter never reaches
-    /// the completion that would have run them.
-    parked_deferred: Vec<crate::hir::region::RuntimeRegion>,
+    /// Everything the still-parked frames owed: their activation owner nodes,
+    /// the releases those activations took over from their own frame-replacing
+    /// tail calls, and their two emitter-recorded release tables.
+    parked: ParkedDues,
     /// The parked non-terminal signal (a yielded value / io request / denial
     /// payload), whose one park escape retain is released on the resume path —
     /// which will never come for a terminal fiber (`release_discarded_signal`).
     parked_signal: Option<(SignalBits, Value)>,
-    /// The values the parked frames still owed a release for, off their own
-    /// value-route slots, and the payload those releases must leave standing
-    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
-    /// still owes"). A frame that can never be re-entered never reaches the
-    /// release, so it runs here.
-    parked_owed: Vec<Value>,
-    parked_owed_regions: Vec<crate::hir::region::MappedRegion>,
+    /// The payload the parked frames' releases must leave standing.
     parked_protect: Option<Value>,
     /// The fiber's own owner node (`Fiber::fiber_owner_node`).
     fiber_node: Option<crate::hir::region::RuntimeRegion>,
 }
 
-/// What the activations of an abandoned frame chain still owed: each parked
-/// frame's owner node, and the releases it took over from its own
-/// frame-replacing tail calls. The frames' continuations will never run, so the
-/// completion release that would have discharged them never fires; it belongs to
-/// whoever abandoned the chain — the discard chokepoint
-/// (`VM::discard_suspended_frames`) or the terminal-fiber teardown
-/// ([`take_fiber_owned`]). A `FiberResume` frame owes nothing (its sub-fiber has
-/// its own lifecycle).
-/// Each region here takes one tolerant decref, node and deferred region alike:
-/// a node's rc goes 1→0 and subtree-drops its adopted members, and a deferred
-/// region's decref is the one its emitting instruction never ran. Order between
-/// them is immaterial — where one holds a counted edge to the other, the cascade
-/// and the direct decref commute.
-pub(crate) fn parked_activation_dues(
-    frames: Vec<SuspendedFrame>,
-) -> impl Iterator<Item = crate::hir::region::RuntimeRegion> {
-    frames.into_iter().flat_map(|frame| match frame {
-        SuspendedFrame::Bytecode(f) => {
-            let dues = f.activation_dues;
-            dues.deferred.into_iter().chain(dues.owner_node)
+/// Release everything a chain of frames nothing can re-enter still owed
+/// ([`ParkedDues`], docs/impl/region/owner.md § "A discard runs what the
+/// abandoned frames owed"). Shared by the squelch/abort discard chokepoint
+/// (`VM::discard_suspended_frames`), where the fiber runs on, and by the
+/// terminal-fiber teardown ([`release_fiber_owned`]), where it does not: what
+/// makes each release owed is a property of the frame, so the fiber's fate is
+/// not part of the reading.
+///
+/// `protect` is the payload the exit leaves with, whose region no release here
+/// may take — a frame's reference to it funds the delivery its reader consumes.
+/// `gather_under`, when set, reparents each node's members onto that node before
+/// the node's own drop, so the whole set goes in one subtree drop.
+pub(crate) fn release_parked_dues(
+    heap: &mut crate::value::fiberheap::FiberHeap,
+    parked: ParkedDues,
+    protect: Option<Value>,
+    gather_under: Option<crate::hir::region::RuntimeRegion>,
+) {
+    // The value-routed half: each is one reference the frame took, whose route
+    // can no longer be reached.
+    let protect_region = protect.and_then(|v| crate::value::arena::region_of(heap, v));
+    for v in parked.owed {
+        let r = crate::value::arena::region_of(heap, v);
+        if r.is_some() && r != protect_region {
+            crate::value::arena::decref_region(heap, r);
         }
-        SuspendedFrame::FiberResume { .. } => Vec::new().into_iter().chain(None),
-    })
+    }
+    // The slot-routed half. The mapping's generation is checked first: a slot
+    // whose region has since been freed and recycled is a leftover the frame's own
+    // release already answered for, and releasing the id's new incarnation would
+    // free a live region.
+    for m in parked.owed_regions {
+        if heap.generation_raw(m.region.get()) != m.gen || protect_region == Some(m.region) {
+            continue;
+        }
+        heap.decref_region_if_present(m.region);
+    }
+    // The deferred releases run before the nodes, so a closure region a node's
+    // member still holds a counted edge to is not freed twice — the decref here
+    // drops this activation's reference and the member's edge keeps it standing
+    // until the subtree drop below cascades through.
+    for region in parked.deferred {
+        heap.decref_region_if_present(region);
+    }
+    // One tolerant decref per node: rc 1→0, subtree drop over node + adopted
+    // members (interior cycles reclaim with the set), the Shared frontier
+    // cascading once from the recorded `outgoing` tables.
+    for node in parked.nodes {
+        if let Some(root) = gather_under {
+            heap.reparent_owned_children(node, root);
+        }
+        heap.decref_region_if_present(node);
+    }
 }
 
 /// Take everything a TERMINAL fiber owns — the parked chain's activation owner
@@ -78,11 +108,8 @@ pub(crate) fn parked_activation_dues(
 pub(crate) fn take_fiber_owned(fiber: &mut crate::value::fiber::Fiber) -> FiberOwned {
     let parked = fiber.take_parked_state();
     FiberOwned {
-        parked_nodes: parked.nodes,
-        parked_deferred: parked.deferred,
+        parked: parked.dues,
         parked_signal: parked.signal,
-        parked_owed: parked.owed,
-        parked_owed_regions: parked.owed_regions,
         parked_protect: parked.protect,
         fiber_node: fiber.fiber_owner_node.take(),
     }
@@ -100,48 +127,14 @@ pub(crate) fn release_fiber_owned(
     owned: FiberOwned,
 ) {
     let FiberOwned {
-        parked_nodes,
-        parked_deferred,
+        parked,
         parked_signal,
-        parked_owed,
-        parked_owed_regions,
         parked_protect,
         fiber_node,
     } = owned;
-    // The releases the parked frames still owed. Each is one reference the frame
-    // took and the route that would have dropped it can no longer be reached; the
-    // payload's own region is skipped, its holder being the fiber's result rather
-    // than any frame.
-    let protect_region = parked_protect.and_then(|v| crate::value::arena::region_of(heap, v));
-    for v in parked_owed {
-        let r = crate::value::arena::region_of(heap, v);
-        if r.is_some() && r != protect_region {
-            crate::value::arena::decref_region(heap, r);
-        }
-    }
-    // The slot-routed half. The mapping's generation is checked first: a slot
-    // whose region has since been freed and recycled is a leftover the frame's own
-    // release already answered for, and releasing the id's new incarnation would
-    // free a live region.
-    for m in parked_owed_regions {
-        if heap.generation_raw(m.region.get()) != m.gen || protect_region == Some(m.region) {
-            continue;
-        }
-        heap.decref_region_if_present(m.region);
-    }
-    // The deferred releases run before the nodes, so a closure region a node's
-    // member still holds a counted edge to is not freed twice — the decref here
-    // drops this activation's reference and the member's edge keeps it standing
-    // until the subtree drop below cascades through.
-    for region in parked_deferred {
-        heap.decref_region_if_present(region);
-    }
-    for node in parked_nodes {
-        if let Some(fnode) = fiber_node {
-            heap.reparent_owned_children(node, fnode);
-        }
-        heap.decref_region_if_present(node);
-    }
+    // What the parked frames owed, with the payload's own region skipped: its
+    // holder is the fiber's result rather than any frame.
+    release_parked_dues(heap, parked, parked_protect, fiber_node);
     if let Some(fnode) = fiber_node {
         heap.decref_region_if_present(fnode);
     }

--- a/tests/elle/region-squelch-unwind-uaf.lisp
+++ b/tests/elle/region-squelch-unwind-uaf.lisp
@@ -1,0 +1,135 @@
+(elle/epoch 12)
+# Soundness complement of region-squelch-unwind.lisp
+# (docs/impl/region/mechanism.md § "A squelch boundary abandons frames the same
+# way, so it runs the same walk"). Run under `--trace=guardfree` by the
+# subprocess pin `region_squelch_unwind_uaf` in tests/integration/elle_scripts.rs.
+#
+# A squelch/attune boundary abandons the frames between the emitting site and
+# itself, so the discard runs the releases each of them still owed. Each is a
+# release that frame genuinely had, run earlier than it would have been — and
+# the fiber SURVIVES, so what has to be whole afterwards is everything the
+# surviving side still reads.
+#
+# Four faces.
+#
+# 1. The CATCHING activation's own values. It is not abandoned, and it goes on
+#    running with the violation in hand.
+# 2. An OUTER, non-discarded frame's values. The boundary sits between it and
+#    the emitting frame, so the discard walks past neither into it.
+# 3. A value the abandoned frame STORED somewhere that outlives it. The store
+#    funnel took a counted reference, so the discard's release drops the frame's
+#    own and no more.
+# 4. REPETITION. A region a discard over-releases drains within a few
+#    iterations, and the scheduler machinery behind the boundary is reused
+#    across them, so every subject runs in a loop and reads its values after.
+#
+# Every read below happens AFTER the discard ran, so an over-release faults at
+# the deref (guardfree) or trips the generation check.
+
+# ── 1. the catching activation's own values ──────────────────────────────────
+# `held` belongs to the frame that CATCHES, and the squelched body holds a
+# pending value of its own for the discard to release.
+
+(def one-body
+  (squelch (fn []
+             (let [s (string "inner-" 1)]
+               (begin
+                 (emit :yield 1)
+                 s))) :yield))
+
+(defn catch-holds [tag]
+  (let [held (string "held-" tag)]
+    (let [[ok e] (protect (one-body))]
+      [(length held) ok (get e :error)])))
+
+(var i 0)
+(while (< i 40)
+  (let [r (catch-holds i)]
+    (assert (< 0 (get r 0)) "the catching frame's own value must be whole")
+    (assert (= (get r 1) false) "the boundary must raise")
+    (assert (= (get r 2) :signal-violation)
+            "the violation must be readable after the discard"))
+  (assign i (+ i 1)))
+
+# ── 2. an outer, non-discarded frame's values ────────────────────────────────
+# `outer` is bound by a frame ABOVE the boundary. The frames the discard
+# abandons are the emitting one and those between it and the boundary, so a
+# release reaching `outer` is one the discard was never entitled to run.
+
+(defn outer-across [tag]
+  (let [outer (string "outer-" tag)]
+    (begin
+      (protect (one-body))
+      (protect (one-body))
+      (length outer))))
+
+(assign i 0)
+(while (< i 40)
+  (assert (< 0 (outer-across i))
+          "an outer frame's value must survive two discards under it")
+  (assign i (+ i 1)))
+
+# ── 3. a value the abandoned frame stored into a longer-lived container ──────
+# `sink` outlives every call. The squelched body stores a fresh string into it
+# and then emits with that string's own binding still live, so the discard
+# releases the frame's reference and the sink's counted one must keep the value
+# alive.
+
+(def sink @[])
+
+(def store-body
+  (squelch (fn []
+             (let [s (string "kept" 1)]
+               (begin
+                 (push sink s)
+                 (emit :yield 1)
+                 s))) :yield))
+
+(assign i 0)
+(while (< i 40)
+  (protect (store-body))
+  (assign i (+ i 1)))
+
+(assert (= (length sink) 40) "every stored value must have reached the sink")
+(var n 0)
+(while (< n (length sink))
+  (assert (= (type-of (get sink n)) :string)
+          "a value the abandoned frame stored must outlive the discard")
+  (assign n (+ n 1)))
+
+# ── 4. the slot route, and an attune boundary ────────────────────────────────
+# A closure the abandoned frame allocated is released by the slot route, whose
+# receipt is the activation map rather than a nil stamp. The enclosing frame
+# calls it after the boundary, so an over-release faults on the read.
+
+(def slot-body
+  (attune |:error|
+          (fn []
+            (let [x 5
+                  f (fn [] (+ x 1))]
+              (begin
+                (emit :yield 1)
+                (f))))))
+
+(defn slot-across [tag]
+  (let [g (fn [] tag)]
+    (begin
+      (protect (slot-body))
+      (g))))
+
+(assign i 0)
+(while (< i 40)
+  (assert (= (slot-across i) i)
+          "the catching frame's own closure must survive the slot route")
+  (assign i (+ i 1)))
+
+# ── 5. the scheduler survives the discards ───────────────────────────────────
+# Fresh fiber machinery after 160 boundaries: a yield round-trip must read
+# intact state, which is where a drained scheduler region would surface.
+
+(def coro (fiber/new (fn [] (yield (string "round" 1))) |:yield|))
+(fiber/resume coro nil)
+(assert (= (type-of (fiber/value coro)) :string)
+        "a fresh fiber must yield intact after the discards")
+
+(println "region-squelch-unwind-uaf: ok")

--- a/tests/elle/region-squelch-unwind.lisp
+++ b/tests/elle/region-squelch-unwind.lisp
@@ -1,0 +1,185 @@
+(elle/epoch 12)
+# A squelch boundary abandons frames the same way an error does
+# (docs/impl/region/mechanism.md § "A squelch boundary abandons frames the same
+# way, so it runs the same walk").
+#
+# A `squelch`/`attune` boundary raises a `signal-violation` the abandoned
+# activation never catches. So the frames between the emitting site and the
+# boundary are abandoned exactly as an error's are: none of their remaining
+# instructions run, and every release among them is one region nobody
+# releases. The rate is per pending value, per abandoned frame — what a
+# `squelch` in a retry loop or a request loop grows by.
+#
+# Two places carry the frames. The chain the boundary parked is abandoned at
+# the discard chokepoint (`VM::discard_suspended_frames`), and the activation
+# the boundary breaks out of is abandoned at the exit itself. Both run the two
+# tables the emitter recorded, off each frame's own `Code`. Every subject below
+# reaches the boundary through a park, so what it gauges is the chain; the
+# chokepoint itself is driven directly by
+# `runtime::tests::ownership::discard_runs_the_abandoned_frames_release_tables`.
+#
+# This file is the LEAK gauge — `arena/count` and `arena/region-count` deltas
+# over a fixed window, BOUNDED for every subject. The soundness complement is
+# region-squelch-unwind-uaf.lisp.
+
+(def window 300)
+
+(defn measure [thunk warm window]
+  (var i 0)
+  (while (%lt i warm)
+    (thunk)
+    (assign i (%add i 1)))
+  (def objects (arena/count))
+  (def regions (arena/region-count))
+  (var j 0)
+  (while (%lt j window)
+    (thunk)
+    (assign j (%add j 1)))
+  [(%sub (arena/count) objects) (%sub (arena/region-count) regions)])
+
+# subjects ─────────────────────────────────────────────────────────────────────
+
+# (a) ONE pending value, held by the frame that emits. Its release sits past
+# the emit, which the boundary never returns from.
+(def one-body
+  (squelch (fn []
+             (let [s (string "x" 1)]
+               (begin
+                 (emit :yield 1)
+                 s))) :yield))
+
+(defn one-pending []
+  (try
+    (one-body)
+    (catch e nil)))
+
+# (b) TWO of them: the rate is per pending value, not per frame.
+(def two-body
+  (squelch (fn []
+             (let [s (string "x" 1)
+                   t (string "y" 2)]
+               (begin
+                 (emit :yield 1)
+                 (get s 0)
+                 (get t 0)
+                 s))) :yield))
+
+(defn two-pending []
+  (try
+    (two-body)
+    (catch e nil)))
+
+# (c) an ENCLOSING frame's pending value: the emitting frame is a callee, so
+# the caller's own release is abandoned with it.
+(defn yielder []
+  (emit :yield 1))
+
+(def enclosing-body
+  (squelch (fn []
+             (let [s (string "x" 1)]
+               (begin
+                 (yielder)
+                 s))) :yield))
+
+(defn enclosing []
+  (try
+    (enclosing-body)
+    (catch e nil)))
+
+# (d) an ATTUNE boundary rather than a squelch: the same enforcement, reached
+# from the complementary mask.
+(def attune-body
+  (attune |:error|
+          (fn []
+            (let [s (string "x" 1)]
+              (begin
+                (emit :yield 1)
+                s)))))
+
+(defn attuned []
+  (try
+    (attune-body)
+    (catch e nil)))
+
+# controls ─────────────────────────────────────────────────────────────────────
+
+# (e) a violation with NOTHING pending. Bounded before this mechanism and
+# after it, so a regression here is the discard running a release no frame
+# ever owed. It is also what isolates the boundary's own `signal-violation`
+# error, which every subject above builds too.
+(def none-body
+  (squelch (fn []
+             (begin
+               (emit :yield 1)
+               7)) :yield))
+
+(defn nothing-pending []
+  (try
+    (none-body)
+    (catch e nil)))
+
+# (f) the same squelched body with NO violation: the ordinary releases run, so
+# this pins that the subjects measure the abandoned release and not the body's
+# own scratch.
+(def clean-body
+  (squelch (fn []
+             (let [s (string "x" 1)]
+               s)) :yield))
+
+(defn no-violation []
+  (try
+    (clean-body)
+    (catch e nil)))
+
+# (g) the CATCHING frame's own value: it is not abandoned, so its release runs
+# where it always did. A regression here is the walk reaching past the frames
+# the boundary actually abandons.
+(defn catching []
+  (let [c (string "c" 1)]
+    (begin
+      (try
+        (none-body)
+        (catch e nil))
+      c)))
+
+# measurement ──────────────────────────────────────────────────────────────────
+
+(def d-one (measure one-pending 20 window))
+(def d-two (measure two-pending 20 window))
+(def d-encl (measure enclosing 20 window))
+(def d-attune (measure attuned 20 window))
+(def d-none (measure nothing-pending 20 window))
+(def d-clean (measure no-violation 20 window))
+(def d-catch (measure catching 20 window))
+
+(println "region-squelch-unwind over " window " iters [objects regions]:")
+(println "  one-pending      " d-one)
+(println "  two-pending      " d-two)
+(println "  enclosing        " d-encl)
+(println "  attuned          " d-attune)
+(println "  nothing-pending  " d-none " (control)")
+(println "  no-violation     " d-clean " (control)")
+(println "  catching         " d-catch " (control)")
+
+(def slack 50)
+
+(defn bounded [label delta]
+  (let [objects (get delta 0)
+        regions (get delta 1)]
+    (begin
+      (assert (< objects slack)
+              (concat label ": objects grew, delta=" (number->string objects)))
+      (assert (< regions slack)
+              (concat label ": regions grew, delta=" (number->string regions))))))
+
+(bounded "control: a violation with nothing pending releases nothing" d-none)
+(bounded "control: a squelched body that never violates reclaims normally"
+         d-clean)
+(bounded "control: the catching frame is not abandoned" d-catch)
+
+(bounded "the emitting frame's pending value is a release it still owed" d-one)
+(bounded "two pending values are two owed releases" d-two)
+(bounded "an enclosing frame's pending release is abandoned too" d-encl)
+(bounded "an attune boundary abandons its frames the same way" d-attune)
+
+(println "region-squelch-unwind: ok")

--- a/tests/elle/region-tail-deferred-exits.lisp
+++ b/tests/elle/region-tail-deferred-exits.lisp
@@ -168,15 +168,12 @@
 (println "  squelch exit   " d-sq " (control " d-sq-c ")")
 (println "  clean break    " d-clean " (control)")
 
-# The trap: a control is not always 0. The squelch control reads one object per
-# op, and it is NOT the boundary's own signal-violation error — a squelch of a
-# body that allocates nothing reads 0. It is the body's own pending value: the
-# squelch exit runs no abandoned-frame walk, so the release table's half of what
-# that frame owed stays owed (docs/impl/region/mechanism.md § "An abandoned frame
-# runs the releases it still owes" — a different mechanism, open at that exit;
-# elle-lisp/elle#1027). So each subject is read against its own control rather
-# than against 0, with one window's slack for allocator noise. When #1027 closes,
-# the squelch control drops to 0 and this reading gets tighter, not wrong.
+# The trap: a subject that leaves by a signal carries TWO mechanisms, and only
+# the deferred set is this file's. The other is the release table the same exit
+# runs (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+# still owes"), which every control reaches too. So each subject is read against
+# its OWN control rather than against 0, with one window's slack for allocator
+# noise — a reading that stays right whichever of the two moves.
 (def slack 50)
 
 (assert (%lt d-clean slack)

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -813,6 +813,24 @@ fn region_error_unwind_uaf() {
     );
 }
 
+// Guard — a squelch/attune boundary abandons its frames the same way an error
+// does, so the discard runs the releases each of them still owed
+// (docs/impl/region/mechanism.md § "A squelch boundary abandons frames the same
+// way, so it runs the same walk"). The fiber SURVIVES the boundary, so what must
+// be whole afterwards is everything the surviving side still reads: the CATCHING
+// activation's own values, an OUTER non-discarded frame's, a value the abandoned
+// frame STORED into a longer-lived container, a closure released by the SLOT
+// route, and the scheduler machinery behind 160 boundaries. Every read happens
+// after the discard ran, so an over-release faults there — SIGSEGV under
+// guardfree. The leak face is `region-squelch-unwind.lisp`.
+#[test]
+fn region_squelch_unwind_uaf() {
+    run_elle_script_with_args(
+        "region-squelch-unwind-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — a deferred tail-call release runs at every end its activation can
 // reach, not only the clean break (docs/impl/region/owner.md § "A deferred
 // tail-call release has the node's life"). Each is a decref the activation


### PR DESCRIPTION
Closes #1027.

## The defect, as filed and as measured

The issue reproduces on `main` exactly as written. Objects and regions per op,
300-op window, debug interpreter, each subject caught with `try`:

| shape | before | after |
|---|---:|---:|
| one pending value in the emitting frame | 1 / 1 | 0 / 0 |
| two pending values | 2 / 2 | 0 / 0 |
| an enclosing frame holds it (the emitter is a callee) | 1 / 1 | 0 / 0 |
| the same under an `attune` boundary | 1 / 1 | 0 / 0 |
| body allocates nothing (control) | 0 / 0 | 0 / 0 |
| squelched body, no violation (control) | 0 / 0 | 0 / 0 |
| the catching frame's own value (control) | 0 / 0 | 0 / 0 |

An error exit runs the releases an abandoned frame still owed, off the two
tables the emitter recorded. A squelch/attune boundary raises a
`signal-violation` the abandoned activation never catches, so it abandons the
same frames the same way — and ran none of it.

## What this does

**The exit is the error exit, so it is written as one.** `trampoline_loop` had
two arms: a squelch arm that broke immediately, and an error arm below it that
walked. The squelch arm now turns the bits into `SIG_ERROR` and falls through,
so there is one exit and one place to keep the accounting in step. It hands the
frame's operand stack out for the same reason the error arm does — a fiber
body's first run parks that frame, and what a parked frame owes runs at its
discharge rather than nowhere.

**The discard reads the frames' own tables.** Every frame parked between the
emitting site and the boundary is discarded at one chokepoint,
`VM::discard_suspended_frames`, which all six enforcement sites reach through
`squelch_violation` — so the fix is below `enforce_squelch`, not bolted onto the
interpreter trampoline. The chokepoint had only released the dues; it now runs
the whole set a frame chain can owe, read the same way
`Fiber::take_parked_state` reads it for a fiber that can never run again. That
reading is now one function, `ParkedDues::of`, shared by the discard, the
terminal teardown, and the region free path's fiber discharge; the partial
third reader (`parked_activation_dues`) is gone.

### What the fiber's survival costs the argument

Nothing, and that is the point. The tables are a claim about the FRAME: a
discarded frame's saved stack and saved activation map were taken and cloned at
its own park, and the activation they came from returned before the boundary was
reached, so no live frame reads either. Within them each route names only the
executing function's own slots and carries its own receipt — the value route's
nil stamp, the mapping the slot route takes — so a slot still holding a heap
value, or still mapped, is a release that frame genuinely owed and did not run.

The rest of the parked map stays refused, unchanged: a blanket per-slot release
carries no receipt at all, and the regions it names may be an outer,
non-discarded frame's or the catching activation's — the historical squelch
double-free.

### The payload exemption

The boundary's own `signal-violation` is what leaves with the signal, so it is
the payload the discard's releases must leave standing. `escaping_error` builds
it in a fresh region and records no delivery mint, so in practice it exempts
nothing and the tables run in full. The signal the boundary DISPLACES is not the
exemption's subject: a squelched park's payload is delivered to nobody, and the
park's own escape retain holds it independently of any frame.

## Gauges

- `tests/elle/region-squelch-unwind.lisp` — the leak gauge, bounded for every
  subject beside three controls. Fails on `main` for the right reason on all
  four subjects.
- `tests/elle/region-squelch-unwind-uaf.lisp` — the soundness pin, run under
  `--trace=guardfree` by `region_squelch_unwind_uaf`. Five faces, all read after
  the discard ran: the catching activation's own values, an outer non-discarded
  frame's, a value the abandoned frame stored into a longer-lived container, a
  closure released by the slot route, and fresh fiber machinery after 160
  boundaries.
- `runtime::tests::ownership::discard_runs_the_abandoned_frames_release_tables`
  — the chokepoint driven directly, where both routes and the untabled slot
  beside each are visible without a program that allocates into them, plus the
  payload exemption and its withdrawal under a recorded mint.

Counter-factual: with the two table loops removed from `release_parked_dues`,
every gauge subject reads its old rate and the unit test fails at the first
assertion.

Every gauge subject reaches the boundary through an emit park. A boundary over
an **io** park still reads 1 object per op after this change, and what it strands
is a different value rather than a table entry — the request the park left
behind, filed with its measurement as #1031.

All three project gauges run clean: `oracle.lisp` → `oracle: ok`, `open
defects: 0 across 0 roots; by-design: 5`; `cargo test -p elle --test lib
region_` → 99 passed; `cargo test -p elle --lib` → 2429 passed; `make smoke-elle` (release, unpiped) → 665 pass, 9 skip, 0 fail, 0 diverge, 0 timeout; `make qa` and
`make fmt-check` green.

`tests/elle/region-tail-deferred-exits.lisp`'s squelch control read 1 because of
this defect; it reads 0 now, and its comment no longer names the open exit.

