### PR TITLE
subprocess: a kill asks the handle whether there is still a child to signal

### DIFF
--- a/docs/io.md
+++ b/docs/io.md
@@ -460,9 +460,53 @@ send signals.
 
 # Spawn, kill, reap
 (def proc (subprocess/exec "sleep" ["60"]))
-(subprocess/kill proc :sigterm)
+(subprocess/kill proc :sigterm)              # => :signaled
 (subprocess/wait proc)                       # => non-zero
 ```
+
+### Killing a child that may already be gone
+
+A pid names a child only until somebody reaps it. The kernel then returns the
+number to the pool and hands it out again, so a signal sent on a reaped child's
+pid reaches whatever holds that number now — nothing on a quiet machine, another
+child of this program or an unrelated process on a busy one.
+
+So `subprocess/kill` asks the handle before it asks the kernel. When the handle
+holds the child's exit status, the child is gone, and the call sends no signal
+at all. The status gets there by `subprocess/wait` — or by any other reap, since
+a reap is recorded rather than spent (see the wait section above).
+
+The answer says which happened, so a caller that cares can tell them apart.
+Each one reports what the call observed, and nothing beyond it:
+
+| Answer | What it means |
+|---|---|
+| `:signaled` | `kill(2)` took the signal for this handle's child. |
+| `:exited` | The handle holds the child's exit status. No signal was sent. |
+| `:missing` | No process holds that pid. Nothing was signalled. |
+
+`:exited` and `:missing` are two different pieces of evidence, which is why they
+are two answers. The handle's status says the child is gone and says whose child
+it was; `ESRCH` says only that the number named nobody at that moment, and a pid
+carries no record of who used to hold it.
+
+All three are success. Killing a child that is already dead is not an error —
+the state the kill asked for already holds — and a program that kills on a timer
+while a fiber waits reaches this as a race rather than a mistake:
+
+```lisp
+(ev/run (fn []
+          (let [child (subprocess/exec "sleep" ["30"])]
+            (assert (= :signaled (subprocess/kill child :sigterm))
+                    "the child is still there, so the signal goes to it")
+            (subprocess/wait child)
+            (assert (= :exited (subprocess/kill child :sigterm))
+                    "the wait reaped it, so this kill has nothing to signal"))))
+```
+
+`subprocess/pid` still answers the number after a reap, and so does the `:pid`
+field of the exec result. The number is what the child had; what a caller does
+with it afterwards is outside this runtime.
 
 ### Subprocess options
 

--- a/src/io/AGENTS.md
+++ b/src/io/AGENTS.md
@@ -291,6 +291,18 @@ and the record is already there.
 exit status is delivered to a waiter, or held until one asks — which also
 covers a child legitimately waited on twice.
 
+The record is also what says whether a **pid still names this child**, which is
+the other question a reap settles. The kernel returns a reaped pid to the pool
+and hands it out again, so `subprocess/kill` reads the record before it makes a
+`kill(2)`: a handle holding a status has no child of its own left, and the call
+sends nothing rather than signalling whatever holds that number now. The two
+readings of the record are the same fact — the child is gone — asked by a
+waiter and by a killer. `docs/io.md` § "Killing a child that may already be
+gone" carries the argument and the answers the primitive gives, and
+`a_kill_on_a_reaped_child_sends_no_signal`
+(`src/primitives/subprocess/tests.rs`) is the pin — a handle built over a pid
+that names somebody else, since a test cannot recycle a pid on demand.
+
 Each mechanism is pinned on its own, because each fails on its own.
 `a_stopped_wait_that_reaped_the_child_keeps_its_status` and
 `a_wait_on_an_already_reaped_child_answers_from_the_record`

--- a/src/io/aio/tests/process.rs
+++ b/src/io/aio/tests/process.rs
@@ -1,19 +1,7 @@
 //! `subprocess/wait` through the async backend.
 
 use super::*;
-use crate::io::request::zombie_child;
-
-/// A reaped placeholder child for a `ProcessHandle` whose real child is already
-/// gone. `ProcessHandle::new` demands a `Child`, and its `Drop` calls
-/// `try_wait`, so the stand-in is a process that has already exited.
-fn child_stub() -> std::process::Child {
-    // Resolved through `PATH`, not hardcoded: no absolute path is right
-    // everywhere. macOS ships no `/bin/true`, and a busybox image ships no
-    // `/usr/bin/true`.
-    let mut child = std::process::Command::new("true").spawn().unwrap();
-    child.wait().unwrap();
-    child
-}
+use crate::io::request::{reaped_child, zombie_child};
 
 /// Submit a wait on `handle` through `backend`.
 fn submit_wait(backend: &AsyncBackend, handle: Value) -> Result<SubmissionId, String> {
@@ -94,15 +82,15 @@ fn test_async_submit_process_wait_uring() {
 #[test]
 fn a_failed_pool_process_wait_names_waitpid() {
     crate::value::arena::with_test_region(|| {
-        // Already reaped by `child_stub`, so the pool worker's own `waitpid`
-        // has no child left — and the stub's `ProcessHandle` carries an empty
-        // record, because nothing in this process reaped through one.
-        let pid = child_stub().id();
+        // Already reaped by `reaped_child`, so the pool worker's own `waitpid`
+        // has no child left — and the stand-in's `ProcessHandle` carries an
+        // empty record, because nothing in this process reaped through one.
+        let pid = reaped_child().id();
 
         let h = crate::primitives::ctx::TestHeap::new();
         let handle_val = h
             .ctx()
-            .external("process", ProcessHandle::new(pid, child_stub()));
+            .external("process", ProcessHandle::new(pid, reaped_child()));
 
         let backend = AsyncBackend::new_thread_pool().unwrap();
         let id = submit_wait(&backend, handle_val).unwrap();

--- a/src/io/request.rs
+++ b/src/io/request.rs
@@ -22,9 +22,9 @@ pub use spawn::*;
 pub(crate) use buffer::{
     bytes_to_string_in_place, set_struct_field_in_place, truncate_buffer, writeable_buffer_ptr,
 };
-#[cfg(test)]
-pub(crate) use process::zombie_child;
 pub(crate) use process::{exit_code_from_siginfo, ExitRecord, ProcessHandle, Reap};
+#[cfg(test)]
+pub(crate) use process::{reaped_child, zombie_child};
 
 /// Boxed closure type for `IoOp::Task`.
 pub type TaskClosure = Box<dyn FnOnce() -> (i32, Vec<u8>) + Send>;

--- a/src/io/request/process.rs
+++ b/src/io/request/process.rs
@@ -173,6 +173,21 @@ pub(crate) unsafe fn exit_code_from_siginfo(si: &libc::siginfo_t) -> i32 {
     }
 }
 
+/// A child that has exited and has already been reaped.
+///
+/// `ProcessHandle::new` demands a `Child`, so a test that builds a handle over
+/// a pid of its own choosing still has to supply one. This stand-in is already
+/// reaped, so it leaves no zombie and its `Drop` has nothing to do.
+#[cfg(test)]
+pub(crate) fn reaped_child() -> Child {
+    // Resolved through `PATH`, not hardcoded: no absolute path is right
+    // everywhere. macOS ships no `/bin/true`, and a busybox image ships no
+    // `/usr/bin/true`.
+    let mut child = std::process::Command::new("true").spawn().unwrap();
+    child.wait().unwrap();
+    child
+}
+
 /// A child that has exited and is still waiting to be reaped.
 ///
 /// The trap the tests here depend on: `waitpid` cannot leave a status in place.

--- a/src/primitives/AGENTS.md
+++ b/src/primitives/AGENTS.md
@@ -309,9 +309,12 @@ Syntax: `{[name][:spec]}` where spec is `[[fill]align][width][.precision][type]`
 
 - `subprocess/wait handle` — Waits for a subprocess to exit. Returns exit code as integer (0 = success). Emits `SIG_EXEC | SIG_IO | SIG_YIELD`. Accepts either a process handle (external) or an exec result struct (extracts `:process` key).
 
-- `subprocess/kill handle [signal]` — Sends a signal to a subprocess synchronously. Returns `nil` on success. Emits `SIG_ERROR` only (no yield). Default signal is `SIGTERM` (15). Accepts either a process handle or an exec result struct.
+- `subprocess/kill handle [signal]` — Sends a signal to a subprocess synchronously. Emits `SIG_ERROR` only (no yield). Default signal is `SIGTERM` (15). Accepts either a process handle or an exec result struct. Three answers, each reporting what the call observed and nothing beyond it:
+  - `:signaled` — `kill(2)` took the signal for this handle's child.
+  - `:exited` — the handle's `ExitRecord` holds a status, so no `kill(2)` was made. The handle decides this, not the kernel: a reaped pid belongs to the OS again and gets handed out again, so the syscall would reach whatever holds that number now. See `src/io/AGENTS.md` § "A reap is never wasted" for the record, and `docs/io.md` § "Killing a child that may already be gone" for the argument.
+  - `:missing` — `kill(2)` reported `ESRCH`. Separate from `:exited` because it is separate evidence: a pid carries no record of who used to hold it, so `ESRCH` says the number named nobody at that moment and cannot say the process it names was ever this handle's child.
 
-- `subprocess/pid handle` — Extracts the OS process ID from a process handle or exec result struct. Returns integer PID. Emits `SIG_ERROR` only (no yield). Accepts either a process handle (external) or an exec result struct (extracts `:process` key).
+- `subprocess/pid handle` — Extracts the OS process ID from a process handle or exec result struct. Returns integer PID, whether or not the child has been reaped — the same number the exec result's `:pid` field carries. Emits `SIG_ERROR` only (no yield). Accepts either a process handle (external) or an exec result struct (extracts `:process` key).
 
 **Handle extraction pattern:** `subprocess/wait`, `subprocess/kill`, and `subprocess/pid` all accept either:
 1. A direct process handle (external with type name "process")

--- a/src/primitives/subprocess.rs
+++ b/src/primitives/subprocess.rs
@@ -10,6 +10,9 @@ use crate::value::{sorted_struct_get, Value};
 mod exec;
 use exec::*;
 
+#[cfg(test)]
+mod tests;
+
 /// Exit the process with an optional exit code
 ///
 /// (exit)       ; exits with code 0
@@ -276,7 +279,7 @@ primitive! {
     "subprocess/kill" => prim_subprocess_kill {
         signal: Signal::errors(),
         arity: Arity::Range(1, 2),
-        doc: "Send a signal to a subprocess. signal is an integer or a keyword like :sigterm, :sigkill, :sighup, :sigint, :sigquit, :sigpipe, :sigalrm, :sigusr1, :sigusr2, :sigchld, :sigcont, :sigstop, :sigtstp, :sigttin, :sigttou, :sigwinch (default: :sigterm).",
+        doc: "Send a signal to a subprocess. signal is an integer or a keyword like :sigterm, :sigkill, :sighup, :sigint, :sigquit, :sigpipe, :sigalrm, :sigusr1, :sigusr2, :sigchld, :sigcont, :sigstop, :sigtstp, :sigttin, :sigttou, :sigwinch (default: :sigterm). Returns :signaled when kill(2) took the signal, :exited when the handle holds the child's status and nothing was sent, :missing when no process holds the pid.",
         params: &["handle", "signal"],
         category: "sys",
         example: "(subprocess/kill proc :sigterm)",

--- a/src/primitives/subprocess/exec.rs
+++ b/src/primitives/subprocess/exec.rs
@@ -383,7 +383,10 @@ pub(super) fn prim_subprocess_wait(
 /// (subprocess/kill handle-or-struct 15)        ; integer (must round-trip to a named signal)
 /// (subprocess/kill handle-or-struct :sigterm)  ; keyword signal name
 ///
-/// Synchronous — returns (SIG_OK, nil) on success, (SIG_ERROR, error) on failure.
+/// Synchronous. Each answer reports what the call observed: (SIG_OK,
+/// `:signaled`) when `kill(2)` took the signal, (SIG_OK, `:exited`) when the
+/// handle's record holds a status and no signal was sent, (SIG_OK, `:missing`)
+/// when no process holds the pid. (SIG_ERROR, error) on failure.
 pub(super) fn prim_subprocess_kill(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
@@ -424,12 +427,22 @@ pub(super) fn prim_subprocess_kill(
     } else {
         libc::SIGTERM
     };
+    // The handle decides whether there is a child to signal, not the kernel. A
+    // reap gives the pid back to the OS, which hands the number out again, so a
+    // `kill(2)` on a handle whose record holds a status would reach whoever
+    // holds that number now (src/io/AGENTS.md § "A reap is never wasted").
+    if handle.exit().status().is_some() {
+        return (SIG_OK, ctx.keyword("exited"));
+    }
     let ret = unsafe { libc::kill(handle.pid() as i32, signal) };
     if ret < 0 {
         let err = std::io::Error::last_os_error();
         if err.raw_os_error() == Some(libc::ESRCH) {
-            // Process already exited — treat as success
-            (SIG_OK, Value::NIL)
+            // Nothing holds the number, so nothing was signalled. A separate
+            // answer from `:exited` because it is separate evidence: a pid
+            // carries no record of who used to hold it, so `ESRCH` cannot say
+            // the process it names was ever this handle's child.
+            (SIG_OK, ctx.keyword("missing"))
         } else {
             (
                 SIG_ERROR,
@@ -437,7 +450,7 @@ pub(super) fn prim_subprocess_kill(
             )
         }
     } else {
-        (SIG_OK, Value::NIL)
+        (SIG_OK, ctx.keyword("signaled"))
     }
 }
 

--- a/src/primitives/subprocess/tests.rs
+++ b/src/primitives/subprocess/tests.rs
@@ -1,0 +1,144 @@
+//! `subprocess/kill` against the handle's exit record.
+
+use super::*;
+use crate::io::request::{reaped_child, Reap};
+use crate::primitives::ctx::TestHeap;
+use std::process::{Child, Command};
+use std::time::Duration;
+
+/// A process that outlives the test around it, so "still running" means
+/// nothing signalled it rather than "the test was quick enough".
+fn long_lived_child() -> Child {
+    Command::new("sleep").arg("30").spawn().unwrap()
+}
+
+/// Send `signal` through the primitive.
+///
+/// The trap: the answer is compared as a value rather than as a spelling. A
+/// keyword IS its name hash (docs/impl/symbol.md), and the spelling lives in a
+/// symbol table a bare `TestHeap` VM does not carry — so `keyword_spelling`
+/// here answers `None` for a keyword the primitive minted correctly.
+fn kill(h: &TestHeap, handle: Value, signal: &str) -> (SignalBits, Value) {
+    let mut ctx = h.ctx();
+    let signal = ctx.keyword(signal);
+    prim_subprocess_kill(&mut ctx, &[handle, signal])
+}
+
+/// A kill on a handle whose record holds a status makes no `kill(2)` at all.
+///
+/// The trap: a pid cannot be recycled on demand. The kernel decides who gets a
+/// freed number, and waiting for it to pick this one is not a test. So the
+/// handle is built over a pid that already belongs to somebody else, which puts
+/// the kill in front of the same choice with a known victim.
+///
+/// The counter-factual is `ESRCH`, which the primitive reports as success: on a
+/// quiet machine a reaped child's number is free, so signalling it looks fine
+/// and a test that kills a reaped child of its own passes either way. `SIGKILL`
+/// is what makes the victim's side readable — it cannot be caught or blocked,
+/// so a process still running is one that was never signalled.
+#[test]
+fn a_kill_on_a_reaped_child_sends_no_signal() {
+    crate::value::arena::with_test_region(|| {
+        let mut victim = long_lived_child();
+        let pid = victim.id();
+
+        let h = TestHeap::new();
+        let handle = ProcessHandle::new(pid, reaped_child());
+        // The state a `subprocess/wait` leaves behind: the child this handle
+        // was spawned for is gone, and its status is here.
+        handle.exit().keep(0);
+        let handle_val = h.ctx().external("process", handle);
+
+        let (bits, answer) = kill(&h, handle_val, "sigkill");
+
+        // The syscall first: this is what the answer below is only a report of,
+        // and it fails on its own.
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            matches!(victim.try_wait(), Ok(None)),
+            "the pid's current owner was signalled, so the kill reached the kernel"
+        );
+
+        assert_eq!(bits, SIG_OK, "a child that is already gone is not an error");
+        assert_eq!(
+            answer,
+            Value::keyword("exited"),
+            "the answer must say the child had exited"
+        );
+
+        victim.kill().unwrap();
+        victim.wait().unwrap();
+    });
+}
+
+/// A kill that finds nobody holding the pid says that, rather than claiming the
+/// child exited.
+///
+/// The trap: `ESRCH` is the one answer the kernel gives about a number rather
+/// than about a process. A pid keeps no record of who used to hold it, so
+/// `ESRCH` cannot establish that the process it names was ever this handle's
+/// child — which is why it is not folded into `:exited`, whose evidence is the
+/// handle's own status.
+///
+/// The record is left empty on purpose: with a status in it the call answers
+/// from the record and never reaches the syscall this test is about.
+#[test]
+fn a_kill_on_a_pid_nobody_holds_reports_it_missing() {
+    crate::value::arena::with_test_region(|| {
+        // Reaped before the handle is built, so the number names nobody.
+        let pid = reaped_child().id();
+
+        let h = TestHeap::new();
+        let handle_val = h
+            .ctx()
+            .external("process", ProcessHandle::new(pid, reaped_child()));
+
+        let (bits, answer) = kill(&h, handle_val, "sigterm");
+        assert_eq!(bits, SIG_OK, "a pid nobody holds is not an error");
+        assert_eq!(
+            answer,
+            Value::keyword("missing"),
+            "the answer must report the pid, not infer a child from it"
+        );
+    });
+}
+
+/// A kill on a handle whose child is still there sends the signal and says so.
+///
+/// The other half of the answer: without this, "send nothing" would pass by
+/// never sending anything.
+#[test]
+fn a_kill_on_a_live_child_signals_it() {
+    crate::value::arena::with_test_region(|| {
+        let child = long_lived_child();
+        let pid = child.id();
+
+        let h = TestHeap::new();
+        let handle_val = h.ctx().external("process", ProcessHandle::new(pid, child));
+
+        let (bits, answer) = kill(&h, handle_val, "sigkill");
+        assert_eq!(bits, SIG_OK, "signalling a live child succeeds");
+        assert_eq!(
+            answer,
+            Value::keyword("signaled"),
+            "the answer must say the signal was sent"
+        );
+
+        // `SIGKILL` is not instant: the child is reapable once the kernel has
+        // torn it down, so ask until it is rather than once.
+        let record = handle_val
+            .as_external::<ProcessHandle>()
+            .expect("the handle is a process")
+            .exit();
+        loop {
+            match record.reap(pid) {
+                Reap::Exited(code) => {
+                    assert_eq!(code, -libc::SIGKILL, "the child died from the signal sent");
+                    break;
+                }
+                Reap::Running => std::thread::sleep(Duration::from_millis(10)),
+                Reap::Failed(errno) => panic!("waitpid failed: errno {}", errno),
+            }
+        }
+    });
+}

--- a/tests/elle/subprocess.lisp
+++ b/tests/elle/subprocess.lisp
@@ -60,6 +60,16 @@
   (subprocess/kill proc 15)
   (subprocess/wait proc))
 
+# subprocess/pid: a reaped child still reports the number it had
+#
+# The counter-factual: answering nil or raising once the status is in would
+# split one fact into two answers, since the exec result's :pid field keeps
+# handing out the same number regardless.
+(let [proc (subprocess/exec "true" [])]
+  (subprocess/wait proc)
+  (assert (= (subprocess/pid proc) (get proc :pid))
+          "subprocess/pid: still matches :pid after the child is reaped"))
+
 # ── subprocess/kill ──────────────────────────────────────────────────────────────
 
 # subprocess/kill: send SIGTERM, wait, exit is nonzero
@@ -79,6 +89,26 @@
              (subprocess/kill proc :sigterm)
              (subprocess/wait proc))]
   (assert (not (= exit 0)) "subprocess/kill :sigterm: nonzero exit"))
+
+# subprocess/kill: the answer says whether a signal was sent
+#
+# The trap: a pid names a child only until somebody reaps it, and the kernel
+# then hands the number out again. The second kill below must therefore make no
+# syscall — the status the wait left on the handle is what says there is no
+# child of ours left to signal.
+#
+# The counter-factual is :missing, which the ESRCH path answers. On this quiet
+# machine the reaped pid names nobody, so a kill that DID reach the kernel would
+# report :missing rather than raising; reading :exited is what says the record
+# answered and the syscall never happened. Which process a kill would have
+# reached needs a pid naming somebody else, and that is
+# `a_kill_on_a_reaped_child_sends_no_signal` (src/primitives/subprocess/tests.rs).
+(let [proc (subprocess/exec "sleep" ["60"])]
+  (assert (= (subprocess/kill proc :sigterm) :signaled)
+          "subprocess/kill: a live child is signaled")
+  (subprocess/wait proc)
+  (assert (= (subprocess/kill proc :sigterm) :exited)
+          "subprocess/kill: a reaped child answers :exited"))
 
 # ── child signal mask is reset ───────────────────────────────────────────────
 #


### PR DESCRIPTION
## What was wrong

`subprocess/kill` signalled `handle.pid()` however the child's life had ended:

```rust
let ret = unsafe { libc::kill(handle.pid() as i32, signal) };
```

A reap gives the pid back to the OS, which hands the number out again. So a kill
after a `subprocess/wait` reached whatever holds that number now — nothing on a
quiet machine, another child of this program or an unrelated process on a busy
one. `ESRCH` already read as success, so the free-number case looked correct and
the taken-number case looked identical to it.

The documented idiom kills before it waits, and that order is safe. A supervisor
that kills on a timer while a fiber waits reaches the reverse as a race rather
than by writing it.

## What the change does

The `ExitRecord` every `ProcessHandle` carries already knows: a handle holding a
status has no child of its own left. `subprocess/kill` reads the record before it
makes a `kill(2)`, and sends nothing when the status is in. That is the fact
`subprocess/wait` reads from the same record, asked by a killer rather than by a
waiter.

Every path through the primitive, in the order the code takes them:

| # | State at the call | `kill(2)` issued | Signal | Value |
|---|---|---|---|---|
| 1 | 0 args, or more than 2 | no | `SIG_ERROR` | `argument-error` |
| 2 | arg 0 is neither a `process` external nor a struct | no | `SIG_ERROR` | `type-error` |
| 3 | arg 0 is a struct with no `:process` key | no | `SIG_ERROR` | `type-error` |
| 4 | `:process` holds something that is not a process handle | no | `SIG_ERROR` | `type-error` |
| 5 | signal arg names no signal | no | `SIG_ERROR` | `argument-error` |
| 6 | **record holds a status** | **no** | `SIG_OK` | **`:exited`** |
| 7 | record empty, `kill` returns 0 | yes | `SIG_OK` | `:signaled` |
| 8 | record empty, `kill` returns `ESRCH` | yes | `SIG_OK` | `:missing` |
| 9 | record empty, `kill` returns any other errno | yes | `SIG_ERROR` | `exec-error` |

Row 6 is the defect. Before this change rows 6, 7 and 8 all made the syscall and
all returned `nil`; row 6 landed wherever the number had gone — row 7's answer on
a stranger it could signal, row 9's on one it could not.

Three answers rather than two, because the call has three different pieces of
evidence to report:

| Answer | What the call observed |
|---|---|
| `:signaled` | `kill(2)` took the signal for this handle's child. |
| `:exited` | The handle's record holds a status. No signal was sent. |
| `:missing` | `ESRCH` — no process holds that pid. Nothing was signalled. |

`:exited` and `:missing` are not folded together. The record establishes both
that the child is gone and whose child it was; `ESRCH` says only that the number
named nobody at that moment, and a pid keeps no record of who used to hold it.

All three are success. Killing a child that is already dead is not an error — the
state the kill asked for already holds — and a supervisor racing a kill against a
wait must not have to wrap its kill in `protect`.

`subprocess/pid` still answers the number after a reap. The exec result's `:pid`
field hands out the same number regardless, so refusing here would split one fact
into two answers, and what a caller does with a pid afterwards is outside this
runtime.

## Which tests pin it

- `a_kill_on_a_reaped_child_sends_no_signal` (`src/primitives/subprocess/tests.rs`)
  builds the handle over the pid of a `sleep` the test owns, because a test cannot
  recycle a pid on demand. `SIGKILL` cannot be caught, so a process still running
  is one that nothing signalled. Against the old code it fails on that assertion:
  the kill really did reach the stranger.
- `a_kill_on_a_pid_nobody_holds_reports_it_missing` leaves the record empty so the
  call reaches the syscall, and holds `ESRCH` to its own answer. It fails against
  a version that answers `:exited` there.
- `a_kill_on_a_live_child_signals_it` is the third, so "send nothing" cannot pass
  by never sending anything.
- `tests/elle/subprocess.lisp` pins the answers a program can reach, and that
  `subprocess/pid` still matches `:pid` after the child is reaped. With `:missing`
  distinct, reading `:exited` there is itself evidence that the record answered
  and no syscall happened.
- The `docs/io.md` example runs under `make doctest`; breaking the expected
  keyword deliberately exits 1, so the block is executed rather than decorative.

## How it was measured

`make smoke` (green, 1094 corpus runs + doctest + embedding), `make qa`,
`cargo test --workspace --lib --all-features` (2557 passed), and
`cargo test --test '*' -- --skip property` (993 passed).

A zombie accepts `kill(2)`, which is what makes row 6 the only unsound one — the
pid of an unreaped child cannot be recycled. Measured rather than recalled:

```
kill(zombie) = 0 errno=0 (ESRCH=3)
kill(reaped) = -1 errno=3 (ESRCH=3)
```

Closes #1045
