### PR TITLE
value: an immutable struct's entries and its keys are region data

### DIFF
--- a/docs/impl/image.md
+++ b/docs/impl/image.md
@@ -5,8 +5,8 @@ configurations: the **boot** image (core, prelude, and stdlib pre-compiled
 into the binary) and **environment** images (user `save`/`load`) — the same
 format, dumper, and hydrator throughout, differing only in dependency list
 and dump policy (see *One mechanism, two configurations*). This doc owns the
-design argument. Nothing here is implemented yet; the test plan at the end
-names the pins each milestone must land with.
+design argument. *Landing order* below says what has landed and what has not;
+the test plan at the end names the pins each milestone must land with.
 
 ## The problem
 
@@ -159,13 +159,18 @@ Identity comes free; display does not. A hydrating instance holds none of the
 dump's names, which is what the name table below is for, and replaying it is
 also where a cross-build collision is caught.
 
-### Region-native immutable structs
+### Region-native immutable structs — landed
 
-`LStruct` holds `Vec<(TableKey, Value)>` and `TableKey::String` owns a
-`String`. Move the payload to `RegionSlice<(TableKey, Value)>` with string
-keys inline in the region, as arrays and strings already do. Payoff now:
-immutable structs stop allocating on the Rust heap. Payoff for images:
-structs become body data.
+`LStruct` used to hold `Vec<(TableKey, Value)>`, and two `TableKey` arms owned
+Rust heap memory: `String` owned a `String` and `Array` owned a
+`Vec<TableKey>`. The payload is now `RegionSlice<(TableKey, Value)>` and both
+key arms hold a `Value` pointing at a region-resident string or array, as
+arrays and strings already did. `TableKey` is `Copy` and sealed;
+[values.md](values.md) § "Struct keys" owns the key model — a borrowed probe
+key, an interned stored key, and an owning `SendKey` for `send` and the disk
+cache. Payoff now: immutable structs allocate nothing on the Rust heap, and a
+`get` probe builds its key without allocating. Payoff for images: structs are
+body data, and a struct's key bytes are self-edges of its own region.
 
 ### Region-native closure templates
 
@@ -760,7 +765,9 @@ code, and each deletes image machinery:
    ([symbol.md](symbol.md)); deleted the symbol remap pass, the
    sorted-container re-sort hazard, the `symbol_names` maps, and `send`'s
    re-interning.
-2. **struct** — region-native immutable struct payloads.
+2. **struct** — landed. Region-native immutable struct payloads and keys
+   ([values.md](values.md) § "Struct keys"); deleted the per-probe key
+   allocation and the owned-key arms the dumper would have had to encode.
 3. **template** — landed. The blueprint / payload / header split
    ([region/template.md](region/template.md)); deleted the per-creation
    blueprint clone, the `HashMap` location map, and the `Rc`-shared template

--- a/docs/impl/stdlib-cache.md
+++ b/docs/impl/stdlib-cache.md
@@ -194,16 +194,18 @@ These two fields were missing from `SendableClosure`; adding them makes the
 send/spawn path and the cache path share the same machinery and incidentally
 fixes a send/spawn omission.
 
-### `SendValue` and `TableKey` serialize through symmetric mirror enums
+### `SendValue` serializes through a symmetric mirror enum
 
 Hand-written tuple serialization drifts from derived deserialization
-(bincode's enum-tag encoding differs), so both directions of each impl go
-through one derived mirror enum (`src/value/send/mirror.rs`). A symbol
-`TableKey` or symbol `Value` refuses to serialize: it carries only a
-process-local id, no name a loader could re-intern — symbols cross by name as
-`SendValue::Symbol` or `LirConst::Symbol` instead. Heap `Value`s are likewise
-rejected — compound literals in the constant pool lower to `MaterializeConst`
-templates at compile time and never enter the pool.
+(bincode's enum-tag encoding differs), so both directions go through one
+derived mirror enum (`src/value/send/mirror.rs`). Struct keys travel as
+`SendKey`, the owning key form (docs/impl/values.md § "Struct keys"), which
+owns its bytes and derives serde directly; a symbol or keyword key travels as
+its name hash, which names the same symbol in the loading process
+(docs/impl/symbol.md). An identity key has no `SendKey` form and is refused,
+which the cache layer turns into a miss. Heap `Value`s are rejected too —
+compound literals in the constant pool lower to `MaterializeConst` templates at
+compile time and never enter the pool.
 
 ## Integration point
 

--- a/docs/impl/values.md
+++ b/docs/impl/values.md
@@ -56,7 +56,7 @@ Tag                   HeapObject variant
 TAG_STRING_MUT (11)   LStringMut { data: Rc<RefCell<Vec<u8>>>, traits }
 TAG_ARRAY (12)        LArray { elements: RegionSlice<Value>, traits }
 TAG_ARRAY_MUT (13)    LArrayMut { data: Rc<RefCell<Vec<Value>>>, traits }
-TAG_STRUCT (14)       LStruct { data: Vec<(TableKey, Value)>, traits }
+TAG_STRUCT (14)       LStruct { data: RegionSlice<(TableKey, Value)>, traits }
 TAG_STRUCT_MUT (15)   LStructMut { data: Rc<RefCell<BTreeMap<TableKey, Value>>>, traits }
 TAG_CONS (16)         Pair { first: Value, rest: Value, traits }
 TAG_CLOSURE (17)      Closure { closure: Closure, traits }
@@ -114,8 +114,8 @@ This structure means:
 
 ### Immutable types use RegionSlice
 
-Immutable collections (arrays, strings, bytes, sets) store their data inline
-in their region's pages via `RegionSlice<T>` — a `(ptr, len)` view into
+Immutable collections (arrays, strings, bytes, sets, structs) store their data
+inline in their region's pages via `RegionSlice<T>` — a `(ptr, len)` view into
 region-owned bytes, usually adjacent to the containing `HeapObject` header. This
 avoids inner `Vec` or `Box<str>` allocations for the common case. Mutable types
 use `Rc<RefCell<...>>` for cross-fiber live-update semantics.
@@ -127,6 +127,80 @@ initialized to `NIL`. The five infrastructure variants (`Float`, `LibHandle`,
 `FFISignature`, `FFIType`, `ClosureTemplate`) do not. `with-traits` accepts only
 a struct (`LStruct` or `LStructMut`) as the table to store here. The field is
 invisible to equality, ordering, and hashing.
+
+## Struct keys
+
+A struct key is a `TableKey` (`src/value/types.rs`). Every variant is `Copy`,
+and no variant owns a Rust-heap allocation: a key's payload is either an
+immediate or a `Value` that points into a region. The entries of an immutable
+struct are therefore page bytes, which is what lets an image dump a struct as
+body data (see [impl/image.md](image.md) § Foundations).
+
+### A key is borrowed to probe and interned to store
+
+`TableKey::from_value` builds a **probe** key. It aliases the value it reads
+and allocates nothing, so `(get s "name")` costs no allocation.
+
+`TableKey::intern_into` builds a **stored** key. It copies a string or array
+payload into the destination region, so a struct's entries and the bytes of
+its keys share one region. Storing a probe key instead would leave the struct
+pointing into whatever region the caller's key came from. The struct would
+pin that region for its whole life, and a chain of `put`s would pin one
+region per link.
+
+The split reproduces what the owned representation did. A string key used to
+copy its bytes, and `intern_into` copies them too. A `Heap` key — a pair, a
+set, a struct, a fiber, a closure — used to alias its value, and it still
+aliases: interning one would break the identity that a fiber or closure key
+depends on.
+
+Every store site interns: the constructors in `value/build.rs`, the `@struct`
+store funnel in `value/arena/mutate.rs`, `with-traits`, the trait-table root
+builder, and the receiving side of `send`. A key already resident in the
+destination region is left alone, and a rebind interns nothing — the map keeps
+the key it already holds.
+
+### Keys rank in their own order, not `Value`'s
+
+`TableKey::Ord` ranks variants in declaration order: nil, bool, int, symbol,
+string, keyword, empty list, array, heap. `Value::Ord` ranks the same types
+differently — it puts keywords before strings. The two orders are
+independent, and a struct prints its entries in `TableKey` order, so the key
+ranking is user-visible. A string key compares by content, and an array key
+compares element-wise as keys. That is why both keep a variant of their own
+instead of folding into `Heap`, whose comparison delegates to `Value::Ord`.
+
+### A key's region is counted like a value's
+
+`TableKey::for_each_heap_value` enumerates the `Value`s a key holds. Two
+ledgers walk it: the alloc-time scan (`find_object_cross_refs`) for a struct
+born with its keys, and the `@struct` store funnels (`value/arena/mutate.rs`)
+for a key put or deleted later. Both count a key's heap value on one rule —
+**only when it resolves to a region other than the container's**. On that
+rule a key's region is increfed and its edge recorded exactly as a struct
+value's is, and the free-time cascade releases both.
+
+An interned key resolves to the container's own region, so it is a self-edge
+that neither ledger counts, and a key costs nothing to hold. A `Heap` key is
+not interned, stays a real cross-region reference, and both ledgers count it.
+
+The rule has to be the same on both sides, because the remove half cannot
+tell how the key it removes arrived. Count a self-edge in the put funnel
+alone and the container's region holds a reference to itself that the free
+cascade never releases — the cascade filters `own_id` — so every `put` of a
+string or array key leaks the whole region unless a later `del` cancels it.
+Count one in the remove funnel alone and `del` decrefs a reference the
+constructor never took, which frees the container under its own reader.
+
+### The wire key owns its bytes
+
+`SendKey` (`value/send/mod.rs`) is the key form that crosses a thread or a
+process: an owning enum with no `Value` in it. `SendValue::Struct` and
+`SendValue::StructMut` are keyed on it. A `TableKey` holds raw region
+pointers, so it is never `Send` and never serialized. The conversion reads a
+string key's bytes on the way out and allocates a fresh string in the
+receiving region on the way in. `SendKey` has no `Heap` arm, which is how an
+identity key is refused at the boundary.
 
 ## Closures
 

--- a/docs/traits.md
+++ b/docs/traits.md
@@ -228,8 +228,8 @@ The hot path for builtin types:
 - Linear scan for method keyword (5 entries in the method struct)
 - Native function call (same Rust code as the old type cascade)
 
-`lookup_keyword` avoids allocating a `TableKey` — it compares the
-keyword discriminant and string directly.
+`lookup_keyword` compares the keyword's name hash against each entry's key
+directly, so it builds no key at all.
 
 ---
 

--- a/src/io/request/buffer.rs
+++ b/src/io/request/buffer.rs
@@ -142,8 +142,9 @@ pub(crate) unsafe fn bytes_to_string_in_place(
 /// (an int) into the result struct that was pre-allocated on the requesting
 /// fiber's heap — without re-composing the struct or allocating a new one.
 ///
-/// `LStruct.data` is a plain `Vec<(TableKey, Value)>` (on the Rust heap, not the
-/// arena), so this is an ordinary in-place slot write; the sorted key order is
+/// `LStruct.data` is a `RegionSlice` over the struct's own region pages, which
+/// the region owns and may write; the slice hands out only shared borrows, so
+/// the write goes through the backing pointer. The sorted key order is
 /// preserved because we never change a key.
 ///
 /// # Safety
@@ -164,7 +165,9 @@ pub(crate) unsafe fn set_struct_field_in_place(
         .expect("recv result must be a heap value") as *mut HeapObject;
     match &mut *ptr {
         HeapObject::LStruct { data, .. } => {
-            for entry in data.iter_mut() {
+            let entries = data.as_ptr() as *mut (crate::value::heap::TableKey, Value);
+            for i in 0..data.len() {
+                let entry = &mut *entries.add(i);
                 if &entry.0 == key {
                     entry.1 = val;
                     return;

--- a/src/jit/dispatch/structops.rs
+++ b/src/jit/dispatch/structops.rs
@@ -119,7 +119,7 @@ pub extern "C" fn elle_jit_struct_rest(
         let result: Vec<_> = struct_map
             .iter()
             .filter(|(k, _)| !exclude.contains(k))
-            .map(|(k, v)| (k.clone(), *v))
+            .map(|(k, v)| (*k, *v))
             .collect();
         let ctx = crate::primitives::ctx::Alloc::new(unsafe { &mut *vm_ref.heap_ptr });
         JitValue::from_value(ctx.struct_from_sorted(result))
@@ -128,9 +128,9 @@ pub extern "C" fn elle_jit_struct_rest(
             .borrow()
             .iter()
             .filter(|(k, _)| !exclude.contains(k))
-            .map(|(k, v)| (k.clone(), *v))
+            .map(|(k, v)| (*k, *v))
             .collect();
-        result.sort_by(|(a, _), (b, _)| a.cmp(b));
+        result.sort_by_key(|(a, _)| *a);
         let ctx = crate::primitives::ctx::Alloc::new(unsafe { &mut *vm_ref.heap_ptr });
         JitValue::from_value(ctx.struct_from_sorted(result))
     } else {

--- a/src/plugin_api/capi/collections.rs
+++ b/src/plugin_api/capi/collections.rs
@@ -73,7 +73,9 @@ pub(in crate::plugin_api) extern "C" fn struct_key(
                             None => return std::ptr::null(),
                         }
                     }
-                    TableKey::String(s) => intern_str(s.clone()),
+                    TableKey::String(v) => {
+                        intern_str(v.as_str().expect("a string key holds a string").to_string())
+                    }
                     _ => return std::ptr::null(),
                 };
                 *out_len = s.len();

--- a/src/primitives/collection.rs
+++ b/src/primitives/collection.rs
@@ -275,7 +275,7 @@ pub fn coll_to_vec(val: &Value, ctx: &mut NativeCtx) -> Result<Vec<Value>, Value
         return Ok(s
             .iter()
             .map(|(k, v)| {
-                let key = k.to_value(ctx);
+                let key = k.to_value();
                 ctx.array(vec![key, *v])
             })
             .collect());
@@ -285,7 +285,7 @@ pub fn coll_to_vec(val: &Value, ctx: &mut NativeCtx) -> Result<Vec<Value>, Value
             .borrow()
             .iter()
             .map(|(k, v)| {
-                let key = k.to_value(ctx);
+                let key = k.to_value();
                 ctx.array(vec![key, *v])
             })
             .collect());
@@ -309,10 +309,10 @@ fn struct_entries(
     v: &Value,
 ) -> Option<std::collections::BTreeMap<crate::value::heap::TableKey, Value>> {
     v.as_struct()
-        .map(|s| s.iter().map(|(k, v)| (k.clone(), *v)).collect())
+        .map(|s| s.iter().map(|(k, v)| (*k, *v)).collect())
         .or_else(|| {
             v.as_struct_mut()
-                .map(|s| s.borrow().iter().map(|(k, v)| (k.clone(), *v)).collect())
+                .map(|s| s.borrow().iter().map(|(k, v)| (*k, *v)).collect())
         })
 }
 

--- a/src/primitives/ctx.rs
+++ b/src/primitives/ctx.rs
@@ -128,6 +128,14 @@ impl<'h> Alloc<'h> {
         let region = self.region;
         self.heap().alloc_region_slice_in_region(items, region)
     }
+
+    /// Build the stored form of a struct key in the ctx's region — the
+    /// forwarder a native body uses before putting a key into a struct it
+    /// builds here (docs/impl/values.md § "Struct keys").
+    pub fn intern_key(&self, key: &crate::value::heap::TableKey) -> crate::value::heap::TableKey {
+        let region = self.region;
+        key.intern_into(self.heap(), region)
+    }
 }
 
 /// The native-call capability: an [`Alloc`] plus the **non-null** driving VM

--- a/src/primitives/intrinsics/data.rs
+++ b/src/primitives/intrinsics/data.rs
@@ -353,7 +353,7 @@ pub(crate) fn prim_freeze(
     let result = if let Some(a) = val.as_array_mut() {
         ctx.array(a.borrow().clone())
     } else if let Some(t) = val.as_struct_mut() {
-        let entries: Vec<_> = t.borrow().iter().map(|(k, v)| (k.clone(), *v)).collect();
+        let entries: Vec<_> = t.borrow().iter().map(|(k, v)| (*k, *v)).collect();
         ctx.struct_from_sorted(entries)
     } else if let Some(s) = val.as_set_mut() {
         ctx.set(s.borrow().clone())
@@ -384,8 +384,7 @@ pub(crate) fn prim_thaw(
     let result = if let Some(a) = val.as_array() {
         ctx.array_mut(a.to_vec())
     } else if let Some(s) = val.as_struct() {
-        let entries: std::collections::BTreeMap<_, _> =
-            s.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        let entries: std::collections::BTreeMap<_, _> = s.iter().map(|(k, v)| (*k, *v)).collect();
         ctx.struct_mut_from(entries)
     } else if let Some(s) = val.as_set() {
         ctx.set_mut(s.iter().cloned().collect())

--- a/src/primitives/json/parser.rs
+++ b/src/primitives/json/parser.rs
@@ -382,18 +382,19 @@ impl<'a, 'h> JsonParser<'a, 'h> {
             }
 
             let key_value = self.parse_string()?;
-            let key = match key_value.with_string(|s| s.to_string()) {
-                Some(s) => {
-                    if self.use_keyword_keys {
-                        // A JSON key is a spelling that exists only at run
-                        // time — learn it so the struct's keys can print.
-                        self.ctx.keyword(&s);
-                        TableKey::keyword(&s)
-                    } else {
-                        TableKey::String(s)
-                    }
-                }
-                _ => unreachable!(),
+            let key = if self.use_keyword_keys {
+                // A JSON key is a spelling that exists only at run time —
+                // learn it so the struct's keys can print.
+                let name = key_value
+                    .as_str()
+                    .expect("parse_string yields a string")
+                    .to_string();
+                self.ctx.keyword(&name);
+                TableKey::keyword(&name)
+            } else {
+                // The parsed string IS the key; the struct constructor interns
+                // it into the struct's region.
+                TableKey::String(key_value)
             };
 
             self.skip_whitespace();

--- a/src/primitives/json/serializer.rs
+++ b/src/primitives/json/serializer.rs
@@ -67,7 +67,9 @@ pub fn serialize_value(
         let mut pairs = Vec::new();
         for (k, v) in mstruct.iter() {
             let key_str = match k {
-                TableKey::String(s) => escape_json_string(s),
+                TableKey::String(v) => {
+                    escape_json_string(v.as_str().expect("a string key holds a string"))
+                }
                 TableKey::Keyword(hash) => {
                     match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
                         Some(name) => escape_json_string(name),
@@ -91,7 +93,9 @@ pub fn serialize_value(
         let mut pairs = Vec::new();
         for (k, v) in s.iter() {
             let key_str = match k {
-                TableKey::String(s) => escape_json_string(s),
+                TableKey::String(v) => {
+                    escape_json_string(v.as_str().expect("a string key holds a string"))
+                }
                 TableKey::Keyword(hash) => {
                     match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
                         Some(name) => escape_json_string(name),
@@ -256,7 +260,9 @@ pub fn serialize_value_pretty(
         let mut pairs = Vec::new();
         for (k, v) in mstruct.iter() {
             let key_str = match k {
-                TableKey::String(s) => escape_json_string(s),
+                TableKey::String(v) => {
+                    escape_json_string(v.as_str().expect("a string key holds a string"))
+                }
                 TableKey::Keyword(hash) => {
                     match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
                         Some(name) => escape_json_string(name),
@@ -288,7 +294,9 @@ pub fn serialize_value_pretty(
         let mut pairs = Vec::new();
         for (k, v) in s.iter() {
             let key_str = match k {
-                TableKey::String(s) => escape_json_string(s),
+                TableKey::String(v) => {
+                    escape_json_string(v.as_str().expect("a string key holds a string"))
+                }
                 TableKey::Keyword(hash) => {
                     match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
                         Some(name) => escape_json_string(name),

--- a/src/primitives/lstruct.rs
+++ b/src/primitives/lstruct.rs
@@ -162,11 +162,11 @@ pub(crate) fn prim_keys(
     if args[0].is_struct_mut() {
         let mstruct = prim_arg!(ctx, args, 0, as_struct_mut, "keys", "struct");
         let borrowed = mstruct.borrow();
-        let keys: Vec<Value> = borrowed.keys().map(|k| k.to_value(ctx)).collect();
+        let keys: Vec<Value> = borrowed.keys().map(|k| k.to_value()).collect();
         (SIG_OK, ctx.list(keys))
     } else if args[0].is_struct() {
         let s = prim_arg!(ctx, args, 0, as_struct, "keys", "struct");
-        let keys: Vec<Value> = s.iter().map(|(k, _)| k.to_value(ctx)).collect();
+        let keys: Vec<Value> = s.iter().map(|(k, _)| k.to_value()).collect();
         (SIG_OK, ctx.list(keys))
     } else {
         type_error!(ctx, args[0], "keys", "struct")

--- a/src/primitives/sets.rs
+++ b/src/primitives/sets.rs
@@ -24,7 +24,7 @@ pub(crate) fn freeze_value(v: Value, ctx: &mut crate::primitives::ctx::Alloc) ->
         let map: std::collections::BTreeMap<crate::value::TableKey, Value> = tbl
             .borrow()
             .iter()
-            .map(|(k, v)| (k.clone(), freeze_value(*v, ctx)))
+            .map(|(k, v)| (*k, freeze_value(*v, ctx)))
             .collect();
         ctx.struct_from(map)
     } else if let Some(s) = v.as_set_mut() {

--- a/src/primitives/structs.rs
+++ b/src/primitives/structs.rs
@@ -185,7 +185,7 @@ fn deep_freeze_val(ctx: &mut crate::primitives::ctx::NativeCtx<'_>, val: Value) 
         let map: BTreeMap<TableKey, Value> = t
             .borrow()
             .iter()
-            .map(|(k, v)| (k.clone(), deep_freeze_val(ctx, *v)))
+            .map(|(k, v)| (*k, deep_freeze_val(ctx, *v)))
             .collect();
         return ctx.struct_from(map);
     }
@@ -193,7 +193,7 @@ fn deep_freeze_val(ctx: &mut crate::primitives::ctx::NativeCtx<'_>, val: Value) 
     if let Some(t) = val.as_struct() {
         let entries: Vec<(TableKey, Value)> = t
             .iter()
-            .map(|(k, v)| (k.clone(), deep_freeze_val(ctx, *v)))
+            .map(|(k, v)| (*k, deep_freeze_val(ctx, *v)))
             .collect();
         return ctx.struct_from_sorted(entries);
     }
@@ -264,7 +264,7 @@ pub(crate) fn prim_thaw(
 
     // struct → @struct
     if let Some(s) = args[0].as_struct() {
-        let map: BTreeMap<_, _> = s.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        let map: BTreeMap<_, _> = s.iter().map(|(k, v)| (*k, *v)).collect();
         return (SIG_OK, ctx.struct_mut_from(map));
     }
     if args[0].is_struct_mut() {
@@ -317,9 +317,11 @@ pub(crate) fn prim_pairs(
     ) -> Value {
         let mut result = Value::EMPTY_LIST;
         for (key, value) in entries.iter().rev() {
-            // `to_value` is the single source of truth for TableKey → Value
-            // (docs/impl/region/ctx.md): born in the call's region via `ctx`.
-            let key_val = key.to_value(ctx);
+            // `to_value` is the single source of truth for TableKey → Value.
+            // A stored key IS its value, so this allocates nothing and the
+            // pair below takes an ordinary cross-region reference to the
+            // struct's own key (docs/impl/values.md § "Struct keys").
+            let key_val = key.to_value();
             let pair = ctx.array(vec![key_val, *value]);
             result = ctx.pair(pair, result);
         }
@@ -332,8 +334,7 @@ pub(crate) fn prim_pairs(
 
     if let Some(map) = args[0].as_struct_mut() {
         let borrowed = map.borrow();
-        let entries: Vec<(TableKey, Value)> =
-            borrowed.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        let entries: Vec<(TableKey, Value)> = borrowed.iter().map(|(k, v)| (*k, *v)).collect();
         return (SIG_OK, pairs_from_slice(ctx, &entries));
     }
 

--- a/src/primitives/subprocess.rs
+++ b/src/primitives/subprocess.rs
@@ -173,7 +173,7 @@ pub(crate) fn prim_sys_env(
     for (key, val) in
         std::env::vars_os().filter_map(|(k, v)| k.into_string().ok().zip(v.into_string().ok()))
     {
-        fields.insert(TableKey::String(key), ctx.string(val));
+        fields.insert(TableKey::String(ctx.string(key)), ctx.string(val));
     }
     (SIG_OK, ctx.struct_from(fields))
 }

--- a/src/primitives/subprocess/exec.rs
+++ b/src/primitives/subprocess/exec.rs
@@ -52,7 +52,9 @@ pub(super) fn parse_exec_opts(
                                 )),
                             }
                         }
-                        TableKey::String(s) => s.clone(),
+                        TableKey::String(v) => {
+                            v.as_str().expect("a string key holds a string").to_string()
+                        }
                         _ => {
                             return Err((
                                 SIG_ERROR,

--- a/src/primitives/traitregistry/methods.rs
+++ b/src/primitives/traitregistry/methods.rs
@@ -101,12 +101,23 @@ pub(super) fn build_collection_methods(heap: &mut FiberHeap) -> Value {
 /// sweep releases the root region by RC (`teardown_process_root_regions`), so the
 /// table is reclaimed when the instance ends.
 pub(super) fn alloc_trait_table(heap: &mut FiberHeap, entries: BTreeMap<TableKey, Value>) -> Value {
+    use crate::value::arena::root_region;
     use crate::value::heap::{alloc_root, HeapObject};
-    let sorted: Vec<(TableKey, Value)> = entries.into_iter().collect();
+    // The entry slice shares the header's region, so it is built through the
+    // root region rather than through `alloc_root` alone. The table carries no
+    // traits of its own: it IS a trait table, and `build::struct_from_sorted`
+    // would ask the registry for a default set that does not exist yet at VM
+    // init.
+    let region = root_region(heap);
+    let sorted: Vec<(TableKey, Value)> = entries
+        .into_iter()
+        .map(|(k, v)| (k.intern_into(heap, region), v))
+        .collect();
+    let slice = heap.alloc_region_slice_in_region::<(TableKey, Value)>(&sorted, region);
     alloc_root(
         heap,
         HeapObject::LStruct {
-            data: sorted,
+            data: slice,
             traits: Value::NIL,
         },
     )

--- a/src/primitives/traits.rs
+++ b/src/primitives/traits.rs
@@ -119,14 +119,28 @@ unsafe fn clone_with_traits(
             data: std::rc::Rc::new(std::cell::RefCell::new(data.borrow().clone())),
             traits: table,
         })),
-        HeapObject::LStructMut { data, .. } => Ok(ctx.alloc(HeapObject::LStructMut {
-            data: std::rc::Rc::new(std::cell::RefCell::new(data.borrow().clone())),
-            traits: table,
-        })),
-        HeapObject::LStruct { data, .. } => Ok(ctx.alloc(HeapObject::LStruct {
-            data: data.clone(),
-            traits: table,
-        })),
+        HeapObject::LStructMut { data, .. } => {
+            let entries: std::collections::BTreeMap<_, _> = data
+                .borrow()
+                .iter()
+                .map(|(k, v)| (ctx.intern_key(k), *v))
+                .collect();
+            Ok(ctx.alloc(HeapObject::LStructMut {
+                data: std::rc::Rc::new(std::cell::RefCell::new(entries)),
+                traits: table,
+            }))
+        }
+        HeapObject::LStruct { data, .. } => {
+            // Keys are interned into the clone's region like the entry slice
+            // itself: a traited copy that kept the source's key strings would
+            // pin the source's region for its whole life.
+            let entries: Vec<(crate::value::heap::TableKey, Value)> =
+                data.iter().map(|(k, v)| (ctx.intern_key(k), *v)).collect();
+            Ok(ctx.alloc(HeapObject::LStruct {
+                data: ctx.alloc_slice::<(crate::value::heap::TableKey, Value)>(&entries),
+                traits: table,
+            }))
+        }
         HeapObject::Closure { closure, .. } => Ok(ctx.alloc(HeapObject::Closure {
             closure: closure.clone(),
             traits: table,

--- a/src/syntax/convert.rs
+++ b/src/syntax/convert.rs
@@ -80,17 +80,24 @@ fn table_key_to_syntax(
             let name = symbols.name(*id).ok_or("Unknown symbol in table key")?;
             SyntaxKind::Symbol(name.to_string())
         }
-        TableKey::String(s) => SyntaxKind::String(s.clone()),
+        TableKey::String(v) => {
+            SyntaxKind::String(v.as_str().expect("a string key holds a string").to_string())
+        }
         TableKey::Keyword(hash) => {
             let name = crate::value::keyword::resolve_keyword_name(Some(symbols), *hash)
                 .ok_or_else(|| format!("Unknown keyword {:#x} in table key", hash))?;
             SyntaxKind::Keyword(name.to_string())
         }
         TableKey::EmptyList => SyntaxKind::List(vec![]),
-        TableKey::Array(keys) => {
-            let elements: Result<Vec<_>, _> = keys
+        TableKey::Array(v) => {
+            let elements: Result<Vec<_>, String> = v
+                .as_array()
+                .expect("an array key holds an array")
                 .iter()
-                .map(|k| table_key_to_syntax(k, symbols, span))
+                .map(|elem| {
+                    let k = TableKey::from_value(elem).expect("from_value validated every element");
+                    table_key_to_syntax(&k, symbols, span)
+                })
                 .collect();
             return Ok(Syntax::new(SyntaxKind::Array(elements?), span.clone()));
         }

--- a/src/value/AGENTS.md
+++ b/src/value/AGENTS.md
@@ -43,6 +43,8 @@ Runtime value representation using a tagged union.
 | `Parameter` | `heap.rs` | Dynamic parameter with id and default value, looked up at runtime |
 | `LSet` | `heap.rs` | Immutable set (`RegionSlice<Value>`, region-inline), no `RefCell` |
 | `LSetMut` | `heap.rs` | Mutable set (`Rc<RefCell<BTreeSet<Value>>>`) (type name `:@set`) |
+| `TableKey` | `types.rs` | Struct key. `Copy`; string and array keys hold a `Value`, so a key owns no Rust heap memory (docs/impl/values.md § "Struct keys") |
+| `SendKey` | `send/mod.rs` | The owning key form `SendValue`'s maps are keyed on — the only key type that crosses a thread or reaches serde |
 
 ### Fiber fields for parent/child chain
 
@@ -119,6 +121,15 @@ These are set during the swap protocol in `vm/fiber.rs::with_child_fiber`.
      holds the bytecode, constants, env, IP, and operand stack for a suspended
      fiber. Signal suspension has an empty stack; yield suspension captures the
      stack.
+
+8. **A stored struct key is interned into the struct's region.** `TableKey`
+     is `Copy` and its string and array arms hold a `Value`, so a key built by
+     `TableKey::from_value` merely borrows what it was built from — correct for
+     a probe, wrong to store. Every site that puts a key into a struct calls
+     `TableKey::intern_into` first, which copies a string or array payload into
+     the destination region; a `Heap` key keeps aliasing, because its identity
+     is the point. `SendKey` is the owning form for `send` and serde
+     (docs/impl/values.md § "Struct keys").
 
 ## Value encoding
 

--- a/src/value/README.md
+++ b/src/value/README.md
@@ -101,7 +101,7 @@ All non-immediate values are heap-allocated via `Rc`. Mutable heap objects use `
 - `Cons` — list pair
 - `LArrayMut` — mutable vector
 - `LStructMut` — mutable BTreeMap
-- `LStruct` — immutable BTreeMap
+- `LStruct` — immutable struct: key-value entries sorted by key, inline in the region
 - `LArray` — immutable vector
 - `LStringMut` — mutable byte vector
 - `LBytes` — immutable byte vector

--- a/src/value/arena/mutate.rs
+++ b/src/value/arena/mutate.rs
@@ -35,6 +35,31 @@ fn unrecord_store(heap: &mut FiberHeap, container: Value, elem: Value) {
     heap.unrecord_outgoing_edge(src, dst);
 }
 
+/// The heap `Value`s of `key` that this seam counts: the ones resolving to a
+/// region other than `container`'s. A stored key is interned into the
+/// container's own region, so its heap value is normally a self-edge, which
+/// neither ledger counts — the rule the free-time cascade follows through its
+/// `own_id` filter. A `Heap` key is not interned, stays a real cross-region
+/// reference, and does come back from here.
+///
+/// Both @struct funnels resolve their key edges here, because the remove half
+/// cannot tell how the key it removes was stored (docs/impl/values.md § "A
+/// key's region is counted like a value's").
+fn counted_key_values(
+    heap: &FiberHeap,
+    container: Value,
+    key: &crate::value::heap::TableKey,
+) -> Vec<Value> {
+    let own = region_of(heap, container);
+    let mut counted = Vec::new();
+    key.for_each_heap_value(&mut |kv| {
+        if region_of(heap, *kv) != own {
+            counted.push(*kv);
+        }
+    });
+    counted
+}
+
 /// Push a value into a mutable @array, tracking the cross-region reference.
 /// Panics if `collection` is not an @array.
 /// Returns the collection value.
@@ -220,20 +245,32 @@ pub fn struct_put_with_rebind(
     key: crate::value::heap::TableKey,
     val: Value,
 ) -> Option<Value> {
-    // A heap-valued KEY (fiber/closure/list) is a cross-region reference the struct
-    // holds, exactly like the value — the free-time content scan enumerates it
-    // (`find_object_cross_refs`'s `LStructMut` arm walks keys). So a NEW key must be
-    // increfed and its outgoing edge recorded here, symmetric with the alloc-scan
-    // that does it for a struct BUILT with keys (region-struct-heap-key-uaf.lisp);
+    // A heap-valued KEY the struct holds outside its own region is a reference
+    // like the value's, and the free-time content scan enumerates it
+    // (`find_object_cross_refs`'s `LStructMut` arm walks keys). A NEW one is
+    // increfed and its edge recorded here, symmetric with the alloc-scan that
+    // does it for a struct BUILT with keys (region-struct-heap-key-uaf.lisp);
     // otherwise the recorded edge table and the free scan disagree (a missed
-    // store-funnel edge the equivalence oracle detonates on). Captured before
-    // `insert` moves the key. A rebind (`Some(old)`) keeps the pre-existing key
-    // (BTreeMap::insert does not replace an equal key), so its edge is untouched.
-    let mut key_heap_vals: Vec<Value> = Vec::new();
-    key.for_each_heap_value(&mut |kv| key_heap_vals.push(*kv));
+    // store-funnel edge the equivalence oracle detonates on). `counted_key_values`
+    // decides WHICH of the key's values that is. A rebind (`Some(old)`) keeps the
+    // pre-existing key (BTreeMap::insert does not replace an equal key), so its
+    // edge is untouched.
+    //
+    // The caller's key borrows whatever it was built from (`TableKey::
+    // from_value`), so a key that is actually stored is interned into the
+    // container's own region first — the discipline the immutable constructors
+    // follow (docs/impl/values.md § "Struct keys"). Membership is probed with
+    // the BORROWED key, because a rebind stores no key and interning one would
+    // leave the copy unreachable in the container's region.
     let map_ref = collection
         .as_struct_mut_raw()
         .expect("struct_put_with_rebind: expected @struct");
+    let replacing = map_ref.borrow().contains_key(&key);
+    let key = match region_of(heap, collection) {
+        Some(r) if !replacing => key.intern_into(heap, r),
+        _ => key,
+    };
+    let key_heap_vals = counted_key_values(heap, collection, &key);
     let old = map_ref.borrow_mut().insert(key, val);
     match old {
         Some(old) => {
@@ -269,17 +306,24 @@ pub fn struct_remove_with_decref(
     // `remove_entry` hands back the STORED key, not the caller's lookup key — for a
     // value-equal-but-distinct heap key (a list) they are two allocations in two
     // regions, and the edge was recorded against the STORED one (mirrors the @set
-    // del fix). Release the stored key's heap edges symmetrically with the incref/
-    // record `struct_put_with_rebind` added.
+    // del fix). Its heap edges are released through `counted_key_values`, which is
+    // also what `struct_put_with_rebind` takes them on: this half cannot tell
+    // whether the key it removes was interned by a constructor or by that funnel,
+    // so the two must agree on which of a key's values is a reference at all.
     let removed = map_ref.borrow_mut().remove_entry(key);
     if let Some((stored_key, v)) = removed {
-        // Un-record before decref (the decref may free `v`'s region — see `pop`).
+        // Every region this call will release is resolved FIRST, and every
+        // un-record runs before any decref: a decref may free a region, and a
+        // freed page can no longer answer `region_of` (see `pop`).
+        let key_heap_vals = counted_key_values(heap, collection, &stored_key);
         unrecord_store(heap, collection, v);
-        decref_removed_element(heap, v);
-        stored_key.for_each_heap_value(&mut |kv| {
+        for kv in &key_heap_vals {
             unrecord_store(heap, collection, *kv);
-            decref_removed_element(heap, *kv);
-        });
+        }
+        decref_removed_element(heap, v);
+        for kv in key_heap_vals {
+            decref_removed_element(heap, kv);
+        }
         return Some(v);
     }
     None

--- a/src/value/arena/root.rs
+++ b/src/value/arena/root.rs
@@ -41,6 +41,11 @@ pub fn teardown_process_root_regions(heap: &mut FiberHeap) -> usize {
 }
 /// Mint-or-get `heap`'s pinned process-lifetime root region, registering it as a
 /// process root on first use so teardown releases it by RC.
+///
+/// `pub(crate)` for the root values whose payload must be built in the same
+/// region as their header — a slice-backed root cannot go through
+/// [`alloc_root`] alone (docs/impl/region/model.md, "RegionSlice contents share
+/// their object's region").
 pub(crate) fn root_region(heap: &mut FiberHeap) -> RuntimeRegion {
     if let Some(r) = heap.root_region_slot() {
         return r;

--- a/src/value/arena/tests.rs
+++ b/src/value/arena/tests.rs
@@ -477,3 +477,173 @@ fn deref_panics_on_tag_object_mismatch() {
     };
     let _ = unsafe { deref(bad) };
 }
+
+// ── Struct key interning at the @struct store funnel ───────────────────────
+
+// A key that is actually stored is interned into the container's region, so an
+// `@struct` never holds a key borrowed from whatever region the caller built it
+// in (docs/impl/values.md § "Struct keys").
+#[test]
+fn a_stored_at_struct_key_is_interned_into_the_container_region() {
+    use crate::value::heap::TableKey;
+
+    let heap_ptr = crate::value::arena::leaked_test_heap();
+    let heap = unsafe { &mut *heap_ptr };
+    let source_region = heap.new_runtime_region();
+    let source = crate::value::build::string(heap, "name", source_region);
+
+    let heap = unsafe { &mut *heap_ptr };
+    let container_region = heap.new_runtime_region();
+    let container = crate::value::build::struct_mut(heap, container_region);
+
+    let heap = unsafe { &mut *heap_ptr };
+    let probe = TableKey::from_value(&source).expect("a string is a valid key");
+    struct_put_with_rebind(heap, container, probe, Value::int(1));
+
+    let map = container.as_struct_mut_raw().expect("an @struct");
+    let stored = *map.borrow().keys().next().expect("one entry");
+    assert_ne!(
+        stored.to_value().payload,
+        source.payload,
+        "the stored key must not alias the string it was built from"
+    );
+    assert_eq!(
+        region_of(unsafe { &*heap_ptr }, stored.to_value()),
+        Some(container_region),
+        "the stored key's bytes belong to the container's region"
+    );
+}
+
+// A rebind stores no key: `BTreeMap::insert` keeps the entry's existing key, so
+// interning one for a key already present would leave the copy unreachable in
+// the container's region for the rest of its life.
+#[test]
+fn rebinding_an_at_struct_key_interns_nothing_new() {
+    use crate::value::heap::TableKey;
+
+    let heap_ptr = crate::value::arena::leaked_test_heap();
+    let heap = unsafe { &mut *heap_ptr };
+    let source_region = heap.new_runtime_region();
+    let first = crate::value::build::string(heap, "name", source_region);
+    let second = crate::value::build::string(heap, "name", source_region);
+
+    let heap = unsafe { &mut *heap_ptr };
+    let container_region = heap.new_runtime_region();
+    let container = crate::value::build::struct_mut(heap, container_region);
+
+    let heap = unsafe { &mut *heap_ptr };
+    let probe = TableKey::from_value(&first).expect("a string is a valid key");
+    struct_put_with_rebind(heap, container, probe, Value::int(1));
+    let map = container.as_struct_mut_raw().expect("an @struct");
+    let stored = *map.borrow().keys().next().expect("one entry");
+
+    let heap = unsafe { &mut *heap_ptr };
+    let probe = TableKey::from_value(&second).expect("a string is a valid key");
+    let displaced = struct_put_with_rebind(heap, container, probe, Value::int(2));
+
+    assert_eq!(
+        displaced,
+        Some(Value::int(1)),
+        "the rebind displaced a value"
+    );
+    assert_eq!(map.borrow().len(), 1, "an equal key is one entry");
+    assert_eq!(
+        map.borrow().keys().next().expect("one entry").to_value(),
+        stored.to_value(),
+        "a rebind keeps the key the first store interned"
+    );
+}
+
+// ── A key's region is counted only when it is another region ───────────────
+//
+// docs/impl/values.md § "A key's region is counted like a value's". An interned
+// key is co-region with its container, so it is a self-edge that neither the RC
+// nor the outgoing-edge table counts — the rule the free-time cascade already
+// follows through its `own_id` filter.
+
+// The counter-factual: a put funnel that increfs the container's own region for
+// its interned key takes a reference the free cascade never releases, because
+// the cascade skips self-edges. `put` of a string key then leaked the container
+// region outright — one region per call, measured in
+// tests/elle/region-struct-key.lisp.
+#[test]
+fn an_interned_at_struct_key_adds_no_reference_to_the_container_region() {
+    use crate::value::heap::TableKey;
+
+    let heap_ptr = crate::value::arena::leaked_test_heap();
+    let heap = unsafe { &mut *heap_ptr };
+    let source_region = heap.new_runtime_region();
+    let source = crate::value::build::string(heap, "name", source_region);
+
+    let heap = unsafe { &mut *heap_ptr };
+    let container_region = heap.new_runtime_region();
+    let container = crate::value::build::struct_mut(heap, container_region);
+
+    let rc_before = region_rc(unsafe { &*heap_ptr }, container_region);
+    let heap = unsafe { &mut *heap_ptr };
+    let probe = TableKey::from_value(&source).expect("a string is a valid key");
+    struct_put_with_rebind(heap, container, probe, Value::int(1));
+
+    let map = container.as_struct_mut_raw().expect("an @struct");
+    let stored = *map.borrow().keys().next().expect("one entry");
+    assert_eq!(
+        region_of(unsafe { &*heap_ptr }, stored.to_value()),
+        Some(container_region),
+        "the put interned the key into the container's region",
+    );
+    assert_eq!(
+        region_rc(unsafe { &*heap_ptr }, container_region),
+        rc_before,
+        "an interned key is a self-edge: it takes no reference on the container's region",
+    );
+    assert!(
+        unsafe { (*heap_ptr).outgoing_edges(container_region) }.is_empty(),
+        "and records no outgoing edge either",
+    );
+}
+
+// The remove half follows the same rule, because it cannot tell whether the key
+// it removes was interned by a constructor or by the put funnel. The
+// counter-factual: `del` of a key `struct_mut_from` interned decrefs the
+// container's region — taking a sole reference to zero — and the next read of
+// the struct lands on a freed page (the macOS `--trace=scrub` crash in
+// tests/elle/array-keys.lisp).
+#[test]
+fn removing_a_constructor_interned_key_leaves_the_container_region_live() {
+    use crate::value::heap::TableKey;
+
+    let heap_ptr = crate::value::arena::leaked_test_heap();
+    let heap = unsafe { &mut *heap_ptr };
+    let source_region = heap.new_runtime_region();
+    let source = crate::value::build::string(heap, "name", source_region);
+    let probe = TableKey::from_value(&source).expect("a string is a valid key");
+
+    // The constructor funnel — what `@{"name" 1}` and the receiving side of
+    // `send` both go through. It interns the key, and the alloc-time scan
+    // counts nothing for it.
+    let heap = unsafe { &mut *heap_ptr };
+    let container_region = heap.new_runtime_region();
+    let container = crate::value::build::struct_mut_from(
+        heap,
+        std::collections::BTreeMap::from([(probe, Value::int(1))]),
+        container_region,
+    );
+    let rc_before = region_rc(unsafe { &*heap_ptr }, container_region);
+
+    let heap = unsafe { &mut *heap_ptr };
+    assert_eq!(
+        struct_remove_with_decref(heap, container, &probe),
+        Some(Value::int(1)),
+        "the interned key is found by the probe it was built from",
+    );
+    assert_eq!(
+        region_rc(unsafe { &*heap_ptr }, container_region),
+        rc_before,
+        "removing a self-edge key releases nothing on the container's region",
+    );
+    assert_eq!(
+        region_of(unsafe { &*heap_ptr }, container),
+        Some(container_region),
+        "the container still lives in its region after the remove",
+    );
+}

--- a/src/value/build.rs
+++ b/src/value/build.rs
@@ -79,16 +79,23 @@ pub(crate) fn struct_mut(heap: &mut FiberHeap, region: RuntimeRegion) -> Value {
 }
 
 /// Allocate a mutable `@struct` with entries into `region` on `heap`.
+///
+/// The keys are interned into `region` like an immutable struct's, so an
+/// `@struct` never holds a key borrowed from the caller's region.
 #[inline]
 pub(crate) fn struct_mut_from(
     heap: &mut FiberHeap,
     entries: BTreeMap<TableKey, Value>,
     region: RuntimeRegion,
 ) -> Value {
+    let interned: BTreeMap<TableKey, Value> = entries
+        .iter()
+        .map(|(k, v)| (k.intern_into(heap, region), *v))
+        .collect();
     let traits = default_traits_for(heap, HeapTag::LStructMut);
     heap.alloc_in_region(
         HeapObject::LStructMut {
-            data: Rc::new(RefCell::new(entries)),
+            data: Rc::new(RefCell::new(interned)),
             traits,
         },
         region,
@@ -109,18 +116,25 @@ pub(crate) fn struct_from(
 
 /// Allocate an immutable struct (from pre-sorted entries) into `region`.
 ///
-/// Keeps the Vec on the Rust heap because `TableKey::String` carries an owned
-/// allocation; an arena memcpy would leak or double-free the String.
+/// Each key is interned into `region` on the way in, so the entry slice and
+/// the bytes its keys point at share one region and the struct pins nothing
+/// else (docs/impl/values.md § "Struct keys"). Interning preserves key order:
+/// a copied string or array compares equal to the one it was copied from.
 #[inline]
 pub(crate) fn struct_from_sorted(
     heap: &mut FiberHeap,
     entries: Vec<(TableKey, Value)>,
     region: RuntimeRegion,
 ) -> Value {
+    let interned: Vec<(TableKey, Value)> = entries
+        .iter()
+        .map(|(k, v)| (k.intern_into(heap, region), *v))
+        .collect();
+    let slice = heap.alloc_region_slice_in_region::<(TableKey, Value)>(&interned, region);
     let traits = default_traits_for(heap, HeapTag::LStruct);
     heap.alloc_in_region(
         HeapObject::LStruct {
-            data: entries,
+            data: slice,
             traits,
         },
         region,

--- a/src/value/fiberheap/census.rs
+++ b/src/value/fiberheap/census.rs
@@ -257,14 +257,6 @@ fn slice_stat<T: 'static>(sl: &RegionSlice<T>, seen: &mut FxHashSet<usize>, stat
     }
 }
 
-fn key_bytes(k: &TableKey) -> usize {
-    match k {
-        TableKey::String(s) => s.len(),
-        TableKey::Array(ks) => ks.iter().map(key_bytes).sum(),
-        _ => 0,
-    }
-}
-
 fn syntax_bytes(s: &Syntax, seen: &mut FxHashSet<usize>) -> usize {
     let mut b = size_of::<Syntax>() + std::mem::size_of_val(s.scopes.as_slice());
     match &s.kind {
@@ -325,9 +317,8 @@ fn measure(obj: &HeapObject, seen: &mut FxHashSet<usize>) -> ObjStat {
             }
         }
         HeapObject::LStruct { data, .. } => {
-            stat.bytes += data.len() * size_of::<(TableKey, Value)>();
+            slice_stat(data, seen, &mut stat);
             for (k, v) in data.iter() {
-                stat.bytes += key_bytes(k);
                 k.for_each_heap_value(&mut |kv| heap_slot(kv, &mut stat));
                 heap_slot(v, &mut stat);
             }
@@ -386,7 +377,6 @@ fn measure(obj: &HeapObject, seen: &mut FxHashSet<usize>) -> ObjStat {
             if let Ok(m) = data.try_borrow() {
                 stat.bytes += m.len() * size_of::<(TableKey, Value)>();
                 for (k, v) in m.iter() {
-                    stat.bytes += key_bytes(k);
                     k.for_each_heap_value(&mut |kv| heap_slot(kv, &mut stat));
                     heap_slot(v, &mut stat);
                 }

--- a/src/value/fiberheap/regionpool/introspect/tests.rs
+++ b/src/value/fiberheap/regionpool/introspect/tests.rs
@@ -48,6 +48,10 @@ fn obj_with_value_in_every_channel(
     };
     let vals_in_own = |store: &mut RegionStore| store.alloc_region_slice(own, &[v2]);
     let table_key = || crate::value::TableKey::from_value(&Value::int(1)).unwrap();
+    // An immutable struct's entry slice is co-region with its header, so the
+    // only cross-region channel it exposes is the value in the entry.
+    let entries_in_own =
+        |store: &mut RegionStore| store.alloc_region_slice(own, &[(table_key(), v2)]);
     // A code object with an empty payload, allocated into `own` — the header is
     // co-region with its payload here, so the payload backing is a self-edge and
     // the arm under test is the only channel.
@@ -100,7 +104,7 @@ fn obj_with_value_in_every_channel(
         ),
         HeapTag::LStruct => (
             HeapObject::LStruct {
-                data: vec![(table_key(), v2)],
+                data: entries_in_own(store),
                 traits: vt,
             },
             both,

--- a/src/value/heap.rs
+++ b/src/value/heap.rs
@@ -163,11 +163,12 @@ pub enum HeapObject {
         traits: Value,
     },
 
-    /// Immutable struct (sorted array of key-value pairs).
-    /// Keys may contain owned String data, so this stays on the Rust heap
-    /// (Vec) rather than inline in the arena.
+    /// Immutable struct: entries sorted by key, inline in the arena. A
+    /// `TableKey` owns no Rust-heap allocation and a stored key's payload is
+    /// interned into this struct's own region, so the whole entry slice is
+    /// page bytes (docs/impl/values.md § "Struct keys").
     LStruct {
-        data: Vec<(TableKey, Value)>,
+        data: RegionSlice<(TableKey, Value)>,
         traits: Value,
     },
 

--- a/src/value/heap/tests.rs
+++ b/src/value/heap/tests.rs
@@ -27,6 +27,32 @@ fn test_alloc_cons() {
     });
 }
 
+// An immutable struct's entries are page bytes of the struct's own region, the
+// way an array's and a set's already are. That is what lets an image dump a
+// struct as body data (docs/impl/image.md § Foundations) and what keeps a
+// struct off the Rust heap. Counter-factual: a `Vec` payload lives outside
+// every region, so its address resolves to no region at all.
+#[test]
+fn immutable_struct_entries_live_in_the_struct_region() {
+    let heap_ptr = crate::value::arena::leaked_test_heap();
+    let heap = unsafe { &mut *heap_ptr };
+    let region = heap.new_runtime_region();
+
+    let mut fields = std::collections::BTreeMap::new();
+    fields.insert(TableKey::keyword("a"), Value::int(1));
+    fields.insert(TableKey::keyword("b"), Value::int(2));
+    let built = crate::value::build::struct_from(heap, fields, region);
+
+    let HeapObject::LStruct { data, .. } = (unsafe { deref(built) }) else {
+        panic!("expected an immutable struct");
+    };
+    assert_eq!(
+        unsafe { &*heap_ptr }.region_of_ptr(data.as_ptr() as *const ()),
+        region.get(),
+        "the entry slice must be backed by the struct's own region pages"
+    );
+}
+
 #[test]
 fn test_heap_tag() {
     crate::value::arena::with_test_region(|| {

--- a/src/value/repr/accessors.rs
+++ b/src/value/repr/accessors.rs
@@ -48,10 +48,11 @@ impl Value {
     // Heap Value Extractors
     // =========================================================================
 
-    /// Access string contents via closure. Works for heap strings.
-    /// Returns None if this is not a string.
+    /// The contents of an immutable string, borrowed from its region pages.
+    /// `None` for every other value, `@string` included — a mutable store is
+    /// behind a `RefCell` and cannot hand out a bare borrow.
     #[inline]
-    pub fn with_string<R>(&self, f: impl FnOnce(&str) -> R) -> Option<R> {
+    pub fn as_str(&self) -> Option<&str> {
         use crate::value::heap::{deref, HeapObject};
         if !self.is_heap() {
             return None;
@@ -60,11 +61,17 @@ impl Value {
             HeapObject::LString { s, .. } => {
                 // SAFETY: LString's bytes are always valid UTF-8 (enforced by
                 // constructors). The arena outlives the borrow.
-                let str_ref = unsafe { std::str::from_utf8_unchecked(s.as_slice()) };
-                Some(f(str_ref))
+                Some(unsafe { std::str::from_utf8_unchecked(s.as_slice()) })
             }
             _ => None,
         }
+    }
+
+    /// Access string contents via closure. Works for heap strings.
+    /// Returns None if this is not a string.
+    #[inline]
+    pub fn with_string<R>(&self, f: impl FnOnce(&str) -> R) -> Option<R> {
+        self.as_str().map(f)
     }
 
     /// Compare two string values lexicographically.

--- a/src/value/send/de.rs
+++ b/src/value/send/de.rs
@@ -173,22 +173,24 @@ pub(super) fn into_value_inner(sv: SendValue, ctx: &mut DeserContext<'_, '_>) ->
             })
         }
         SendValue::Struct(map, traits) => {
-            // BTreeMap iterates in sorted order, so Vec is already sorted.
+            // `SendKey` ranks its variants the way `TableKey` does, so the
+            // BTreeMap already iterates in the order the entry slice needs.
             let entries: Vec<_> = map
                 .into_iter()
-                .map(|(k, sv)| (k, into_value_inner(sv, ctx)))
+                .map(|(k, sv)| (k.to_key(ctx.ctx), into_value_inner(sv, ctx)))
                 .collect();
             let traits_resolved = into_value_inner(*traits, ctx);
             let traits_val = recv_traits(ctx.ctx.heap_mut(), traits_resolved, HeapTag::LStruct);
+            let slice = ctx.alloc_slice::<(crate::value::heap::TableKey, Value)>(&entries);
             ctx.alloc(HeapObject::LStruct {
-                data: entries,
+                data: slice,
                 traits: traits_val,
             })
         }
         SendValue::StructMut(map, traits) => {
             let entries: BTreeMap<_, _> = map
                 .into_iter()
-                .map(|(k, sv)| (k, into_value_inner(sv, ctx)))
+                .map(|(k, sv)| (k.to_key(ctx.ctx), into_value_inner(sv, ctx)))
                 .collect();
             let traits_resolved = into_value_inner(*traits, ctx);
             let traits_val = recv_traits(ctx.ctx.heap_mut(), traits_resolved, HeapTag::LStructMut);

--- a/src/value/send/mirror.rs
+++ b/src/value/send/mirror.rs
@@ -1,5 +1,6 @@
-//! Bincode serde for [`SendValue`] and [`TableKey`], used by the stdlib disk
-//! cache (`crate::compiler::stdlib_cache`).
+//! Bincode serde for [`SendValue`], used by the stdlib disk cache
+//! (`crate::compiler::stdlib_cache`). [`SendKey`], the key form its maps carry,
+//! owns its bytes and derives serde directly, so it needs no mirror here.
 //!
 //! `SendValue` is the owned deep-copy form the send module produces for
 //! cross-thread transport, and it is exactly the shape a disk format needs:
@@ -17,9 +18,10 @@
 //! `Deserialize`, which reads bincode's enum tag
 //! (`tablekey_map_roundtrips_through_bincode` pins this).
 
+use super::SendKey;
 use super::SendValue;
 use super::SendableClosure;
-use crate::value::{TableKey, Value};
+use crate::value::Value;
 
 /// Symmetric serde mirror for `SendValue`. Both directions go through this
 /// enum so the bincode encoding is identical (a hand-written `Serialize` that
@@ -61,7 +63,7 @@ enum Mirror {
     Seq(SeqKind, Vec<Mirror>, Box<Mirror>),
     Map(
         MapKind,
-        std::collections::BTreeMap<TableKey, Mirror>,
+        std::collections::BTreeMap<SendKey, Mirror>,
         Box<Mirror>,
     ),
     Buffer(BytesKind, Vec<u8>, Box<Mirror>),
@@ -191,90 +193,29 @@ impl<'de> serde::Deserialize<'de> for SendValue {
     }
 }
 
-/// Symmetric serde mirror for `TableKey`, for the same reason as [`Mirror`]:
-/// both directions must share one bincode encoding. A symbol or keyword key
-/// travels as its name's hash, which names the same symbol in the loading
-/// process. `Heap` has no variant — it holds a live `Value` — so it is
-/// rejected at serialize time, which the cache layer turns into a miss.
-#[derive(serde::Serialize, serde::Deserialize)]
-enum KeyMirror {
-    Nil,
-    Bool(bool),
-    Int(i64),
-    String(String),
-    Symbol(u64),
-    Keyword(u64),
-    EmptyList,
-    Array(Vec<KeyMirror>),
-}
-
-impl serde::Serialize for TableKey {
-    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        use crate::value::TableKey as TK;
-        use serde::ser::Error;
-        fn to_mirror(k: &TK) -> Result<KeyMirror, String> {
-            Ok(match k {
-                TK::Nil => KeyMirror::Nil,
-                TK::Bool(b) => KeyMirror::Bool(*b),
-                TK::Int(i) => KeyMirror::Int(*i),
-                TK::String(st) => KeyMirror::String(st.clone()),
-                TK::Symbol(id) => KeyMirror::Symbol(id.0),
-                TK::Keyword(hash) => KeyMirror::Keyword(*hash),
-                TK::EmptyList => KeyMirror::EmptyList,
-                TK::Array(a) => {
-                    KeyMirror::Array(a.iter().map(to_mirror).collect::<Result<_, _>>()?)
-                }
-                TK::Heap(_) => {
-                    return Err("TableKey::Heap not serializable by stdlib cache".into());
-                }
-            })
-        }
-        to_mirror(self).map_err(Error::custom)?.serialize(s)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for TableKey {
-    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        use crate::value::TableKey as TK;
-        fn from_mirror(m: KeyMirror) -> TK {
-            match m {
-                KeyMirror::Nil => TK::Nil,
-                KeyMirror::Bool(b) => TK::Bool(b),
-                KeyMirror::Int(i) => TK::Int(i),
-                KeyMirror::String(st) => TK::String(st),
-                KeyMirror::Symbol(id) => TK::Symbol(crate::value::SymbolId(id)),
-                KeyMirror::Keyword(hash) => TK::Keyword(hash),
-                KeyMirror::EmptyList => TK::EmptyList,
-                KeyMirror::Array(a) => TK::Array(a.into_iter().map(from_mirror).collect()),
-            }
-        }
-        Ok(from_mirror(KeyMirror::deserialize(d)?))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
 
-    /// A struct constant's `TableKey`s must survive bincode. The trap: a
+    /// A struct constant's keys must survive bincode. The trap: a
     /// hand-written `Serialize` that emits `(u8, payload)` tuples against a
     /// derived `Deserialize` that reads bincode's enum tag decodes garbage —
     /// every struct-bearing cache entry would fail to load (and the failure
     /// is silent: the caller just recompiles, forever).
     #[test]
-    fn tablekey_map_roundtrips_through_bincode() {
+    fn sendkey_map_roundtrips_through_bincode() {
         use super::SendValue as SV;
 
-        let mut map: BTreeMap<TableKey, SV> = BTreeMap::new();
-        map.insert(TableKey::Int(7), SV::Immediate(Value::int(1)));
-        map.insert(TableKey::String("s".into()), SV::Immediate(Value::int(2)));
+        let mut map: BTreeMap<SendKey, SV> = BTreeMap::new();
+        map.insert(SendKey::Int(7), SV::Immediate(Value::int(1)));
+        map.insert(SendKey::String("s".into()), SV::Immediate(Value::int(2)));
         map.insert(
-            TableKey::Keyword(crate::value::keyword::keyword_hash("k")),
+            SendKey::Keyword(crate::value::keyword::keyword_hash("k")),
             SV::Immediate(Value::int(3)),
         );
         map.insert(
-            TableKey::Array(vec![TableKey::Bool(true), TableKey::EmptyList]),
+            SendKey::Array(vec![SendKey::Bool(true), SendKey::EmptyList]),
             SV::Immediate(Value::int(4)),
         );
         let sv = SV::Struct(map, Box::new(SV::Immediate(Value::NIL)));
@@ -286,14 +227,14 @@ mod tests {
         };
         assert_eq!(m.len(), 4, "all keys survive");
         for (k, want) in [
-            (TableKey::Int(7), 1),
-            (TableKey::String("s".into()), 2),
+            (SendKey::Int(7), 1),
+            (SendKey::String("s".into()), 2),
             (
-                TableKey::Keyword(crate::value::keyword::keyword_hash("k")),
+                SendKey::Keyword(crate::value::keyword::keyword_hash("k")),
                 3,
             ),
             (
-                TableKey::Array(vec![TableKey::Bool(true), TableKey::EmptyList]),
+                SendKey::Array(vec![SendKey::Bool(true), SendKey::EmptyList]),
                 4,
             ),
         ] {
@@ -304,21 +245,21 @@ mod tests {
         }
     }
 
-    /// A symbol `TableKey` travels as the id it holds, because that id is the
-    /// name's hash and names the same symbol in the loading process. The trap
-    /// this guards: writing the key through any name-shaped detour (intern on
-    /// load, a remap table) reintroduces a step that can disagree with the
-    /// hash the rest of the bundle carries. The counter-factual is a key that
-    /// deserializes to a *different* `SymbolId` than it was stored with — the
-    /// struct then answers to a symbol no source text spells.
+    /// A symbol key travels as the id it holds, because that id is the name's
+    /// hash and names the same symbol in the loading process. The trap this
+    /// guards: writing the key through any name-shaped detour (intern on load,
+    /// a remap table) reintroduces a step that can disagree with the hash the
+    /// rest of the bundle carries. The counter-factual is a key that
+    /// deserializes to a *different* id than it was stored with — the struct
+    /// then answers to a symbol no source text spells.
     #[test]
-    fn tablekey_symbol_key_round_trips_as_its_name_hash() {
+    fn sendkey_symbol_key_round_trips_as_its_name_hash() {
         use super::SendValue as SV;
         use crate::value::SymbolId;
 
         let id = SymbolId::of("a-symbol-key");
-        let mut map: BTreeMap<TableKey, SV> = BTreeMap::new();
-        map.insert(TableKey::Symbol(id), SV::Immediate(Value::int(1)));
+        let mut map: BTreeMap<SendKey, SV> = BTreeMap::new();
+        map.insert(SendKey::Symbol(id.0), SV::Immediate(Value::int(1)));
         let sv = SV::Struct(map, Box::new(SV::Immediate(Value::NIL)));
 
         let bytes = bincode::serialize(&sv).expect("a symbol key serializes");
@@ -326,9 +267,41 @@ mod tests {
         let SV::Struct(m, _) = back else {
             panic!("round-trip changed the container kind");
         };
-        let Some(SV::Immediate(v)) = m.get(&TableKey::Symbol(id)) else {
+        let Some(SV::Immediate(v)) = m.get(&SendKey::Symbol(id.0)) else {
             panic!("the symbol key did not come back as the same id");
         };
         assert_eq!(v.as_int(), Some(1));
+    }
+
+    /// `SendKey` ranks its variants the way `TableKey` does. A received
+    /// struct's entry slice is the map's iteration order, and the slice must be
+    /// sorted by key order for the binary search over it to find anything.
+    #[test]
+    fn sendkey_ranks_its_variants_the_way_a_struct_key_does() {
+        let mut keys = [
+            SendKey::Array(vec![]),
+            SendKey::EmptyList,
+            SendKey::Keyword(0),
+            SendKey::String(String::new()),
+            SendKey::Symbol(0),
+            SendKey::Int(0),
+            SendKey::Bool(false),
+            SendKey::Nil,
+        ];
+        keys.sort();
+        let ranks: Vec<usize> = keys
+            .iter()
+            .map(|k| match k {
+                SendKey::Nil => 0,
+                SendKey::Bool(_) => 1,
+                SendKey::Int(_) => 2,
+                SendKey::Symbol(_) => 3,
+                SendKey::String(_) => 4,
+                SendKey::Keyword(_) => 5,
+                SendKey::EmptyList => 6,
+                SendKey::Array(_) => 7,
+            })
+            .collect();
+        assert_eq!(ranks, vec![0, 1, 2, 3, 4, 5, 6, 7]);
     }
 }

--- a/src/value/send/mod.rs
+++ b/src/value/send/mod.rs
@@ -105,16 +105,10 @@ pub enum SendValue {
     Array(Vec<SendValue>, Box<SendValue>),
 
     /// Deep copy of structs (immutable maps, with traits)
-    Struct(
-        BTreeMap<crate::value::heap::TableKey, SendValue>,
-        Box<SendValue>,
-    ),
+    Struct(BTreeMap<SendKey, SendValue>, Box<SendValue>),
 
     /// Deep copy of @structs (mutable maps, with traits)
-    StructMut(
-        BTreeMap<crate::value::heap::TableKey, SendValue>,
-        Box<SendValue>,
-    ),
+    StructMut(BTreeMap<SendKey, SendValue>, Box<SendValue>),
 
     /// Deep copy of arrays (immutable fixed-length sequences, with traits)
     Tuple(Vec<SendValue>, Box<SendValue>),
@@ -196,6 +190,88 @@ pub enum SendValue {
     /// unsendable — their fd is owned and not meaningful in another VM.
     #[allow(private_interfaces)]
     StdioPort(crate::port::PortKind),
+}
+
+/// A struct key in transit — the owning key form, the counterpart of
+/// [`SendValue`] for what `SendValue::Struct` and `SendValue::StructMut` are
+/// keyed on.
+///
+/// A [`TableKey`](crate::value::TableKey) holds raw region pointers, so it is
+/// neither `Send` nor serializable; this owns its bytes. There is no `Heap`
+/// arm: an identity key (a fiber, a closure, a plugin object) cannot be
+/// reproduced on the far side, and its absence here is what refuses one at the
+/// boundary.
+///
+/// Variant order matches `TableKey`'s, because the derived `Ord` decides the
+/// order a received struct's entries land in
+/// (docs/impl/values.md § "Struct keys").
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub enum SendKey {
+    Nil,
+    Bool(bool),
+    Int(i64),
+    /// The symbol's name hash — the same id names the same symbol in every
+    /// instance (docs/impl/symbol.md).
+    Symbol(u64),
+    String(String),
+    /// The keyword's name hash, for the same reason as `Symbol`.
+    Keyword(u64),
+    EmptyList,
+    Array(Vec<SendKey>),
+}
+
+impl SendKey {
+    /// The wire form of `key`, or `None` if the key cannot cross — which is
+    /// exactly the `Heap` arm, directly or nested inside an array key.
+    pub fn from_key(key: &crate::value::TableKey) -> Option<SendKey> {
+        use crate::value::TableKey as TK;
+        Some(match key {
+            TK::Nil => SendKey::Nil,
+            TK::Bool(b) => SendKey::Bool(*b),
+            TK::Int(i) => SendKey::Int(*i),
+            TK::Symbol(id) => SendKey::Symbol(id.0),
+            TK::String(v) => {
+                SendKey::String(v.as_str().expect("a string key holds a string").to_string())
+            }
+            TK::Keyword(hash) => SendKey::Keyword(*hash),
+            TK::EmptyList => SendKey::EmptyList,
+            TK::Array(v) => {
+                let elements: Option<Vec<SendKey>> = v
+                    .as_array()
+                    .expect("an array key holds an array")
+                    .iter()
+                    .map(|e| {
+                        let k = crate::value::TableKey::from_value(e)
+                            .expect("from_value validated every element");
+                        SendKey::from_key(&k)
+                    })
+                    .collect();
+                SendKey::Array(elements?)
+            }
+            TK::Heap(_) => return None,
+        })
+    }
+
+    /// Rebuild this key on the receiving side. A string or array payload is
+    /// allocated through `ctx`, so it lands in the call's region alongside the
+    /// struct being rebuilt — the receiving-side half of interning.
+    pub(crate) fn to_key(&self, ctx: &mut crate::primitives::ctx::Alloc) -> crate::value::TableKey {
+        use crate::value::TableKey as TK;
+        match self {
+            SendKey::Nil => TK::Nil,
+            SendKey::Bool(b) => TK::Bool(*b),
+            SendKey::Int(i) => TK::Int(*i),
+            SendKey::Symbol(id) => TK::Symbol(crate::value::SymbolId(*id)),
+            SendKey::String(s) => TK::String(ctx.string(s)),
+            SendKey::Keyword(hash) => TK::Keyword(*hash),
+            SendKey::EmptyList => TK::EmptyList,
+            SendKey::Array(elements) => {
+                let values: Vec<Value> =
+                    elements.iter().map(|k| k.to_key(ctx).to_value()).collect();
+                TK::Array(ctx.array(values))
+            }
+        }
+    }
 }
 
 /// Unit of cross-thread value transfer.

--- a/src/value/send/ser.rs
+++ b/src/value/send/ser.rs
@@ -108,15 +108,15 @@ pub(super) fn from_value_inner(
         } => {
             let mut copied = BTreeMap::new();
             for (k, v) in s.iter() {
-                if !k.is_sendable() {
+                let Some(key) = super::SendKey::from_key(k) else {
                     return Err("Cannot send struct with identity keys".to_string());
-                }
+                };
                 match k {
                     crate::value::heap::TableKey::Symbol(id) => ctx.note_symbol(*id),
                     crate::value::heap::TableKey::Keyword(hash) => ctx.note_keyword(*hash),
                     _ => {}
                 }
-                copied.insert(k.clone(), from_value_inner(*v, ctx)?);
+                copied.insert(key, from_value_inner(*v, ctx)?);
             }
             let traits_sv = send_traits(*traits, HeapTag::LStruct, ctx)?;
             Ok(SendValue::Struct(copied, Box::new(traits_sv)))
@@ -192,15 +192,15 @@ pub(super) fn from_value_inner(
                 .map_err(|_| "Cannot borrow @struct for sending".to_string())?;
             let mut copied = BTreeMap::new();
             for (k, v) in borrowed.iter() {
-                if !k.is_sendable() {
+                let Some(key) = super::SendKey::from_key(k) else {
                     return Err("Cannot send @struct with identity keys".to_string());
-                }
+                };
                 match k {
                     crate::value::heap::TableKey::Symbol(id) => ctx.note_symbol(*id),
                     crate::value::heap::TableKey::Keyword(hash) => ctx.note_keyword(*hash),
                     _ => {}
                 }
-                copied.insert(k.clone(), from_value_inner(*v, ctx)?);
+                copied.insert(key, from_value_inner(*v, ctx)?);
             }
             let traits_sv = send_traits(*traits, HeapTag::LStructMut, ctx)?;
             Ok(SendValue::StructMut(copied, Box::new(traits_sv)))

--- a/src/value/send/tests.rs
+++ b/src/value/send/tests.rs
@@ -270,7 +270,7 @@ fn a_symbol_struct_key_names_the_same_symbol_on_both_sides() {
             (TableKey::Symbol(alpha), Value::int(7)),
             (TableKey::Symbol(beta), Value::int(8)),
         ];
-        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        entries.sort_by_key(|(a, _)| *a);
         let s = h.ctx().struct_from_sorted(entries);
         let bundle =
             SendBundle::from_value(s, h.heap(), Some(&sender)).expect("struct is sendable");

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -17,11 +17,15 @@
 //! rejected. Mutable values could change after insertion, breaking hash invariants.
 //! Floats are rejected because NaN violates Eq/Hash.
 //!
-//! Compound immutable keys store the original `Value` directly in the `Heap`
-//! variant; `from_value()` recursively validates sub-elements but always stores
-//! the original value, not a reconstructed copy.
+//! No key variant owns a Rust-heap allocation: a string, array, or compound
+//! immutable key holds a `Value` pointing into a region. `from_value()`
+//! recursively validates sub-elements but stores the value it read, not a
+//! reconstructed copy, so the key it returns is a borrowed probe;
+//! `intern_into()` makes the form a struct may store. The whole key model —
+//! probe versus stored, and the owning `SendKey` that crosses threads — is in
+//! [docs/impl/values.md](../../docs/impl/values.md) § "Struct keys".
 
-use crate::primitives::ctx::NativeCtx;
+use crate::hir::region::RuntimeRegion;
 use crate::value::heap::HeapTag;
 use crate::value::Value;
 use std::fmt;
@@ -121,14 +125,25 @@ impl fmt::Display for Arity {
     }
 }
 
-/// Wrapper for table/struct keys - allows specific Value types to be keys
-#[derive(Clone)]
+/// A struct key: any immutable, non-float value, in a form that owns no Rust
+/// heap memory. `Copy`, because the string, array, and heap arms hold a
+/// `Value` pointing into a region rather than an allocation of their own —
+/// which is what lets a struct's entries be page bytes.
+///
+/// A key from [`TableKey::from_value`] **borrows** what it read. That is right
+/// for a probe and wrong to store; [`TableKey::intern_into`] builds the stored
+/// form, copying a string or array payload into the destination region. See
+/// [docs/impl/values.md](../../docs/impl/values.md) § "Struct keys".
+#[derive(Clone, Copy)]
 pub enum TableKey {
     Nil,
     Bool(bool),
     Int(i64),
     Symbol(SymbolId),
-    String(String),
+    /// An immutable string key, held as its `LString` value. Compared and
+    /// hashed by content, so keys spelled alike match wherever their bytes
+    /// live. A mutable `@string` is refused: it could change after insertion.
+    String(Value),
     /// A keyword key is its 64-bit name hash — the keyword value's payload,
     /// exactly as `Symbol` is its `SymbolId`. Identity and order are pure
     /// functions of the hash, so a probe builds a key with no lock and no
@@ -137,11 +152,14 @@ pub enum TableKey {
     /// (docs/impl/symbol.md § "The display memo").
     Keyword(u64),
     EmptyList,
-    /// Immutable array key. All elements must themselves be valid TableKeys.
-    /// Mutable arrays are rejected — mutation after insertion would break
-    /// the hash invariant.
-    Array(Vec<TableKey>),
-    /// Any non-scalar immutable heap value used as a struct key.
+    /// An immutable array key, held as its `LArray` value. Every element is
+    /// itself a valid key (`from_value` validates the whole tree), and the
+    /// elements compare and hash as KEYS rather than as values, so an array
+    /// key ranks its elements in the same order the surrounding struct uses.
+    /// Mutable arrays are refused — mutation after insertion would break the
+    /// hash invariant.
+    Array(Value),
+    /// Any other non-scalar immutable heap value used as a struct key.
     ///
     /// Stores the original `Value` directly. `from_value()` recursively validates
     /// that all sub-elements are themselves valid keys (immutable, non-float) but
@@ -160,7 +178,18 @@ impl TableKey {
         TableKey::Keyword(crate::value::keyword::keyword_hash(name))
     }
 
-    /// Convert a Value to a TableKey if possible.
+    /// The spelling of a string key, borrowed from its region pages. `None`
+    /// for every other variant — the one read site for a string key's bytes.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            TableKey::String(v) => v.as_str(),
+            _ => None,
+        }
+    }
+
+    /// Build a **probe** key over `val`. The key borrows what it reads and
+    /// allocates nothing, so a lookup costs no allocation. Storing the result
+    /// needs [`TableKey::intern_into`] first.
     ///
     /// Returns `None` if the value cannot be used as a key.
     /// Callers produce their own error messages from the `None` case.
@@ -175,14 +204,15 @@ impl TableKey {
             Some(TableKey::Symbol(id))
         } else if let Some(hash) = val.keyword_hash() {
             Some(TableKey::Keyword(hash))
-        } else if let Some(s) = val.with_string(|s| s.to_string()) {
-            Some(TableKey::String(s))
+        } else if val.as_str().is_some() {
+            Some(TableKey::String(*val))
         } else if let Some(arr) = val.as_array() {
-            let mut keys = Vec::with_capacity(arr.len());
+            // Validate the whole tree here, once, so every later walk over an
+            // array key may assume each element converts.
             for elem in arr {
-                keys.push(TableKey::from_value(elem)?);
+                TableKey::from_value(elem)?;
             }
-            Some(TableKey::Array(keys))
+            Some(TableKey::Array(*val))
         } else if val.is_empty_list() {
             Some(TableKey::EmptyList)
         } else if val.is_pair() {
@@ -211,65 +241,107 @@ impl TableKey {
         }
     }
 
-    /// Convert a TableKey back to a Value, born in the call's region
-    /// (`ctx`). This is the inverse of `from_value()`. String and array keys
-    /// allocate (through `ctx`); scalar/keyword/heap keys are immediates or
-    /// pass-throughs and need no region.
-    pub fn to_value(&self, ctx: &mut NativeCtx) -> Value {
+    /// Build the **stored** form of this key, owned by `region`: a string or
+    /// array payload is copied there, so a struct's key bytes are part of the
+    /// struct's own body and the struct pins no region but its own. A key
+    /// already resident in `region` is returned unchanged, and a `Heap` key is
+    /// never copied — its identity is the point (docs/impl/values.md
+    /// § "Struct keys").
+    pub fn intern_into(&self, heap: &mut crate::value::FiberHeap, region: RuntimeRegion) -> Self {
+        match self {
+            TableKey::String(v) => {
+                if crate::value::arena::region_of(heap, *v) == Some(region) {
+                    return *self;
+                }
+                let text = v.as_str().expect("a string key holds a string");
+                TableKey::String(crate::value::build::string(heap, text, region))
+            }
+            TableKey::Array(v) => {
+                if crate::value::arena::region_of(heap, *v) == Some(region) {
+                    return *self;
+                }
+                // Rebuild the spine in `region` with each element interned, so
+                // an array key copies exactly what a string key does and
+                // aliases exactly what a `Heap` element does.
+                let elements: Vec<Value> = v
+                    .as_array()
+                    .expect("an array key holds an array")
+                    .to_vec()
+                    .iter()
+                    .map(|e| {
+                        TableKey::from_value(e)
+                            .expect("from_value validated every element")
+                            .intern_into(heap, region)
+                            .to_value()
+                    })
+                    .collect();
+                TableKey::Array(crate::value::build::array(heap, elements, region))
+            }
+            _ => *self,
+        }
+    }
+
+    /// The `Value` this key is. The inverse of `from_value()`, and
+    /// allocation-free: a scalar key is an immediate and every other key
+    /// already holds its value. A stored key's value belongs to the struct's
+    /// region, so a native handing one to its caller pays the ordinary
+    /// pass-through retain (`arena::pass_through_retain`).
+    pub fn to_value(&self) -> Value {
         match self {
             TableKey::Nil => Value::NIL,
             TableKey::Bool(b) => Value::bool(*b),
             TableKey::Int(i) => Value::int(*i),
             TableKey::Symbol(sid) => Value::symbol(*sid),
-            TableKey::String(s) => ctx.string(s.as_str()),
             TableKey::Keyword(hash) => Value::keyword_from_hash(*hash),
             TableKey::EmptyList => Value::EMPTY_LIST,
-            TableKey::Array(keys) => {
-                let items: Vec<Value> = keys.iter().map(|k| k.to_value(ctx)).collect();
-                ctx.array(items)
-            }
-            TableKey::Heap(v) => *v,
+            TableKey::String(v) | TableKey::Array(v) | TableKey::Heap(v) => *v,
         }
     }
 
     /// Visit every heap `Value` this key holds — the cross-region references a
     /// struct key contributes to its owning struct's region.
     ///
-    /// A `Heap` key stores a `Value` pointing into the region the key value was
-    /// born in; an `Array` key can nest `Heap` keys among its elements. Scalar
-    /// keys (nil/bool/int/symbol/string/keyword/empty-list) carry no region
-    /// reference. The region scan (`find_object_cross_refs`) walks these so a
-    /// struct increfs and records the edge to each heap key's region at alloc,
-    /// balanced by the free-time cascade — the same accounting struct VALUES get.
+    /// A string, array, or heap key holds a `Value` pointing into the region
+    /// the key was interned into or built from; the scalar keys
+    /// (nil/bool/int/symbol/keyword/empty-list) are immediates and carry no
+    /// region reference. The region scan (`find_object_cross_refs`) walks
+    /// these so a struct increfs and records the edge to each key's region at
+    /// alloc, balanced by the free-time cascade — the same accounting struct
+    /// VALUES get. An array key needs no recursion: the array object holds its
+    /// own elements' edges, exactly as a set or struct key does.
     pub fn for_each_heap_value(&self, f: &mut impl FnMut(&Value)) {
         match self {
-            TableKey::Heap(v) => f(v),
-            TableKey::Array(keys) => {
-                for k in keys {
-                    k.for_each_heap_value(f);
-                }
-            }
+            TableKey::String(v) | TableKey::Array(v) | TableKey::Heap(v) => f(v),
             TableKey::Nil
             | TableKey::Bool(_)
             | TableKey::Int(_)
             | TableKey::Symbol(_)
-            | TableKey::String(_)
             | TableKey::Keyword(_)
             | TableKey::EmptyList => {}
         }
     }
 
-    /// Whether this key can be safely sent across thread boundaries.
-    ///
-    /// Heap keys contain `Rc` data that is not thread-safe.
-    /// Value-based keys (nil, bool, int, symbol, string, keyword) are always
-    /// sendable.
+    /// Whether this key can cross a thread boundary. The answer is whether
+    /// [`SendKey`](crate::value::send::SendKey) has a form for it, and it is
+    /// asked there so the two cannot drift.
     pub fn is_sendable(&self) -> bool {
-        match self {
-            TableKey::Heap(_) => false,
-            TableKey::Array(keys) => keys.iter().all(|k| k.is_sendable()),
-            _ => true,
-        }
+        crate::value::send::SendKey::from_key(self).is_some()
+    }
+
+    /// Compare the elements of two array keys AS KEYS, so an array key ranks
+    /// its elements in the order the surrounding struct uses rather than in
+    /// `Value`'s order (which ranks keywords before strings).
+    fn cmp_elements(a: &Value, b: &Value) -> std::cmp::Ordering {
+        let (a, b) = (
+            a.as_array().expect("an array key holds an array"),
+            b.as_array().expect("an array key holds an array"),
+        );
+        a.iter()
+            .map(|e| TableKey::from_value(e).expect("from_value validated every element"))
+            .cmp(
+                b.iter()
+                    .map(|e| TableKey::from_value(e).expect("from_value validated every element")),
+            )
     }
 
     fn discriminant_index(&self) -> u8 {
@@ -296,9 +368,21 @@ impl std::hash::Hash for TableKey {
             TableKey::Bool(b) => b.hash(state),
             TableKey::Int(i) => i.hash(state),
             TableKey::Symbol(id) => id.hash(state),
-            TableKey::String(s) => s.hash(state),
+            // By content, not by pointer: two keys spelled alike must land in
+            // the same bucket wherever their bytes live.
+            TableKey::String(v) => v.as_str().expect("a string key holds a string").hash(state),
             TableKey::Keyword(s) => s.hash(state),
-            TableKey::Array(keys) => keys.hash(state),
+            TableKey::Array(v) => {
+                let elements = v.as_array().expect("an array key holds an array");
+                // Length first, as `Vec`'s own `Hash` does: without it
+                // `[[1] [2]]` and `[[1 2]]` hash alike.
+                elements.len().hash(state);
+                for elem in elements {
+                    TableKey::from_value(elem)
+                        .expect("from_value validated every element")
+                        .hash(state);
+                }
+            }
             // Delegate to Value's Hash. For Fiber/ThreadHandle/External
             // that hashes the backing Rc/Arc rather than the slot pointer,
             // so a `with-traits` wrapper is the same map key as the value
@@ -317,10 +401,12 @@ impl PartialEq for TableKey {
             (TableKey::Bool(a), TableKey::Bool(b)) => a == b,
             (TableKey::Int(a), TableKey::Int(b)) => a == b,
             (TableKey::Symbol(a), TableKey::Symbol(b)) => a == b,
-            (TableKey::String(a), TableKey::String(b)) => a == b,
+            (TableKey::String(a), TableKey::String(b)) => a.as_str() == b.as_str(),
             (TableKey::Keyword(a), TableKey::Keyword(b)) => a == b,
             (TableKey::EmptyList, TableKey::EmptyList) => true,
-            (TableKey::Array(a), TableKey::Array(b)) => a == b,
+            (TableKey::Array(a), TableKey::Array(b)) => {
+                TableKey::cmp_elements(a, b) == std::cmp::Ordering::Equal
+            }
             // Delegate to Value's PartialEq (stable identity for Fiber
             // and friends — see Hash impl above). Structural equality
             // for cons/set/struct/bytes/empty-list.
@@ -353,10 +439,10 @@ impl Ord for TableKey {
             (TableKey::Bool(a), TableKey::Bool(b)) => a.cmp(b),
             (TableKey::Int(a), TableKey::Int(b)) => a.cmp(b),
             (TableKey::Symbol(a), TableKey::Symbol(b)) => a.cmp(b),
-            (TableKey::String(a), TableKey::String(b)) => a.cmp(b),
+            (TableKey::String(a), TableKey::String(b)) => a.as_str().cmp(&b.as_str()),
             (TableKey::Keyword(a), TableKey::Keyword(b)) => a.cmp(b),
             (TableKey::EmptyList, TableKey::EmptyList) => std::cmp::Ordering::Equal,
-            (TableKey::Array(a), TableKey::Array(b)) => a.cmp(b),
+            (TableKey::Array(a), TableKey::Array(b)) => TableKey::cmp_elements(a, b),
             // Delegate to Value's Ord. Stable identity for Fiber and
             // friends — see Hash impl above. Structural ordering for
             // cons/set/struct/bytes/empty-list.
@@ -392,7 +478,13 @@ pub(crate) fn fmt_table_key(
                 write!(f, "{:?}", id)
             }
         }
-        TableKey::String(s) => write!(f, "\"{}\"", s),
+        // A formatter never panics on a broken invariant; it shows one. Every
+        // constructor of a string key passes a string, so the fallback is a
+        // marker a reader can act on rather than an empty pair of quotes.
+        TableKey::String(v) => match v.as_str() {
+            Some(s) => write!(f, "\"{}\"", s),
+            None => write!(f, "#<string-key:{:#x}>", v.payload),
+        },
         TableKey::Keyword(hash) => {
             match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
                 Some(name) => write!(f, ":{}", name),
@@ -400,13 +492,19 @@ pub(crate) fn fmt_table_key(
             }
         }
         TableKey::EmptyList => write!(f, "()"),
-        TableKey::Array(keys) => {
+        TableKey::Array(v) => {
+            let Some(elements) = v.as_array() else {
+                return write!(f, "#<array-key:{:#x}>", v.payload);
+            };
             write!(f, "[")?;
-            for (i, k) in keys.iter().enumerate() {
+            for (i, elem) in elements.iter().enumerate() {
                 if i > 0 {
                     write!(f, " ")?;
                 }
-                fmt_table_key(k, symbols, debug, f)?;
+                match TableKey::from_value(elem) {
+                    Some(k) => fmt_table_key(&k, symbols, debug, f)?,
+                    None => crate::value::display::fmt_value(elem, symbols, debug, f)?,
+                }
             }
             write!(f, "]")
         }

--- a/src/value/types/tests.rs
+++ b/src/value/types/tests.rs
@@ -79,7 +79,7 @@ fn a_struct_built_in_one_table_is_probed_by_another() {
         .enumerate()
         .map(|(i, n)| (TableKey::Symbol(builder.intern(n)), Value::int(i as i64)))
         .collect();
-    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+    entries.sort_by_key(|(a, _)| *a);
 
     for (i, n) in ["probe-zeta", "probe-mu", "probe-alpha"].iter().enumerate() {
         let key = TableKey::Symbol(prober.intern(n));
@@ -90,4 +90,149 @@ fn a_struct_built_in_one_table_is_probed_by_another() {
             n
         );
     }
+}
+
+// ── Struct keys (docs/impl/values.md § "Struct keys") ──────────────────────
+
+// A key owns no Rust-heap allocation, so a struct's entries can be page bytes.
+// `Copy` is the compile-time statement of that: a variant holding a `String` or
+// a `Vec` cannot satisfy it.
+#[test]
+fn a_key_owns_no_rust_heap_allocation() {
+    fn only_copy_types<T: Copy>() {}
+    only_copy_types::<TableKey>();
+}
+
+// A probe key aliases what it reads, so `(get s "name")` allocates nothing.
+#[test]
+fn a_probe_key_borrows_the_value_it_reads() {
+    let h = crate::primitives::ctx::TestHeap::new();
+    let source = h.ctx().string("name");
+    let key = TableKey::from_value(&source).expect("a string is a valid key");
+    let TableKey::String(borrowed) = key else {
+        panic!("a string value must build a string key");
+    };
+    assert_eq!(
+        borrowed.payload, source.payload,
+        "a probe key must not copy the string it reads"
+    );
+}
+
+// A stored key is interned into the destination region, so a struct's key bytes
+// are part of the struct's own body. The trap: `from_value` hands back a
+// borrowed key, and storing it verbatim leaves the struct pointing into
+// whatever region the caller's key came from.
+#[test]
+fn a_stored_string_key_is_copied_into_the_struct_region() {
+    let heap_ptr = crate::value::arena::leaked_test_heap();
+
+    let heap = unsafe { &mut *heap_ptr };
+    let source_region = heap.new_runtime_region();
+    let source = crate::value::build::string(heap, "name", source_region);
+
+    let heap = unsafe { &mut *heap_ptr };
+    let struct_region = heap.new_runtime_region();
+    let mut fields = std::collections::BTreeMap::new();
+    fields.insert(
+        TableKey::from_value(&source).expect("a string is a valid key"),
+        Value::int(1),
+    );
+    let built = crate::value::build::struct_from(heap, fields, struct_region);
+
+    let entries = built.as_struct().expect("an immutable struct");
+    let TableKey::String(stored) = entries[0].0 else {
+        panic!("a string value must build a string key");
+    };
+    assert_ne!(
+        stored.payload, source.payload,
+        "a stored key must not alias the string it was built from"
+    );
+    assert_eq!(
+        crate::value::arena::region_of(unsafe { &*heap_ptr }, stored),
+        Some(struct_region),
+        "a stored key's bytes belong to the struct's own region"
+    );
+}
+
+// Interning is what keeps a struct from pinning the region its key came from.
+// Counter-factual: store the borrowed key instead, and the alloc-time
+// cross-region scan increfs the source region — every `put` in a chain then
+// holds the whole previous link alive.
+#[test]
+fn a_struct_does_not_pin_the_region_its_key_came_from() {
+    let heap_ptr = crate::value::arena::leaked_test_heap();
+
+    let heap = unsafe { &mut *heap_ptr };
+    let source_region = heap.new_runtime_region();
+    let source = crate::value::build::string(heap, "name", source_region);
+    let rc_before = crate::value::arena::region_rc(unsafe { &*heap_ptr }, source_region);
+
+    let heap = unsafe { &mut *heap_ptr };
+    let struct_region = heap.new_runtime_region();
+    let mut fields = std::collections::BTreeMap::new();
+    fields.insert(
+        TableKey::from_value(&source).expect("a string is a valid key"),
+        Value::int(1),
+    );
+    let _built = crate::value::build::struct_from(heap, fields, struct_region);
+
+    assert_eq!(
+        crate::value::arena::region_rc(unsafe { &*heap_ptr }, source_region),
+        rc_before,
+        "an interned key takes no reference to the region it was copied from"
+    );
+}
+
+// The alloc-time scan and the `@struct` store funnels reach a key's region
+// through `for_each_heap_value`. A string or array key holds a `Value`, so it
+// must be enumerated there; a key the walk skips is a region nothing counts.
+#[test]
+fn the_heap_value_walk_enumerates_string_and_array_keys() {
+    let h = crate::primitives::ctx::TestHeap::new();
+    let text = h.ctx().string("name");
+    let nested = h.ctx().array(vec![text, Value::int(1)]);
+
+    let mut seen = Vec::new();
+    TableKey::from_value(&text)
+        .expect("a string is a valid key")
+        .for_each_heap_value(&mut |v| seen.push(*v));
+    assert_eq!(seen, vec![text], "a string key holds one heap value");
+
+    let mut seen = Vec::new();
+    TableKey::from_value(&nested)
+        .expect("an immutable array is a valid key")
+        .for_each_heap_value(&mut |v| seen.push(*v));
+    assert_eq!(seen, vec![nested], "an array key holds one heap value");
+}
+
+// A struct prints and iterates in key order, so the key ranking is user-visible
+// and independent of `Value::Ord`. The trap: `Value::Ord` ranks keywords BEFORE
+// strings, so folding either variant into `Heap` — whose comparison delegates to
+// `Value::Ord` — silently reorders every struct that mixes the two.
+#[test]
+fn keys_rank_in_declaration_order_not_value_order() {
+    let h = crate::primitives::ctx::TestHeap::new();
+    let text = h.ctx().string("s");
+    let array = h.ctx().array(vec![Value::int(1)]);
+    let pair = h.ctx().pair(Value::int(1), Value::EMPTY_LIST);
+
+    let mut keys = vec![
+        TableKey::from_value(&pair).unwrap(),
+        TableKey::from_value(&array).unwrap(),
+        TableKey::EmptyList,
+        TableKey::keyword("k"),
+        TableKey::from_value(&text).unwrap(),
+        TableKey::Symbol(SymbolId::of("s")),
+        TableKey::Int(1),
+        TableKey::Bool(true),
+        TableKey::Nil,
+    ];
+    keys.sort();
+
+    let ranks: Vec<u8> = keys.iter().map(|k| k.discriminant_index()).collect();
+    assert_eq!(
+        ranks,
+        vec![0, 1, 2, 3, 4, 5, 6, 7, 8],
+        "keys must sort nil, bool, int, symbol, string, keyword, empty list, array, heap"
+    );
 }

--- a/src/vm/data/structops.rs
+++ b/src/vm/data/structops.rs
@@ -145,7 +145,7 @@ pub(crate) fn handle_struct_rest(
         let result: Vec<(TableKey, Value)> = struct_map
             .iter()
             .filter(|(k, _)| !exclude.contains(k))
-            .map(|(k, v)| (k.clone(), *v))
+            .map(|(k, v)| (*k, *v))
             .collect();
         let ctx = crate::primitives::ctx::Alloc::new(unsafe { &mut *vm.heap_ptr });
         let rest = ctx.struct_from_sorted(result);
@@ -155,9 +155,9 @@ pub(crate) fn handle_struct_rest(
             .borrow()
             .iter()
             .filter(|(k, _)| !exclude.contains(k))
-            .map(|(k, v)| (k.clone(), *v))
+            .map(|(k, v)| (*k, *v))
             .collect();
-        result.sort_by(|(a, _), (b, _)| a.cmp(b));
+        result.sort_by_key(|(a, _)| *a);
         let ctx = crate::primitives::ctx::Alloc::new(unsafe { &mut *vm.heap_ptr });
         let rest = ctx.struct_from_sorted(result);
         vm.fiber.stack.push(rest);

--- a/src/vm/types/intrinsic.rs
+++ b/src/vm/types/intrinsic.rs
@@ -228,7 +228,7 @@ pub(crate) fn handle_intr_freeze(vm: &mut VM, region: RuntimeRegion) {
     let result = if let Some(a) = val.as_array_mut() {
         crate::value::build::array(heap, a.borrow().clone(), region)
     } else if let Some(t) = val.as_struct_mut() {
-        let entries: Vec<_> = t.borrow().iter().map(|(k, v)| (k.clone(), *v)).collect();
+        let entries: Vec<_> = t.borrow().iter().map(|(k, v)| (*k, *v)).collect();
         crate::value::build::struct_from_sorted(heap, entries, region)
     } else if let Some(s) = val.as_set_mut() {
         crate::value::build::set(heap, s.borrow().clone(), region)
@@ -251,8 +251,7 @@ pub(crate) fn handle_intr_thaw(vm: &mut VM, region: RuntimeRegion) {
     let result = if let Some(a) = val.as_array() {
         crate::value::build::array_mut(heap, a.to_vec(), region)
     } else if let Some(s) = val.as_struct() {
-        let entries: std::collections::BTreeMap<_, _> =
-            s.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        let entries: std::collections::BTreeMap<_, _> = s.iter().map(|(k, v)| (*k, *v)).collect();
         crate::value::build::struct_mut_from(heap, entries, region)
     } else if let Some(s) = val.as_set() {
         crate::value::build::set_mut(heap, s.iter().cloned().collect(), region)

--- a/src/wasm/linker/dataop.rs
+++ b/src/wasm/linker/dataop.rs
@@ -222,7 +222,7 @@ pub fn dispatch_data_op(
                 let filtered: Vec<(TableKey, Value)> = s
                     .iter()
                     .filter(|(k, _)| !exclude_keys.contains(k))
-                    .map(|(k, v)| (k.clone(), *v))
+                    .map(|(k, v)| (*k, *v))
                     .collect();
                 (SIG_OK, ctx.struct_from_sorted(filtered))
             } else if let Some(s) = args[0].as_struct_mut() {
@@ -230,9 +230,9 @@ pub fn dispatch_data_op(
                 let mut filtered: Vec<(TableKey, Value)> = b
                     .iter()
                     .filter(|(k, _)| !exclude_keys.contains(k))
-                    .map(|(k, v)| (k.clone(), *v))
+                    .map(|(k, v)| (*k, *v))
                     .collect();
-                filtered.sort_by(|(a, _), (b, _)| a.cmp(b));
+                filtered.sort_by_key(|(a, _)| *a);
                 (SIG_OK, ctx.struct_from_sorted(filtered))
             } else {
                 (SIG_OK, ctx.struct_from_sorted(vec![]))

--- a/tests/elle/region-struct-key.lisp
+++ b/tests/elle/region-struct-key.lisp
@@ -1,0 +1,135 @@
+(elle/epoch 12)
+# A struct key's region is counted only when it is another region.
+#
+# A key that is actually stored is interned into the container's own region
+# (docs/impl/values.md § "Struct keys"), which makes it a self-edge: the RC and
+# the outgoing-edge table count it on neither side, matching the free-time
+# cascade's `own_id` filter. This file drives both halves of that ledger from
+# Elle, because counting a self-edge on one side only fails two different ways
+# and each way needs its own witness.
+#
+# LEAK half — `put` of a string or array key increfed the container's own
+# region. The free cascade never releases a self-edge, so the whole region
+# leaked, one per call, and only a matching `del` could cancel it. Measured in
+# regions (`arena/region-count`), deterministically.
+#
+# UAF half — `del` of a key a CONSTRUCTOR interned decrefed the container's
+# region. The literal `@{"k" 1}` builds through `build::struct_mut_from`, whose
+# alloc-time scan counts nothing for a co-region key, so that decref took the
+# struct's sole reference to zero and freed the struct under its own binding.
+#
+# The trap: a `del` that frees its own container does NOT reliably crash. The
+# freed page keeps its old bytes and reads through it still answer correctly
+# until something reuses the page — under `--trace=scrub` the page is blanked
+# and the read panics at the deref, which is how CI caught this, but a plain
+# run of the same code can pass. So the witness here is the region gauge, which
+# is exact on every platform and every build: a `del` frees no region, because
+# the region it would free is the one the struct is still living in. The
+# readback assertions come after, for the semantics.
+
+(defn region-delta [f iters]
+  (def before (arena/region-count))
+  (def @i 0)
+  (while (%lt i iters)
+    (f i)
+    (assign i (%add i 1)))
+  (%sub (arena/region-count) before))
+
+# ── LEAK: a put of a heap key holds no region ─────────────────────
+# The keyword drive is the control: a keyword key carries no `Value` at all, so
+# neither ledger has anything to count for it. A rate that moves for the string
+# and array drives but not for this one names the key's heap value as the leak.
+
+(defn put-keyword [k]
+  (let [m @{}]
+    (put m :k 1)
+    0))
+(defn put-string [k]
+  (let [m @{}]
+    (put m "kk" 1)
+    0))
+(defn put-array [k]
+  (let [m @{}]
+    (put m [1 2] 1)
+    0))
+(defn put-then-del-array [k]
+  (let [m @{}]
+    (put m [1 2] 1)
+    (del m [1 2])
+    0))
+
+(let [d-keyword (region-delta put-keyword 200)
+      d-string (region-delta put-string 200)
+      d-array (region-delta put-array 200)
+      d-cancelled (region-delta put-then-del-array 200)]
+  (assert (%lt d-keyword 20)
+          (concat "keyword-key put leak: delta=" (number->string d-keyword)))
+  (assert (%lt d-string 20)
+          (concat "string-key put leak: delta=" (number->string d-string)))
+  (assert (%lt d-array 20)
+          (concat "array-key put leak: delta=" (number->string d-array)))
+  (assert (%lt d-cancelled 20)
+          (concat "put+del array-key leak: delta=" (number->string d-cancelled))))
+
+# ── UAF: del of a constructor-interned key frees no region ─────────
+# Each `del` below removes a key the LITERAL interned, so the remove half has
+# no incref of its own to release. The keyword drive is the control again: its
+# key carries no `Value`, so its `del` releases nothing under either rule.
+#
+# The trap: every VALUE here is an immediate. A `del` that removes a heap value
+# releases that value's region, and freeing it is correct — so a heap value
+# moves the gauge by one on its own and hides whatever the key did.
+
+(let [m @{:b 1 :a 2}
+      before (arena/region-count)]
+  (del m :b)
+  (assert (= (arena/region-count) before) "del of a keyword key frees no region")
+  (assert (not (has? m :b)) "del removes the keyword key")
+  (assert (= (get m :a) 2) "and leaves the other entry readable"))
+
+(let [m @{"kk" 1 :a 2}
+      before (arena/region-count)]
+  (del m "kk")
+  (assert (= (arena/region-count) before)
+          "del of an interned string key frees no region")
+  (assert (not (has? m "kk")) "del removes the interned string key")
+  (assert (= (get m :a) 2) "the struct survives the del of a string key")
+  (assert (= (length m) 1) "and reports the one entry it has left"))
+
+(let [m @{[1 2] 1 :a 2}
+      before (arena/region-count)]
+  (del m [1 2])
+  (assert (= (arena/region-count) before)
+          "del of an interned array key frees no region")
+  (assert (not (has? m [1 2])) "del removes the interned array key")
+  (assert (= (get m :a) 2) "the struct survives the del of an array key")
+  (assert (= (keys m) (quote (:a))) "and lists the one key it has left"))
+
+# The last entry: the del empties the struct, so nothing but the container
+# itself is left to read through.
+(let [m @{"only" 1}
+      before (arena/region-count)]
+  (del m "only")
+  (assert (= (arena/region-count) before)
+          "del of the last interned key frees no region")
+  (assert (= (length m) 0) "the emptied struct is still readable")
+  (put m "again" 2)
+  (assert (= (get m "again") 2) "and still takes a new interned key"))
+
+# ── the same shape past the JIT threshold ─────────────────────────
+# The store funnels are shared by every tier, but the region a literal is built
+# in is chosen by the emitter, so the compiled tier is a separate witness.
+
+(defn del-then-read []
+  (let [m @{[3 4] 9 :a 1}]
+    (del m [3 4])
+    (get m :a)))
+
+(var last 0)
+(var i 0)
+(while (%lt i 500)
+  (assign last (del-then-read))
+  (assign i (%add i 1)))
+(assert (= last 1) "the del-then-read shape holds on the compiled tier too")
+
+(println "region-struct-key: all tests passed")

--- a/tests/elle/struct-string-keys.lisp
+++ b/tests/elle/struct-string-keys.lisp
@@ -1,0 +1,84 @@
+(elle/epoch 12)
+# String and array keys in structs.
+#
+# A struct key holds no Rust-heap memory: a string or array key is a value in
+# the struct's own region (docs/impl/values.md § "Struct keys"). This file
+# pins what stays true of a key whose bytes moved into the region — lookup by
+# content, survival past the region the key was built in, the ranking that
+# decides key order, and the crossing into a worker thread — so a change to
+# the key representation cannot quietly alter any of them.
+
+# ── lookup is by content, not by identity ─────────────────────────
+# The probe string and the stored key are two separate allocations. `concat`
+# builds a fresh string, so an identity comparison would miss.
+
+(let [s (struct "name" 1)]
+  (assert (= (get s (concat "na" "me")) 1) "string key found by content")
+  (assert (has? s "name") "has? finds a string key")
+  (assert (= (get s "other") nil) "absent string key reads nil"))
+
+(let [s (struct [1 2] :found)]
+  (assert (= (get s [1 2]) :found) "array key found by content")
+  (assert (= (get s [1 3]) nil) "unequal array key reads nil"))
+
+# ── a stored key outlives the region it was built in ──────────────
+# `keyed` builds its key string inside its own call, which is released when the
+# call returns. A key that aliased that string instead of copying it would read
+# freed pages here; the loop runs far past the JIT threshold so both tiers see
+# the same reuse.
+
+(defn keyed []
+  (struct (concat "k" "7") 7))
+
+(var last 0)
+(var i 0)
+(while (%lt i 500)
+  (assign last (get (keyed) "k7"))
+  (assign i (%add i 1)))
+(assert (= last 7) "a struct key survives the region its string was built in")
+
+# ── put and del carry string keys ─────────────────────────────────
+
+(let* [s (struct "a" 1)
+       s2 (put s "b" 2)
+       s3 (del s2 "a")]
+  (assert (= (get s2 "a") 1) "put preserves the original string key")
+  (assert (= (get s2 "b") 2) "put adds a string key")
+  (assert (not (has? s3 "a")) "del removes a string key")
+  (assert (= (get s3 "b") 2) "del preserves the other string key"))
+
+# ── keys rank by key order, not by value order ────────────────────
+# Keys sort nil, bool, int, symbol, string, keyword, empty list, array, heap.
+# Value ordering ranks keywords BEFORE strings, so a struct that mixed the two
+# would iterate differently if key order ever delegated to it.
+
+(let [s (struct 42 :int-key "b" :string-key :d :keyword-key)]
+  (assert (= (keys s) (quote (42 "b" :d)))
+          "keys iterate int, then string, then keyword"))
+
+# ── mutable structs take string keys too ──────────────────────────
+
+(let [m @{}]
+  (put m "k" 1)
+  (assert (= (get m "k") 1) "@struct stores a string key")
+  (put m "k" 2)
+  (assert (= (get m "k") 2) "@struct overwrites through a string key")
+  (del m "k")
+  (assert (not (has? m "k")) "@struct removes a string key"))
+
+# ── a string-keyed struct crosses a thread boundary ───────────────
+# The worker builds the struct on its own heap and the value is rebuilt on
+# this one. A key that carried a raw pointer could not make the crossing.
+
+(let [s (sys/join (sys/spawn (fn [] (struct "k" 1 "j" 2))))]
+  (assert (= (get s "k") 1) "a string-keyed struct returns from a worker")
+  (assert (= (get s "j") 2) "every string key survives the return"))
+
+# ── equality and hashing see through the representation ───────────
+
+(assert (= (struct "a" 1 "b" 2) (struct "b" 2 "a" 1))
+        "string-keyed struct equality ignores insertion order")
+(assert (has? (set (struct "a" 1)) (struct "a" 1))
+        "a string-keyed struct hashes as a set element")
+
+(println "struct-string-keys: all tests passed")

--- a/tests/unittests/primitives/json.rs
+++ b/tests/unittests/primitives/json.rs
@@ -127,12 +127,11 @@ fn test_json_parse_arrays() {
 
 /// Read one string-keyed field out of an immutable struct.
 fn json_field(owner: Value, name: &str) -> Value {
-    use elle::value::TableKey;
     owner
         .as_struct()
         .unwrap_or_else(|| panic!("expected an immutable struct, looking for {:?}", name))
         .iter()
-        .find(|(k, _)| matches!(k, TableKey::String(s) if s == name))
+        .find(|(k, _)| k.as_str() == Some(name))
         .map(|(_, v)| *v)
         .unwrap_or_else(|| panic!("no field {:?}", name))
 }

--- a/tests/unittests/table_key.rs
+++ b/tests/unittests/table_key.rs
@@ -1,4 +1,3 @@
-use elle::primitives::ctx::with_test_ctx;
 use elle::value::types::TableKey;
 use elle::Value;
 
@@ -8,21 +7,21 @@ use elle::Value;
 fn test_from_value_nil() {
     let key = TableKey::from_value(&Value::NIL).unwrap();
     assert_eq!(key, TableKey::Nil);
-    assert_eq!(with_test_ctx(|ctx| key.to_value(ctx)), Value::NIL);
+    assert_eq!(key.to_value(), Value::NIL);
 }
 
 #[test]
 fn test_from_value_bool() {
     let key = TableKey::from_value(&Value::TRUE).unwrap();
     assert_eq!(key, TableKey::Bool(true));
-    assert_eq!(with_test_ctx(|ctx| key.to_value(ctx)), Value::TRUE);
+    assert_eq!(key.to_value(), Value::TRUE);
 }
 
 #[test]
 fn test_from_value_int() {
     let key = TableKey::from_value(&Value::int(42)).unwrap();
     assert_eq!(key, TableKey::Int(42));
-    assert_eq!(with_test_ctx(|ctx| key.to_value(ctx)), Value::int(42));
+    assert_eq!(key.to_value(), Value::int(42));
 }
 
 #[test]
@@ -33,7 +32,7 @@ fn test_from_value_keyword() {
         matches!(key, TableKey::Keyword(h) if h == elle::value::keyword::keyword_hash("foo"))
     );
     // to_value produces an equivalent keyword
-    assert!(with_test_ctx(|ctx| key.to_value(ctx)).is_keyword_named("foo"));
+    assert!(key.to_value().is_keyword_named("foo"));
 }
 
 #[test]
@@ -41,7 +40,8 @@ fn test_from_value_string() {
     let h = elle::primitives::ctx::TestHeap::new();
     let val = h.ctx().string("hello");
     let key = TableKey::from_value(&val).unwrap();
-    assert!(matches!(key, TableKey::String(ref s) if s == "hello"));
+    assert_eq!(key.as_str(), Some("hello"));
+    assert_eq!(key.to_value(), val, "a probe key holds the value it read");
 }
 
 // ── EmptyList key ───────────────────────────────────────────
@@ -50,7 +50,7 @@ fn test_from_value_string() {
 fn test_from_value_empty_list() {
     let key = TableKey::from_value(&Value::EMPTY_LIST).unwrap();
     assert_eq!(key, TableKey::EmptyList);
-    assert_eq!(with_test_ctx(|ctx| key.to_value(ctx)), Value::EMPTY_LIST);
+    assert_eq!(key.to_value(), Value::EMPTY_LIST);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn test_external_key_roundtrip() {
     let h = elle::primitives::ctx::TestHeap::new();
     let ext = h.ctx().external("test-type", 42u32);
     let key = TableKey::from_value(&ext).unwrap();
-    let roundtripped = with_test_ctx(|ctx| key.to_value(ctx));
+    let roundtripped = key.to_value();
     // Must be the exact same Value (same tag and pointer payload)
     assert_eq!(roundtripped, ext, "to_value must return the original Value");
 }
@@ -119,12 +119,30 @@ fn test_from_value_table_rejected() {
 
 #[test]
 fn test_is_sendable_value_keys() {
+    let h = elle::primitives::ctx::TestHeap::new();
+    let text = TableKey::from_value(&h.ctx().string("hello")).unwrap();
     assert!(TableKey::Nil.is_sendable());
     assert!(TableKey::Bool(true).is_sendable());
     assert!(TableKey::Int(42).is_sendable());
-    assert!(TableKey::String("hello".to_string()).is_sendable());
+    assert!(text.is_sendable());
     assert!(TableKey::keyword("foo").is_sendable());
     assert!(TableKey::EmptyList.is_sendable());
+}
+
+// An array key travels only if every element does, because `SendKey::Array`
+// carries element keys and has no arm for an identity key.
+#[test]
+fn test_is_sendable_array_key_follows_its_elements() {
+    let h = elle::primitives::ctx::TestHeap::new();
+    let plain = h.ctx().array(vec![Value::int(1), h.ctx().string("x")]);
+    assert!(TableKey::from_value(&plain).unwrap().is_sendable());
+
+    let ext = h.ctx().external("test-type", 42u32);
+    let with_identity = h.ctx().array(vec![Value::int(1), ext]);
+    assert!(
+        !TableKey::from_value(&with_identity).unwrap().is_sendable(),
+        "an array key holding an identity element must not be sendable"
+    );
 }
 
 #[test]


### PR DESCRIPTION
The second foundation from the image design (docs/impl/image.md § "Landing
order"), after #997. Independently valuable at runtime, and it deletes image
machinery that would otherwise have to be built and thrown away.

## What was wrong

`LStruct` held `Vec<(TableKey, Value)>` on the Rust heap, so a struct was the
one immutable collection whose payload was not page bytes — arrays, strings,
bytes, and sets already stored theirs in their own region. Two `TableKey` arms
owned allocations and were the reason: `String` owned a `String`, `Array`
owned a `Vec<TableKey>`.

That cost twice. A struct allocated on the Rust heap and freed there, and
every lookup built its probe key by copying the caller's string:

```rust
} else if let Some(s) = val.with_string(|s| s.to_string()) {
    Some(TableKey::String(s))          // an allocation per `(get s "name")`
```

## What this does

The entry slice is `RegionSlice<(TableKey, Value)>`, co-located with its
header, and both key arms hold a `Value` pointing at a region-resident string
or array. `TableKey` is `Copy` and owns no Rust heap memory.

Keys split by purpose. `TableKey::from_value` builds a **borrowed probe** that
allocates nothing. `TableKey::intern_into` builds the **stored** form, copying
a string or array payload into the destination region. The split reproduces
what the owned representation did — a string key used to copy its bytes, a
`Heap` key used to alias, and interning one would break the identity a fiber or
closure key depends on — while keeping a struct from pinning the region its key
was built in. Without it, a chain of `put`s pins one region per link.

Every store site interns: the constructors in `value/build.rs`, the `@struct`
funnel in `value/arena/mutate.rs`, `with-traits`, the trait-table root builder,
and the receiving side of `send`. A rebind interns nothing, because
`BTreeMap::insert` keeps the key it already holds.

`SendKey` is the owning key form `SendValue::Struct` and `SendValue::StructMut`
are now keyed on. A `TableKey` holds raw region pointers, so it can be neither
`Send` nor serialized; `SendKey` owns its bytes and derives serde directly,
which deletes `KeyMirror` and the hand-written `TableKey` serde impls.

## An interned key is a self-edge, on both sides of the ledger

Interning puts a key's bytes in the container's own region, so the key's heap
value points at the region that holds it. Neither region ledger counts such a
self-edge: the free-time cascade already filtered it through `own_id`, and both
`@struct` store funnels now resolve their key edges through one
`counted_key_values`.

They have to agree, because the remove half cannot tell how the key it removes
was stored. Counting a self-edge on one side only fails two ways:

- **The put half alone** takes a reference the free cascade never releases, so
  every `put` of a string or array key leaks the container's whole region —
  measured at exactly one region per call.
- **The remove half alone** decrefs a reference the constructor never took, so
  `del` of a key an `@{…}` literal interned takes the struct's sole reference
  to zero and frees the struct under its own binding.

docs/impl/values.md § "A key's region is counted like a value's" owns the rule.

## What did not change

Key ranking, equality, hashing, and display. `TableKey::Ord` ranks strings
before keywords and `Value::Ord` ranks keywords before strings, so folding
either arm into `Heap` — whose comparison delegates to `Value::Ord` — would
have silently reordered every struct that mixes the two. Both keep a variant of
their own, and an array key still compares its elements as keys rather than as
values.

docs/impl/values.md § "Struct keys" owns the model; image.md cites it rather
than restating it.

## How it was measured

The representation claims were pinned before the implementation existed, and
failed then: four compile errors on the `Copy`/`Value` claims, and
`the_heap_value_walk_enumerates_string_and_array_keys` failed at runtime
because `for_each_heap_value` skipped both new arms.
`tests/elle/struct-string-keys.lisp` passed against the owned representation
before any code changed, so it is a regression net rather than a restatement of
the new one.

The key ledger was caught by the macOS Smoke job, which runs the corpus under
`--trace=scrub`: `array-keys.lisp` and `pipeline.lisp` panicked at the deref
with a blanked page. It reproduces on Linux under the same flag. The trap is
that a `del` which frees its own container keeps reading correctly until
something reuses the page, so the pins use the region gauge instead — exact on
every platform and every build. Both halves were RED before the fix: 200
regions leaked across 200 `put`s, and one region freed by a `del` that should
free none.

## Pinned by

- `immutable_struct_entries_live_in_the_struct_region` — the entry slice
  resolves to the struct's own region; a `Vec` payload resolves to no region.
- `a_stored_string_key_is_copied_into_the_struct_region` and
  `a_struct_does_not_pin_the_region_its_key_came_from` — the counter-factual
  for storing a borrowed key.
- `a_probe_key_borrows_the_value_it_reads`,
  `a_key_owns_no_rust_heap_allocation`,
  `the_heap_value_walk_enumerates_string_and_array_keys`,
  `keys_rank_in_declaration_order_not_value_order`.
- `a_stored_at_struct_key_is_interned_into_the_container_region` and
  `rebinding_an_at_struct_key_interns_nothing_new` at the `@struct` funnel.
- `an_interned_at_struct_key_adds_no_reference_to_the_container_region` and
  `removing_a_constructor_interned_key_leaves_the_container_region_live` — the
  two sides of the key ledger, in RC terms.
- `tests/elle/region-struct-key.lisp` — the same two sides end to end, each
  against a keyword-key control, plus the shape past the JIT threshold.
- `sendkey_ranks_its_variants_the_way_a_struct_key_does`,
  `sendkey_map_roundtrips_through_bincode`,
  `sendkey_symbol_key_round_trips_as_its_name_hash`.
- `tests/elle/struct-string-keys.lisp` — lookup by content, survival past the
  region the key was built in, key ordering across mixed key types, `@struct`
  stores, and the crossing into a worker thread.

Full `make test` green with the release corpus, and the whole corpus green
under `--trace=scrub` with debug assertions.
