### PR TITLE
regions, vm: three residues an h2 request paid per request, and the diagnostic that found them

### DIFF
--- a/docs/impl/region/diagnostics.md
+++ b/docs/impl/region/diagnostics.md
@@ -53,6 +53,17 @@ the region rules ([rules.md](rules.md)) honest.
   per-region tags name *what* leaked (a stray `Fiber` / `Closure` region pinning
   an unfreed value). The companion `(arena/region-info)` returns the same id / RC
   / count as data (no tags) for assertions.
+- `--trace=arena`: **name the code that minted a region.** Each mint records the
+  running function, the place it was called from, and the mint's kind — `alloc`
+  for an allocation slot, `call result` for a call's own result region — and
+  `arena/dump` prints it after the tags: `region 1673 rc=1 objs=1 tags=[LString]
+  from send-request-frames [alloc] called at lib/http2.lisp:186:20`. The tags say
+  a retained region holds a string; this says which code made it, which is the
+  step from "the window retained 60 regions" to a shape small enough to
+  reproduce. Off by default and free then: the site string is built only while
+  the bit is set, so an untraced dump prints the same line it always did. The
+  mints the **VM** owns are covered; a region minted by a native, by the io
+  backend, or by the env builder prints no site.
 - `(arena/page-claims)`: the live count of pages this heap's `RegionStore` has
   claimed from its page pool, monotonic and never decremented on release. A
   delta across a fixed window is the *page* cost of a shape, the dimension

--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -978,13 +978,25 @@ the body.
 Three boundaries bound the window. Two are about *how many times* a release runs
 rather than where:
 
-- **An iterative scope nested in the block** (`While`/`Loop`). A value allocated
-  in a loop body is re-allocated per iteration, so its release must stay
-  per-iteration: hoisting it to the block's exit would leave one release for N
-  allocations — a worse leak than the one being closed, and the same
-  re-allocation argument the `capture_loop_ext` "bound outside" guard makes. A
-  break out of a loop therefore still strands the *breaking iteration's* regions,
-  an over-keep bounded by one iteration.
+- **An iterative scope nested in the block** (`While`/`Loop`), for a region the
+  loop body ALLOCATES. Such a value is re-allocated per iteration, so its release
+  must stay per-iteration: hoisting it to the block's exit would leave one
+  release for N allocations — a worse leak than the one being closed, and the
+  same re-allocation argument the `capture_loop_ext` "bound outside" guard makes.
+  A break out of a loop therefore still strands the *breaking iteration's* own
+  regions, an over-keep bounded by one iteration.
+
+  A region the loop merely READS is a different case, and the barrier is read off
+  the allocation site rather than the release's position for exactly that reason.
+  A parameter, or anything bound before the loop, is allocated once per
+  activation; its release only *sits* in the loop because that is where its last
+  use is. One release at the anchor covers it exactly once, which is the count
+  the re-allocation argument asks for. Refusing there strands a parameter on
+  every call that breaks — `dt-lookup`'s `name` and `value`, compared against
+  each dynamic-table entry in a `while` and then broken past.
+
+  A region with no allocation site in the unit at all is a parameter by
+  construction: the caller allocated it, so no loop here re-allocates it.
 - **A `Lambda` nested in the block.** Its body's releases run in a different
   activation, against a different frame's slots; the enclosing block's exit label
   is not a point that activation ever reaches.
@@ -992,14 +1004,36 @@ rather than where:
 The third guards the anchor itself — the hoist's premise is that the exit label
 is a point every path **reaches**:
 
-- **A frame-replacing exit in the body** (a `Return`, or a `Call` in tail
-  position, lowered as `TailCall`). That path leaves through the callee instead
-  of arriving at the exit label, so a release moved to the anchor would be dead
-  on exactly the path that used to run it — one leak traded for another. Such a
-  block declines the window whole. This is the `(fn … (forever … (break v)))`
-  tail-block idiom, where the broken value's own pin still applies (it is the
-  *returned* value, and its release is the one the return mint funds) but the
-  window's does not.
+- **A frame-replacing exit on the block's fall-through** — a `Call` in tail
+  position, lowered as `TailCall`. That path leaves through the callee instead of
+  arriving at the exit label, so a release moved to the anchor would be dead on
+  exactly the path that used to run it — one leak traded for another. Such a
+  block declines the window whole.
+
+  An exit inside a targeting break's own **value** is not that case, and reading
+  it as one costs a region per call on any block with more than one break. On the
+  break path the release is already jumped over, so there is nothing left for the
+  exit to strand and the trade is one-sided: every other path gains its release
+  and that path stays exactly as it was. The shape is ordinary because a break's
+  value is walked as a tail value in a tail block, so a `{…}` or `[…]` literal
+  carried by any break past the first is a tail-marked `Call` sitting in the
+  window. `dt-lookup` in `lib/http2/hpack.lisp` is four of them.
+
+  A `Return` node is **not** one of these, and reading it as one costs a region
+  per call on the most ordinary shape there is. `Return` is what
+  `wrap_tail_returns` puts around a *tail value*, and it is its only producer;
+  `lower_return` emits the return **mint** and nothing else, so control falls
+  through it. Both places one can appear inside a block's window — the block's
+  own tail value, and the value of a `break` targeting a tail block — therefore
+  reach the exit label like any other path. Declining there refuses the window of
+  every function whose body is a `block` with a `break` in it, which is how a
+  lookup helper is written: `(defn f [k] (block (let [x (mk k)] (when (hit x)
+  (break …)) …)))` strands `x` on every call that breaks.
+
+  The tail-block idiom `(fn … (forever … (break v)))` is unaffected either way:
+  the broken value's own pin applies (it is the *returned* value, and its release
+  is the one the return mint funds), and the `forever` is an iterative-scope
+  barrier that keeps the window off the loop body regardless.
 
 All three leave the conservative baseline (the release stays where it is,
 skipped on the break path), never a mis-free.
@@ -1341,9 +1375,9 @@ region per collected argument per call, plus its cascade.
 The runtime closes it where the collection is built (`populate_env`,
 src/vm/env.rs). On a **move** — a tail call or an FFI callback, the calls that
 pass `own_params = false` — the surplus reference is released once the collected
-value holds its own. Which collector took the value over does not enter the
-argument: what makes the reference surplus is that the argument went into a
-collection rather than into an env slot, which is true of all three.
+value holds its own. The release is per collector *kind*-independent: what makes
+the reference surplus is that the argument went into a collection rather than
+into an env slot, which is true of all three.
 
 Aliasing is what the release must not read past. One value in two argument
 positions arrives with a single moved reference, and a fixed slot or an earlier

--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1326,6 +1326,38 @@ any other holder and its cascade drops the `cell ⊇ closure` edge ahead of the 
 What the deferral drops afterwards is the frame's own slot reference, the last one
 standing.
 
+### A collector parameter takes the moved reference over itself
+
+The exemption above is a claim about the **callee's owned-param release**: the
+caller drops its release of a moved argument because the callee's release of
+that parameter consumes the reference. A `&`, `&keys`, or `&named` parameter is
+where that claim runs out. Its binding names the collected list or struct, not
+the argument, and the collected value is built in a region of its own with its
+own reference on each member (`alloc_obj`'s cross-region incref). So the
+callee's one release frees the collection and drops the collection's reference —
+never the caller's moved one. The move arrives and nothing consumes it: one
+region per collected argument per call, plus its cascade.
+
+The runtime closes it where the collection is built (`populate_env`,
+src/vm/env.rs). On a **move** — a tail call or an FFI callback, the calls that
+pass `own_params = false` — the surplus reference is released once the collected
+value holds its own. Which collector took the value over does not enter the
+argument: what makes the reference surplus is that the argument went into a
+collection rather than into an env slot, which is true of all three.
+
+Aliasing is what the release must not read past. One value in two argument
+positions arrives with a single moved reference, and a fixed slot or an earlier
+member may already consume it; a second release would free a value still in use.
+So a value is released only where it occurs exactly once across the whole
+argument list — leak-safe in the other direction, never mis-freeing.
+
+An **owned** call (`own_params = true`, the ordinary non-tail call) is not this
+case at all: the caller keeps its reference and releases it at the argument's own
+last use, so releasing here would over-free.
+
+`tests/elle/region-collector-arg-move.lisp` pins the rate for each collector kind
+against a positional-parameter control.
+
 ### The relocation point outlives the block, and a branch merge inherits it
 
 Inside the tail call's own block the relocation is a **move**: the instruction is

--- a/src/hir/region/infer/analyze/decref.rs
+++ b/src/hir/region/infer/analyze/decref.rs
@@ -1083,6 +1083,20 @@ fn pin_break_skipped_releases(
     let low = compute_subtree_low(hir, order);
     let mut scopes = BreakWindowScopes::default();
     collect_window_scopes(hir, order, &low, &mut scopes);
+    // Where each region is allocated, as post-order indices — what the loop
+    // barrier below is read off. A region absent here is allocated by a caller
+    // (a parameter), so no loop in this unit re-allocates it. Capture cells
+    // count as allocated at their `Begin`, which is where `populate_env` mints
+    // them.
+    let mut alloc_sites: HashMap<Region, Vec<u32>> = HashMap::new();
+    for (alloc_id, &region) in &info.alloc_region {
+        alloc_sites.entry(region).or_default().push(ord(*alloc_id));
+    }
+    for (begin_id, cells) in &info.begin_cell_regions {
+        for &(_b, region) in cells {
+            alloc_sites.entry(region).or_default().push(ord(*begin_id));
+        }
+    }
 
     for (block_id, sites) in break_skip_blocks {
         // The window opens at the EARLIEST targeting break: a release after it is
@@ -1097,33 +1111,68 @@ fn pin_break_skipped_releases(
         let anchor_ord = ord(anchor);
         // Only the barriers nested INSIDE this block matter: one enclosing the
         // block encloses the anchor too, so it constrains nothing here.
-        let inner: Vec<(u32, u32)> = scopes
-            .barriers
+        let inner_loops: Vec<(u32, u32)> = scopes
+            .loops
             .iter()
             .copied()
             .filter(|&(lo, hi)| block_lo <= lo && hi < block_hi)
             .collect();
-        // Does anything in the window leave the frame before the exit label? A
-        // nested lambda's own exits belong to that lambda, not to this block.
-        let lambdas: Vec<(u32, u32)> = scopes
+        // A nested lambda is two things at once: a barrier for the releases
+        // inside it, and the frame boundary that says whose exits a
+        // `frame_exits` entry belongs to.
+        let inner_lambdas: Vec<(u32, u32)> = scopes
             .lambdas
             .iter()
             .copied()
             .filter(|&(lo, hi)| block_lo <= lo && hi < block_hi)
             .collect();
+        // A frame exit inside a targeting break's own VALUE does not refuse the
+        // window: that break already jumps over every release in it, so on that
+        // path there is nothing left for the exit to strand
+        // (docs/impl/region/mechanism.md § "A release the break jumps over is not
+        // a release", third boundary). Only an exit on a path that would
+        // otherwise ARRIVE at the release — the block's fall-through — does.
+        let break_values: Vec<(u32, u32)> = sites
+            .iter()
+            .map(|s| (low.get(s).copied().unwrap_or(0), ord(*s)))
+            .collect();
         if scopes.frame_exits.iter().any(|&e| {
-            e >= first_break && e <= block_hi && !lambdas.iter().any(|&(lo, hi)| lo <= e && e <= hi)
+            e >= first_break
+                && e <= block_hi
+                && !inner_lambdas.iter().any(|&(lo, hi)| lo <= e && e <= hi)
+                && !break_values.iter().any(|&(lo, hi)| lo <= e && e <= hi)
         }) {
             continue;
         }
-        for d in info.region_data.values_mut() {
+        for (region, d) in info.region_data.iter_mut() {
             let dord = ord(d.decref_point);
             // In the body (the block node's own decrefs are already at the
             // anchor), at or after the break, and not already later than it.
             if dord < first_break || dord < block_lo || dord >= block_hi || dord >= anchor_ord {
                 continue;
             }
-            if inner.iter().any(|&(lo, hi)| lo <= dord && dord <= hi) {
+            // A lambda's body releases against its own frame's slots, so the
+            // enclosing block's exit label is not a point that activation
+            // reaches — a release there never hoists, whatever it names.
+            if inner_lambdas
+                .iter()
+                .any(|&(lo, hi)| lo <= dord && dord <= hi)
+            {
+                continue;
+            }
+            // A loop barrier is about the COUNT: it holds back a region the loop
+            // body allocates, which is re-allocated per iteration and so needs
+            // its release per iteration. A region allocated outside — a
+            // parameter above all, which has no allocation site here at all — is
+            // one per activation, and one release at the anchor covers it
+            // exactly once.
+            if inner_loops.iter().any(|&(lo, hi)| {
+                lo <= dord
+                    && dord <= hi
+                    && alloc_sites
+                        .get(region)
+                        .is_some_and(|sites| sites.iter().any(|&a| lo <= a && a <= hi))
+            }) {
                 continue;
             }
             d.decref_point = anchor;
@@ -1135,18 +1184,24 @@ fn pin_break_skipped_releases(
 /// unit, all as post-order indices so containment is an interval test.
 #[derive(Default)]
 struct BreakWindowScopes {
-    /// Subtree intervals of the scopes a release may not be hoisted OUT of: an
-    /// iterative scope (`While`/`Loop`, whose body re-allocates per iteration)
-    /// and a `Lambda` (whose body runs in its own activation, against its own
-    /// frame's slots).
-    barriers: Vec<(u32, u32)>,
-    /// Subtree intervals of the `Lambda`s alone — the frame boundary, which says
-    /// whose exits a `frame_exits` entry belongs to.
+    /// Subtree intervals of the iterative scopes (`While`/`Loop`). A release
+    /// inside one is held back only for a region that scope ALLOCATES, which is
+    /// re-allocated per iteration and so needs its release per iteration; a
+    /// region the loop merely reads is one per activation and hoists.
+    loops: Vec<(u32, u32)>,
+    /// Subtree intervals of the `Lambda`s: both an unconditional barrier (the
+    /// body runs in its own activation, against its own frame's slots) and the
+    /// frame boundary that says whose exits a `frame_exits` entry belongs to.
     lambdas: Vec<(u32, u32)>,
     /// Nodes that leave the enclosing frame instead of falling through to it: a
-    /// `Return`, and a `Call` in tail position (lowered as a frame-replacing
-    /// `TailCall`). One in a block's window means the block's exit label is not
-    /// a point every path reaches.
+    /// `Call` in tail position, lowered as a frame-replacing `TailCall`. One in a
+    /// block's window means the block's exit label is not a point every path
+    /// reaches.
+    ///
+    /// A `Return` node is deliberately NOT one (docs/impl/region/mechanism.md
+    /// § "A release the break jumps over is not a release", third boundary):
+    /// `lower_return` emits the return mint and no control flow, so control falls
+    /// through it to the exit label like any other value.
     frame_exits: Vec<u32>,
 }
 
@@ -1160,12 +1215,8 @@ fn collect_window_scopes(
     let lo = low.get(&hir.id).copied().unwrap_or(0);
     let hi = order.get(&hir.id).copied().unwrap_or(0);
     match &hir.kind {
-        HirKind::While { .. } | HirKind::Loop { .. } => out.barriers.push((lo, hi)),
-        HirKind::Lambda { .. } => {
-            out.barriers.push((lo, hi));
-            out.lambdas.push((lo, hi));
-        }
-        HirKind::Return { .. } => out.frame_exits.push(hi),
+        HirKind::While { .. } | HirKind::Loop { .. } => out.loops.push((lo, hi)),
+        HirKind::Lambda { .. } => out.lambdas.push((lo, hi)),
         HirKind::Call { is_tail: true, .. } => out.frame_exits.push(hi),
         _ => {}
     }

--- a/src/hir/region/infer/tests/blocks.rs
+++ b/src/hir/region/infer/tests/blocks.rs
@@ -308,6 +308,37 @@ fn a_frame_replacing_exit_in_the_body_refuses_the_window() {
 }
 
 #[test]
+fn a_return_mint_in_the_body_does_not_refuse_the_window() {
+    // The frame-exit boundary above reads a *frame-replacing* exit. A `Return`
+    // node is not one: it is what `wrap_tail_returns` puts around a tail value,
+    // and `lower_return` emits the return mint and no control flow, so control
+    // falls through it to the exit label. Here the block is the function's tail,
+    // which `Return`-wraps both its own tail value and the break's value — and
+    // the window still applies to `x`, whose release the break jumps over.
+    //
+    // The counter-factual: reading `Return` as a frame exit refuses this window,
+    // and `x` strands once per call that breaks. That is every lookup helper
+    // written as a block of guarded breaks.
+    let (hir, _arena, info) = pipeline(
+        "(defn h [n] (block (let [x \"s\"] (if (%int? n) (break 1) nil) \
+                              (%string? x))))",
+    );
+    let block = first_block(&hir).expect("a Block node");
+    let dp = first_string_decref_point(&hir, &info);
+    let order = compute_order(&hir);
+    let ord = |id: HirId| order.get(&id).copied().unwrap_or(0);
+    assert!(
+        ord(dp) >= ord(block),
+        "skipped region in a TAIL block dies at @{} (order {}), before the \
+         block @{} (order {}) — the break jumps over that release",
+        dp.0,
+        ord(dp),
+        block.0,
+        ord(block),
+    );
+}
+
+#[test]
 fn break_through_a_branch_anchors_both_arms_at_the_block() {
     // The floor travels with the value through the tail-transparent forms: an
     // `if` in break position hands EITHER arm to the block, so neither arm may

--- a/src/value/fiberheap/region.rs
+++ b/src/value/fiberheap/region.rs
@@ -304,6 +304,13 @@ impl FiberHeap {
         self.region_store.region_tags(id)
     }
 
+    /// File where physical id `id` was just minted, for the `--trace=arena`
+    /// attribution `debug_dump` prints beside a region's tags. Only the VM's
+    /// mint sites call this, and only while that trace bit is set.
+    pub fn note_region_mint_site(&mut self, id: u32, site: std::rc::Rc<str>) {
+        self.region_store.note_mint_site(id, site);
+    }
+
     /// How many times this heap has freed the region filed under `id` — the
     /// counter that tells one incarnation of a recycled id from the next
     /// (docs/impl/region/generations.md § "Region generations").

--- a/src/value/fiberheap/regionstore.rs
+++ b/src/value/fiberheap/regionstore.rs
@@ -166,6 +166,17 @@ pub(crate) struct RegionStore {
     /// from its earlier incarnation by generation. `None` outside such a scope
     /// (the common case: one branch on the mint path).
     mint_log: Option<Vec<(u32, u32)>>,
+    /// Where each id was last minted, keyed by physical region id — the
+    /// `--trace=arena` attribution `arena/dump` prints beside a region's tags
+    /// (docs/impl/region/diagnostics.md § "Naming the code that minted a
+    /// region"). A tag census says a retained region holds a string; this says
+    /// which function made it.
+    ///
+    /// Empty unless that trace bit is set: `note_mint_site` is the only writer
+    /// and its callers gate on the bit, so an untraced run pays one `is_empty`
+    /// read at dump time and nothing at mint time. Bounded by the id
+    /// high-water mark, since a recycled id overwrites its entry.
+    mint_sites: std::collections::HashMap<u32, std::rc::Rc<str>>,
     /// This instance's trace cell (a clone of the heap's), handed to each
     /// `RegionPool` at creation so the `PAGES` page-claim gate reads its own
     /// instance's trace state rather than a process-global.
@@ -224,6 +235,7 @@ impl RegionStore {
             generations: Vec::new(),
             store_id: NEXT_STORE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             mint_log: None,
+            mint_sites: std::collections::HashMap::new(),
             trace,
         }
     }

--- a/src/value/fiberheap/regionstore/introspect.rs
+++ b/src/value/fiberheap/regionstore/introspect.rs
@@ -159,15 +159,35 @@ impl RegionStore {
             .unwrap_or_default()
     }
 
+    /// Record where physical id `id` was just minted, for the `--trace=arena`
+    /// attribution `debug_dump` prints. Callers gate on the trace bit, so an
+    /// untraced run never reaches this.
+    pub fn note_mint_site(&mut self, id: u32, site: std::rc::Rc<str>) {
+        self.mint_sites.insert(id, site);
+    }
+
+    /// The recorded mint site of `id`, or `None` when the run is untraced or
+    /// the id was minted before the bit was set.
+    pub fn mint_site(&self, id: u32) -> Option<&str> {
+        self.mint_sites.get(&id).map(|s| &**s)
+    }
+
     pub fn debug_dump(&self) {
         for (idx, slot) in self.regions.iter().enumerate() {
             if let Some(e) = slot.as_ref() {
+                // The mint site is present only under `--trace=arena`; an
+                // untraced dump keeps its historical one-line-per-region shape.
+                let site = match self.mint_site(idx as u32) {
+                    Some(s) => format!(" from {s}"),
+                    None => String::new(),
+                };
                 eprintln!(
-                    "  region {} rc={} objs={} tags={:?}",
+                    "  region {} rc={} objs={} tags={:?}{}",
                     idx,
                     e.count(),
                     e.pool.obj_count(),
-                    e.pool.debug_tags()
+                    e.pool.debug_tags(),
+                    site
                 );
             }
         }

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -172,6 +172,18 @@ pub struct VM {
     /// call sites. This also protects against fiber error propagation
     /// overwriting the child fiber's error origin.
     pub(crate) error_loc: Option<SourceLoc>,
+    /// The instruction the interpreter is executing, as `--trace=arena` reports
+    /// it: the running function's name and the source location of the
+    /// instruction itself (docs/impl/region/diagnostics.md § `--trace=arena`).
+    ///
+    /// Written only while that trace bit is set — the dispatch loop reads the
+    /// bit once per frame into a local, so an ordinary run pays one predictable
+    /// branch per instruction and never resolves a location. It names the
+    /// ALLOCATION rather than the enclosing call, which is the difference
+    /// between "a string was made somewhere in this function" and the line that
+    /// made it, and it is the only reading available inside a fiber's entry
+    /// closure, where the call stack is still empty.
+    pub(crate) arena_site: Option<(SourceLoc, Option<&'static str>)>,
     /// Reason carried by the most recent uncaught `:gated` error to propagate
     /// out of `execute_proto`. A loud `(gate! …)` whose condition is unmet
     /// raises `{:error :gated :reason …}`; when that escapes to the top level

--- a/src/vm/core/lifecycle.rs
+++ b/src/vm/core/lifecycle.rs
@@ -106,6 +106,7 @@ impl VM {
             pending_error_park: false,
             trampoline_parent_override: None,
             error_loc: None,
+            arena_site: None,
             gated_exit_reason: None,
             active_tier: "bytecode",
             exit_trapped: false,

--- a/src/vm/core/region.rs
+++ b/src/vm/core/region.rs
@@ -32,6 +32,65 @@ impl FrameLocals<'_> {
 }
 
 impl VM {
+    /// Record where a just-minted region came from, for `--trace=arena`
+    /// (docs/impl/region/diagnostics.md § "Naming the code that minted a
+    /// region"). `arena/dump` prints it beside the region's tags, so a region a
+    /// residue window reports as retained names the Elle code that made it.
+    ///
+    /// The site is the running function and the place it was called from — the
+    /// same two facts a stack-trace line carries, read from the innermost
+    /// `CallFrame`. `what` names the mint kind and, for a mint the compiler
+    /// assigned a slot, that slot: `--dump=regions` on the running function maps
+    /// `rN` back to the allocation node, which the call site alone cannot do
+    /// when a function allocates in several places.
+    ///
+    /// Off by default and one relaxed atomic load then: the string is built only
+    /// while the bit is set.
+    /// `kind` names the mint; `slot` is the compiler's region slot where the mint
+    /// has one. Nothing is formatted unless the bit is set, so the allocation path
+    /// pays one relaxed atomic load in an ordinary run.
+    #[inline]
+    pub(crate) fn note_region_mint(
+        &mut self,
+        id: RuntimeRegion,
+        kind: &str,
+        slot: Option<StaticRegion>,
+    ) {
+        if !self
+            .runtime_config
+            .has_trace_bit(crate::config::trace_bits::ARENA)
+        {
+            return;
+        }
+        let slot = match slot {
+            Some(s) => format!(" r{}", s.get()),
+            None => String::new(),
+        };
+        // The allocating instruction names itself. The call stack is the
+        // fallback for a mint the interpreter loop did not set a site for — a
+        // compiled frame, or one made off an instruction entirely.
+        let site = match &self.arena_site {
+            Some((loc, name)) => format!(
+                "{} [{}{}] at {}",
+                name.unwrap_or("<anonymous>"),
+                kind,
+                slot,
+                loc
+            ),
+            None => match self.fiber.call_stack.last() {
+                Some(f) => {
+                    let loc = match f.location() {
+                        Some(l) => format!("{l}"),
+                        None => "?".to_string(),
+                    };
+                    format!("{} [{}{}] called at {}", f.name(), kind, slot, loc)
+                }
+                None => format!("<no frame> [{kind}{slot}]"),
+            },
+        };
+        self.heap().note_region_mint_site(id.get(), site.into());
+    }
+
     /// Resolve a static region slot to a **fresh** physical region for an
     /// allocation that has a matching compiler-emitted `DecrefRegion` at its
     /// decref_point (Pair, arrays, structs, closures, capture cells).
@@ -65,6 +124,7 @@ impl VM {
         // slot-0 case: the operand is a `StaticRegion`, always ≥ 1.)
         let phys = self.heap().new_runtime_region();
         let gen = self.heap().generation_raw(phys.get());
+        self.note_region_mint(phys, "alloc", Some(static_id));
         self.fiber
             .activation_region_maps
             .last_mut()
@@ -153,7 +213,9 @@ impl VM {
         &mut self,
         _static_id: StaticRegion,
     ) -> RegionMint {
-        self.heap().new_runtime_region_tracked()
+        let mint = self.heap().new_runtime_region_tracked();
+        self.note_region_mint(mint.region(), "call result", Some(_static_id));
+        mint
     }
     /// Close out a call-result mint: return its id to the free list unless the
     /// call materialized the region (docs/impl/region/model.md § "Physical id

--- a/src/vm/dispatch/interp.rs
+++ b/src/vm/dispatch/interp.rs
@@ -98,6 +98,20 @@ impl VM {
         let consts: &[Value] = code.constants();
         let locations = code.locations();
 
+        // `--trace=arena` attribution (docs/impl/region/diagnostics.md): the bit
+        // is read ONCE per frame, so an untraced run pays a predictable branch
+        // on a local per instruction and resolves no location. A toggle through
+        // `(vm/config-set :trace …)` therefore takes effect at the next frame,
+        // which is what a diagnostic needs and what keeps this off the hot path.
+        let trace_arena = self
+            .runtime_config
+            .has_trace_bit(crate::config::trace_bits::ARENA);
+        let arena_fn_name = if trace_arena {
+            code.template().name()
+        } else {
+            None
+        };
+
         // The executing-closure register is a possibly-dead borrow here: an
         // activation can outlive its closure's heap value (the region solver
         // frees the value at its last use; `code`/`env` live on as `Rc`s), and a
@@ -142,6 +156,10 @@ impl VM {
             }
 
             instr_ip = ip; // save instruction start before reading opcode
+
+            if trace_arena {
+                self.arena_site = locations.get(instr_ip).map(|l| (l, arena_fn_name));
+            }
 
             // Locals live beneath the operands on this same stack, so nothing
             // may pop through the reserved region (see `Code::reserved_locals`).

--- a/src/vm/env.rs
+++ b/src/vm/env.rs
@@ -206,28 +206,7 @@ impl VM {
                     &[]
                 };
                 let collected = match closure.template.vararg_tag() {
-                    crate::value::VarargTag::List => {
-                        let list = Self::args_to_list(rest_args, heap);
-                        // On a MOVE (`own_params = false`: a tail call / FFI callback),
-                        // the caller's owning reference to each arg transferred to us. A
-                        // fixed param lands that reference in its env slot; a rest arg
-                        // instead lives in the collected list, which `args_to_list`'s
-                        // `alloc_obj` gave its OWN incref. So a rest arg's moved-in
-                        // reference is surplus — release it, or it leaks one region per
-                        // rest arg per call (the variadic tail-forward leak: `(defn g [&
-                        // rest] …) (defn f [x] (g x))`; `store-wrapper` in the oracle).
-                        // An OWNED call keeps the caller's reference (freed at the arg's
-                        // last use), so it must NOT be released. Only release when the
-                        // value appears EXACTLY ONCE across all arg positions: an aliased
-                        // arg (same value in a fixed slot and/or another rest position)
-                        // shares one transferred reference that a fixed slot / earlier
-                        // cons already consumes, so a second release would over-free
-                        // (a UAF — leak-safe conservatism, never mis-free).
-                        if !own_params {
-                            Self::release_moved_rest_args(rest_args, args, heap);
-                        }
-                        list
-                    }
+                    crate::value::VarargTag::List => Self::args_to_list(rest_args, heap),
                     crate::value::VarargTag::Struct => {
                         match Self::collect_struct_in_own_region(fiber, heap, rest_args, None) {
                             Some(v) => v,
@@ -243,6 +222,18 @@ impl VM {
                         }
                     }
                 };
+                // On a MOVE (`own_params = false`: a tail call / FFI callback) the
+                // caller's owning reference to each arg transferred to us, and a
+                // collected arg lands in `collected` — which took its own reference
+                // when it stored the value — rather than in an env slot. So the
+                // moved reference is surplus and is released here, whichever
+                // collector took the value over (docs/impl/region/mechanism.md
+                // § "A collector parameter takes the moved reference over itself").
+                // Released after `collected` is built, so the collection's own
+                // reference already stands.
+                if !own_params {
+                    Self::release_moved_rest_args(rest_args, args, heap);
+                }
                 // The rest-param's collected list/struct is built into the env
                 // region here, not moved in by the caller — it is a borrow, not
                 // an owned param, so no caller incref balances it: `false`.
@@ -384,13 +375,18 @@ impl VM {
         list
     }
 
-    /// Release the moved-in reference of each rest arg on a MOVE call
-    /// (`own_params = false`). See the caller (`populate_env`, the `List` vararg
-    /// arm) for why: the rest arg lives in the collected list (its own incref), so
-    /// the caller's transferred reference is surplus. Released ONLY for a value that
+    /// Release the moved-in reference of each collected arg on a MOVE call
+    /// (`own_params = false`), for every collector kind — `&`, `&keys`, `&named`
+    /// alike (docs/impl/region/mechanism.md § "A collector parameter takes the
+    /// moved reference over itself"; rate pinned by
+    /// `tests/elle/region-collector-arg-move.lisp`). Released ONLY for a value that
     /// appears exactly once across ALL arg positions (`all_args`) — an aliased value
-    /// shares one transferred reference a fixed slot / earlier cons already consumes,
-    /// so a second release would over-free (leak-safe: never mis-free).
+    /// shares one transferred reference a fixed slot / earlier member already
+    /// consumes, so a second release would over-free (leak-safe: never mis-free).
+    ///
+    /// A keyword key in `rest_args` is an immediate, so `region_of` reports no
+    /// region for it and the `&keys`/`&named` keys are skipped without a special
+    /// case — only the values they name are released.
     ///
     /// The occurrence counts come from ONE pass over `all_args`, so the whole
     /// step is linear in the argument count. Counting per rest arg instead —

--- a/tests/elle/h2-stress-scoped.lisp
+++ b/tests/elle/h2-stress-scoped.lisp
@@ -63,8 +63,8 @@
 # delta must fit under. Shrink-only — see "The pins" above.
 (def residue-small 10)
 (def residue-large 30)
-(def max-objects-per-request 16)
-(def max-regions-per-request 16)
+(def max-objects-per-request 9)
+(def max-regions-per-request 9)
 
 # ── Helpers ──────────────────────────────────────────────────────────
 

--- a/tests/elle/region-break-skip.lisp
+++ b/tests/elle/region-break-skip.lisp
@@ -13,12 +13,15 @@
 #
 # The close re-anchors those regions to the same point the broken value takes,
 # `last_use[block]`, which the break path and the fall-through path both reach.
-# Three boundaries stop the hoist: an iterative scope nested in the block (a
-# loop-body value is re-allocated per iteration, so one release cannot cover N),
-# a lambda nested in the block (its releases run in another activation, against
-# another frame's slots), and a frame-replacing tail call in the body (the
-# fall-through path leaves through the callee, so the exit label is not a point
-# every path reaches).
+# Three boundaries stop the hoist, and each is narrower than the scope it sits
+# in: an iterative scope nested in the block, for a region that scope ALLOCATES
+# (re-allocated per iteration, so one release cannot cover N — a region the loop
+# only reads is one per activation and hoists); a lambda nested in the block,
+# unconditionally (its releases run in another activation, against another
+# frame's slots); and a frame-replacing tail call on the block's FALL-THROUGH
+# (that path leaves through the callee, so the exit label is not a point every
+# path reaches — one inside a break's own value is on a path that already jumps
+# over these releases and refuses nothing).
 #
 # This file is the LEAK gauge — an `arena/region-count` delta over a fixed
 # window, which must be BOUNDED for every placement of a skipped release, and
@@ -42,6 +45,11 @@
 
 (defn mk ()
   {:a 1})
+
+# A fresh heap value the CALLER allocates, so the callee's parameter names a
+# region the caller owns and the callee releases.
+(defn mk-string ()
+  (concat "ab" "cd"))
 
 # subjects ─────────────────────────────────────────────────────────────────────
 
@@ -95,6 +103,41 @@
                  (when (%gt n 0) (break 1))
                  (%add 2 (length (keys x)))))))
 
+# (g) the block is the function's TAIL. Every subject above ends its body with a
+# trailing `nil`, which keeps the block out of tail position and so keeps a
+# `Return` out of the window; a lookup helper is not written that way. The tail
+# value and the break's value are both `Return`-wrapped here, and a `Return` is
+# the return MINT — control falls through it to the exit label — so neither is a
+# frame-replacing exit and the window still applies.
+(defn skip-tail-block (n)
+  (block (let [x (mk)]
+           (when (%gt n 0) (break 1))
+           (%struct? x))))
+
+# (h) the same, with the break carrying a FRESH value rather than an immediate.
+# The carried value takes the return mint; the skipped `x` has no mint and must
+# still be released at the anchor.
+(defn skip-tail-heap-break (n)
+  (block (let [x (mk)]
+           (when (%gt n 0) (break {:b 2}))
+           x)))
+
+# (i) a tail block with SEVERAL breaks, each carrying a heap literal — the shape
+# a lookup helper is written in, and the one where the frame-exit boundary has
+# to read which path an exit is on. A break's value is walked as a tail value in
+# a tail block, so each `{…}` here is a tail-marked call sitting in the window.
+# An exit inside a break's own value is on a path that already jumps over these
+# releases, so it does not refuse the window; only one on the fall-through does
+# (`bound-tailcall`).
+# Each guard names one value of `n`, so every break is reachable on its own and
+# the value asserts below exercise all three exits rather than only the first.
+(defn skip-tail-many-breaks (n)
+  (block (let [x (mk)]
+           (when (= n 1) (break {:b 1}))
+           (when (= n 2) (break {:b 2}))
+           (when (= n 3) (break {:b 3}))
+           (%struct? x))))
+
 # boundaries ───────────────────────────────────────────────────────────────────
 # Each drives a break that never fires, so the guarded code RUNS and its releases
 # must fire where they were placed. A hoist that crossed a boundary would leave
@@ -108,6 +151,19 @@
     (while (%lt i 8)
       (let [x (mk)]
         (%struct? x))
+      (assign i (%add i 1)))
+    nil))
+
+# The loop barrier is read off the ALLOCATION site, not off where the release
+# sits. `s` is a parameter — allocated once by the caller — whose last use is
+# inside the loop, so its release sits there while the value is still one per
+# activation. One release at the anchor covers it exactly once. The break here
+# DOES fire, so a refusal strands `s` on every call.
+(defn skip-loop-read-param (n s)
+  (block (when (%gt n 0) (break 1))
+    (def @i 0)
+    (while (%lt i 4)
+      (when (%eq (length s) 999) (break 2))
       (assign i (%add i 1)))
     nil))
 
@@ -155,6 +211,13 @@
 (def skip-deep-break-d (measure (fn () (skip-deep-break 1)) 200 window))
 (def skip-nested-block-d (measure (fn () (skip-nested-block 1)) 200 window))
 (def skip-used-d (measure (fn () (skip-used 1)) 200 window))
+(def skip-tail-block-d (measure (fn () (skip-tail-block 1)) 200 window))
+(def skip-tail-heap-break-d
+  (measure (fn () (skip-tail-heap-break 1)) 200 window))
+(def skip-tail-many-breaks-d
+  (measure (fn () (skip-tail-many-breaks 1)) 200 window))
+(def skip-loop-read-param-d
+  (measure (fn () (skip-loop-read-param 1 (mk-string))) 200 window))
 (def bound-loop-d (measure (fn () (bound-loop 1)) 200 window))
 (def bound-lambda-d (measure (fn () (bound-lambda 1)) 200 window))
 (def bound-tailcall-d (measure (fn () (bound-tailcall 1)) 200 window))
@@ -165,6 +228,9 @@
 (println "  call " skip-call-d "  literal " skip-literal-d "  two " skip-two-d
          "  deep " skip-deep-break-d)
 (println "  nested-block " skip-nested-block-d "  used " skip-used-d)
+(println "  tail-block " skip-tail-block-d "  tail-heap-break "
+         skip-tail-heap-break-d "  tail-many-breaks " skip-tail-many-breaks-d)
+(println "  loop-read-param " skip-loop-read-param-d)
 (println "  boundaries: loop " bound-loop-d "  lambda " bound-lambda-d
          "  tailcall " bound-tailcall-d)
 (println "  controls: nobreak " ctl-nobreak-d "  before-break "
@@ -184,6 +250,13 @@
 (bounded? skip-deep-break-d "skipped release under a nested break")
 (bounded? skip-nested-block-d "skipped release inside a nested block")
 (bounded? skip-used-d "skipped release under a consumed block result")
+(bounded? skip-tail-block-d "skipped release in a block in TAIL position")
+(bounded? skip-tail-heap-break-d
+          "skipped release beside a break carrying a fresh value")
+(bounded? skip-tail-many-breaks-d
+          "skipped release in a tail block with several breaks")
+(bounded? skip-loop-read-param-d
+          "skipped release of a param the loop only reads")
 
 (bounded? bound-loop-d "loop nested in the window: per-iteration release")
 (bounded? bound-lambda-d "lambda nested in the window: per-activation release")
@@ -196,5 +269,16 @@
 (assert (= (bound-loop 1) nil) "boundary loop body diverged")
 (assert (= (bound-lambda 1) nil) "boundary lambda body diverged")
 (assert (= (bound-tailcall 1) 2) "boundary tail call body diverged")
+(assert (= (skip-tail-block 1) 1) "tail block: breaking result lost")
+(assert (= (skip-tail-block 0) true) "tail block: fall-through result lost")
+(assert (= (skip-tail-heap-break 1) {:b 2})
+        "tail block: the value the break carried did not survive")
+(assert (= (skip-tail-heap-break 0) {:a 1})
+        "tail block: the fall-through value did not survive")
+(assert (= (skip-tail-many-breaks 1) {:b 1}) "tail block: first break lost")
+(assert (= (skip-tail-many-breaks 2) {:b 2}) "tail block: second break lost")
+(assert (= (skip-tail-many-breaks 3) {:b 3}) "tail block: third break lost")
+(assert (= (skip-tail-many-breaks 0) true)
+        "tail block: many-break fall-through lost")
 
 (println "region-break-skip: ok")

--- a/tests/elle/region-collector-arg-move.lisp
+++ b/tests/elle/region-collector-arg-move.lisp
@@ -1,0 +1,243 @@
+(elle/epoch 12)
+# A fresh heap value handed to a collector parameter over a frame-replacing tail
+# call, and what the callee owes for it.
+#
+# A tail call MOVES its arguments: the caller does not incref them, and the
+# release it never runs is the reference the callee's owned-param release
+# consumes. A collector parameter — `&`, `&keys`, `&named` — is where that trade
+# stops working on its own. The binding names the collected list or struct, so
+# the callee's one release frees the COLLECTION and drops the collection's own
+# reference to each member. The caller's moved reference is a second one, and
+# nothing in the callee names it.
+#
+# docs/impl/region/mechanism.md § "A collector parameter takes the moved
+# reference over itself" owns the argument. This file measures the rate.
+#
+# ── The counter-factual ──────────────────────────────────────────────
+#
+# A ceiling on a single drive proves nothing about a rate, so each shape runs at
+# two counts and both must read 0. The controls are what tell a real reclamation
+# from a dead gauge in the other direction: a positional parameter takes the same
+# move through the ordinary owned-param release and must also read 0, and the
+# retaining case at the end must read MORE than 0 — a callee that stores its
+# collected struct in a module-level sink keeps every value handed to it, so a
+# run where these numbers all came back 0 for the wrong reason fails there.
+#
+# ── The trap ─────────────────────────────────────────────────────────
+#
+# The call has to be in TAIL position, and the argument has to be allocated by
+# the caller in the same call. A non-tail call keeps the caller's release, and a
+# value allocated at module scope is one the caller never owned — either one
+# reads 0 whatever the collector does, which is why both appear below as their
+# own cases rather than as the way the leaking cases are written.
+
+(def small 20)
+(def large 60)
+
+# ── The gauge ────────────────────────────────────────────────────────
+#
+# One run ahead of every window is not counted: the first call through a shape
+# pays one-off costs (the callee's code, its template) that are not per call.
+# The delta is compared against `ceiling × n` rather than divided, so a
+# sub-integer rate cannot floor to 0 and report a leak as reclaimed.
+
+(defn residue [n body]
+  (body 0)
+  (let [c0 (arena/count)
+        r0 (arena/region-count)]
+    (def @i 0)
+    (while (< i n)
+      (body i)
+      (assign i (+ i 1)))
+    [(- (arena/count) c0) (- (arena/region-count) r0)]))
+
+(defn bounded [label body]
+  "`body` leaves nothing behind, at two counts."
+  (def @c 0)
+  (each n in [small large]
+    (let [[objects regions] (residue n body)]
+      (assert (= objects 0)
+              (string label " n=" n ": " objects " objects retained, expected 0"))
+      (assert (= regions 0)
+              (string label " n=" n ": " regions " regions retained, expected 0"))
+      (println "  " label " n=" n ": " objects " objects, " regions " regions")))
+  true)
+
+(defn grows [label body]
+  "`body` retains at least one object and one region per run."
+  (let [[objects regions] (residue large body)]
+    (assert (<= large objects)
+            (string "GAUGE DEAD: " label " retained " objects " objects over "
+                    large " runs — every bound in this file" " is void"))
+    (assert (<= large regions)
+            (string "GAUGE DEAD: " label " retained " regions " regions over "
+                    large " runs — every bound in this file" " is void"))
+    (println "  " label " n=" large ": " objects " objects, " regions " regions"))
+  true)
+
+# ── The callees ──────────────────────────────────────────────────────
+#
+# Each returns its first parameter, so the collected value is dead at the
+# callee's exit and every case below differs only in how the value was
+# collected.
+
+(defn take-rest [x & xs]
+  x)
+(defn take-keys [x &keys k]
+  x)
+(defn take-named [x &named body]
+  x)
+(defn take-plain [x y]
+  x)
+
+# ── The drivers ──────────────────────────────────────────────────────
+#
+# The call is the driver's whole body, so it is in tail position and the
+# argument is allocated inside the same call.
+
+(defn drive-rest []
+  (take-rest 1 (bytes "abcdef")))
+(defn drive-keys []
+  (take-keys 1 :body (bytes "abcdef")))
+(defn drive-named []
+  (take-named 1 :body (bytes "abcdef")))
+(defn drive-plain []
+  (take-plain 1 (bytes "abcdef")))
+
+(println "one fresh value moved into a collector...")
+
+(bounded "& rest list" (fn [i] (drive-rest)))
+(bounded "&keys struct" (fn [i] (drive-keys)))
+(bounded "&named struct" (fn [i] (drive-named)))
+(bounded "positional parameter" (fn [i] (drive-plain)))
+
+# ── Several values ───────────────────────────────────────────────────
+#
+# The release is per collected argument, so a collector holding three fresh
+# values owes three.
+
+(defn drive-rest-three []
+  (take-rest 1 (bytes "a") (bytes "b") (bytes "c")))
+
+(defn drive-keys-three []
+  (take-keys 1 :a (bytes "a") :b (bytes "b") :c (bytes "c")))
+
+(println "several fresh values into one collector...")
+
+(bounded "& rest list, three values" (fn [i] (drive-rest-three)))
+(bounded "&keys struct, three values" (fn [i] (drive-keys-three)))
+
+# ── The same value twice: what the release must not read past ────────
+#
+# One value in two argument positions arrives with ONE moved reference, and a
+# fixed slot or an earlier member may already consume it. Releasing per position
+# would free a value the callee still holds, so the release is declined for any
+# value occurring more than once. That is a deliberate trade in the leak
+# direction — never a mis-free — so these shapes retain the one reference nobody
+# took over, and the rate below is that conservatism, not a defect in the
+# release.
+#
+# Each case asserts the callee's answer as well as the rate. That is the half
+# that cannot be traded away: a release moved past the aliasing check shows up
+# here as a wrong answer or a fault, where the rate alone would only get
+# smaller and look like an improvement.
+
+(def max-aliased-regions-per-call 1)
+
+(defn at-most [label per-call body]
+  "`body` retains no more than `per-call` objects and regions per run."
+  (each n in [small large]
+    (let [[objects regions] (residue n body)]
+      (assert (<= objects (* per-call n))
+              (string label " n=" n ": " objects " objects exceeds the "
+                      per-call "/call ceiling"))
+      (assert (<= regions (* per-call n))
+              (string label " n=" n ": " regions " regions exceeds the "
+                      per-call "/call ceiling"))
+      (println "  " label " n=" n ": " objects " objects, " regions " regions")))
+  true)
+
+(defn take-rest-len [x & xs]
+  (length xs))
+(defn take-keys-a [x &keys k]
+  (length (bytes k:a)))
+
+(defn drive-rest-aliased []
+  (let [b (bytes "abcdef")]
+    (take-rest-len 1 b b)))
+
+(defn drive-keys-aliased []
+  (let [b (bytes "abcdef")]
+    (take-keys-a 1 :a b :b b)))
+
+(println "one value in two argument positions...")
+
+(at-most "& rest list, aliased value" max-aliased-regions-per-call
+         (fn [i]
+           (assert (= (drive-rest-aliased) 2)
+                   "the callee saw both rest arguments")))
+(at-most "&keys struct, aliased value" max-aliased-regions-per-call
+         (fn [i]
+           (assert (= (drive-keys-aliased) 6)
+                   "the callee read the aliased value")))
+
+# ── The value in a collector position is still readable ──────────────
+#
+# A release that fired while the callee still held the value would show up
+# here as a wrong answer rather than as a heap number.
+
+(defn take-named-read [x &named body]
+  (length (bytes body)))
+
+(defn drive-named-read []
+  (take-named-read 1 :body (bytes "abcdef")))
+
+(println "the collected value survives the call it was collected for...")
+
+(bounded "&named struct, callee reads the value"
+         (fn [i]
+           (assert (= (drive-named-read) 6)
+                   "the callee read its collected value")))
+
+# ── The shapes that read 0 for a different reason ────────────────────
+#
+# Neither is a control for the release above — each removes the move itself —
+# but both are shapes ordinary code writes, and a change that broke either would
+# be invisible in the cases above.
+
+(defn drive-keys-nontail []
+  (let [r (take-keys 1 :body (bytes "abcdef"))]
+    (+ r 0)))
+
+(def module-level-value (bytes "abcdef"))
+
+(defn drive-keys-borrowed []
+  (take-keys 1 :body module-level-value))
+
+(println "no move to take over...")
+
+(bounded "&keys struct, call not in tail" (fn [i] (drive-keys-nontail)))
+(bounded "&keys struct, value the caller never owned"
+         (fn [i] (drive-keys-borrowed)))
+
+# ── The gauge-live gate ──────────────────────────────────────────────
+#
+# Every bound above passes for two reasons: the release runs, or the gauge is
+# dead. A callee that keeps what it collects is unbounded by construction, so it
+# must read at least one object and one region per run through the same helper.
+
+(def @sink @[])
+
+(defn take-keys-keeps [x &keys k]
+  (push sink k))
+
+(defn drive-keys-kept []
+  (take-keys-keeps 1 :body (bytes "abcdef")))
+
+(println "gauge-live gate...")
+
+(grows "&keys struct the callee keeps" (fn [i] (drive-keys-kept)))
+
+(assert (= (length sink) (+ large 1)) "the sink kept every struct it was given")
+
+(println "region collector arg move: every moved reference was taken over")


### PR DESCRIPTION
Three defects an HTTP/2 request paid per request, and the diagnostic that found
them. Over `tests/elle/h2-stress-scoped.lisp`'s residue drive, a request over an
already-connected session falls from **16 objects / 16 regions to 9 / 9**, and
the client half of the request falls to **0**.

None of the three is h2 code. Each is general, and each has its own rate test
beside the h2 ceiling.

## The diagnostic

`arena/dump` printed a region's tags. The tags say a retained region holds a
string; nothing said which code made it, so localising a leak meant guessing at
the source and driving candidate shapes one at a time.

`--trace=arena` now records, for each mint the VM owns, the running function, the
source location of the allocating instruction, and the mint's kind and region
slot:

    region 1673 rc=1 objs=1 tags=[LString] from send-request-frames
      [alloc r11131] at lib/http2.lisp:171:20

It is the allocation's own location, not the enclosing call's — which is also the
only reading available inside a fiber's entry closure, where the call stack is
still empty. Off by default and free then: the dispatch loop reads the bit once
per frame into a local.

## 1. A collector parameter takes over the reference its caller moved

A tail call MOVES its arguments: the caller does not incref them, and the release
it never runs is the reference the callee's owned-param release consumes. A `&`,
`&keys`, or `&named` parameter is where that trade stops working. The binding
names the collected list or struct, and the collection took its own reference on
each member when it stored it — so the callee's one release frees the collection
and drops the collection's reference, never the caller's moved one.

`&` already closed this; the two struct collectors did not, and the reason the
release is owed has nothing to do with which collector took the value.

| callee, one fresh value over a tail call | before | after |
|---|---:|---:|
| `(defn f [x & xs] …)` | 0 / 0 | 0 / 0 |
| `(defn f [x &keys k] …)` | 1 / 1 per call | 0 / 0 |
| `(defn f [x &named body] …)` | 1 / 1 per call | 0 / 0 |
| `(defn f [x y] …)` | 0 / 0 | 0 / 0 |

## 2–4. Each boundary on a skipped release reads the path, or the count, it was written for

A `break` jumps to its block's exit label, so releases placed between the break
site and that label are emitted into code the jump passes over. The close
re-anchors them to the first point both paths reach. Three boundaries stop that
hoist, and each was reading something wider than the argument that justifies it.

**A `Return` node is not a frame-replacing exit.** The boundary is about a path
that leaves through the callee. `wrap_tail_returns` is `Return`'s only producer
and it wraps a tail value; `lower_return` emits the return mint and no control
flow. Reading it as an exit refuses the window of every function whose body IS a
block with a break in it — which is how a lookup helper is written.

**A frame exit inside a break's own value is on a path that already skipped.**
There is nothing left for it to strand, so the trade is one-sided. The shape is
ordinary because a break's value is walked as a tail value in a tail block, so a
`{…}` literal carried by any break past the first is a tail-marked call sitting
in the window. `dt-lookup` in `lib/http2/hpack.lisp` is four of them.

**The loop barrier reads the allocation site, not the release's position.** A
loop holds a release back because a value the body ALLOCATES is re-allocated per
iteration. A region the loop merely READS is allocated once per activation and
its release only sits there because that is where its last use is. Refusing
stranded a parameter on every call that breaks — `dt-lookup`'s `name` and
`value`, compared against each table entry in a `while` and then broken past.

The lambda barrier is unchanged and unconditional.

| shape, two windows of 200 calls | before | after |
|---|---:|---:|
| `hpack:encode`, per header pair | 2 / 2 | 0 / 0 |
| `http2:open-stream`, per call | 5 / 5 | 0 / 0 |

## Tests

- `tests/elle/region-collector-arg-move.lisp` — the rate for each collector kind
  at two counts, with a positional control, a gauge-live gate, the two shapes
  that read 0 for a different reason, and the aliased case whose asserted half is
  the callee's answer.
- `tests/elle/region-break-skip.lisp` gains four subjects — a tail block, one
  whose break carries a fresh value, a tail block with several breaks, and a
  parameter the loop only reads. Each reads 2000 over the window before its own
  fix and 0 after; every pre-existing subject and all three boundary shapes read
  0 throughout. Each asserts the function's ANSWER beside its rate.
- `a_return_mint_in_the_body_does_not_refuse_the_window` — the placement,
  structurally, beside the tail-call boundary test that still must refuse.
- `region-break-skip-uaf.lisp` and `region-break-transfer-uaf.lisp` are the
  soundness complements and are unchanged.
- `h2-stress-scoped.lisp`'s shrink-only ceilings come down to 9, tight at both
  counts. They do not reach 0 because that file measures the client and the
  server in one process and the server's own rate is untouched here (#1053).

Green: `make smoke`, `make qa`, `cargo test --workspace --lib` (2549), and
`cargo test --test '*'` (978).

Closes #1047.
