### PR TITLE
regions, sched: four residues an h2 request paid per request

### DIFF
--- a/docs/impl/region/bindings.md
+++ b/docs/impl/region/bindings.md
@@ -618,6 +618,16 @@ re-stores the cell's *content* (StoreCapture: incref the new content's region,
 decref the displaced prior). Its `DecrefCellRegion` (the release of the cell
 box's own region) must therefore also fire **exactly once per activation**.
 
+Which binder introduced the local decides nothing here. `def @s` and `let [@s …]`
+inside a lambda are the same env cell, minted the same way and released the same
+way, so both binders record the cell placeholder that arms the release — the
+`Let` arm of [`region::infer::walk`](../../../src/hir/region/infer/walk.rs) and
+`lower_let` beside their `Define` twins. A binder that records it for one and not
+the other leaks one region and one object per activation per such local, which is
+the cost of the closure-as-module idiom: a constructor returning a struct of
+closures over its own mutable state pays it once per field, on every
+construction (`tests/elle/region-let-capture-cell-leak.lisp`).
+
 The binding-chain `decref_point` extension places a cell-release region's
 release at the binding's last use. When the only use is a capture by a closure
 built inside a loop, that last use sits *inside the loop body*, so the release
@@ -647,6 +657,20 @@ iteration, so its release must stay per-iteration — which is exactly why the
 `capture_loop_ext` "bound outside" guard refuses to hoist non-cell regions. Env
 cells are the exception that guard does not cover, because their allocation is
 loop-independent.
+
+The rule is about how many times the release RUNS, so it binds every mechanism
+that places one. A branch whose arms each loop over the cell's holder gives the
+cell a second placement: the arms that do not hold the region's `decref_point`
+get a compensating release of their own, placed after that arm's last use
+([`region::infer::compensate`](../../../src/hir/region/infer/compensate.rs)).
+Where the arm's use is inside a loop, that point is per-iteration and frees the
+once-per-activation box on iteration 1, exactly as the unhoisted `decref_point`
+does. So the compensating release takes the same hoist, to the outermost
+`While`/`Loop` **contained in that arm** — the loop the arm can host, since a
+loop enclosing the whole branch is refused upstream by the loop-invariant guard.
+`each` splices its body into one arm per sequence type, which is how ordinary
+code reaches this shape; both are pinned by
+`tests/elle/region-capture-cell-loop-uaf.lisp`.
 
 The same "the box is not the slot" fact carries the cell's release past the other
 placement rule it meets. A frame that ends in a closure tail call runs nothing the

--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1091,6 +1091,25 @@ only the frame's reference, and the moved value survives it. The one node with n
 such count is the inline `%`-opcode above, which is why the descent passes through
 it to the operand that owns the page.
 
+**A leaf is a part, not the whole.** What the exemption withholds is the frame's
+own release, on the strength of the callee's owned-parameter release standing in
+for it — so the two must name one reference. A **destructured leaf** is where they
+come apart. `(let [[a b] t] (f a b))` hands `f` the leaves; `t` itself never
+reaches the call, and each leaf is an element with a region of its own, which is
+the region the callee's release names. Yet a leaf carries the source's regions in
+`binding_source_regions`, because a leaf MAY live inside the source, so the naive
+reading withholds `t`'s release and nothing takes it over: one region per call,
+which every builder of the shape
+`(let [[ft fl si pl] (make-…)] (send-frame s ft fl si pl))` pays. So a leaf
+argument (`RegionInfo::destructure_leaf_bindings`) is reconsidered against the
+region's release ROUTE: the exemption stands only where the call passes the very
+slot that route loads. Every other binding that names a region names the whole
+value — an alias binder is a second name for the reference the call moves, and
+hoisting its release ahead of the call would free what the callee is about to take
+over (stdlib `zip`'s `arrs`, a second name for the array an inner `let` returned).
+Pinned by `tests/elle/region-tailcall-arg-transfer.lisp`, whose alias case is the
+counter-factual for reading a leaf's rule onto a whole.
+
 **Whether the frame holds the region alone** — the admission, and escape is its
 sole authority. The exemption above is a statement about *arguments*, and
 arguments are not the only path into a callee: a tail callee reaches its

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -124,18 +124,22 @@ long as the record lasts.
 
 One invariant governs the records:
 
-- **A record lasts only as long as a reader needs it.** A delivered join
-  or abort drops both records for that fiber. Nothing reads them
-  afterwards: the status is re-derived from the fiber itself whenever the
-  record is absent, the value was always read from the fiber rather than
-  from the record, and the unjoined-error tail at the end of the loop
-  looks only at fibers nobody joined. A record that outlives its readers
-  makes every `ev/spawn` a permanent allocation, which a long-running
-  program pays for once per fiber it ever ran.
+- **A record lasts only as long as a reader needs it.** A fiber that ends
+  in success drops both records the moment it completes, joined or not.
+  Nothing reads a success record: the status is re-derived from the fiber
+  itself whenever the record is absent, the value was always read from
+  the fiber rather than from the record, and the unjoined-error tail at
+  the end of the loop looks only at failures. A record that outlives its
+  readers makes every `ev/spawn` a permanent allocation, which a
+  long-running program pays for once per fiber it ever ran — and a server
+  that spawns a handler fiber per request and never joins it pays that
+  once per request.
 
-The program's own fibers — the thunks `ev/run` hands the loop — are the
-exception. Their records are what tells the loop the program finished,
-so they last until the loop ends.
+Two kinds of fiber keep their records. A **failed** one, because the mark
+is what stops the tail from re-raising an error its joiner already took.
+And the program's own fibers — the thunks `ev/run` hands the loop —
+because their records are what tells the loop the program finished, so
+they last until the loop ends.
 
 `tests/elle/sched-completion-records.lisp` pins the bound through
 `ev/report`'s `:records` / `:marks`; `tests/elle/ev-unjoined-error.lisp` pins

--- a/src/hir/region/infer.rs
+++ b/src/hir/region/infer.rs
@@ -182,6 +182,9 @@ struct RegionInference {
     /// (`region_of` the cell), not `DecrefValueRegion` (`result_region_of` the
     /// inner value). See `RegionInfo::cell_release_regions`.
     cell_release_regions: rustc_hash::FxHashSet<Region>,
+    /// The leaf bindings a `Destructure` pattern binds. See
+    /// `RegionInfo::destructure_leaf_bindings`.
+    destructure_leaf_bindings: rustc_hash::FxHashSet<Binding>,
     /// `(return_node_id, regions of the returned value)` for every
     /// `HirKind::Return`. The post-pass extends each region's `decref_point`
     /// to the Return node so the region's `DecrefRegion` is emitted
@@ -314,6 +317,7 @@ impl RegionInference {
             funnel_result_containers: Vec::new(),
             moves_out_release_sites: rustc_hash::FxHashSet::default(),
             cell_release_regions: rustc_hash::FxHashSet::default(),
+            destructure_leaf_bindings: rustc_hash::FxHashSet::default(),
             return_sites: Vec::new(),
             destructure_sites: Vec::new(),
             block_regions: HashMap::new(),

--- a/src/hir/region/infer/build.rs
+++ b/src/hir/region/infer/build.rs
@@ -125,6 +125,7 @@ impl RegionInference {
             // (the `-mut` sites where locus A released a container). Empty here.
             container_release_sites: rustc_hash::FxHashSet::default(),
             cell_release_regions: self.cell_release_regions,
+            destructure_leaf_bindings: self.destructure_leaf_bindings,
             hard_edge_sites: self.hard_edge_sites,
             suppressed_decref_regions: rustc_hash::FxHashSet::default(),
             drop_on_overwrite_sites: rustc_hash::FxHashSet::default(),

--- a/src/hir/region/infer/compensate.rs
+++ b/src/hir/region/infer/compensate.rs
@@ -149,10 +149,45 @@ pub(super) struct BranchComp {
     pub container_release_sites: std::collections::HashSet<HirId>,
 }
 
-/// A `While`/`Loop`'s post-order subtree interval, for the loop-invariant guard.
+/// A `While`/`Loop`'s node and post-order subtree interval, for the
+/// loop-invariant guard and for the env cell's once-per-activation hoist.
 struct IterScope {
+    id: HirId,
     lo: u32,
     hi: u32,
+}
+
+/// The node an env cell's per-arm release takes instead of `at`, so that it
+/// fires once per execution of the arm rather than once per iteration of a loop
+/// inside it: the outermost `While`/`Loop` that encloses `at` and is itself
+/// contained in the arm, which the lowerer emits after the loop.
+///
+/// This is the per-arm analogue of the global `decref_point`'s
+/// `post_loop_placement` (`analyze/decref.rs`), and it exists for the same
+/// reason: `populate_env` mints the box once per activation, so a release
+/// anchored at an in-loop use frees it on the first iteration and the next
+/// iteration reads a recycled cell (docs/impl/region/bindings.md § "Env cells in
+/// loops: release once per activation, not per iteration").
+///
+/// The loop must lie INSIDE the arm — a loop enclosing the whole branch is not a
+/// point this arm can host, and the loop-invariant guard has already refused the
+/// region if one encloses the branch but not the cell's allocation. `None` when
+/// `at` is in no such loop, or is already at or past the loop's own node.
+fn arm_post_loop_placement(
+    at: HirId,
+    loops: &[IterScope],
+    arm_lo: u32,
+    arm_hi: u32,
+    order: &HashMap<HirId, u32>,
+) -> Option<HirId> {
+    let ord = |id: HirId| order.get(&id).copied().unwrap_or(0);
+    let at_ord = ord(at);
+    loops
+        .iter()
+        .filter(|l| l.lo <= at_ord && at_ord <= l.hi && arm_lo <= l.lo && l.hi <= arm_hi)
+        .max_by_key(|l| l.hi)
+        .map(|l| l.id)
+        .filter(|&id| ord(id) > at_ord)
 }
 
 /// Compute the per-arm compensating decrefs (`head` + `tail`). See the module doc
@@ -462,6 +497,10 @@ pub(super) fn compute_branch_compensation(
                             .into_iter()
                             .max_by_key(|&n| ord(n))
                             .expect("a non-empty candidate set has a max");
+                        // Once per execution of the arm, never once per
+                        // iteration of a loop inside it.
+                        let node = arm_post_loop_placement(node, &loops, arm_lo, arm_hi, order)
+                            .unwrap_or(node);
                         tail.entry(node).or_default().push(r);
                     }
                     continue;
@@ -561,6 +600,7 @@ fn collect(
     let lo = |id: HirId| low.get(&id).copied().unwrap_or(0);
     if let HirKind::While { .. } | HirKind::Loop { .. } = &hir.kind {
         loops.push(IterScope {
+            id: hir.id,
             lo: lo(hir.id),
             hi: ord(hir.id),
         });

--- a/src/hir/region/infer/format.rs
+++ b/src/hir/region/infer/format.rs
@@ -51,6 +51,23 @@ pub fn format_regions(
         writeln!(buf, "  {:<20} → r{}", name, region.0).unwrap();
     }
 
+    // The regions a binding's VALUE may live in, which is a different question
+    // from the scope region above: the scope says where the binder sits, the
+    // source set says what its release will name. A release that never fires is
+    // read here — a binding whose source region has no `decref points` entry
+    // below owns a value nothing frees.
+    if !info.binding_source_regions.is_empty() {
+        writeln!(buf).unwrap();
+        writeln!(buf, ";; ── binding source regions ──").unwrap();
+        let mut sources: Vec<_> = info.binding_source_regions.iter().collect();
+        sources.sort_by_key(|(b, _)| b.0);
+        for (b, regions) in &sources {
+            let name = bname(**b, arena);
+            let rs: Vec<String> = regions.iter().map(|r| format!("r{}", r.0)).collect();
+            writeln!(buf, "  {:<20} → [{}]", name, rs.join(" ")).unwrap();
+        }
+    }
+
     if !info.cross_region_refs.is_empty() {
         writeln!(buf).unwrap();
         writeln!(buf, ";; ── cross-region refs ──").unwrap();

--- a/src/hir/region/infer/tests/inline.rs
+++ b/src/hir/region/infer/tests/inline.rs
@@ -98,6 +98,38 @@ fn a_base_arms_result_is_released_in_the_base_arm() {
 }
 
 #[test]
+fn an_inlined_callee_keeps_its_rest_params_collected_region() {
+    // A collector puts ONE binding in both `params` and `rest_param`, so the
+    // inline's save/restore visits it twice. The trap: the second visit's
+    // snapshot is taken after the first visit has already overwritten the
+    // entry, so restoring the snapshots in order ends on the overwritten value
+    // and the rest param names nothing at all.
+    //
+    // The counter-factual a plain "does it still have a region" assertion would
+    // miss is that nothing downstream complains: the collected keyword struct
+    // still allocates, the callee still runs, and only `arena/region-count`
+    // reads the difference — one region and one object per call, for every
+    // `&named`/`&keys`/`&` callee this unit can resolve
+    // (tests/elle/region-inline-rest-param-leak.lisp).
+    let (hir, arena, _symbols, info) = analyze_with_class("(let [k (fn (&named a) 42)] (k))");
+    let p = find_binding_by_name(&hir, "__named_param", &arena).expect("the named param");
+    let regions = info
+        .binding_source_regions
+        .get(&p)
+        .expect("the named param is a holder");
+    assert!(
+        !regions.is_empty(),
+        "the collected keyword struct's region must survive the callee's inline"
+    );
+    assert!(
+        regions
+            .iter()
+            .any(|r| info.region_data.contains_key(r) && info.call_result_regions.contains(r)),
+        "the collected struct's region must be an owned placeholder with a release point"
+    );
+}
+
+#[test]
 fn an_inlined_result_region_keeps_one_holder() {
     // The second consequence of adopting the callee's naming: the region gains a
     // holder binding in the sibling arm, and a two-holder region is refused the

--- a/src/hir/region/infer/walk.rs
+++ b/src/hir/region/infer/walk.rs
@@ -218,6 +218,21 @@ impl RegionInference {
                     let init_regions = self.counted_cell_read_regions(*b, init, init_regions);
                     self.binding_regions.insert(*b, init_regions);
                     self.record_binder_init_site(*b, init.id);
+                    // Captured local materialized as a `populate_env` env cell: ADD a
+                    // cell placeholder so the lowerer releases the CELL at the
+                    // binding's last use, WITHOUT dropping the init value's own
+                    // region(s). Which binder introduced the local decides nothing
+                    // about the cell — `env_cell_placeholder` answers `None` outside a
+                    // lambda, where the compiled `MakeCaptureCell` the arm head mints
+                    // a region for is the cell instead — so this is the same
+                    // treatment, and the same argument, as the `Define` binder's
+                    // (tests/elle/region-let-capture-cell-leak.lisp).
+                    if let Some(cell_r) = self.env_cell_placeholder(*b) {
+                        let entry = self.binding_regions.entry(*b).or_default();
+                        if !entry.contains(&cell_r) {
+                            entry.push(cell_r);
+                        }
+                    }
                 }
 
                 // `cell ⊇ content`: the cells minted above hold their init value by an

--- a/src/hir/region/infer/walk/inline.rs
+++ b/src/hir/region/infer/walk/inline.rs
@@ -76,16 +76,33 @@ impl RegionInference {
             } => (params, rest_param, body),
             _ => return Inlined::No,
         };
-        // Save and bind params to caller's arg regions.
+        // Snapshot every binding this inline is about to rebind, BEFORE any of
+        // the rebinding writes. A collector parameter (`&`, `&keys`, `&named`)
+        // is one binding occupying the last fixed slot, so it appears in
+        // `params` AND in `rest_param`: snapshotting per write would record the
+        // rest write's "before" as the value the param write just installed,
+        // and the restore would hand that back. The callee's collector binding
+        // would then name no region at all, and the collected list/struct — an
+        // owned value the callee releases at that binding's last use — would
+        // have nothing for a release to name. Pinned by
+        // `tests/elle/region-inline-rest-param-leak.lisp`.
         let mut saved: Vec<(Binding, Option<Vec<Region>>)> = Vec::new();
+        let mut snapshotted = rustc_hash::FxHashSet::default();
+        for b in params.iter().chain(rest_param.iter()) {
+            if snapshotted.insert(*b) {
+                saved.push((*b, self.binding_regions.get(b).cloned()));
+            }
+        }
+        // Bind params to the caller's arg regions.
         for (i, p) in params.iter().enumerate() {
-            saved.push((*p, self.binding_regions.get(p).cloned()));
             let regions = arg_regions.get(i).cloned().unwrap_or_default();
             self.binding_regions.insert(*p, regions);
             self.binding_region.insert(*p, self.current_region);
         }
+        // The rest write lands last on a collector binding, and must: the
+        // collected value is built by the callee's own calling convention, so it
+        // belongs to no caller region.
         if let Some(rp) = rest_param {
-            saved.push((*rp, self.binding_regions.get(rp).cloned()));
             self.binding_regions.insert(*rp, Vec::new());
             self.binding_region.insert(*rp, self.current_region);
         }

--- a/src/hir/region/infer/walk/walkrest.rs
+++ b/src/hir/region/infer/walk/walkrest.rs
@@ -339,6 +339,12 @@ impl RegionInference {
                 self.destructure_sites.push((hir.id, val_regions.clone()));
                 for b in pattern.bindings().bindings {
                     self.binding_region.insert(b, self.current_region);
+                    // A leaf NAMES the source without holding it, which the
+                    // region set below cannot express on its own. Recorded so
+                    // the consumers that ask "who owns this value" can tell a
+                    // leaf from a whole-value alias
+                    // (`RegionInfo::destructure_leaf_bindings`).
+                    self.destructure_leaf_bindings.insert(b);
                     // Destructured bindings may hold values that live in
                     // the source's region(s) — `(rest list)` returns a
                     // sublist sharing list's region; `(first xs)` on a

--- a/src/hir/region/info.rs
+++ b/src/hir/region/info.rs
@@ -538,6 +538,15 @@ pub struct RegionInfo {
     /// unwrap the cell to the inner value's caller-owned region). docs/impl/region/rules.md
     /// Rule 8 (no leaks) — these env cells need an explicit release.
     pub cell_release_regions: FxHashSet<Region>,
+    /// The leaf bindings a `Destructure` pattern binds. Each inherits the
+    /// destructured value's source regions (`Destructure` in
+    /// `region::infer::walk`), because a leaf may be an element that LIVES in
+    /// them — so a leaf NAMES the source without holding it, which is the one
+    /// way `binding_source_regions` records an alias to a part rather than to a
+    /// whole. A consumer that reads a binding's regions to decide who owns the
+    /// value has to know the difference; the tail call's ownership move is the
+    /// one that does (`lir::lower::emitops::drop_named_only_arg_exemptions`).
+    pub destructure_leaf_bindings: FxHashSet<Binding>,
     /// Call HirIds whose may-store edges are HARD: native call sites with a
     /// declared uncounted-store effect (`Stores`/`Mixed`/`Unknown`). At these
     /// sites the lowerer emits the edge incref for a call-result source by
@@ -891,6 +900,7 @@ impl RegionInfo {
             moves_out_release_sites: FxHashSet::default(),
             container_release_sites: FxHashSet::default(),
             cell_release_regions: FxHashSet::default(),
+            destructure_leaf_bindings: FxHashSet::default(),
             hard_edge_sites: FxHashSet::default(),
             suppressed_decref_regions: FxHashSet::default(),
             drop_on_overwrite_sites: FxHashSet::default(),

--- a/src/lir/lower/AGENTS.md
+++ b/src/lir/lower/AGENTS.md
@@ -167,7 +167,12 @@ other is structural ownership-location, NOT escape:
   stops at a `Call`/`Lambda` and records that node's own region, then closes
   the set under the three alias relations, so a region an inner call merely
   used is not exempt while one its result may live inside still is
-  (docs/impl/region/mechanism.md § "What an operand names is its VALUE").
+  (docs/impl/region/mechanism.md § "What an operand names is its VALUE"). A
+  **destructured leaf** argument names a PART of the value it was read out of,
+  and the callee takes over the leaf rather than the source, so such an argument
+  keeps the exemption only where the call passes the slot the region's own
+  release route loads (`drop_named_only_arg_exemptions`, mechanism.md § "A leaf
+  is a part, not the whole").
   And the region must be frame-held
   (`RegionInfo::frame_held_regions`), because a tail callee also reaches
   its CAPTURED environment, which no argument names. A region escaping by the

--- a/src/lir/lower/binding/let.rs
+++ b/src/lir/lower/binding/let.rs
@@ -80,6 +80,12 @@ impl<'a> Lowerer<'a> {
 
             if self.in_lambda && needs_capture {
                 self.upvalue_bindings.insert(*binding);
+                // Captured local → a `populate_env` env cell (StoreCapture into a
+                // pre-allocated cell, no compiled MakeCaptureCell). Record its
+                // env-cell placeholder so `emit_decrefs_for` releases the cell at
+                // this binding's last use (`LoadCaptureRaw` + `DecrefCellRegion`),
+                // exactly as `lower_define` does for the same cell.
+                self.record_env_cell_release_slot(*binding, slot);
                 self.emit(LirInstr::StoreCapture {
                     index: slot,
                     src: init_reg,

--- a/src/lir/lower/emitops.rs
+++ b/src/lir/lower/emitops.rs
@@ -398,9 +398,22 @@ impl<'a> Lowerer<'a> {
             exempt.insert(self.region_info.merged_root(root));
         }
         self.collect_operand_regions(func, &mut exempt);
+        // The argument half is reconsidered per region before it joins `exempt`,
+        // so a region the CALLEE or the call's own result already exempts keeps
+        // that exemption whatever an argument names.
+        let mut by_args = rustc_hash::FxHashSet::default();
         for a in args {
-            self.collect_operand_regions(&a.expr, &mut exempt);
+            self.collect_operand_regions(&a.expr, &mut by_args);
         }
+        for a in args {
+            self.drop_named_only_arg_exemptions(
+                &a.expr,
+                &operand_locals,
+                &operand_captures,
+                &mut by_args,
+            );
+        }
+        exempt.extend(by_args);
         // This call dominates every position after it in the block, so it alone
         // covers them — any points a merge left here name arms that reach this
         // call, not the releases that follow it.
@@ -424,6 +437,60 @@ impl<'a> Lowerer<'a> {
         out: &mut rustc_hash::FxHashSet<crate::hir::region::Region>,
     ) {
         self.region_info.operand_value_regions(h, out);
+    }
+
+    /// Take back the exemption of a region an argument only NAMES.
+    ///
+    /// An argument's region is exempt because the callee's owned-parameter
+    /// release stands in for the caller's — which holds only where the reference
+    /// the callee takes over is the one the caller's release would have dropped.
+    /// A destructured leaf is where the two come apart: `(let [[a b] t] (f a b))`
+    /// hands `f` the leaves, never `t`, yet each leaf names `t`'s region through
+    /// `binding_source_regions` (a leaf may BE an element living in it). So `t`'s
+    /// release is withheld, nothing takes it over, and `t` is held to fiber
+    /// teardown — one region per call, which every h2 frame builder pays.
+    ///
+    /// Only a leaf is reconsidered (`RegionInfo::destructure_leaf_bindings`).
+    /// Every other binding that names a region names the whole value: an alias
+    /// binder is a second name for the very reference the call moves — `arrs` for
+    /// the array `a` built and returned by an inner `let` (stdlib `zip`) — and
+    /// hoisting its release ahead of the call would free what the callee is about
+    /// to take over.
+    ///
+    /// The slot is the second half of the reading, and it is what admits the leaf
+    /// that IS the whole: a rest pattern binds a tail that shares the source's
+    /// region and can be the reference the call moves. Where the region's value
+    /// route loads a slot the call passes, the move is real and the exemption
+    /// stands whatever the binding's kind. A region with no recorded slot releases
+    /// by id, where there is no slot to compare, and stands too.
+    fn drop_named_only_arg_exemptions(
+        &self,
+        h: &Hir,
+        operand_locals: &rustc_hash::FxHashSet<u16>,
+        operand_captures: &rustc_hash::FxHashSet<u16>,
+        exempt: &mut rustc_hash::FxHashSet<crate::hir::region::Region>,
+    ) {
+        let HirKind::Var(b) = &h.kind else { return };
+        if !self.region_info.destructure_leaf_bindings.contains(b) {
+            return;
+        }
+        for &r in self
+            .region_info
+            .binding_source_regions
+            .get(b)
+            .into_iter()
+            .flatten()
+        {
+            let root = self.region_info.merged_root(r);
+            let moved = match self.region_to_slot.get(&root) {
+                Some(super::ValueSlot::Local(s)) => operand_locals.contains(s),
+                Some(super::ValueSlot::Env(i)) => operand_captures.contains(i),
+                None => true,
+            };
+            if !moved {
+                exempt.remove(&root);
+            }
+        }
     }
 
     /// Emit `f`'s instructions for `region`, placed so that every path runs the

--- a/src/stdlib.lisp
+++ b/src/stdlib.lisp
@@ -1771,13 +1771,14 @@
       (del select-sets waiter))
 
     (defn retire-fiber [fiber]
-      "Drop the scheduler's records of a fiber whose result a caller took.
+      "Drop the scheduler's records of a fiber that ended in success.
        Both records are keyed by the fiber, so keeping them keeps the fiber
        and its closure alive for the scheduler's whole life — one permanent
-       allocation per spawn. Nothing reads them after the delivery:
+       allocation per spawn. Nothing reads a success record at all:
        `get-completion` re-derives the status from the fiber whenever the
-       record is absent, and the unjoined-error tail reads only fibers
-       nobody joined.
+       record is absent, and the unjoined-error tail reads only failures.
+       So this runs at COMPLETION: a fiber nobody ever joins costs the loop
+       the same as one whose result a caller took.
 
        Two fibers keep their records. The program's own — `:pump` reads
        their record to know the program finished. And a FAILED one: its
@@ -1835,10 +1836,14 @@
           (let [pair [(= status :ok) (fiber/value fiber)]]
             (each w in ws
               (fiber/resume w pair)
-              (handle-fiber-after-resume w)))  # Every waiter was a joiner, and each now holds the result, so
-          # the record just written has no reader left.
-          (retire-fiber fiber))  # Wake select waiters
-        (wake-select-waiters fiber)))
+              (handle-fiber-after-resume w))))  # Wake select waiters
+        (wake-select-waiters fiber))  # A success record has no reader — the loop's tail raises failures
+      # alone, and a join that arrives later re-derives the status from the
+      # fiber — so it is retired HERE, not at a join that may never come.
+      # `retire-fiber` keeps a failure and keeps the program's own fibers;
+      # what it drops is the per-spawn record a server that never joins its
+      # handler fiber would otherwise pay for every request it ever served.
+      (retire-fiber fiber))
 
     (defn get-completion [fiber]
       "Return fiber's completion status (:ok or :error), or nil if the fiber
@@ -1867,8 +1872,7 @@
         (if (not (nil? comp))  # Already completed — resume immediately
           (begin
             (fiber/resume caller [(= comp :ok) (fiber/value target)])
-            (handle-fiber-after-resume caller)  # The caller holds the result; the records have no reader left.
-            (retire-fiber target))  # Still running — park caller on target's join waiter list
+            (handle-fiber-after-resume caller))  # Still running — park caller on target's join waiter list
           (let [ws (or (get waiters target)
                        (let [w @[]]
                          (put waiters target w)
@@ -1904,9 +1908,7 @@
             (del pending id)
             (del fiber-io target)))  # Graceful abort (runs defer/protect)
         (fiber/abort target {:error :aborted})  # Route the aborted fiber through completion
-        (handle-fiber-after-resume target))  # The aborter observed the target on its own behalf, so the
-      # records retire on the same rule a delivered join uses.
-      (retire-fiber target)  # Resume caller with nil
+        (handle-fiber-after-resume target))  # Resume caller with nil
       (fiber/resume caller nil)
       (handle-fiber-after-resume caller))
 

--- a/tests/elle/h2-stress-scoped.lisp
+++ b/tests/elle/h2-stress-scoped.lisp
@@ -63,8 +63,8 @@
 # delta must fit under. Shrink-only — see "The pins" above.
 (def residue-small 10)
 (def residue-large 30)
-(def max-objects-per-request 51)
-(def max-regions-per-request 45)
+(def max-objects-per-request 16)
+(def max-regions-per-request 16)
 
 # ── Helpers ──────────────────────────────────────────────────────────
 

--- a/tests/elle/region-capture-cell-loop-uaf.lisp
+++ b/tests/elle/region-capture-cell-loop-uaf.lisp
@@ -84,4 +84,80 @@
                 (string (varying))))
 (println "  3. capture cell content tracks per-iteration re-def: ok")
 
+## ── 4. the per-arm compensating release, hoisted past the arm's loop ─────
+## The same once-per-activation rule, on the other route to a release.
+##
+## When a cell's `decref_point` lands inside one arm of a branch, the arms
+## that do not hold it get a compensating release of their own — for an env
+## cell, after that arm's last use of the binding. Where the arm's use sits
+## in a LOOP, that last use is a per-iteration point, so the compensating
+## release frees the once-per-activation box on iteration 1 and the next
+## iteration reads a recycled cell.
+##
+## The ingredients: two arms whose bodies both loop over a closure that
+## captures the cell, and a reassign between two such branches. Without the
+## reassign, or with only one arm using the cell, the release lands outside
+## the arms and neither route fires. The counter-factual is section 1's:
+## a release that is per-iteration reads a freed cell, and `get` on the
+## freed box reports `nil` rather than the array.
+##
+## `each` is the shape this reaches in ordinary code — it splices its body
+## into one arm per sequence type — which is why the direct form is written
+## out here and the macro is exercised beside it.
+(defn arm-loops [k]
+  (def @cell @[1])
+  (def @acc 0)
+  (if (= k :a)
+    (begin
+      (def @i 0)
+      (while (%lt i 4)
+        (let [cl (fn [] (get cell 0))]
+          (assign acc (+ acc (cl))))
+        (assign i (%add i 1))))
+    (begin
+      (def @i2 0)
+      (while (%lt i2 4)
+        (let [cl (fn [] (get cell 0))]
+          (assign acc (+ acc (cl))))
+        (assign i2 (%add i2 1)))))
+  (assign cell @[10])
+  (if (= k :a)
+    (begin
+      (def @j 0)
+      (while (%lt j 4)
+        (let [cl (fn [] (get cell 0))]
+          (assign acc (+ acc (cl))))
+        (assign j (%add j 1))))
+    (begin
+      (def @j2 0)
+      (while (%lt j2 4)
+        (let [cl (fn [] (get cell 0))]
+          (assign acc (+ acc (cl))))
+        (assign j2 (%add j2 1)))))
+  acc)  ## 4 × 1 + 4 × 10 = 44, whichever arm runs
+(assert (= (arm-loops :a) 44)
+        (concat "arm-loop capture cell (first arm): expected 44, got "
+                (string (arm-loops :a))))
+(assert (= (arm-loops :b) 44)
+        (concat "arm-loop capture cell (second arm): expected 44, got "
+                (string (arm-loops :b))))
+(println "  4. per-arm capture-cell release fires once per activation: ok")
+
+## ── 5. the same shape through `each` ─────────────────────────────────────
+(defn each-loops [n]
+  (def @cell @[1])
+  (def @acc 0)
+  (each _ in (range 0 n)
+    (let [cl (fn [] (get cell 0))]
+      (assign acc (+ acc (cl)))))
+  (assign cell @[10])
+  (each _ in (range 0 n)
+    (let [cl (fn [] (get cell 0))]
+      (assign acc (+ acc (cl)))))
+  acc)
+(assert (= (each-loops 4) 44)
+        (concat "each-loop capture cell: expected 44, got "
+                (string (each-loops 4))))
+(println "  5. capture cell survives an `each` body that captures it: ok")
+
 (println "region-capture-cell-loop-uaf: all tests passed")

--- a/tests/elle/region-capture-cell-loop-uaf.lisp
+++ b/tests/elle/region-capture-cell-loop-uaf.lisp
@@ -25,9 +25,8 @@
 ## activation populate_env allocation. See docs/impl/region/bindings.md "Env
 ## cells in loops: release once per activation, not per iteration".
 ##
-## This is the deferred Stage-2 captured-cell facet from hand-off.md; the
-## capture analogue NOTE in tests/elle/nested-loop-inner-invariant.lisp points
-## here. Both single-loop and nested-loop shapes are covered.
+## The capture analogue NOTE in tests/elle/nested-loop-inner-invariant.lisp
+## points here. Both single-loop and nested-loop shapes are covered.
 
 ## ── 1. single loop: mutable captured local, closure called in place ──────
 ## Minimal repro. `s` is `def @s` (mutable → env cell), captured by `cl`,

--- a/tests/elle/region-inline-rest-param-leak.lisp
+++ b/tests/elle/region-inline-rest-param-leak.lisp
@@ -1,0 +1,129 @@
+(elle/epoch 12)
+# A collector parameter's collected value is released once per call, whoever
+# calls it.
+#
+# `&`, `&keys` and `&named` all collect their surplus arguments into ONE value
+# built by the callee's calling convention in a region of its own
+# (`collect_struct_in_own_region` / `args_to_list`, src/vm/env.rs). One
+# reference stands on that region, and the callee owes it a release at the
+# collector parameter's last use.
+#
+# ── Why the call site is at file scope ──────────────────────────────
+#
+# The region walk INLINES a callee it can resolve to a lambda, to collect the
+# edges of the intrinsics inside it. Which call sites resolve that way is not a
+# property a reader can see from the callee, so each drive below is written at
+# file scope, where the resolution holds — a drive wrapped in a `defn` does not
+# inline here, reads 0 whatever the callee's parameter list does, and would pass
+# on a compiler that never releases a collected value at all.
+#
+# ── Reading the numbers ─────────────────────────────────────────────
+#
+# Each drive runs the same loop at `calls` iterations after an identical warmup
+# loop, so a per-call cost reads `calls` and a one-off reads about 0. The
+# controls are the same drive over a callee with a plain parameter list: they
+# fix the window's own bookkeeping cost, which is what `slack` is sized for. A
+# per-call leak is two orders of magnitude above it.
+
+(def calls 200)
+(def slack 20)
+
+(defn plain [a]
+  (if a 1 0))
+(defn rest-list [& xs]
+  (length xs))
+(defn keys-struct [&keys k]
+  (if k 1 0))
+(defn named-struct [&named a b]
+  (if a 1 0))
+
+# ── plain control ────────────────────────────────────────────────────
+
+(def @i 0)
+(while (< i calls)
+  (plain 1)
+  (assign i (+ i 1)))
+(def plain-objects0 (arena/count))
+(def plain-regions0 (arena/region-count))
+(assign i 0)
+(while (< i calls)
+  (plain 1)
+  (assign i (+ i 1)))
+(def plain-objects (- (arena/count) plain-objects0))
+(def plain-regions (- (arena/region-count) plain-regions0))
+
+# ── (& xs) ───────────────────────────────────────────────────────────
+
+(assign i 0)
+(while (< i calls)
+  (rest-list 1 2 3)
+  (assign i (+ i 1)))
+(def rest-objects0 (arena/count))
+(def rest-regions0 (arena/region-count))
+(assign i 0)
+(while (< i calls)
+  (rest-list 1 2 3)
+  (assign i (+ i 1)))
+(def rest-objects (- (arena/count) rest-objects0))
+(def rest-regions (- (arena/region-count) rest-regions0))
+
+# ── (&keys k) ────────────────────────────────────────────────────────
+
+(assign i 0)
+(while (< i calls)
+  (keys-struct :a 1 :b 2)
+  (assign i (+ i 1)))
+(def keys-objects0 (arena/count))
+(def keys-regions0 (arena/region-count))
+(assign i 0)
+(while (< i calls)
+  (keys-struct :a 1 :b 2)
+  (assign i (+ i 1)))
+(def keys-objects (- (arena/count) keys-objects0))
+(def keys-regions (- (arena/region-count) keys-regions0))
+
+# ── (&named a b) ─────────────────────────────────────────────────────
+
+(assign i 0)
+(while (< i calls)
+  (named-struct :a 1)
+  (assign i (+ i 1)))
+(def named-objects0 (arena/count))
+(def named-regions0 (arena/region-count))
+(assign i 0)
+(while (< i calls)
+  (named-struct :a 1)
+  (assign i (+ i 1)))
+(def named-objects (- (arena/count) named-objects0))
+(def named-regions (- (arena/region-count) named-regions0))
+
+# ── report and assert ────────────────────────────────────────────────
+
+(println "region-inline-rest-param-leak over " calls
+         " calls (object/region deltas):")
+(println "  plain  obj=" plain-objects " reg=" plain-regions)
+(println "  &      obj=" rest-objects " reg=" rest-regions)
+(println "  &keys  obj=" keys-objects " reg=" keys-regions)
+(println "  &named obj=" named-objects " reg=" named-regions)
+
+(assert (<= plain-objects slack)
+        (string "control: a plain call leaks objects, delta=" plain-objects))
+(assert (<= plain-regions slack)
+        (string "control: a plain call leaks regions, delta=" plain-regions))
+
+(assert (<= rest-objects slack)
+        (string "(& xs) leaks objects per call, delta=" rest-objects))
+(assert (<= rest-regions slack)
+        (string "(& xs) leaks regions per call, delta=" rest-regions))
+
+(assert (<= keys-objects slack)
+        (string "(&keys k) leaks objects per call, delta=" keys-objects))
+(assert (<= keys-regions slack)
+        (string "(&keys k) leaks regions per call, delta=" keys-regions))
+
+(assert (<= named-objects slack)
+        (string "(&named a b) leaks objects per call, delta=" named-objects))
+(assert (<= named-regions slack)
+        (string "(&named a b) leaks regions per call, delta=" named-regions))
+
+(println "region-inline-rest-param-leak: ok")

--- a/tests/elle/region-let-capture-cell-leak.lisp
+++ b/tests/elle/region-let-capture-cell-leak.lisp
@@ -1,0 +1,106 @@
+(elle/epoch 12)
+# A `@`-mutable local a closure captures costs one env cell per activation,
+# and that cell is released whichever binder introduced it.
+#
+# Such a local lives in the activation's environment: `populate_env` mints one
+# `CaptureCell` for it, in a region of its own, once per call. Nothing frees
+# that region unless the compiler emits a release for it, and the release is
+# armed by a placeholder the region walk records against the binding.
+#
+# ── The shape ───────────────────────────────────────────────────────
+#
+# The binder decides nothing about the cell — `def @v` and `let [@v …]` inside
+# a lambda are the same env cell, minted the same way — so a placeholder
+# recorded for one binder and not the other is a leak in whichever binder is
+# missed, at one region and one object per activation per such local.
+#
+# This is the closure-as-module idiom's cost: a constructor that returns a
+# struct of closures over its own mutable state pays it once per field, on
+# every construction. lib/http2/stream.lisp's `make-channel` is two.
+#
+# ── Reading the numbers ─────────────────────────────────────────────
+#
+# Each drive runs the same construction at `calls` iterations after an
+# identical warmup, so a per-call cost reads `calls` (or a multiple) and a
+# one-off reads about 0. The controls fix the window's own bookkeeping cost,
+# which is what `slack` is sized for.
+
+(def calls 200)
+(def slack 20)
+
+# ── controls: no env cell to release ─────────────────────────────────
+
+(defn immutable-capture []
+  (let [v 1]
+    {:read (fn [] v)}))
+
+(defn uncaptured-mutable []
+  (let [@v 1]
+    (assign v 2)
+    v))
+
+# ── subjects: one env cell per captured @-mutable local ──────────────
+
+(defn def-bound []
+  (def @v 1)
+  {:set (fn [] (assign v 2))})
+
+(defn let-bound []
+  (let [@v 1]
+    {:set (fn [] (assign v 2))}))
+
+(defn let-bound-two []
+  (let [@v 1
+        @w 2]
+    {:set (fn []
+            (assign v 2)
+            (assign w 3))}))
+
+# The closure never leaves the call, so nothing outside can be holding the
+# cell when the activation ends.
+(defn let-bound-local []
+  (let [@v 1]
+    ((fn [] (assign v 2)))
+    v))
+
+(defmacro drive [label form]
+  `(begin
+     (def @w0 0)
+     (while (< w0 calls)
+       (begin
+         ,form)
+       (assign w0 (+ w0 1)))
+     (def c0 (arena/count))
+     (def r0 (arena/region-count))
+     (def @w1 0)
+     (while (< w1 calls)
+       (begin
+         ,form)
+       (assign w1 (+ w1 1)))
+     (def objects (- (arena/count) c0))
+     (def regions (- (arena/region-count) r0))
+     (println "  " ,label " obj=" objects " reg=" regions)
+     (assert (<= objects slack)
+             (string ,label " leaks objects per call, delta=" objects))
+     (assert (<= regions slack)
+             (string ,label " leaks regions per call, delta=" regions))))
+
+(println "region-let-capture-cell-leak over " calls " calls:")
+
+(drive "immutable-capture " (immutable-capture))
+(drive "uncaptured-mutable" (uncaptured-mutable))
+(drive "def-bound         " (def-bound))
+(drive "let-bound         " (let-bound))
+(drive "let-bound-two     " (let-bound-two))
+(drive "let-bound-local   " (let-bound-local))
+
+# The cell must still be readable and writable for the whole activation: a
+# release that fired early would be caught by section 4 of
+# region-capture-cell-loop-uaf.lisp, and one that never fires is the leak
+# above, so this pins the behaviour the two bound between them.
+
+(let [m (let-bound)]
+  (m:set)
+  (assert (= (m:set) 2) "the captured cell is still writable after the call"))
+
+(println "region-let-capture-cell-leak: ok")

--- a/tests/elle/region-tailcall-arg-transfer.lisp
+++ b/tests/elle/region-tailcall-arg-transfer.lisp
@@ -42,6 +42,39 @@
     (let [_ (sink s)]
       (sink s))))
 
+# (4) a value the tail call's arguments only READ OUT OF. The callee takes
+#     over each destructured leaf, never `t` itself, so `t`'s own reference is
+#     still the caller's to drop and must be dropped ahead of the frame
+#     replacement. Every h2 frame builder is this shape —
+#     `(let [[ft fl si pl] (make-…)] (send-frame s ft fl si pl))`.
+(defn mk4 (n)
+  [(string "a" n) 2 3 4])
+(defn sink4 (a b c d)
+  7)
+(defn leaves-to-tail (n)
+  (let [[a b c d] (mk4 n)]
+    (sink4 a b c d)))
+
+# (5) the same with ONE leaf reaching the callee: the source has no later use
+#     to ride, and the leaf that does reach it is the heap element, so this is
+#     the corner where a release hoisted ahead of the call must not free what
+#     the callee is about to read.
+(defn one-leaf-to-tail (n)
+  (let [[a b c d] (mk4 n)]
+    (sink a)))
+
+# (6) an ALIAS of the moved value, not a part of it: `w` is a second name for
+#     the array the inner `let` built and returned, so the call moves that very
+#     reference and the caller must NOT drop it (the stdlib `zip` shape — a
+#     double-free if a leaf's reading is applied to a whole-value alias).
+(defn build ()
+  (let [a @[]]
+    (push a "m")
+    a))
+(defn alias-to-tail (n)
+  (let [w (build)]
+    (sink w)))
+
 (defn region-delta (f iters)
   (def before (arena/region-count))
   (def @i 0)
@@ -53,12 +86,25 @@
 # Correctness first: the aliasing case must return the right value.
 (assert (= (pass-through-tail 1) "y-1")
         "tail call returning its arg must survive")
+(assert (= (leaves-to-tail 1) 7)
+        "tail call over destructured leaves must still run")
+(assert (= (one-leaf-to-tail 1) 7)
+        "tail call over one destructured leaf must still run")
+(assert (= (alias-to-tail 1) 7)
+        "tail call over a whole-value alias must still run")
 
 # Boundedness: region growth must not scale with iteration count.
 (let [d1 (region-delta pass-to-tail 200)
       d2 (region-delta pass-through-tail 200)
-      d3 (region-delta keep-then-tail 200)]
+      d3 (region-delta keep-then-tail 200)
+      d4 (region-delta leaves-to-tail 200)
+      d5 (region-delta one-leaf-to-tail 200)
+      d6 (region-delta alias-to-tail 200)]
   (assert (%lt d1 20) (concat "pass-to-tail leak: delta=" (number->string d1)))
   (assert (%lt d2 20)
           (concat "pass-through-tail leak: delta=" (number->string d2)))
-  (assert (%lt d3 20) (concat "keep-then-tail leak: delta=" (number->string d3))))
+  (assert (%lt d3 20) (concat "keep-then-tail leak: delta=" (number->string d3)))
+  (assert (%lt d4 20) (concat "leaves-to-tail leak: delta=" (number->string d4)))
+  (assert (%lt d5 20)
+          (concat "one-leaf-to-tail leak: delta=" (number->string d5)))
+  (assert (%lt d6 20) (concat "alias-to-tail leak: delta=" (number->string d6))))

--- a/tests/elle/sched-completion-records.lisp
+++ b/tests/elle/sched-completion-records.lisp
@@ -7,11 +7,11 @@
 # fiber closed over — for as long as the loop runs. A server that spawns
 # a fiber per request would then pay for every request it ever served.
 #
-# Nothing reads a record once the result is delivered: a later join
-# re-derives the status from the fiber itself, and the unjoined-error
-# tail at the end of the loop looks only at fibers NOBODY joined. So a
-# delivered join or abort must retire both records. The program's own
-# fibers are the exception — the loop reads their record to know the
+# Nothing reads a SUCCESS record: a later join re-derives the status from
+# the fiber itself, and the unjoined-error tail at the end of the loop
+# looks only at failures. So a fiber that ends `:ok` retires both records
+# the moment it finishes, whether or not anyone joined it. The program's
+# own fibers are the exception — the loop reads their record to know the
 # program finished.
 #
 # `ev/report` exposes the two counts (`:records`, `:marks`), which is
@@ -106,11 +106,66 @@
 
 (println "an unobserved failure keeps its record...")
 
-(let [before (get (ev/report) :records)]
-  (ev/spawn (fn [] 7))
+(def unjoined-failure-base (get (ev/report) :records))
+(ev/abort (ev/spawn (fn [] (ev/sleep 30))))
+(assert (> (get (ev/report) :records) unjoined-failure-base)
+        "a fiber that FAILED keeps the record the loop's tail reads")
+
+# ── 5. A fiber nobody joins leaves nothing behind either ─────────────
+# The success record has no reader at all, so it is retired at completion
+# rather than at a join that may never come. A server that spawns one
+# handler fiber per request and never joins it is the shape this bound
+# exists for: without it the loop holds that fiber, its closure, and
+# everything the closure captured, for every request it ever served.
+#
+# The trap the record count alone would miss: a bounded record count is
+# not a bounded heap, because the record is one entry in a struct the
+# loop keeps. Both gauges are read, over two windows of the same size, so
+# a per-spawn cost reads `churn` and a one-off reads about 0.
+
+(println "a fiber nobody joins leaves no record...")
+
+(def churn 200)
+
+(defn spawn-churn [n]
+  (def @i 0)
+  (while (< i n)
+    (ev/spawn (fn [] 7))
+    (assign i (+ i 1))))
+
+(spawn-churn churn)
+(ev/sleep 0)
+(def unjoined-base-records (get (ev/report) :records))
+(def unjoined-base-objects (arena/count))
+(def unjoined-base-regions (arena/region-count))
+
+(spawn-churn churn)
+(ev/sleep 0)
+(def unjoined-records (- (get (ev/report) :records) unjoined-base-records))
+(def unjoined-objects (- (arena/count) unjoined-base-objects))
+(def unjoined-regions (- (arena/region-count) unjoined-base-regions))
+
+(println "  " churn " unjoined spawns: records=" unjoined-records " objects="
+         unjoined-objects " regions=" unjoined-regions)
+
+(assert (< unjoined-records 5)
+        (string churn " unjoined fibers left " unjoined-records
+                " new completion records (must stay bounded)"))
+(assert (< unjoined-objects 20)
+        (string churn " unjoined fibers left " unjoined-objects
+                " objects behind (must stay bounded)"))
+(assert (< unjoined-regions 20)
+        (string churn " unjoined fibers left " unjoined-regions
+                " regions behind (must stay bounded)"))
+
+# Retiring at completion loses nothing: a join that arrives after the
+# record is gone re-derives the answer from the fiber itself.
+
+(println "a retired unjoined fiber still answers a later join...")
+
+(let [f (ev/spawn (fn [] 42))]
   (ev/sleep 0)
-  (let [after (get (ev/report) :records)]
-    (assert (>= after before)
-            "a fiber nobody joined keeps the record the loop reads")))
+  (assert (= (fiber/status f) :dead) "the fiber ran without being joined")
+  (assert (= (ev/join f) 42) "and a later join reads its value from itself"))
 
 (println "sched-completion-records: ok")

--- a/tests/golden/escape/closures.snap
+++ b/tests/golden/escape/closures.snap
@@ -64,7 +64,7 @@
   #223 params=[] captures=[]
   #225 params=[b47(n)] captures=[b46(f)<Recursive>]
 [return_frontier]
-  [r15, r16, r35, r46, r49, r51, r7]
+  [r15, r16, r35, r46, r49, r51, r55, r7]
 [suppressed_decref_regions]
   []
 [region_instrs]
@@ -119,6 +119,7 @@
   ; closure[1] <anon>
     block0: IncrefRegion s17
     block0: IncrefRegion s18
+    block0: DecrefCellRegion v3
     block0: DecrefRegion s18
   ; closure[2] <anon>
     block0: IncrefRegion s19

--- a/tests/integration/dump_cli.rs
+++ b/tests/integration/dump_cli.rs
@@ -118,6 +118,15 @@ fn regions_prints_region_assignments() {
         "missing region assignments section:\n{}",
         out
     );
+    // The regions a binding's VALUE may live in, which the scope-region section
+    // above does not answer. A binding whose source region has no entry in the
+    // decref-point section owns a value nothing frees, and that reading needs
+    // both sections side by side.
+    assert!(
+        out.contains("binding source regions"),
+        "missing binding source regions section:\n{}",
+        out
+    );
     assert!(
         out.contains("region inference stats"),
         "missing stats:\n{}",


### PR DESCRIPTION
Four residues an HTTP/2 request paid per request, and the tests that pin each
one. Over `tests/elle/h2-stress-scoped.lisp`'s residue drive, a request over an
already-connected session falls from **51 objects / 45 regions to 16 / 16**
(83 / 61 before #1038, which this branch is rebased onto).

Each fix is general — none of them is h2 code — and each has its own rate test
beside the h2 ceiling.

## 1. An inlined callee's collector parameter keeps the region it collects into

The region walk inlines a resolvable lambda callee to collect its intrinsics'
edges, binding the callee's parameters to the caller's argument regions and
restoring them afterwards. A collector parameter (`&`, `&keys`, `&named`) is
ONE binding occupying the last fixed slot, so it appears in `params` AND as
`rest_param`. The save/restore snapshotted per write, so the rest write's
"before" was the value the parameter write had just installed; restoring in
order ended on that value and the binding came out naming no region.

The collected list/struct is an owned value the callee must release at that
binding's last use, so no release was emitted at all.

| callee, 200 calls | before | after |
|---|---:|---:|
| `(defn plain [a] …)` | 0 / 0 | 0 / 0 |
| `(defn rest-list [& xs] …)`, 3 args | 598 / 599 | 0 / 0 |
| `(defn keys-struct [&keys k] …)` | 198 / 199 | 0 / 0 |
| `(defn named-struct [&named a b] …)` | 198 / 199 | 0 / 0 |

## 2. A fiber that ends in success retires its records at completion

The scheduler keeps a status record and a join mark per finished fiber, both
keyed by the fiber, so a record holds the fiber and everything its closure
captured. They were dropped only where a join or abort had delivered the
result — so a server that spawns one handler fiber per request and never joins
it paid one record per request it ever served.

Nothing reads a SUCCESS record: `get-completion` re-derives the status from the
fiber, the value was always read from the fiber, and the unjoined-error tail
reads only failures. A failure keeps its record, and so do the program's own
fibers.

| 200 unjoined spawns | records | objects | regions |
|---|---:|---:|---:|
| before | 200 | 598 | 399 |
| after | 0 | -2 | -1 |

## 3. An env cell is released once per activation, whichever binder made it

Two rules govern the per-value `CaptureCell` `populate_env` mints for a
captured `@`-mutable local, and each was broken on one route.

**The binder does not decide whether the cell is released.** `def @v` and
`let [@v …]` inside a lambda are the same cell, but only the `Define` binder
recorded the placeholder that arms the release. A `let`-bound one leaked one
region and one object per activation, per such local — the closure-as-module
idiom's cost, once per field on every construction. `lib/http2/stream.lisp`'s
`make-channel` is two of them, and `make-stream` builds one per h2 stream.

**A compensating release is per arm, not per iteration.** The global
`decref_point` is hoisted past any enclosing loop because the box is minted
once per activation; the per-arm compensating release was not. Where the arm's
last use of the cell sat inside a loop, the box was freed on iteration 1 and
the next iteration read a recycled cell. `each` is how ordinary code reaches
this — it splices its body into one arm per sequence type — and that program
read `nil` out of the cell.

| construction, 200 calls | before | after |
|---|---:|---:|
| `(let [@v 1] {:set (fn [] (assign v 2))})` | 200 / 200 | 0 / 0 |
| `(def @v 1)` + the same closure | 0 / 0 | 0 / 0 |

## 4. A tail call's ownership move covers what it takes over

A release emitted after a frame-replacing `TailCall` is relocated ahead of it,
unless the call can still reach the region — and an ARGUMENT's region is
exempt, because the callee's owned-parameter release stands in for the
caller's. That holds only where the reference the callee takes over is the one
the caller's release would have dropped.

A destructured leaf is where the two come apart. `(let [[a b] t] (f a b))`
hands `f` the leaves; `t` never reaches the call, and each leaf is an element
with a region of its own. Yet a leaf carries the source's regions, so `t`'s
release was withheld and nothing took it over. Every h2 frame builder is that
shape: `(let [[ft fl si pl] (make-…)] (send-frame s ft fl si pl))`.

A leaf argument is now reconsidered against the region's release route: the
exemption stands only where the call passes the slot that route loads. Every
other binding that names a region names the whole value — stdlib `zip`'s
`arrs` is a second name for the array an inner `let` returned, and hoisting its
release would free what the callee is about to take over.

| shape, 200 calls | before | after |
|---|---:|---:|
| whole value to a tail call | 0 / 0 | 0 / 0 |
| four leaves to a tail call | 200 / 200 | 0 / 0 |
| one leaf to a tail call | 200 / 200 | 0 / 0 |
| heap leaf to a tail call | 400 / 400 | 0 / 0 |
| leaves, call NOT in tail | 0 / 0 | 0 / 0 |

## Tests

New:
- `tests/elle/region-inline-rest-param-leak.lisp` — the collector rate for
  `&`, `&keys` and `&named`, with a plain-parameter control. The drives are at
  file scope on purpose: a drive wrapped in a `defn` does not inline here and
  reads 0 whatever the parameter list does.
- `tests/elle/region-let-capture-cell-leak.lisp` — the per-construction rate,
  with immutable-capture and uncaptured-mutable controls, and a check that the
  returned closure can still read and write the cell.
- `an_inlined_callee_keeps_its_rest_params_collected_region` — the collector
  binding still holds an owned placeholder with a release point after an
  inline.

Extended:
- `tests/elle/region-capture-cell-loop-uaf.lisp` — the branch-arm shape written
  out, and the same shape through `each`.
- `tests/elle/region-tailcall-arg-transfer.lisp` — leaves to a tail call, one
  leaf to a tail call, and the whole-value ALIAS whose release must stay
  behind. Each asserts the call's result as well as the bound, so a release
  moved too early shows up as a fault rather than as a number.
- `tests/elle/sched-completion-records.lisp` — the unjoined-spawn bound on the
  record count AND both heap gauges, and that a join arriving after the record
  is gone still reads the value from the fiber.
- `tests/elle/h2-stress-scoped.lisp` — ceilings to 16 / 16. Both are tight:
  lowering either by one fails today.

Diagnostics:
- `--dump=regions` grows a `binding source regions` section — the regions a
  binding's VALUE may live in, which the scope-region section does not answer.
  A binding whose source region has no decref point owns a value nothing
  frees, which is the reading that found fix 1. Pinned by
  `regions_prints_region_assignments`.

## What ran

`make smoke-elle`, `make smoke-nouring`, `make qa`,
`cargo test -p elle --lib`, `cargo test --test '*'` — all green, including the
`oracle.lisp` and `plumb.lisp` dashboards at 0 open defects on both io
backends.

Closes #1036 — every cause it names is fixed and the rate it was opened
against is down by 81%. The 16 / 16 that remains is a differently-shaped
defect with its own census and its own ruled-out shapes, tracked in #1047.

Closes #1039 — both halves: the `let`-bound env cell's missing release, and
the per-arm release that made the `each`-loop use-after-free reachable. Its
reproducer now prints `ok`.

Closes #1040 — the `&named` strand, and the same strand for `&keys` and `&`.
Its measurement table reads 0 per call for every callee in it.
