### PR TITLE
ci: the plugins job compiles every plugin, not the portable list

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -248,10 +248,17 @@ jobs:
   # Checking out at the recorded pointer is also what keeps the pointer fresh: a
   # pointer left behind an ABI change names plugins that no longer compile.
   #
-  # `make plugins` builds; `make smoke-plugins` asserts every artifact and then
-  # runs the corpus. Without the assertion the corpus reports success over a
-  # plugin that never built — see docs/analysis/ci.md § "Why the job asserts its
-  # build output".
+  # `make plugins-all` builds, and it is `plugins-all` rather than `plugins`
+  # because the break above is a compile error: five plugins sit outside the
+  # `PORTABLE` list, and a job that skipped them would leave the hole open for
+  # them. They need nothing extra on this runner — each opens its system library
+  # with dlopen rather than the linker. See docs/analysis/ci.md § "Why the job
+  # builds every plugin, not the portable set".
+  #
+  # `make smoke-plugins` then asserts every portable artifact and runs the
+  # corpus. Without the assertion the corpus reports success over a plugin that
+  # never built — see docs/analysis/ci.md § "Why the job asserts its build
+  # output".
   plugins:
     name: Plugin Tests
     needs: changes
@@ -292,8 +299,8 @@ jobs:
           echo "LIBCLANG_PATH=$(dirname "$lib")" >> "$GITHUB_ENV"
       - name: make elle
         run: make elle
-      - name: make plugins
-        run: make plugins
+      - name: make plugins-all
+        run: make plugins-all
       - name: make smoke-plugins
         run: make smoke-plugins
 

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ MCP_PATCH := --config 'patch."https://github.com/elle-lisp/elle".elle-plugin.pat
 plugins:  ## Build all portable plugins (from plugins submodule)
 	$(MAKE) -C plugins portable
 
-plugins-all:  ## Build all plugins including system-dep ones (vulkan, egui, etc.)
+plugins-all:  ## Build every plugin in the submodule's workspace
 	$(MAKE) -C plugins all
 
 mcp: elle  ## Build elle + MCP plugins (oxigraph, syn)

--- a/docs/analysis/ci.md
+++ b/docs/analysis/ci.md
@@ -104,11 +104,32 @@ a plugin loads, so it catches a stale `.so` built against an older SDK. A
 source break never reaches a load. Only a job that compiles the submodule sees
 one.
 
-So `Plugin Tests` checks the submodule out at its recorded pointer, builds the
-portable plugins, asserts the artifacts, and runs `plugins/tests/*.lisp`
-against the release binary. Building at the recorded pointer is also what keeps
-the pointer fresh: a pointer left behind an ABI change names plugins that no
-longer compile, and the job fails on them.
+So `Plugin Tests` checks the submodule out at its recorded pointer, builds
+every plugin in the workspace, asserts the portable artifacts, and runs
+`plugins/tests/*.lisp` against the release binary. Building at the recorded
+pointer is also what keeps the pointer fresh: a pointer left behind an ABI
+change names plugins that no longer compile, and the job fails on them.
+
+#### Why the job builds every plugin, not the portable set
+
+`make plugins` builds the packages in `plugins/Makefile`'s `PORTABLE` list.
+Five plugins sit outside that list — `elle-arrow`, `elle-polars`,
+`elle-vulkan`, `elle-egui` and `elle-wayland` — so a job that stopped at `make
+plugins` left the hole above open for them. The break this job exists to catch
+is a compile error, so compiling every plugin is the whole gate. The job runs
+`make plugins-all`, which builds the workspace.
+
+The five cost nothing extra on the runner. Each reaches its system library
+through `dlopen` rather than through the linker: `ash` is taken with the
+`loaded` feature, and `wayland-client`, `winit` and `glutin` open theirs at run
+time. `ldd` over the five artifacts names nothing outside libc, and the five
+build from a cold target directory with `PKG_CONFIG` pointed at a program that
+always fails. The install list below is therefore the same list `make plugins`
+needed.
+
+`PORTABLE` still decides what the artifact assertion demands and what the
+corpus can rely on. It is a statement about what is safe to **run** on a
+headless runner, not about what compiles.
 
 #### What the runner has to install
 
@@ -154,12 +175,18 @@ the artifacts asserted, the self-gating is harmless — the tests never have to 
 the thing that detects a missing plugin. `make smoke-plugins` runs the
 assertion before the corpus for the same reason.
 
-The assertion names the portable set, not every plugin. `elle-polars` does not
-build on the current toolchain: its `ethnum` dependency fails a
-`mem::transmute` size check under this rustc, unrelated to elle. `elle-arrow`
-carries heavy optional dependencies, and `elle-vulkan`, `elle-egui` and
-`elle-wayland` need a GPU or a display to exercise. The tests for those plugins
-gate themselves out of the run.
+The assertion names the portable set, not every plugin, because the two lists
+answer different questions. Compiling is what the job builds all of them for.
+Asserting an artifact matters where a corpus file would otherwise report
+success over a plugin that never built, and `elle-vulkan`, `elle-egui` and
+`elle-wayland` need a GPU or a display before they can do anything a corpus
+file could assert.
+
+That leaves one thing for a test to hold. `make plugins-all` compiles the
+members of `plugins/Cargo.toml`'s workspace, so a plugin directory missing from
+that list is compiled by nothing and asserted by nothing, and the job stays
+green over it. `tests/integration/plugins.rs` pins every plugin directory to a
+workspace member.
 
 ### Adding a job
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -59,10 +59,17 @@ git submodule update --init plugins
 Then build from the elle repo root:
 
 ```bash
-make plugins          # portable plugins (no system deps)
-make plugins-all      # all plugins (requires vulkan, wayland, egui libs)
+make plugins          # portable plugins
+make plugins-all      # every plugin in the workspace
 make mcp              # just oxigraph + syn (for the MCP server)
 ```
+
+`make plugins` builds the `PORTABLE` list in `plugins/Makefile`.
+`make plugins-all` adds `elle-arrow`, `elle-polars`, `elle-vulkan`,
+`elle-egui` and `elle-wayland`. All five compile on a stock toolchain — each
+opens its system library with dlopen — but the last three need a GPU or a
+display before they can do anything. That is what keeps them out of the
+portable list; docs/analysis/ci.md § "The plugins job" owns the split.
 
 Or build individual plugins:
 

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -106,8 +106,8 @@ Tests are organized by feature area in separate files:
 | `elle_scripts.rs` | Process-global runtime-mode pins (guardfree/no-uring/mlir-off); the corpus itself runs via `elle test` |
 | `paths.rs` | The paths and URLs the Makefile and the doc generator name in text, checked against the tree |
 | `bytecode_doc.rs` | The instruction names and source paths the bytecode documents spell, checked against the `Instruction` enum |
-| `workflows.rs` | The PR workflow's merge gate: every job needed and enforced by `all-checks`, a job that builds the `plugins/` submodule, no job serializing the corpus and the Rust suite, no shared cache key |
-| `plugins.rs` | The plugin artifacts the Makefile demands, checked against the submodule's crates, and the assertion that fails when one is missing |
+| `workflows.rs` | The PR workflow's merge gate: every job needed and enforced by `all-checks`, a job that builds every plugin in the `plugins/` submodule, no job serializing the corpus and the Rust suite, no shared cache key |
+| `plugins.rs` | Every plugin directory checked against the submodule workspace's `members`, the plugin artifacts the Makefile demands checked against the submodule's crates, and the assertion that fails when one is missing |
 | `budget.rs` | The wall-clock budget the Makefile's per-file corpus passes give one file |
 | `doctest.rs` | The plugins the literate documents load, checked against what the Makefile's `doctest` target builds |
 | `environment.rs` | Environment variables |

--- a/tests/integration/plugins.rs
+++ b/tests/integration/plugins.rs
@@ -8,9 +8,10 @@
 // every gate stayed green (#1023). The argument, and why the ABI version guard
 // cannot stand in for the job, are in docs/analysis/ci.md § "The plugins job".
 //
-// These tests cover the two halves the job cannot check for itself: that the
-// list of artifacts it demands still describes the submodule, and that the
-// demand actually fails when an artifact is absent.
+// These tests cover the halves the job cannot check for itself: that every
+// plugin is inside the workspace the job compiles, that the list of artifacts
+// it demands still describes the submodule, and that the demand actually fails
+// when an artifact is absent.
 
 use std::fs;
 use std::path::PathBuf;
@@ -37,10 +38,10 @@ fn run_make(target: &str, overrides: &[&str]) -> (bool, String) {
     (out.status.success(), text)
 }
 
-/// The plugins the assertion must not demand: `elle-polars` fails to build on
-/// the current toolchain, `elle-arrow` carries heavy optional dependencies, and
-/// the last three need a GPU or a display. docs/analysis/ci.md § "The plugins
-/// job" owns the reasons.
+/// The plugins the artifact assertion must not demand. `make plugins-all`
+/// compiles them and `make plugins` does not build them, so a `plugins-verify`
+/// that named them would fail every portable build.
+/// docs/analysis/ci.md § "The plugins job" owns the split.
 const NOT_PORTABLE: &[&str] = &["polars", "arrow", "vulkan", "egui", "wayland"];
 
 /// The package name a plugin directory declares, or `None` when the directory
@@ -49,6 +50,92 @@ fn package_name(dir: &str) -> Option<String> {
     let text = fs::read_to_string(repo_root().join("plugins").join(dir).join("Cargo.toml")).ok()?;
     let line = text.lines().find(|l| l.trim_start().starts_with("name = "))?;
     Some(line.split('"').nth(1)?.to_string())
+}
+
+/// The directories under `plugins/` that hold a crate.
+fn plugin_directories() -> Vec<String> {
+    let root = repo_root().join("plugins");
+    let mut dirs: Vec<String> = fs::read_dir(&root)
+        .unwrap_or_else(|e| panic!("read {}: {e}", root.display()))
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|dir| root.join(dir).join("Cargo.toml").is_file())
+        .collect();
+    dirs.sort();
+    dirs
+}
+
+/// The `members` list of `plugins/Cargo.toml`'s `[workspace]` table.
+fn workspace_members() -> Vec<String> {
+    let path = repo_root().join("plugins/Cargo.toml");
+    let text = fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let (_, rest) = text
+        .split_once("members = [")
+        .unwrap_or_else(|| panic!("{} declares no `members` list", path.display()));
+    let (inner, _) = rest
+        .split_once(']')
+        .unwrap_or_else(|| panic!("{}'s `members` list does not close", path.display()));
+    // The list is one quoted directory name per line, so the odd fields of a
+    // split on the quote character are the names.
+    inner
+        .split('"')
+        .skip(1)
+        .step_by(2)
+        .map(str::to_string)
+        .collect()
+}
+
+// The job compiles the workspace, and `plugins/Cargo.toml` decides what that
+// is. A plugin directory the `members` list does not name is compiled by
+// nothing: `cargo build` over the workspace never descends into it, the
+// artifact assertion cannot demand a `.so` that no target produces, and the
+// corpus file for it exits 0 on the import it could not resolve. Three gates
+// agree, and none of them looked.
+//
+// The trap: cargo reports an unlisted directory only when a build STARTS
+// inside it ("current package believes it's in a workspace when it's not"), and
+// CI never starts a build there. From the workspace root the directory is
+// invisible, not an error.
+//
+// The counter-factual: drop `csv` from `members`, and `make plugins-all`,
+// `make plugins-verify` and the plugin corpus all stay green over a plugin
+// that no longer compiles at all.
+#[test]
+fn every_plugin_directory_is_a_workspace_member() {
+    if !repo_root().join("plugins/Cargo.toml").exists() {
+        eprintln!("SKIPPED: the `plugins/` submodule is not checked out");
+        return;
+    }
+
+    let members = workspace_members();
+    // A parse that returned nothing would assert nothing. The workspace has
+    // held around twenty-five crates since the submodule was split out.
+    assert!(
+        members.len() > 10,
+        "plugins/Cargo.toml names only {members:?} as workspace members; the \
+         parse of the `members` list is broken, not the manifest"
+    );
+
+    let unlisted: Vec<String> = plugin_directories()
+        .into_iter()
+        .filter(|dir| !members.contains(dir))
+        .collect();
+    assert!(
+        unlisted.is_empty(),
+        "these plugin directories hold a crate that plugins/Cargo.toml's \
+         `members` list does not name, so `make plugins-all` never compiles \
+         them and an ABI break in them reaches no gate: {unlisted:?}"
+    );
+
+    let empty: Vec<&String> = members
+        .iter()
+        .filter(|dir| package_name(dir).is_none())
+        .collect();
+    assert!(
+        empty.is_empty(),
+        "plugins/Cargo.toml names these members, which declare no package: \
+         {empty:?}"
+    );
 }
 
 // The artifact list is derived, not written down: the Makefile reads `PORTABLE`

--- a/tests/integration/workflows.rs
+++ b/tests/integration/workflows.rs
@@ -211,19 +211,26 @@ fn no_job_serializes_the_corpus_and_the_rust_suite() {
 // The counter-factual: this is the state main was in. Delete the job, or leave
 // it building a `plugins/` it never checked out, and an ABI change breaks every
 // plugin with nothing going red.
+//
+// The target matters as much as the job. `make plugins` builds `PORTABLE`,
+// which is five plugins short of the workspace, so it reproduces the same
+// silence for `elle-arrow`, `elle-polars`, `elle-vulkan`, `elle-egui` and
+// `elle-wayland`. The trap: `make plugins-all` carries `make plugins` as a
+// prefix, so a search for the shorter string accepts either target and lets
+// that substitution through.
 #[test]
-fn a_job_builds_the_plugins_submodule() {
+fn a_job_builds_every_plugin_in_the_submodule() {
     let text = workflow_text();
 
     let building: Vec<(String, String)> = jobs(&text)
         .into_iter()
-        .filter(|(_, body)| body.contains("make plugins") && body.contains("make smoke-plugins"))
+        .filter(|(_, body)| body.contains("make plugins-all") && body.contains("make smoke-plugins"))
         .collect();
     assert!(
         !building.is_empty(),
-        "no job in {} runs both `make plugins` and `make smoke-plugins`, so \
-         nothing in CI compiles the `plugins/` workspace against this tree's \
-         `elle-plugin`",
+        "no job in {} runs both `make plugins-all` and `make smoke-plugins`, so \
+         nothing in CI compiles the whole `plugins/` workspace against this \
+         tree's `elle-plugin`",
         workflow_path().display()
     );
 


### PR DESCRIPTION
## What was wrong

`Plugin Tests` ran `make plugins`, which builds `plugins/Makefile`'s `PORTABLE`
list. Five plugins sit outside that list — `elle-arrow`, `elle-polars`,
`elle-vulkan`, `elle-egui` and `elle-wayland` — so for those five the job still
had the hole it was created to close in #1023: an `elle_api!` change breaks
their call sites and nothing goes red. The break is a compile error, so a job
that does not compile them cannot see it.

`docs/analysis/ci.md` and `tests/integration/plugins.rs` recorded one exclusion
as a toolchain failure: "`elle-polars` does not build on the current toolchain:
its `ethnum` dependency fails a `mem::transmute` size check under this rustc".
That described a resolve of `ethnum` 1.5.2 against a rustc where
`core::num::TryFromIntError` is no longer zero-sized. `ethnum` 1.5.3 fixes it,
`plugins/Cargo.lock` is not committed, and a fresh resolve takes the fix. The
sentence outlived what it described, in both copies.

## What the change does

The job runs `make plugins-all`, which builds the submodule's workspace.

`make smoke-plugins` is unchanged. It still asserts the artifacts `PORTABLE`
names and runs the corpus over them, because `PORTABLE` decides what is safe to
**run** on a headless runner, not what compiles. `elle-vulkan`, `elle-egui` and
`elle-wayland` need a GPU or a display before they can do anything a corpus
file could assert.

One consequence for the runner: the job's build set gains the arrow, polars and
egui dependency trees, so its cold build and its `plugins` cache entry both
grow.

## How it was measured

- `make plugins-all` followed by `make smoke-plugins ELLE=./target/release/elle
  CARGO_PROFILE=--release`: 20 portable artifacts asserted, corpus green.
  `plugins/tests/arrow.lisp` now runs its assertions instead of taking the
  `SKIP` branch it took when the plugin was never built.
- `make test ELLE=./target/release/elle CARGO_PROFILE=--release`: green.
- The five need no new package on the runner. `ldd` over the five artifacts
  names nothing outside libc, and all five build from a cold target directory
  with `PKG_CONFIG` set to a program that always fails — the class of failure an
  apt `-dev` package answers.

## Tests

- `workflows.rs::a_job_builds_every_plugin_in_the_submodule` matches `make
  plugins-all`. `make plugins-all` carries `make plugins` as a prefix, so a
  search for the shorter string accepts either target; the test fails against
  the workflow as it stood before this change.
- `plugins.rs::every_plugin_directory_is_a_workspace_member` pins every plugin
  directory to `plugins/Cargo.toml`'s `members`. `make plugins-all` compiles
  the members, so a plugin directory outside that list is compiled by nothing
  and asserted by nothing. Verified by dropping `csv` from `members`: the test
  fails, and `cargo build --release --workspace` over the submodule stays
  silent — cargo objects to an unlisted directory only when a build starts
  inside it.
