### PR TITLE
vm,jit,wasm: a message that shows a value spells the names it carries

### DIFF
--- a/src/jit/calls/callops.rs
+++ b/src/jit/calls/callops.rs
@@ -274,7 +274,7 @@ pub extern "C" fn elle_jit_call(
             }
         }
     } else {
-        vm.set_error("type-error", format!("Cannot call {:?}", func));
+        vm.set_error("type-error", format!("Cannot call {}", vm.show_value(func)));
         JitValue::nil()
     }
 }

--- a/src/jit/calls/callops/arraycall.rs
+++ b/src/jit/calls/callops/arraycall.rs
@@ -411,7 +411,7 @@ fn jit_tail_call_inner(
         }
     }
 
-    vm.set_error("type-error", format!("Cannot call {:?}", func));
+    vm.set_error("type-error", format!("Cannot call {}", vm.show_value(func)));
     JitValue::nil()
 }
 

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -453,11 +453,12 @@ impl Ord for TableKey {
 }
 
 /// Render a `TableKey` — the shared body for `Display` (`debug == false`) and
-/// `Debug` (`debug == true`). A symbol key's name comes from the process-global
-/// registry (docs/impl/symbol.md), so nothing is threaded. The two modes diverge
-/// only in the symbol arm (Display prints the raw `SymbolId`; Debug prints the
-/// quoted name) and in the nested recursion of array/heap keys, which follows the
-/// outer mode.
+/// `Debug` (`debug == true`). A symbol or keyword key is a name hash, so its
+/// spelling comes from the threaded `symbols` memo; without one it renders
+/// unresolved (docs/impl/symbol.md § "Reading a name, and not reading one"). The
+/// two modes diverge only in the symbol arm (Display prints the raw `SymbolId`;
+/// Debug prints the quoted name) and in the nested recursion of array/heap keys,
+/// which follows the outer mode.
 pub(crate) fn fmt_table_key(
     key: &TableKey,
     symbols: Option<&crate::symbol::SymbolTable>,

--- a/src/vm/call/inner.rs
+++ b/src/vm/call/inner.rs
@@ -501,14 +501,10 @@ impl VM {
         }
 
         // Cannot call this value
-        eprintln!(
-            "[DEBUG] Cannot call: tag={:#x} payload={:#x} type={} on_fiber_heap={}",
-            func.tag,
-            func.payload,
-            func.type_name(),
-            self.heap().value_in_region_store(func)
+        self.set_error(
+            "type-error",
+            format!("Cannot call {}", self.show_value(func)),
         );
-        self.set_error("type-error", format!("Cannot call {:?}", func));
         self.fiber.stack.push(Value::NIL);
         None
     }

--- a/src/vm/call/inner/tail.rs
+++ b/src/vm/call/inner/tail.rs
@@ -407,14 +407,10 @@ impl VM {
         }
 
         // Cannot call this value
-        eprintln!(
-            "[DEBUG tailcall] Cannot call: tag={:#x} payload={:#x} type={} on_fiber_heap={}",
-            func.tag,
-            func.payload,
-            func.type_name(),
-            self.heap().value_in_region_store(func)
+        self.set_error(
+            "type-error",
+            format!("Cannot call {}", self.show_value(func)),
         );
-        self.set_error("type-error", format!("Cannot call {:?}", func));
         Some(SIG_ERROR)
     }
 }

--- a/src/vm/core/format.rs
+++ b/src/vm/core/format.rs
@@ -1,6 +1,18 @@
 use super::*;
 
 impl VM {
+    /// The spelling of `value` for a message the author reads.
+    ///
+    /// Every such message goes through here. A symbol or keyword IS its name
+    /// hash, and only this instance's memo holds the spelling
+    /// (docs/impl/symbol.md § "Reading a name, and not reading one"): a bare
+    /// `Display`/`Debug` threads no memo and prints `#<symbol:hash>` for every
+    /// name outside the static keyword vocabulary. A bare VM with no
+    /// `RuntimeCore` has no memo to thread, and prints those forms itself.
+    pub(crate) fn show_value(&self, value: Value) -> String {
+        format!("{}", value.debug_with(self.symbols().map(|table| &*table)))
+    }
+
     /// Format a runtime error value with source location.
     pub(crate) fn format_error_with_location(&self, err_value: Value) -> String {
         let mut result = String::new();
@@ -47,10 +59,9 @@ impl VM {
             }
         }
 
-        // Error value last. `{:?}` resolves symbol names through the global
-        // registry (docs/impl/symbol.md), so a symbol-bearing error value shows
-        // names, not raw ids.
-        result.push_str(&format!("✗ Runtime error: {:?}", err_value));
+        // Error value last, through the memo: a bare `{:?}` would hand the
+        // author `#<keyword:hash>` for every name the program coined.
+        result.push_str(&format!("✗ Runtime error: {}", self.show_value(err_value)));
 
         result
     }

--- a/src/wasm/store/call.rs
+++ b/src/wasm/store/call.rs
@@ -398,7 +398,16 @@ pub fn run_module(
             eprintln!("SKIP (gated): {}", reason);
             return Ok(value);
         }
-        return Err(wasmtime::Error::msg(format!("Runtime error: {}", value)));
+        // Shown through the driving VM's `show_value`, the same spelling the
+        // bytecode tier's report gives the author: a symbol or keyword in the
+        // raised value is a name hash only this instance's memo can spell
+        // (docs/impl/symbol.md § "Reading a name, and not reading one"). The
+        // host's VM pointer is the memo's only route in here.
+        let shown = match unsafe { store.data().vm.as_ref() } {
+            Some(vm) => vm.show_value(value),
+            None => format!("{:?}", value),
+        };
+        return Err(wasmtime::Error::msg(format!("Runtime error: {}", shown)));
     }
 
     Ok(value)

--- a/src/wasm/tests.rs
+++ b/src/wasm/tests.rs
@@ -585,6 +585,29 @@ fn wasm_full_uncaught_error_fails() {
 }
 
 #[test]
+fn wasm_full_uncaught_error_report_spells_the_names_it_carries() {
+    // The report an uncaught error prints is all the author gets, and a keyword
+    // in the raised value is a name hash: only the instance memo can spell it
+    // (docs/impl/symbol.md § "Reading a name, and not reading one"). The trap:
+    // the keywords the Rust runtime mints from fixed strings — `:error`,
+    // `:message` — resolve through the static vocabulary with no memo at all, so
+    // a test written with those names goes green while every name the program
+    // itself coined prints as `#<keyword:hash>`. The counter-factual: assert
+    // only that the report is an `Err`, and a report of raw hashes passes for
+    // the error the author named.
+    let report = super::eval_wasm_with_stdlib("(error {:sigil-wasm-kind 9})", "<uncaught>")
+        .expect_err("an uncaught error must fail under --wasm=full");
+    assert!(
+        report.contains(":sigil-wasm-kind"),
+        "the report must spell the keyword the raised value carries, got: {report}"
+    );
+    assert!(
+        !report.contains("#<keyword:"),
+        "no keyword in the report may fall back to its hash, got: {report}"
+    );
+}
+
+#[test]
 fn wasm_full_gated_skip_is_not_a_failure() {
     // A `(gate! …)` whose condition is unmet raises a `:gated` error that the
     // harness records as SKIP (an unbuilt plugin/feature), NOT a failure. The

--- a/tests/elle/error-report-names.lisp
+++ b/tests/elle/error-report-names.lisp
@@ -1,0 +1,68 @@
+(elle/epoch 12)
+# ── A message that shows a value spells the names it carries ──────────
+#
+# A symbol or keyword IS its name hash; the spelling lives in the
+# instance memo, and a formatter that does not thread the memo prints
+# `#<keyword:hash>` (docs/impl/symbol.md § "Reading a name, and not
+# reading one").
+#
+# The trap: a spelling the Rust runtime mints from a fixed string —
+# `:error`, `:message`, `:kind` — resolves through the static keyword
+# vocabulary with no memo at all. A test written with those names goes
+# green while every name the program itself coined prints as a hash.
+# So every name below is coined at run time, is asserted through the
+# spelling the runtime hands back rather than through a literal, and
+# appears nowhere in this file's text. A report may quote the source
+# line it came from, and a literal would let that quote fake the pass.
+
+# ── The report of an error that escapes eval ──────────────────────────
+#
+# An error raised inside `eval` reaches its caller as a report string
+# under `:eval-error`, so that report is one such formatter.
+
+(def kind (keyword (append "sigil-eval-" "kind")))
+(def form (gensym (append "sigil-eval-" "form")))
+
+(def [ok? err]
+  (protect (eval (list 'error {:error kind :form (list 'quote form)}))))
+
+(assert (not ok?)
+        "an error raised inside eval escapes to its caller as an error")
+
+(def report (get err :message))
+
+(assert (string/contains? report (append ":" (string kind)))
+        "the report spells the keyword the evaluated code raised")
+(assert (string/contains? report (string form))
+        "the report spells the symbol the raised value carries")
+
+# The counter-factual for the two asserts above: a report that prints
+# every coined name as a hash still contains `:error` and `:message`
+# from the vocabulary, so an assert that only demanded "some keyword
+# survived" would pass on the broken report.
+
+(assert (not (string/contains? report "#<keyword"))
+        "no keyword in the report falls back to its hash")
+(assert (not (string/contains? report "#<symbol"))
+        "no symbol in the report falls back to its hash")
+
+# ── The message naming a value that cannot be called ──────────────────
+#
+# The same rule for every other message that shows a value. The corpus
+# runs this file under both jit policies, so the bytecode and the JIT
+# call paths each answer for their own message.
+
+(def uncallable-symbol (gensym (append "sigil-call-" "symbol")))
+(def uncallable-keyword (keyword (append "sigil-call-" "keyword")))
+
+(def [sym-ok? sym-err] (protect (uncallable-symbol 1)))
+(def [kw-ok? kw-err] (protect (uncallable-keyword 1)))
+
+(assert (not sym-ok?) "a symbol is not callable")
+(assert (not kw-ok?) "a keyword is not callable")
+
+(assert (string/contains? (get sym-err :message) (string uncallable-symbol))
+        "the type error spells the symbol it could not call")
+(assert (string/contains? (get kw-err :message)
+                          (append ":" (string uncallable-keyword)))
+        "the type error spells the keyword it could not call")

--- a/tests/integration/error_reporting.rs
+++ b/tests/integration/error_reporting.rs
@@ -425,6 +425,44 @@ fn an_unhandled_signal_at_the_root_is_named_by_its_keyword() {
 }
 
 #[test]
+fn an_uncaught_errors_value_is_reported_with_the_names_it_carries() {
+    // An error that no handler catches is printed, and the print is all the
+    // author gets. The trap: a keyword the Rust runtime mints from a fixed
+    // string (`:error`, `:message`) resolves through the static vocabulary with
+    // no memo at all, so a report can read perfectly well while every name the
+    // program itself coined prints as `#<keyword:hash>`. The names below are
+    // coined here and appear in no vocabulary. The counter-factual: assert only
+    // that the report is an error, or that it mentions `:error`, and a report of
+    // raw hashes passes for the error the author named.
+    crate::common::eval_source(
+        "(error {:error :sigil-root-kind :form 'sigil-root-form})",
+        |result| {
+            let report = result.expect_err("nothing catches the error, so it reaches the root");
+            assert!(
+                report.contains(":sigil-root-kind"),
+                "the report must spell the keyword the error carries, got:\n{}",
+                report,
+            );
+            assert!(
+                report.contains("sigil-root-form"),
+                "the report must spell the symbol the error carries, got:\n{}",
+                report,
+            );
+            assert!(
+                !report.contains("#<keyword:"),
+                "no keyword in the report may fall back to its hash, got:\n{}",
+                report,
+            );
+            assert!(
+                !report.contains("#<symbol:"),
+                "no symbol in the report may fall back to its hash, got:\n{}",
+                report,
+            );
+        },
+    );
+}
+
+#[test]
 fn test_closure_has_location_map() {
 
     let mut symbols = SymbolTable::new();


### PR DESCRIPTION
## What was wrong

A symbol or keyword IS its name hash (docs/impl/symbol.md); the spelling lives
in the instance memo and nowhere else. Several messages the author reads
rendered a value with a bare `{:?}` or `{}`, which threads no memo, so every
name the program itself coined arrived as a hash:

```
✗ Runtime error: {#<keyword:0xeb4f5db4cc3d6cc> #<symbol:0x83731c3de462e219>
                  :error #<keyword:0xfcc3d89caf44cdf7> :message "m"}
Cannot call #<symbol:0x7108d57ebc0993cf>
```

`:error` and `:message` survived because the Rust runtime mints them from
fixed strings, so they resolve through the static keyword vocabulary with no
memo at all. That is what kept the defect looking narrow: the common keys read
correctly and the author's own read as hashes.

The runtime error report is also the string `eval` hands back. An error raised
inside `(eval …)` reaches a `protect` as `{:error :eval-error :message "<the
report>"}`, so a keyword lost its name by crossing the eval boundary while the
same keyword raised in the enclosing unit kept it:

```
(protect (error {:error :made-here :message "m"}))
# => [false {:error :made-here :message "m"}]

(protect (eval '(error {:error :made-in-eval :message "m"})))
# => [false {:error :eval-error
#            :message "Error: ✗ Runtime error: {:error #<keyword:0xf9ca…>
#                      :message \"m\"}"}]
```

## What this does

`VM::show_value` is the one spelling of a value for a message the author
reads. It renders through `vm.symbols()` — this instance's memo — and every
such message now goes through it: the runtime error report, the "Cannot call"
type error on all four call paths (bytecode call and tail call, and the JIT's
two), and the WASM tier's uncaught-error report, which reaches the method
through the host's threaded VM pointer.

Two `[DEBUG] Cannot call:` `eprintln!`s went with them. Nothing gated them, so
every uncallable value printed its raw tag and payload to stderr in a release
build, in the very form this change exists to remove.

Two doc comments claimed a symbol name comes from a "process-global registry".
There is no such registry; that claim is what the bare `{:?}` rested on. Both
now state the memo rule and cite the section that owns it.

## Tests

- `tests/elle/error-report-names.lisp`: the keyword and symbol an error raised
  inside `eval` carries survive that error's report, and the "Cannot call"
  message spells the symbol and the keyword it could not call. The corpus runs
  the file under both jit policies, so each tier answers for its own message.
- `an_uncaught_errors_value_is_reported_with_the_names_it_carries`: the root
  report for an error no handler catches.
- `wasm_full_uncaught_error_report_spells_the_names_it_carries`: the same
  contract under `--wasm=full`.

Every name a test asserts on is coined at run time and read back through the
spelling the runtime hands out, so no literal the asserts look for appears in
the test's own text — a report that quotes its source line cannot fake a pass.
Each test fails on the pre-fix build with its coined name printed as a hash.
