### PR TITLE
lint,trace,docs: four small fixes, each with the gate that would have caught it

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,6 +90,13 @@ jobs:
         run: cargo doc --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: "-D warnings"
+      # `cargo doc` renders a doc example; it does not compile one. Without
+      # this step a `///` example goes on rendering after the signature it
+      # calls has changed, because no other job builds it: the suite's own
+      # `cargo test` invocations pass `--lib` and `--test '*'`, both of which
+      # exclude doctests.
+      - name: Compile documentation examples
+        run: cargo test --workspace --doc
 
   # The documentation site is generated from docs/*.md plus the Elle sources
   # under src/, so it breaks on a renamed heading or a moved source file as

--- a/Makefile
+++ b/Makefile
@@ -545,10 +545,16 @@ MLIR_ENV    := LLVM_SYS_220_PREFIX=$(MLIR_PREFIX) \
 # CI documents private items too, and most of this crate is private — without
 # the flag rustdoc never resolves a link into a `pub(crate)` item, so a broken
 # one reaches CI unseen. Keep the flag here and in .github/workflows in step.
-qa: crosscheck  ## The PR gate's QA job, locally (~2min, no smoke): rustfmt, workspace clippy, rustdoc
+#
+# `--doc` is separate from `cargo doc` because rendering an example is not
+# compiling one: `cargo doc` will happily render a call whose signature moved
+# under it. Nothing else builds doctests — `test` passes `--lib` and
+# `--test '*'`, both of which exclude them.
+qa: crosscheck  ## The PR gate's QA job, locally (~2min, no smoke): rustfmt, workspace clippy, rustdoc, doctests
 	cargo fmt --check
 	$(MLIR_ENV) cargo clippy --workspace --all-targets --all-features -- -D warnings
 	$(MLIR_ENV) RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features --document-private-items
+	$(MLIR_ENV) cargo test --workspace --doc
 
 test: smoke smoke-nouring qa  ## Rust unit + integration tests + QA (fmt/clippy/crosscheck/rustdoc) after smoke
 	$(MLIR_ENV) cargo test --workspace --lib --all-features

--- a/docs/cookbook/lint-rules.md
+++ b/docs/cookbook/lint-rules.md
@@ -112,10 +112,26 @@ that lands without its row here fails that test.
 reads the `is_tail` flag `src/hir/tailcall.rs` sets. Neither rule tracks
 its own state, and neither adds a field to `BindingInner`.
 
+These are the analysis failures, which are not rules — no linter pass raises
+them:
+
+| Code | Rule | Fires on |
+|------|------|----------|
+| `E000` | `analysis-error` | Any analysis failure with no code of its own. |
+| `E001` | `undefined-variable` | A name nothing in scope binds. |
+| `E002` | `signal-mismatch` | A call whose signal the context does not allow. |
+| `E003` | `unterminated-form` | A form the reader reached end of input inside. |
+| `E004` | `compile-error` | A failure raised by a compiler pass. |
+| `E005` | `syntax-error` | Source the reader could not parse. |
+
+`LintCode::for_error_kind` (`src/lint/diagnostics.rs`) maps an `ErrorKind` to
+one of these, and the lint CLI, `compile/diagnostics`, and the LSP all read it
+— so one failure reports one code whichever surface a consumer asks. The same
+test holds this table and `diagnostics::ERRORS` in step.
+
 `W001` is unclaimed and no rule raises it, so the table has no row for it.
-Use `W006+` for new warnings. `E000`–`E005` are analysis failures the lint
-CLI reports (`src/lint/cli.rs`), not rules; take `E006` for a new error and
-`I001` for the first info diagnostic.
+Use `W006+` for new warnings, `E006+` for a new error, and `I001` for the
+first info diagnostic.
 
 ### How linting runs
 

--- a/docs/impl/vm.md
+++ b/docs/impl/vm.md
@@ -47,7 +47,8 @@ bytecodes — see [impl/bytecode.md](bytecode.md) § Arithmetic.
 
 ## Fiber integration
 
-- **Emit** (`Instruction::Emit` with a u16 signal bits operand) — saves
+- **Emit** (`Instruction::Emit` with a signal bits operand — see
+  [impl/bytecode.md](bytecode.md) § "Signal-bits operands") — saves
   the current frame as a `SuspendedFrame`, returns control to the parent
   fiber or scheduler
 - **Signal emission** — checks the fiber's signal mask to decide

--- a/src/compiler/bytecode/instruction.rs
+++ b/src/compiler/bytecode/instruction.rs
@@ -124,7 +124,8 @@ pub enum Instruction {
     /// Update a capture cell's value
     UpdateCapture,
 
-    /// Emit a signal (suspends execution). Operand: u16 signal bits.
+    /// Emit a signal (suspends execution). Operand: signal bits
+    /// (docs/impl/bytecode.md § "Signal-bits operands").
     /// `(emit :yield val)` emits SIG_YIELD; `(emit :io val)` emits SIG_IO.
     Emit,
 
@@ -207,7 +208,8 @@ pub enum Instruction {
     IsSetMut,
 
     /// Check that a closure's signal satisfies a bound.
-    /// Operand: u32 allowed_bits.
+    /// Operand: `allowed_bits`, signal bits
+    /// (docs/impl/bytecode.md § "Signal-bits operands").
     /// Pops the value from the stack. If it's a closure whose
     /// `signal.bits & !allowed_bits != 0`, signals `:error`.
     /// Non-closures pass silently.

--- a/src/compiler/stdlib_cache.rs
+++ b/src/compiler/stdlib_cache.rs
@@ -378,12 +378,12 @@ pub fn load_bytecode(
         symbols,
     )?;
     let tracing = crate::trace::compile();
-    crate::trace::phase(tracing, "compile", "stdlib deserialize_templates", t0);
+    crate::phase!(tracing, "compile", t0, "stdlib deserialize_templates");
     let t1 = std::time::Instant::now();
     let entry = templates
         .pop()
         .expect("deserialize_templates returns one per input");
-    crate::trace::phase(tracing, "compile", "stdlib pop+extract", t1);
+    crate::phase!(tracing, "compile", t1, "stdlib pop+extract");
     // Restore the cross-unit registries the skipped stdlib compile would have
     // populated.
     let (dispatch_wrappers, fn_inline) = cctx.compile_registries_mut();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //!
 //! ```
 //! use elle::{eval, init_stdlib, register_primitives, SymbolTable, VM};
+//! use elle::compiler::stdlib_cache::StdlibCache;
 //! use elle::pipeline::CompileCtx;
 //!
 //! let mut vm = VM::new();
@@ -43,7 +44,10 @@
 //! let mut cctx = CompileCtx::new();
 //! vm.set_compile_ctx(&mut cctx as *mut CompileCtx);
 //! vm.set_symbols(&mut symbols as *mut SymbolTable);
-//! init_stdlib(&mut vm, &mut symbols, &mut cctx);
+//! // The standard-library disk cache is a construction parameter, not
+//! // process-global state, so an embedder names one per instance;
+//! // `Process` takes the process-wide `--cache` choice, as `Runtime` does.
+//! init_stdlib(&mut vm, &mut symbols, &mut cctx, &StdlibCache::Process);
 //!
 //! let code = "(+ 1 2 3)";
 //! let result = eval(code, &mut symbols, &mut vm, &mut cctx, "<example>").unwrap();

--- a/src/lint/cli.rs
+++ b/src/lint/cli.rs
@@ -86,15 +86,8 @@ impl Linter {
 
     /// Convert an LError to a Diagnostic
     fn lerror_to_diagnostic(error: &crate::error::LError, file: &str) -> Diagnostic {
-        use crate::error::ErrorKind;
-        let (code, rule) = match &error.kind {
-            ErrorKind::UndefinedVariable { .. } => ("E001", "undefined-variable"),
-            ErrorKind::SignalMismatch { .. } => ("E002", "signal-mismatch"),
-            ErrorKind::UnterminatedForm { .. } => ("E003", "unterminated-form"),
-            ErrorKind::CompileError { .. } => ("E004", "compile-error"),
-            ErrorKind::SyntaxError { .. } => ("E005", "syntax-error"),
-            _ => ("E000", "analysis-error"),
-        };
+        let crate::lint::diagnostics::LintCode { code, rule } =
+            crate::lint::diagnostics::LintCode::for_error_kind(&error.kind);
         let loc = error
             .location
             .clone()

--- a/src/lint/diagnostics.rs
+++ b/src/lint/diagnostics.rs
@@ -38,6 +38,31 @@ impl LintCode {
     }
 }
 
+impl LintCode {
+    /// The code an analysis failure reports under, on **every** surface.
+    ///
+    /// The lint CLI, `compile/diagnostics`, and the LSP each used to spell this
+    /// mapping out for themselves, and they disagreed: a syntax error was
+    /// `E005` from `elle lint`, `E000` from `compile/diagnostics` (whose match
+    /// had no `SyntaxError` arm at all), and `E0001` from the LSP — a shape the
+    /// documented `E00x` scheme does not even have. A consumer that filters or
+    /// counts by code could not do it across surfaces.
+    ///
+    /// Kinds with no code of their own report as [`ANALYSIS_ERROR`], which is
+    /// what each site's fallback arm already did.
+    pub fn for_error_kind(kind: &crate::error::ErrorKind) -> LintCode {
+        use crate::error::ErrorKind;
+        match kind {
+            ErrorKind::UndefinedVariable { .. } => UNDEFINED_VARIABLE,
+            ErrorKind::SignalMismatch { .. } => SIGNAL_MISMATCH,
+            ErrorKind::UnterminatedForm { .. } => UNTERMINATED_FORM,
+            ErrorKind::CompileError { .. } => COMPILE_ERROR,
+            ErrorKind::SyntaxError { .. } => SYNTAX_ERROR,
+            _ => ANALYSIS_ERROR,
+        }
+    }
+}
+
 pub const ARITY_MISMATCH: LintCode = LintCode::new("W002", "arity-mismatch");
 pub const MUTABLE_BINDING_NEVER_ASSIGNED: LintCode =
     LintCode::new("W003", "mutable-binding-never-assigned");
@@ -54,6 +79,28 @@ pub const WARNINGS: &[LintCode] = &[
     MUTABLE_BINDING_NEVER_ASSIGNED,
     UNUSED_BINDING,
     NON_TAIL_SELF_RECURSION,
+];
+
+pub const ANALYSIS_ERROR: LintCode = LintCode::new("E000", "analysis-error");
+pub const UNDEFINED_VARIABLE: LintCode = LintCode::new("E001", "undefined-variable");
+pub const SIGNAL_MISMATCH: LintCode = LintCode::new("E002", "signal-mismatch");
+pub const UNTERMINATED_FORM: LintCode = LintCode::new("E003", "unterminated-form");
+pub const COMPILE_ERROR: LintCode = LintCode::new("E004", "compile-error");
+pub const SYNTAX_ERROR: LintCode = LintCode::new("E005", "syntax-error");
+
+/// Every analysis failure a surface reports, in code order.
+///
+/// These are not rules — no linter pass raises them. They are the codes
+/// [`LintCode::for_error_kind`] hands to the lint CLI, `compile/diagnostics`,
+/// and the LSP, published to rule authors for the same reason [`WARNINGS`] is:
+/// as the index of codes already taken.
+pub const ERRORS: &[LintCode] = &[
+    ANALYSIS_ERROR,
+    UNDEFINED_VARIABLE,
+    SIGNAL_MISMATCH,
+    UNTERMINATED_FORM,
+    COMPILE_ERROR,
+    SYNTAX_ERROR,
 ];
 
 /// A linter diagnostic with source location

--- a/src/lint/diagnostics/tests.rs
+++ b/src/lint/diagnostics/tests.rs
@@ -50,23 +50,71 @@ fn code_row(line: &str) -> Option<(&str, &str)> {
 }
 
 #[test]
-fn the_cookbook_code_table_names_exactly_the_warnings_the_linter_raises() {
-    // The cookbook's table is a rule author's index of codes already taken, and
-    // it is prose: nothing but this test stops it drifting from `WARNINGS`.
+fn the_cookbook_code_tables_name_exactly_the_codes_that_are_taken() {
+    // The cookbook's tables are a rule author's index of codes already taken,
+    // and they are prose: nothing but this test stops them drifting from
+    // `WARNINGS` and `ERRORS`.
     //
     // The trap: drift is silent in both directions and neither is cosmetic. A
-    // code the table lists but no rule raises gets skipped as taken, so the
-    // next rule takes a further code and the numbering grows holes. A code a
-    // rule raises but the table omits gets handed to a second rule, and two
-    // rules then answer to one code.
+    // code the table lists but nothing raises gets skipped as taken, so the
+    // next rule takes a further code and the numbering grows holes. A code
+    // something raises but the table omits gets handed to a second rule, and
+    // two rules then answer to one code.
     const COOKBOOK: &str = include_str!("../../../docs/cookbook/lint-rules.md");
 
     let documented: Vec<(&str, &str)> = COOKBOOK.lines().filter_map(code_row).collect();
-    let raised: Vec<(&str, &str)> = WARNINGS.iter().map(|w| (w.code, w.rule)).collect();
+    // Warnings first, then errors — the order the two tables appear in.
+    let taken: Vec<(&str, &str)> = WARNINGS
+        .iter()
+        .chain(ERRORS)
+        .map(|c| (c.code, c.rule))
+        .collect();
 
     assert_eq!(
-        documented, raised,
+        documented, taken,
         "docs/cookbook/lint-rules.md § Diagnostic codes disagrees with \
-         diagnostics::WARNINGS"
+         diagnostics::WARNINGS ++ diagnostics::ERRORS"
     );
+}
+
+// The defect this registry closes: the same failure carried a different code
+// depending on which surface reported it. A syntax error was `E005` from
+// `elle lint`, `E000` from `compile/diagnostics` — whose match had no
+// `SyntaxError` arm and fell through — and `E0001` from the LSP, a four-digit
+// shape the documented `E00x` scheme does not have.
+//
+// The counter-factual: with the mapping written out at each site, this test
+// reads three different codes for one kind.
+#[test]
+fn one_error_kind_reports_one_code() {
+    use crate::error::ErrorKind;
+
+    let syntax = ErrorKind::SyntaxError {
+        message: "unbalanced".to_string(),
+        line: Some(1),
+    };
+    assert_eq!(LintCode::for_error_kind(&syntax), SYNTAX_ERROR);
+    assert_eq!(SYNTAX_ERROR.code, "E005");
+
+    // Every code the mapping can produce is a code the tables publish, so a
+    // consumer filtering by the documented index cannot miss one.
+    for kind in [
+        ErrorKind::SyntaxError {
+            message: String::new(),
+            line: None,
+        },
+        ErrorKind::UndefinedVariable {
+            name: String::new(),
+            suggestions: Vec::new(),
+        },
+        ErrorKind::DivisionByZero,
+    ] {
+        let code = LintCode::for_error_kind(&kind);
+        assert!(
+            ERRORS.contains(&code),
+            "{:?} maps to {}, which no table publishes",
+            kind,
+            code.code
+        );
+    }
 }

--- a/src/lsp/state.rs
+++ b/src/lsp/state.rs
@@ -146,10 +146,15 @@ impl CompilerState {
             Err(e) => {
                 // Analysis error - add as diagnostic
                 let location = extract_location_from_error(&e);
+                // `analyze_file` hands back a message, not an `ErrorKind`, so
+                // the classification is fixed here rather than looked up —
+                // but the code comes from the registry, so the LSP reports the
+                // same one the lint CLI and `compile/diagnostics` do.
+                let syntax_error = crate::lint::diagnostics::SYNTAX_ERROR;
                 doc.diagnostics.push(Diagnostic::new(
                     Severity::Error,
-                    "E0001",
-                    "syntax-error",
+                    syntax_error.code,
+                    syntax_error.rule,
                     e,
                     location,
                 ));

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -113,15 +113,15 @@ impl CompileCtx {
         // `init_stdlib` runs); seed it before `load_prelude`, whose macro
         // expansions evaluate transformer bodies via `eval_syntax`.
         expander.set_eval_meta(build_primitive_meta(&mut init_symbols));
-        crate::trace::phase(boot, "boot", "primitives-macrovm", t);
+        crate::phase!(boot, "boot", t, "primitives-macrovm");
         let t = std::time::Instant::now();
         compile_core(&mut vm, &mut init_symbols, &mut meta, &mut expander);
-        crate::trace::phase(boot, "boot", "core", t);
+        crate::phase!(boot, "boot", t, "core");
         let t = std::time::Instant::now();
         expander
             .load_prelude(&mut init_symbols, &mut vm)
             .expect("prelude loading must succeed");
-        crate::trace::phase(boot, "boot", "prelude", t);
+        crate::phase!(boot, "boot", t, "prelude");
         // `init_symbols` is a throwaway used only for this setup; `expand` pointed
         // the macro VM at it. Reset to null so the dropped table is never reached
         // — the next `expand` (a real compile) re-points the VM at the instance's

--- a/src/pipeline/compile.rs
+++ b/src/pipeline/compile.rs
@@ -294,7 +294,7 @@ fn compile_file_inner(
     let pc = crate::lir::intrinsics::PrimitiveClassification::new(cctx.primitive_meta());
     let region_info =
         crate::hir::analyze_regions_with(&hir, &arena, pc.call_classification.clone());
-    crate::trace::phase(ct, "compile", &format!("{} regions", source_name), t);
+    crate::phase!(ct, "compile", t, "{} regions", source_name);
     if crate::config::get().trace_bits() & crate::config::trace_bits::REGIONS != 0 {
         eprintln!(
             "[trace:regions] compile_file:\n{}",
@@ -309,14 +309,14 @@ fn compile_file_inner(
         .with_region_info(region_info);
 
     let lir_module = lowerer.lower(&hir)?;
-    crate::trace::phase(ct, "compile", &format!("{} lower", source_name), t);
+    crate::phase!(ct, "compile", t, "{} lower", source_name);
 
     // Emit bytecode
     let t = std::time::Instant::now();
     let signal = lir_module.entry.signal;
     let mut emitter = Emitter::new();
     let (mut bytecode, _, _) = emitter.emit_module(&lir_module);
-    crate::trace::phase(ct, "compile", &format!("{} emit", source_name), t);
+    crate::phase!(ct, "compile", t, "{} emit", source_name);
     bytecode.signal = signal;
     bytecode.signal_projection = signal_projection;
 

--- a/src/pipeline/compile/frontend.rs
+++ b/src/pipeline/compile/frontend.rs
@@ -52,11 +52,12 @@ pub(super) fn compile_file_frontend_xform(
     with_transient(cctx.heap_ptr(), || {
         let t = std::time::Instant::now();
         let syntaxes = read_syntax_all_for(source, source_name)?;
-        crate::trace::phase(
+        crate::phase!(
             crate::trace::compile(),
             "compile",
-            &format!("{} read", source_name),
             t,
+            "{} read",
+            source_name
         );
         crate::epoch::check_lexicon_agreement(&syntaxes, source, source_name)?;
         compile_syntaxes_frontend_xform_inner(syntaxes, symbols, cctx, source_name, xform)
@@ -122,7 +123,7 @@ fn compile_syntaxes_frontend_xform_inner(
             }
             Ok::<_, String>((expanded_forms, expander, meta))
         })?;
-    crate::trace::phase(ct, "compile", &format!("{} expand", source_name), t);
+    crate::phase!(ct, "compile", t, "{} expand", source_name);
     let t = std::time::Instant::now();
 
     // A fresh scope for any accumulator/temporaries `xform` injects, minted after
@@ -179,7 +180,7 @@ fn compile_syntaxes_frontend_xform_inner(
 
     let (dispatch_wrappers, fn_inline) = cctx.compile_registries_mut();
     crate::hir::regularize(&mut hir, &mut arena, symbols, dispatch_wrappers, fn_inline)?;
-    crate::trace::phase(ct, "compile", &format!("{} analyze", source_name), t);
+    crate::phase!(ct, "compile", t, "{} analyze", source_name);
 
     Ok((hir, arena, expander, prim_values, signal_projection))
 }

--- a/src/primitives/compile/query/analysis.rs
+++ b/src/primitives/compile/query/analysis.rs
@@ -82,14 +82,8 @@ pub(in crate::primitives::compile) fn prim_compile_analyze(
 
     // Convert accumulated analysis errors to diagnostics
     for err in &result.errors {
-        use crate::error::ErrorKind;
-        let (code, rule) = match &err.kind {
-            ErrorKind::UndefinedVariable { .. } => ("E001", "undefined-variable"),
-            ErrorKind::SignalMismatch { .. } => ("E002", "signal-mismatch"),
-            ErrorKind::UnterminatedForm { .. } => ("E003", "unterminated-form"),
-            ErrorKind::CompileError { .. } => ("E004", "compile-error"),
-            _ => ("E000", "analysis-error"),
-        };
+        let crate::lint::diagnostics::LintCode { code, rule } =
+            crate::lint::diagnostics::LintCode::for_error_kind(&err.kind);
         let loc = err
             .location
             .clone()

--- a/src/primitives/module_init.rs
+++ b/src/primitives/module_init.rs
@@ -39,24 +39,19 @@ pub fn init_stdlib(
     let (bytecode, source) =
         match crate::compiler::stdlib_cache::try_load(STDLIB, cache, vm, symbols, cctx) {
             Some(Ok(bc)) => {
-                crate::trace::phase(boot, "boot", "stdlib-compile (cache hit)", t);
+                crate::phase!(boot, "boot", t, "stdlib-compile (cache hit)");
                 (bc, StdlibSource::Cache)
             }
             absent_or_rejected => {
                 if let Some(Err(e)) = absent_or_rejected {
-                    crate::trace::phase(
-                        boot,
-                        "boot",
-                        &format!("stdlib-cache-rejected ({e}); recompiling"),
-                        t,
-                    );
+                    crate::phase!(boot, "boot", t, "stdlib-cache-rejected ({e}); recompiling");
                 }
                 let t = std::time::Instant::now();
                 let result = match compile_file(STDLIB, symbols, cctx, "<stdlib>") {
                     Ok(r) => r,
                     Err(e) => panic!("stdlib compilation failed: {}", e),
                 };
-                crate::trace::phase(boot, "boot", "stdlib-compile", t);
+                crate::phase!(boot, "boot", t, "stdlib-compile");
                 let t = std::time::Instant::now();
                 // Persist so the next process start skips the front end. A write
                 // failure is not fatal — the cache is a speedup, and a fresh
@@ -69,7 +64,7 @@ pub fn init_stdlib(
                     symbols,
                     cctx,
                 );
-                crate::trace::phase(boot, "boot", "stdlib-cache-store", t);
+                crate::phase!(boot, "boot", t, "stdlib-cache-store");
                 (result.bytecode, StdlibSource::Compiled)
             }
         };
@@ -79,7 +74,7 @@ pub fn init_stdlib(
         Ok(v) => v,
         Err(e) => panic!("stdlib execution failed: {}", e),
     };
-    crate::trace::phase(boot, "boot", "stdlib-execute", t);
+    crate::phase!(boot, "boot", t, "stdlib-execute");
     // Call the returned closure to get the exports struct.
     let exports_val = call_closure(vm, closure_val);
     register_exports(vm, symbols, cctx, closure_val, exports_val);
@@ -125,7 +120,7 @@ fn register_exports(
     // Extract exports from the struct and register them.
     let exports = extract_exports(exports_val, symbols);
     register_stdlib_exports(cctx, symbols, &exports);
-    crate::trace::phase(boot, "boot", "stdlib-exports", t);
+    crate::phase!(boot, "boot", t, "stdlib-exports");
     // Arm guardfree page-protection (no-op unless --trace=guardfree): from
     // here on, freed pages are mprotected so the first user-program
     // use-after-free faults at the exact dereference. Stdlib init has its

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -98,7 +98,7 @@ impl RuntimeCore {
         let mut symbols = Box::new(SymbolTable::new());
         let t = std::time::Instant::now();
         let meta = register_primitives(&mut vm, &mut symbols);
-        crate::trace::phase(crate::trace::boot(), "boot", "primitives", t);
+        crate::phase!(crate::trace::boot(), "boot", t, "primitives");
         // Point the VM at this instance's symbol table (stable boxed address),
         // so the runtime `eval` instruction, the meta/read/debug primitives, and
         // value name-resolution resolve in THIS instance's own table. Mirrors

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -43,13 +43,28 @@ pub(crate) fn compile() -> bool {
 }
 
 /// Print one phase-timing mark: `[trace:SUBSYSTEM] LABEL 12.3ms`.
-pub(crate) fn phase(enabled: bool, subsystem: &str, label: &str, start: std::time::Instant) {
-    if enabled {
-        eprintln!(
-            "[trace:{}] {} {:.1}ms",
-            subsystem,
-            label,
-            start.elapsed().as_secs_f64() * 1000.0
-        );
-    }
+///
+/// The label is a format string plus arguments, and it is formatted *inside*
+/// the `enabled` check — the shape [`etrace!`] uses next door. A function
+/// taking an already-formatted `&str` cannot do that: Rust evaluates arguments
+/// before the call, so every `format!` at a call site allocated a `String` on
+/// every compile phase whether or not `--trace=compile` was on.
+///
+/// `subsystem` must be a literal; it is concatenated into the format string.
+///
+/// Cost when tracing is off: one branch.
+#[macro_export]
+macro_rules! phase {
+    ($enabled:expr, $subsystem:literal, $start:expr, $($label:tt)*) => {
+        if $enabled {
+            eprintln!(
+                concat!("[trace:", $subsystem, "] {} {:.1}ms"),
+                format_args!($($label)*),
+                $start.elapsed().as_secs_f64() * 1000.0
+            );
+        }
+    };
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/trace/tests.rs
+++ b/src/trace/tests.rs
@@ -1,0 +1,41 @@
+//! Unit tests (`super` is the parent impl module).
+
+use std::cell::Cell;
+use std::fmt;
+
+/// A label whose formatting is observable, so a test can tell whether the
+/// macro reached it.
+struct Probe<'a>(&'a Cell<bool>);
+
+impl fmt::Display for Probe<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.set(true);
+        f.write_str("probe")
+    }
+}
+
+// The trap the macro exists for: Rust evaluates a call's arguments before the
+// call, so a `phase` taking an already-formatted `&str` builds its label
+// whether or not tracing is on — six `format!`s per file compiled, every
+// compile. A macro can put the formatting inside the branch; a function
+// cannot.
+//
+// The counter-factual: against the function form this test fails, because
+// `&format!("{}", Probe(&reached))` runs at the call site.
+#[test]
+fn a_disabled_phase_never_formats_its_label() {
+    let reached = Cell::new(false);
+    let start = std::time::Instant::now();
+    crate::phase!(false, "test", start, "{}", Probe(&reached));
+    assert!(!reached.get(), "a disabled phase formatted its label");
+}
+
+// The other half: the label must still reach the output when tracing is on, or
+// the branch above would be indistinguishable from a mark that never prints.
+#[test]
+fn an_enabled_phase_formats_its_label() {
+    let reached = Cell::new(false);
+    let start = std::time::Instant::now();
+    crate::phase!(true, "test", start, "{}", Probe(&reached));
+    assert!(reached.get(), "an enabled phase did not format its label");
+}

--- a/tests/integration/lsp.rs
+++ b/tests/integration/lsp.rs
@@ -194,7 +194,11 @@ fn test_lsp_syntax_error_diagnostic_location() {
     assert!(!diags.is_empty(), "should have at least one diagnostic");
 
     let d = &diags[0];
-    assert_eq!(d["code"], "E0001");
+    // The code comes from `diagnostics::SYNTAX_ERROR`, the same entry the lint
+    // CLI and `compile/diagnostics` read, so an editor and `elle lint` agree
+    // about one file. It used to be a hard-coded `E0001` here — four digits,
+    // matching neither surface nor the documented `E00x` shape.
+    assert_eq!(d["code"], "E005");
 
     // Verify no u32::MAX (4294967295) from underflow
     let start_line = d["range"]["start"]["line"].as_u64().unwrap();


### PR DESCRIPTION
lint,trace,docs: four small fixes, each with the gate that would have caught it

Closes #1030, #973, #971, #965. The `trivial` label reads "minor needs best
mingled", so they travel together.

## #1030 — the embedder doctest calls `init_stdlib` without its cache argument

`init_stdlib` gained a fourth parameter with the standard-library disk cache
(#908), and the doctest showing an embedder driving the VM by hand still
passed three. It failed to compile, and nothing noticed.

Nothing in the gates ran rustdoc doctests. `cargo doc` renders a doc example;
it does not compile one, and the suite's own `cargo test` invocations pass
`--lib` and `--test '*'`, both of which exclude doctests. So the example went
on rendering after the signature it calls had moved.

The doctest now passes `&StdlibCache::Process`, the choice `Runtime::new`
makes, and `cargo test --workspace --doc` is a step in `make qa` and in the
PR gate's QA job. The fix is the second part: without it this rots again the
next time a public signature moves.

## #973 — `trace::phase` formatted its label even when tracing was off

`phase` took an already-formatted `&str`. Rust evaluates arguments before the
call, so six `format!` sites allocated a `String` per file compiled whether or
not `--trace=compile` was on, and `phase` discarded them.

It is a macro now, formatting the label inside the `enabled` branch — the
shape `etrace!` next door already used. A function cannot do this; that is the
whole reason for the change. Output is byte-identical, and
`tests/integration/trace_boot.rs` still passes.

`a_disabled_phase_never_formats_its_label` pins it with a label whose `Display`
impl records that it ran. Checked against the old form before landing: it
fails there, because `&format!("{}", probe)` runs at the call site.

## #971 — three comments gave a signal-bits operand the wrong width

`Emit` was documented as `u16` and `CheckSignalBound` as `u32`, in
`instruction.rs` and again in `docs/impl/vm.md`. Both operands are eight
bytes: `emit_signal_bits` writes eight, `read_signal_bits` reads eight, the
disassembler skips eight. A `u16` operand could not name a user signal at all,
since `(signal :keyword)` allocates from bit 32 upward.

All three now cite `docs/impl/bytecode.md` § "Signal-bits operands" instead of
restating the encoding, so there is one place to be wrong.

## #965 — the same syntax error carried three different codes

The `ErrorKind` → code mapping had three homes and they disagreed. A syntax
error was `E005` from `elle lint`, `E000` from `compile/diagnostics` — whose
match had no `SyntaxError` arm and fell through — and `E0001` from the LSP, a
four-digit shape the documented `E00x` scheme does not have. A consumer that
filters or counts by code could not do it across surfaces.

`LintCode::for_error_kind` is the one home, beside the `WARNINGS` table that
already gave warning codes one. All three sites read it. The cookbook gains
the error table, and the test that holds the warning table and the cookbook in
step now covers both.

`one_error_kind_reports_one_code` pins the mapping and that every code it can
produce is one the tables publish. `tests/integration/lsp.rs` asserted the
`E0001` this removes; its expectation moves to `E005`.

Full `make test` green with the release corpus.
