### PR TITLE
io: every install that ends an io park releases the request's region

### DIFF
--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -346,15 +346,18 @@ parked fiber's accounting symmetric with its unpark:
   (`take_bodyless`) as the receipt. Both readings run at every install, and neither asks
   what the other did.
 
-  **What is resume-only is the SKIP, not the release.** A `Fresh` io op
-  (`port/read`, `accept`) builds its completion buffer IN the request's region and hands
-  that buffer back as the resume value, so at a resume that region is still live and the
-  resumer's release of the resume result is its second consumer — releasing there too
-  would free the buffer under the caller. `release_resumed_io_request` is that skip and
-  nothing else; every other install reaches the release directly. An injected error is
-  not a delivery — the abort's own `AbortDelivery` mint funds the consumer it does have —
-  so an error value that happens to live in the request's region owes this release all
-  the same, and the skip must not travel to the injection.
+  **A shared region exempts no install.** A `Fresh` io op (`port/read`, `accept`) mints
+  ONE region for the call and builds both the request and the completion buffer in it,
+  then hands that buffer back as the resume value — so the resume is the one install that
+  finds the region still live. It owes the release all the same. Two references stand on
+  such a region and they answer to different consumers: the `Fresh` mint, consumed by the
+  release of the value the suspend hands back (the request at the park, the buffer at the
+  resume), and the `SuspendEscape`, consumed here. A resume that stands down because the
+  resume value shares the region leaves the second with no consumer at all, and the region
+  survives with its buffer and its request — one region and two objects per read, which a
+  socket reader pays per frame. `tests/elle/region-io-read-strand.lisp` bounds the rate
+  and pins the other side: the release drops the retain, not the buffer, which its held
+  chunks read back after the reads that followed them.
 
   **An in-flight request needs no waiting on.** An abort reaches a fiber whose request
   the scheduler already submitted, where the release must not free a buffer the kernel

--- a/src/primitives/fibers.rs
+++ b/src/primitives/fibers.rs
@@ -163,7 +163,7 @@ pub(crate) fn prim_fiber_resume(
             // goes first because it is the one that READS the parked value to
             // decide, and the denial arm's release may have been the payload's
             // last (`release_displaced_denial_payload`).
-            crate::vm::fiber::release_resumed_io_request(ctx.heap_mut(), parked, resume_value);
+            crate::vm::fiber::release_displaced_io_request(ctx.heap_mut(), parked);
             crate::vm::fiber::release_displaced_denial_payload(ctx.heap_mut(), handle);
             // And a parked TERMINAL result this resume displaces (a restarted
             // `:error` fiber, a re-resumed drained stream source): its

--- a/src/vm/AGENTS.md
+++ b/src/vm/AGENTS.md
@@ -250,9 +250,9 @@ other did, which is what a fiber denied `:io` needs: it parks under the same
 `SIG_IO` bit, and the install may reach a fiber that only relays the park and
 holds no record to defer to. The installs are `fiber/resume`, the `fiber/abort` /
 `fiber/refuse` injection, and the three `FiberResume` deliveries that reach an
-inner fiber directly. Only the resume adds a skip of its own
-(`release_resumed_io_request`), for the `Fresh` op whose completion buffer lives
-in the request's region. See docs/impl/region/owner.md § "A payload the RUNTIME
+inner fiber directly, and each owes the release — a `Fresh` op whose completion
+buffer lives in the request's own region is a second value there, not a second
+consumer of the retain. See docs/impl/region/owner.md § "A payload the RUNTIME
 built is released by the install that displaces it".
 
 Key methods:

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -52,7 +52,7 @@ pub(crate) use owned::{kill_fiber, release_fiber_owned, release_parked_dues, tak
 use refcount::{incref_signal_region, release_discarded_signal};
 pub(crate) use refcount::{
     is_terminal_signal, release_displaced_denial_payload, release_displaced_io_request,
-    release_displaced_terminal_signal, release_resumed_io_request,
+    release_displaced_terminal_signal,
 };
 // Re-exported for the WASM resume path (`crate::vm::fiber::record_terminal_signal_park`),
 // the only external caller; `owned::kill_fiber` reaches it by module path. Unused

--- a/src/vm/fiber/propagate.rs
+++ b/src/vm/fiber/propagate.rs
@@ -23,7 +23,7 @@ impl VM {
     ///
     /// - A NON-TERMINAL signal (a yield, an io request). The fiber runs again,
     ///   so the resume path proper governs the payload —
-    ///   `release_resumed_io_request` for an io request, the resumed body's own
+    ///   `release_displaced_io_request` for an io request, the resumed body's own
     ///   pending release otherwise.
     ///   `with_child_fiber` step 6a excludes exactly this set from its park
     ///   retain for the same reason ("retaining here would leak"), and the

--- a/src/vm/fiber/refcount.rs
+++ b/src/vm/fiber/refcount.rs
@@ -159,13 +159,11 @@ pub(crate) fn release_displaced_terminal_signal(
 /// park no longer names what is in the slot, and an `(emit :fs v)` under the same
 /// withheld bits is a body-allocated payload this must never touch.
 ///
-/// No resume-value skip, unlike [`release_resumed_io_request`]: that skip answers
-/// for a `Fresh` io op building its completion buffer IN the request's region,
-/// and a denial payload is complete before the park. A resume value read back OUT
-/// of the payload shares its region and still owes this release — the child's
-/// continuation releases the denied call's RESULT, which the delivery's own
-/// `ResumeDelivery` mint funds. A no-op for a fiber with no record, a record that
-/// no longer names the parked signal, or an immediate payload.
+/// A resume value read back OUT of the payload shares its region and still owes
+/// this release — the child's continuation releases the denied call's RESULT,
+/// which the delivery's own `ResumeDelivery` mint funds. A no-op for a fiber with
+/// no record, a record that no longer names the parked signal, or an immediate
+/// payload.
 ///
 /// Runs beside [`release_displaced_io_request`], never in place of it: the two
 /// name disjoint payloads, this one whatever the record names and that one an
@@ -210,6 +208,18 @@ pub(crate) fn release_displaced_denial_payload(
 /// built is released by the install that displaces it"): the resume that
 /// delivers a completion, and the injected error `fiber/abort` / `fiber/refuse`
 /// raise at the fiber's own suspension point.
+///
+/// **Every install owes it, the resume included.** A `Fresh` io op
+/// (`port/read`, `accept`) mints ONE region for the call and builds both the
+/// request and the completion buffer in it, then hands that buffer back as the
+/// resume value — so the resume is the one install that finds the region still
+/// live. It owes the release all the same, because the two references answer to
+/// different consumers: the `Fresh` mint is consumed by the release of the value
+/// the suspend hands back, and the `SuspendEscape` is consumed here. Standing
+/// down on a resume value sharing the region leaves the second reference with no
+/// consumer at all, and the region survives with its buffer and its request —
+/// one per read. `tests/elle/region-io-read-strand.lisp` bounds the rate and
+/// pins that the buffer still outlives this release.
 ///
 /// **In flight is no reason to wait.** An abort reaches a fiber whose request
 /// the scheduler already submitted, and a `Fresh` op's completion buffer lives in
@@ -271,37 +281,6 @@ fn io_request_region(
         .as_external::<crate::io::request::IoRequest>()
         .is_some()
         .then_some(region)
-}
-
-/// [`release_displaced_io_request`] as the RESUME path takes it: the one install
-/// that hands a value back in place of the request, and so the one that can find
-/// the request's region still live.
-///
-/// The `Fresh` io ops (`port/read`/`accept`) build their completion buffer *in*
-/// the IoRequest's region and hand it back as `resume_value`. There the caller's
-/// `DecrefValueRegion` on the buffer balances the `SuspendEscape`, and a decref
-/// here would free the buffer out from under the caller. So a resume value
-/// sharing the request's region is the signature that the region is still live,
-/// and the release stands down.
-///
-/// The skip is a fact about a DELIVERY, which is why it lives here rather than in
-/// the release: an injected error is not one — the abort's own `AbortDelivery`
-/// mint funds the consumer it has — so an error value that happens to live in the
-/// request's region owes the release all the same. The gauges are `oracle.lisp`'s
-/// `io-yield ev/sleep` probe for this path and `tests/elle/region-io-park.lisp`
-/// per install.
-pub(crate) fn release_resumed_io_request(
-    heap: &mut crate::value::fiberheap::FiberHeap,
-    parked: Option<(SignalBits, Value)>,
-    resume_value: Value,
-) {
-    let Some(region) = io_request_region(heap, parked) else {
-        return;
-    };
-    if crate::value::arena::region_of(heap, resume_value) == Some(region) {
-        return;
-    }
-    crate::value::arena::decref_region(heap, Some(region));
 }
 
 #[cfg(test)]

--- a/src/vm/fiber/refcount/tests.rs
+++ b/src/vm/fiber/refcount/tests.rs
@@ -18,12 +18,6 @@ fn payload(
     alloc_in_fresh_region(heap, cons())
 }
 
-/// A resume value on a region of its own — what a mediating parent hands back,
-/// which never shares the denial payload's region.
-fn foreign(heap: &mut crate::value::fiberheap::FiberHeap) -> Value {
-    alloc_in_fresh_region(heap, cons()).0
-}
-
 /// An `IoRequest` on a region of its own — the payload a yielding io op parks,
 /// and the one thing the io arm answers for. A `Sleep` because it is the portless
 /// op: nothing else in the request has to be built for the type to be right.
@@ -244,67 +238,35 @@ fn a_non_io_park_is_answered_without_dereferencing_its_payload() {
     release_displaced_io_request(&mut heap, Some((SIG_YIELD, p)));
 }
 
-// -- release_resumed_io_request: the same arm, plus the delivery's skip --
+// -- the shared region exempts no install --
 
-/// The resume adds a shared-region skip: a `Fresh` io op builds its completion
-/// buffer in the request's own region and hands it back as the resume value, so
-/// that region is still live and the caller's release answers for it.
+/// A `Fresh` io op (`port/read`, `accept`) builds its completion buffer in the
+/// request's OWN region and hands that buffer back as the resume value. A second
+/// value on the region is not a second consumer of the suspend retain: the
+/// buffer's holders release what they took, and this arm is the retain's only
+/// consumer. An install that stands down on the shared region leaves the retain
+/// standing for good — the region survives with its buffer and its request, once
+/// per read (`tests/elle/region-io-read-strand.lisp` bounds the rate).
+///
+/// The second reference below stands for the resume value's own holder, which is
+/// what makes the release safe: it drops the retain, not the buffer.
 #[test]
-fn an_io_park_whose_resume_value_shares_its_region_releases_nothing() {
+fn an_io_park_is_released_though_its_resume_value_shares_its_region() {
     let mut heap = crate::value::fiberheap::FiberHeap::new();
     let (request, rid) = io_request(&mut heap);
-    let completion = heap.alloc_in_region(cons(), rid);
+    let _completion = heap.alloc_in_region(cons(), rid);
+    crate::value::arena::incref_region(&mut heap, Some(rid));
     let before = region_rc(&heap, rid);
 
-    release_resumed_io_request(&mut heap, Some((SIG_IO, request)), completion);
-
-    assert_eq!(
-        region_rc(&heap, rid),
-        before,
-        "the completion buffer built in the request's region keeps it live",
-    );
-}
-
-/// …and releases when the resume value comes from elsewhere, which is the io
-/// request's own orphaned escape retain.
-#[test]
-fn an_io_park_whose_resume_value_is_foreign_is_released() {
-    let mut heap = crate::value::fiberheap::FiberHeap::new();
-    let (request, rid) = io_request(&mut heap);
-    let completion = foreign(&mut heap);
-    let before = region_rc(&heap, rid);
-
-    release_resumed_io_request(&mut heap, Some((SIG_IO, request)), completion);
-
-    assert_eq!(
-        region_rc(&heap, rid),
-        before - 1,
-        "a submitted io request is dead at the resume — its region owes one decref",
-    );
-}
-
-/// The skip belongs to the DELIVERY, not to the io park: an injected error that
-/// happens to live in the request's region is not a resume value, so the
-/// injection's release stands. Sharing a region is what the resume reads as
-/// "still live"; here it means nothing.
-#[test]
-fn a_displaced_io_request_takes_no_skip_from_a_payload_sharing_its_region() {
-    let mut heap = crate::value::fiberheap::FiberHeap::new();
-    let (request, rid) = io_request(&mut heap);
-    let error_value = heap.alloc_in_region(cons(), rid);
-    let before = region_rc(&heap, rid);
-
-    release_resumed_io_request(&mut heap, Some((SIG_IO, request)), error_value);
-    let after_resume_reading = region_rc(&heap, rid);
     release_displaced_io_request(&mut heap, Some((SIG_IO, request)));
 
     assert_eq!(
-        after_resume_reading, before,
-        "the resume reading skips on a shared region — which is why it must not travel",
-    );
-    assert_eq!(
         region_rc(&heap, rid),
         before - 1,
-        "an injected error sharing the request's region still owes the release",
+        "a resume value sharing the request's region still owes the suspend retain",
+    );
+    assert!(
+        region_rc(&heap, rid) > 0,
+        "the release drops the suspend retain, not the buffer the resume hands back",
     );
 }

--- a/tests/elle/h2-stress-scoped.lisp
+++ b/tests/elle/h2-stress-scoped.lisp
@@ -63,8 +63,8 @@
 # delta must fit under. Shrink-only — see "The pins" above.
 (def residue-small 10)
 (def residue-large 30)
-(def max-objects-per-request 83)
-(def max-regions-per-request 61)
+(def max-objects-per-request 51)
+(def max-regions-per-request 45)
 
 # ── Helpers ──────────────────────────────────────────────────────────
 

--- a/tests/elle/region-io-read-strand.lisp
+++ b/tests/elle/region-io-read-strand.lisp
@@ -1,0 +1,113 @@
+(elle/epoch 12)
+# Counterfactual for the strand a `Fresh` io op leaves on its own region.
+#
+# `port/read` and its siblings declare `RegionEffect::Fresh` and mint ONE
+# region per call, holding both the IoRequest the native returns and the read
+# buffer the completion fills in place. Two references stand on that region and
+# they answer to different consumers:
+#
+#   - the `Fresh` mint, consumed by the release of the value the suspend hands
+#     back — the request at the park, the buffer at the resume;
+#   - the `SuspendEscape` retain the park takes so the scheduler can read the
+#     request out of `fiber.signal`, which the install that displaces the park
+#     owes (docs/impl/region/owner.md § "A payload the RUNTIME built is
+#     released by the install that displaces it").
+#
+# An install that releases only the first leaves the second standing, and the
+# region survives with its buffer and its request — one region and two objects
+# per read, so unbounded in any program that reads in a loop. A socket reader
+# pays it per frame, which is what makes it a server's leak rather than a
+# script's.
+
+(def reads 400)
+
+# ── Leak bound: a sized read strands no region ────────────────────────
+# The gauge is sampled by the program around a fixed window of reads on one
+# open port. The port is rewound by re-opening rather than by seeking, so the
+# window measures the reads alone.
+(defn read-region-churn [p n]
+  (def before (arena/region-count))
+  (def @i 0)
+  (while (%lt i n)
+    (port/read p 4)
+    (assign i (%add i 1)))
+  (%sub (arena/region-count) before))
+
+(defn read-object-churn [p n]
+  (def before (arena/count))
+  (def @i 0)
+  (while (%lt i n)
+    (port/read p 4)
+    (assign i (%add i 1)))
+  (%sub (arena/count) before))
+
+(defn make-payload [n]
+  (let [@parts @[]]
+    (def @i 0)
+    (while (%lt i n)
+      (push parts "abcd")
+      (assign i (%add i 1)))
+    (apply concat (freeze parts))))
+
+(with-temp-dir tmp
+               (let [path (string tmp "/reads.bin")]
+                 (file/write path (make-payload (* reads 4)))
+                 (let [p (port/open path :read)]
+                   (let [d (read-region-churn p reads)]
+                     (assert (%lt d 40)
+                             (string "io request region strand: " reads
+                                     " file reads grew the region count by " d
+                                     " (must stay bounded — Rule 8)")))
+                   (port/close p))
+                 (let [p (port/open path :read)]
+                   (let [d (read-object-churn p reads)]
+                     (assert (%lt d 40)
+                             (string "io request object strand: " reads
+                                     " file reads grew the live count by " d
+                                     " (must stay bounded — Rule 8)")))
+                   (port/close p))))
+
+# ── The same bound on a socket, the shape a server loop runs ──────────
+# A loopback pair is read one 4-byte chunk at a time, so the window counts
+# reads and not bytes. The writer sends the whole payload up front: a socket
+# whose peer writes per read would measure the write path too.
+(let* [listener (tcp/listen "127.0.0.1" 0)
+       lpath (port/path listener)
+       lport (parse-int (slice lpath (+ 1 (string/find lpath ":"))))
+       af (ev/spawn (fn [] (tcp/accept listener)))
+       cli (tcp/connect "127.0.0.1" lport)
+       srv (ev/join af)]
+  (port/write cli (bytes (make-payload (* reads 4))))
+  (let [d (read-region-churn srv reads)]
+    (assert (%lt d 40)
+            (string "io request region strand: " reads
+                    " socket reads grew the region count by " d
+                    " (must stay bounded — Rule 8)")))
+  (port/close cli)
+  (port/close srv)
+  (port/close listener))
+
+# ── Correctness: the buffer outlives the install that ends the park ───
+# The counter-factual for the bound above going too far. The install releases
+# the suspend retain, not the buffer: the `Fresh` mint is a separate reference
+# and the resume value's own holders are separate again. Every chunk read below
+# is held past the reads that follow it, so a release that took one reference
+# too many frees a chunk under this array and the comparison reads garbage.
+(with-temp-dir tmp
+               (let [path (string tmp "/held.bin")]
+                 (file/write path "0123456789abcdefghij")
+                 (let [p (port/open path :read)
+                       @chunks @[]]
+                   (def @i 0)
+                   (while (%lt i 5)
+                     (push chunks (port/read p 4))
+                     (assign i (%add i 1)))
+                   (port/close p)
+                   (assert (= (get chunks 0) "0123")
+                           (string "first chunk survived four later reads: "
+                                   (get chunks 0)))
+                   (assert (= (get chunks 4) "ghij")
+                           (string "last chunk read back: " (get chunks 4)))
+                   (assert (= (apply concat (freeze chunks))
+                              "0123456789abcdefghij")
+                           "every held chunk survived the reads that followed it"))))

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -1957,6 +1957,19 @@ fn region_io_completion_leak_guardfree() {
     );
 }
 
+// Guard — a `Fresh` io op builds its completion buffer in the request's own
+// region, and the install that ends the park releases the suspend retain there
+// like any other. The buffer the resume hands back must survive that release:
+// under the UAF oracle a release that took one reference too many faults at the
+// read of a held chunk instead of returning it.
+#[test]
+fn region_io_read_strand_guardfree() {
+    run_elle_script_with_args(
+        "region-io-read-strand",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // =============================================================================
 // I/O backend selection (`--no-uring`)
 // =============================================================================


### PR DESCRIPTION
## What was wrong

A `Fresh` io op — `port/read`, `port/read-exact`, `port/read-line`, `accept` —
mints ONE region for the call and builds both the `IoRequest` and the read
buffer in it. Two references stand on that region and they answer to different
consumers:

- the `Fresh` mint, consumed by the release of the value the suspend hands back
  (the request at the park, the buffer at the resume);
- the `SuspendEscape` retain the park takes so the scheduler can read the
  request out of `fiber.signal`, consumed by the install that displaces the
  park.

`release_resumed_io_request` stood down on the second whenever the resume value
shared the request's region — which is exactly the `Fresh` case — on the reading
that the caller's release answered for it. The caller's release answers for the
mint. Nothing consumed the suspend retain, so the region survived at rc=1 with
its buffer and its request, once per read.

## How it was measured

`arena/count` and `arena/region-count` sampled by the program around a fixed
window of reads on one open port:

| drive | objects/read | regions/read |
|---|---:|---:|
| 400 file reads, before | 2 | 1 |
| 400 socket reads, before | 2 | 1 |
| both, after | 0 | 0 |

The same rate on a file port and a socket port, under io_uring and `--no-uring`,
under `--jit=off` and `--jit=eager`. A socket reader pays it per frame, which is
what makes it a server's leak: an h2 request over a live session went from 83
objects and 61 regions to 51 and 45 (#1036).

## The change

The resume takes the same release as every other install; `prim_fiber_resume`
calls `release_displaced_io_request` and the skip is gone. The buffer still
outlives the release: at the resume the region carries the completion struct's
recorded edge and the resume value's own holder, so the release drops the
retain and no more.

## Tests

- `tests/elle/region-io-read-strand.lisp` — bounds the per-read rate on a file
  port and a socket port on both gauges, and pins the other side: five chunks
  held across the reads that followed them read back whole. Registered under
  `--trace=guardfree` in the integration harness, where a release that took one
  reference too many faults at the held chunk's read.
- `tests/elle/h2-stress-scoped.lisp` — the per-request residue now has a
  shrink-only ceiling (51 objects, 45 regions), measured at two request counts
  behind a gauge-live gate that runs first.
- `runtime::…::an_io_park_is_released_though_its_resume_value_shares_its_region`
  replaces the three unit tests that pinned the skip.

`cargo test -p elle --lib` (2426 pass), `make smoke-elle`, and `make qa` are
green.