### PR TITLE
regions: a boundary ends a park with no reader and no install

### DIFF
--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1752,7 +1752,10 @@ no delivery mint, so no frame's reference funds its delivery and every release t
 tables name runs. The signal the boundary displaces is not the exemption's subject
 either: a squelched park's payload is delivered to nobody, and the park's own escape
 retain holds it independently of any frame, so a frame's reference to it is that
-frame's to release like any other.
+frame's to release like any other. That retain is then the boundary's own to release,
+along with whatever a displacing install would have owed — the park having ended with
+neither a reader nor an install ([owner.md](owner.md) § "A boundary ends a park with no
+reader and no install").
 
 **The compiled tier runs the same walk.** A compiled frame leaves by an error at two
 points, and each runs the walk before its activation's region-map pop: the check after

--- a/docs/impl/region/owner.md
+++ b/docs/impl/region/owner.md
@@ -383,6 +383,39 @@ parked fiber's accounting symmetric with its unpark:
   pinned guardfree by `tests/elle/region-denial-park-uaf.lisp` and
   `tests/elle/region-io-park-uaf.lisp`, whose `:io` witnesses are the collision, direct
   and relayed.
+- **A boundary ends a park with no reader and no install, so it owes both references.** A
+  `squelch`/`attune` violation is the third way a park can end, and it is neither of the two
+  the rules above are written for. No resumer reads the payload out of `fiber.signal`, so the
+  **delivery** reference — the escape retain the park took — has no consumer at all, where a
+  fiber torn down while parked did have one: its park crossed to a resumer first, the signal
+  reaching the fiber boundary by the one route out of the driving loop that a boundary cuts.
+  And no install replaces the payload in the slot, so a payload the RUNTIME built keeps the
+  reference its allocation left besides. The boundary therefore owes two decrefs where each
+  neighbouring seam owes one, and it runs the readings above to tell them apart: the io arm
+  and the denial record for a runtime-built payload, then one further decref for the
+  delivery, which a body-allocated payload owes exactly as an `IoRequest` does. A body's OWN
+  reference is the one thing the boundary does not owe — the abandoned frames' release tables
+  name it, and the payload is exempted from those tables only where a fiber's result carries
+  it out ([mechanism.md](mechanism.md) § "A squelch boundary abandons frames the same way, so
+  it runs the same walk").
+
+  **Two records decide it, because neither answers on its own.** The **ledger** says the
+  delivery retain has no reader — a fact only the site that took the retain knows, and one no
+  reading of a signal slot recovers, so that site writes the payload beside the retain
+  (`park_primitive` / `park_denial` / `park_emit`, next to the `bodyless` record already
+  there). The **enforcement site** says which park this exit ends, and it must: two sites reach
+  `squelch_violation` through `invoke_closure_jit`, which restores the CALLER's signal before
+  asking the boundary's question and holds the parked one in a local, so a chokepoint reading
+  the slot releases a live caller's value there. Comparing the two bit-wise is what makes the
+  release safe without a claim about every route out of a park: a record left over from a park
+  some other host ended (`VM::abandon_hosted_park`'s subject) names a payload this exit is not
+  looking at, and the next park overwrites it. That is the gate
+  `release_displaced_denial_payload` makes for the same reason, and it is why the ledger's
+  `assert_consumed` net covers the resume funding alone — a payload-named record needs no
+  route-completeness argument. Taking the record is the second receipt, so two boundaries over
+  one park release one set of references. Gauged by
+  `tests/elle/region-boundary-park.lisp` and pinned guardfree by
+  `tests/elle/region-boundary-park-uaf.lisp`.
 - **What yields is the emit OPERATION, not the `Emit` node.** A first argument the compiler
   cannot read as a keyword set falls through to the `emit` primitive
   ([../../signals/emit.md](../../signals/emit.md) § "Dynamic emit"), which parks the same way
@@ -611,6 +644,12 @@ the same way (`ParkedDues::of`). Three readings:
 - the releases the frame still owed off its **two release tables**, read against its
   saved locals and its saved activation map ([mechanism.md](mechanism.md) § "An abandoned
   frame runs the releases it still owes").
+
+A fourth reading answers for the **park itself** rather than for the frames, and it is
+the ledger's rather than any frame's: a boundary ends a park with no reader and no
+install, so what the crossing and the install would each have consumed is owed here
+(§ "A boundary ends a park with no reader and no install"). It runs after the three
+above, whose entries the delivery retain keeps standing until they have all run.
 
 Each reading names regions the discard is entitled to release, and none of them names a
 region a live frame still counts on. A node's members are exactly the regions the

--- a/src/jit/calls.rs
+++ b/src/jit/calls.rs
@@ -112,7 +112,7 @@ fn jit_handle_primitive_signal(vm: &mut crate::vm::VM, bits: SignalBits, value: 
             // delivery owes the reference the missing `Return` mint would have
             // carried (docs/impl/region/owner.md § "A delivery into a replayed
             // frame carries one owning reference").
-            vm.fiber.delivery.park_primitive();
+            vm.fiber.delivery.park_primitive(bits, value);
             vm.fiber.signal = Some((bits, value));
             YIELD_SENTINEL
         }
@@ -155,7 +155,7 @@ pub(crate) fn jit_capability_denial(
     // because the RUNTIME built it and the install that displaces the park owes
     // the reference the allocation left (docs/impl/region/owner.md § "Park/unpark
     // symmetry").
-    vm.fiber.delivery.park_denial(payload);
+    vm.fiber.delivery.park_denial(blocked, payload);
     vm.fiber.signal = Some((blocked, payload));
     YIELD_SENTINEL
 }

--- a/src/jit/calls/callops.rs
+++ b/src/jit/calls/callops.rs
@@ -170,7 +170,7 @@ pub extern "C" fn elle_jit_call(
                         // what each parked frame owed before handing back the error
                         // (docs/impl/region/owner.md § "A discard runs what the
                         // abandoned frames owed").
-                        let err = vm.squelch_violation(squelched);
+                        let err = vm.squelch_violation(squelched, vm.fiber.signal);
                         vm.fiber.signal = Some((SIG_ERROR, err));
                         return JitValue::nil();
                     }
@@ -246,7 +246,7 @@ pub extern "C" fn elle_jit_call(
         let squelched = crate::signals::squelched_bits(bits, closure_squelch_mask);
         if !squelched.is_empty() {
             // The squelch discard chokepoint (see the JIT-to-JIT arm above).
-            let err = vm.squelch_violation(squelched);
+            let err = vm.squelch_violation(squelched, vm.fiber.signal);
             vm.fiber.signal = Some((SIG_ERROR, err));
             return JitValue::nil();
         }

--- a/src/jit/suspend.rs
+++ b/src/jit/suspend.rs
@@ -176,6 +176,13 @@ pub extern "C" fn elle_jit_yield(
     // discharge reclaim the raise chain's own reference.
     if sig.intersects(crate::value::fiber::SIG_ERROR) {
         vm.fiber.delivery.record_mint(yielded);
+    } else {
+        // …and every other emit records the PARK, so a `squelch`/`attune`
+        // boundary can release the delivery retain no reader will consume
+        // (docs/impl/region/owner.md § "A boundary ends a park with no reader
+        // and no install"). The record follows the retain this helper took just
+        // above, which is what keeps the two balanced whatever the bits are.
+        vm.fiber.delivery.park_emit(sig, yielded);
     }
     vm.fiber.signal = Some((sig, yielded));
 

--- a/src/runtime/tests/ownership/fnode.rs
+++ b/src/runtime/tests/ownership/fnode.rs
@@ -460,7 +460,7 @@ fn discard_frees_parked_activation_owner_node() {
             "the body parks at the yield"
         );
 
-        vm.discard_suspended_frames(crate::value::Value::NIL);
+        vm.discard_suspended_frames(crate::value::Value::NIL, None);
         assert!(
             vm.fiber.suspended.is_none(),
             "the discard consumed the parked chain"
@@ -473,7 +473,7 @@ fn discard_frees_parked_activation_owner_node() {
              (gen {gen_before} -> {gen_after})",
         );
         // A second discard finds nothing — the release ran exactly once.
-        vm.discard_suspended_frames(crate::value::Value::NIL);
+        vm.discard_suspended_frames(crate::value::Value::NIL, None);
     }
 
     // ── multi-frame chain: two parked activations, one discard frees both ──
@@ -498,7 +498,7 @@ fn discard_frees_parked_activation_owner_node() {
         chain.extend(vm.fiber.suspended.take().expect("second park"));
 
         vm.fiber.suspended = Some(chain);
-        vm.discard_suspended_frames(crate::value::Value::NIL);
+        vm.discard_suspended_frames(crate::value::Value::NIL, None);
         let bumped_a = unsafe { &*heap_ptr }.generation_raw(rid_a.get()) > gen_a;
         let bumped_b = unsafe { &*heap_ptr }.generation_raw(rid_b.get()) > gen_b;
         assert!(
@@ -591,7 +591,7 @@ fn discard_runs_the_abandoned_frames_release_tables() {
             &[(9, mapped_rid), (8, unmapped_rid)],
         );
 
-        vm.discard_suspended_frames(Value::NIL);
+        vm.discard_suspended_frames(Value::NIL, None);
 
         assert_eq!(
             vm.heap().region_rc(owed_rid),
@@ -623,7 +623,7 @@ fn discard_runs_the_abandoned_frames_release_tables() {
         let (payload, payload_rid) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
         park(&mut vm, vec![Value::NIL, payload], &[]);
 
-        vm.discard_suspended_frames(payload);
+        vm.discard_suspended_frames(payload, None);
 
         assert_eq!(
             vm.heap().region_rc(payload_rid),
@@ -638,13 +638,59 @@ fn discard_runs_the_abandoned_frames_release_tables() {
         park(&mut vm, vec![Value::NIL, payload], &[]);
         vm.fiber.delivery.record_mint(payload);
 
-        vm.discard_suspended_frames(payload);
+        vm.discard_suspended_frames(payload, None);
 
         assert_eq!(
             vm.heap().region_rc(payload_rid),
             0,
             "a recorded mint funds the delivery, so the frame's own reference is \
              reclaimed at the discard too",
+        );
+    }
+
+    // ── the park's own references, beside the frames' ──
+    // A body-allocated park: its payload sits in the frame's value-route slot,
+    // so the table drops the body's reference and the chokepoint drops the
+    // delivery retain the boundary left with no reader
+    // (docs/impl/region/owner.md § "A boundary ends a park with no reader and
+    // no install"). The exit's own payload is a different value here — the
+    // boundary's `signal-violation`, which never shares the park's region.
+    {
+        let (parked, parked_rid) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
+        let (violation, _) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
+        unsafe { &mut *heap_ptr }.incref_region(parked_rid);
+        park(&mut vm, vec![Value::NIL, parked], &[]);
+        vm.fiber
+            .delivery
+            .park_emit(crate::value::fiber::SIG_YIELD, parked);
+
+        vm.discard_suspended_frames(violation, Some((crate::value::fiber::SIG_YIELD, parked)));
+
+        assert_eq!(
+            vm.heap().region_rc(parked_rid),
+            0,
+            "the frame's table drops the body's reference and the chokepoint the \
+             delivery retain — two references, two seams the boundary cut",
+        );
+    }
+
+    // A boundary that ends NO park releases nothing extra, whatever the ledger
+    // last recorded. The two records decide together: the exit names the park it
+    // is ending, and a record that does not name it is a park some other route
+    // already ended.
+    {
+        let (stale, stale_rid) = alloc_in_fresh_region(unsafe { &mut *heap_ptr }, cons());
+        park(&mut vm, vec![Value::NIL, Value::NIL], &[]);
+        vm.fiber
+            .delivery
+            .park_emit(crate::value::fiber::SIG_YIELD, stale);
+
+        vm.discard_suspended_frames(Value::NIL, None);
+
+        assert_eq!(
+            vm.heap().region_rc(stale_rid),
+            1,
+            "a stale record names a park this exit is not ending",
         );
     }
 }
@@ -1039,7 +1085,11 @@ fn a_primitive_park_delivery_is_worth_one_retain() {
             // park shape the classifier recorded when the fiber suspended.
             f.signal = Some((crate::value::fiber::SIG_OK, payload));
             if unfunded {
-                f.delivery.park_primitive();
+                // The park's own payload is `nil` here: this face gauges the
+                // resume funding, and an immediate payload's record names no
+                // region, so it cannot move the counts below.
+                f.delivery
+                    .park_primitive(crate::value::fiber::SIG_YIELD, crate::value::Value::NIL);
             }
         });
         rc!("after the park is installed — the delivery has not run", 1);

--- a/src/value/fiber/delivery.rs
+++ b/src/value/fiber/delivery.rs
@@ -15,7 +15,7 @@
 //! content scan records no edge for them. The counted edge for the same value
 //! is `Fiber::signal`'s.
 
-use crate::value::Value;
+use crate::value::{SignalBits, Value};
 
 /// The funding record of a fiber's current park. One instance rides each
 /// `Fiber` (`Fiber::delivery`); see the module doc for the model and
@@ -49,6 +49,36 @@ pub struct Delivery {
     /// displacing install ([`Self::take_bodyless`]) so no second install can
     /// release the same reference.
     bodyless: Option<Value>,
+    /// The live park's payload and bits, whose DELIVERY reference — the escape
+    /// retain the park took as the value went into `Fiber::signal` — no reader
+    /// has consumed. A resume consumes it: the resumer's compiler-emitted
+    /// release of the resume result is that reader, so [`Self::take_resume_funding`]
+    /// clears the record at the crossing. A `squelch`/`attune` boundary is the
+    /// one end of a park that has no reader at all, and it releases what this
+    /// names (docs/impl/region/owner.md § "A boundary ends a park with no reader
+    /// and no install").
+    ///
+    /// Written by the site that TAKES the retain — the two suspend arms, the two
+    /// denial arms, the `Emit` handler, and their JIT twins — so a record exists
+    /// exactly where a retain does and names the value it was taken on. That is
+    /// what the boundary cannot read out of `Fiber::signal`: two enforcement
+    /// sites reach it through `invoke_closure_jit`, which restores the CALLER's
+    /// signal first and holds the parked one in a local.
+    ///
+    /// An IMMEDIATE payload records nothing: `incref_for_escape` is a no-op for a
+    /// value living in no region, so such a park took no retain and there is no
+    /// reference for any seam to consume. Written through [`Self::record_park`],
+    /// which is where that gate lives.
+    ///
+    /// Payload-named like [`Self::bodyless`], and gated the same way: the consumer
+    /// compares it bit-wise against the signal it is looking at, so a record left
+    /// over from a park some other route ended names nothing and is overwritten by
+    /// the next park rather than needing a clear on every route.
+    ///
+    /// Uncounted like every other field here: the payload is compared bit-wise
+    /// and its region resolved, never structurally read, and the counted edge for
+    /// the same value is `Fiber::signal`'s.
+    undelivered: Option<(SignalBits, Value)>,
     /// Whether this fiber's innermost suspension is a PRIMITIVE call, whose
     /// resume value therefore arrives owing one reference. A parked frame
     /// re-enters at its suspending call's continuation, which runs that call's
@@ -71,19 +101,41 @@ impl Delivery {
     /// resume value owes one `ResumeDelivery` mint at the delivery funnel.
     /// Callers: `handle_primitive_signal[_tail]`'s Suspend arms and their JIT
     /// twin (`jit_handle_primitive_signal`).
-    pub(crate) fn park_primitive(&mut self) {
+    pub(crate) fn park_primitive(&mut self, bits: SignalBits, payload: Value) {
         self.assert_consumed();
         self.resume_unfunded = true;
+        self.record_park(bits, payload);
+    }
+
+    /// An `Emit` node parked (`handle_emit` and its JIT twin `elle_jit_yield`).
+    /// The compiler funds this continuation itself — the emit's own decref_point
+    /// balances the release past the suspend — so the park owes no resume mint,
+    /// and the record is the escape retain's alone. Never reached by a TERMINAL
+    /// emit: an error raise parks nothing and records its mint instead, and a
+    /// halt takes no retain at all.
+    pub(crate) fn park_emit(&mut self, bits: SignalBits, payload: Value) {
+        self.assert_consumed();
+        self.record_park(bits, payload);
     }
 
     /// A capability denial parked: a primitive park (the denied call never
     /// returns) whose payload also has no body reference, so the resume owes
     /// its region one decref besides the mint. Callers:
     /// `handle_capability_denial[_tail]` and `jit_capability_denial`.
-    pub(crate) fn park_denial(&mut self, payload: Value) {
+    pub(crate) fn park_denial(&mut self, bits: SignalBits, payload: Value) {
         self.assert_consumed();
         self.resume_unfunded = true;
         self.bodyless = Some(payload);
+        self.record_park(bits, payload);
+    }
+
+    /// Record the park whose escape retain no reader has consumed, where there
+    /// was a retain to take. An immediate payload lives in no region, so
+    /// `incref_for_escape` did nothing at the park and there is nothing here for
+    /// a boundary to release — recording one would leave [`Self::assert_consumed`]
+    /// asserting over a park that owes no seam anything.
+    fn record_park(&mut self, bits: SignalBits, payload: Value) {
+        self.undelivered = payload.as_heap_ptr().is_some().then_some((bits, payload));
     }
 
     /// The net for a park shape wired without a consume seam: every route out
@@ -91,6 +143,11 @@ impl Delivery {
     /// or [`Self::discharge`], so a park write finding the previous park's
     /// funding still standing means some route skipped all three — one region
     /// leaked per cycle in release builds, a panic here.
+    ///
+    /// [`Self::undelivered`] is deliberately outside the net, exactly as
+    /// [`Self::bodyless`] is: both are payload-named records, gated at their
+    /// consumers by bit-wise identity with the signal the consumer is looking
+    /// at, so a stale one names nothing and is overwritten by the next park.
     #[track_caller]
     fn assert_consumed(&self) {
         debug_assert!(
@@ -118,6 +175,7 @@ impl Delivery {
     pub(crate) fn install_abort(&mut self, payload: Value) {
         self.minted = Some(payload);
         self.bodyless = None;
+        self.undelivered = None;
         self.resume_unfunded = false;
     }
 
@@ -129,6 +187,10 @@ impl Delivery {
     /// one method for both tiers, so they cannot drift.
     pub(crate) fn take_resume_funding(&mut self) -> bool {
         self.minted = None;
+        // The crossing: the resumer read the payload out and its own release of
+        // the resume result consumes the escape retain, so the park is delivered
+        // and no boundary may claim it again.
+        self.undelivered = None;
         std::mem::take(&mut self.resume_unfunded)
     }
 
@@ -143,6 +205,7 @@ impl Delivery {
     pub(crate) fn displace(&mut self) {
         self.minted = None;
         self.bodyless = None;
+        self.undelivered = None;
     }
 
     /// `Fiber::take_parked_state` consumed the park of a fiber that can never
@@ -151,6 +214,7 @@ impl Delivery {
     pub(crate) fn discharge(&mut self) {
         self.minted = None;
         self.bodyless = None;
+        self.undelivered = None;
         self.resume_unfunded = false;
     }
 
@@ -169,6 +233,15 @@ impl Delivery {
     /// finds nothing and releases nothing.
     pub(crate) fn take_bodyless(&mut self) -> Option<Value> {
         self.bodyless.take()
+    }
+
+    /// Take the live park whose delivery reference no reader consumed — the one
+    /// consuming read, run by the `squelch`/`attune` discard chokepoint. Taking
+    /// is the receipt, so a second boundary over the same fiber releases nothing.
+    /// `None` for a fiber with no live park, and for one whose park already
+    /// crossed to a resumer.
+    pub(crate) fn take_undelivered(&mut self) -> Option<(SignalBits, Value)> {
+        self.undelivered.take()
     }
 
     /// The recorded bodyless payload, without consuming it — a read for tests;

--- a/src/value/fiber/delivery/tests.rs
+++ b/src/value/fiber/delivery/tests.rs
@@ -2,21 +2,47 @@
 //! debug net for a park shape wired without a consume.
 
 use super::*;
+use crate::value::{SIG_IO, SIG_YIELD};
 
-/// A heap-shaped payload stand-in. The ledger never dereferences what it
-/// names — identity is bit-wise — so any distinct non-nil values serve.
+/// A payload on a region of its own. The ledger never dereferences what it
+/// names — identity is bit-wise — but it does gate the park record on the value
+/// living in a region at all, so a park stand-in has to be a heap value. The
+/// heap is leaked so the pair stays resident for the test.
 fn payload() -> Value {
-    Value::int(1)
+    PAIRS.with(|p| p.0)
 }
 
 fn other() -> Value {
-    Value::int(2)
+    PAIRS.with(|p| p.1)
+}
+
+thread_local! {
+    /// Two distinct heap pairs, minted once per test thread so every call
+    /// returns the same representation — the gates below are all bit-wise
+    /// identity, so a fresh pair per call would name a different value each time.
+    static PAIRS: (Value, Value) = (heap_pair(), heap_pair());
+}
+
+fn heap_pair() -> Value {
+    use crate::value::heap::{HeapObject, Pair};
+    let heap = crate::value::arena::leaked_test_heap();
+    let (v, _) = crate::value::arena::alloc_in_fresh_region(
+        unsafe { &mut *heap },
+        HeapObject::Pair(Pair::new(Value::NIL, Value::NIL)),
+    );
+    v
+}
+
+/// The immediate face of the same question: a park whose payload lives in no
+/// region took no escape retain, so there is nothing for a seam to consume.
+fn immediate() -> Value {
+    Value::int(1)
 }
 
 #[test]
 fn a_primitive_park_funds_exactly_one_resume() {
     let mut d = Delivery::new();
-    d.park_primitive();
+    d.park_primitive(SIG_IO, payload());
     assert!(
         d.take_resume_funding(),
         "the park's resume value owes a mint"
@@ -30,7 +56,7 @@ fn a_primitive_park_funds_exactly_one_resume() {
 #[test]
 fn a_denial_park_records_both_facts() {
     let mut d = Delivery::new();
-    d.park_denial(payload());
+    d.park_denial(SIG_IO, payload());
     assert_eq!(
         d.bodyless().map(|p| p.bit_identical(payload())),
         Some(true),
@@ -42,7 +68,7 @@ fn a_denial_park_records_both_facts() {
 #[test]
 fn an_abort_install_displaces_the_park_and_records_the_mint() {
     let mut d = Delivery::new();
-    d.park_denial(payload());
+    d.park_denial(SIG_IO, payload());
     d.install_abort(other());
     assert!(
         d.bodyless().is_none(),
@@ -72,7 +98,7 @@ fn the_mint_gate_is_representation_identity() {
 #[test]
 fn a_displace_clears_the_payload_records_but_keeps_the_resume_funding() {
     let mut d = Delivery::new();
-    d.park_denial(payload());
+    d.park_denial(SIG_IO, payload());
     d.record_mint(payload());
     d.displace();
     assert!(d.bodyless().is_none());
@@ -90,7 +116,7 @@ fn a_displace_clears_the_payload_records_but_keeps_the_resume_funding() {
 #[test]
 fn a_discharge_leaves_no_funding() {
     let mut d = Delivery::new();
-    d.park_denial(payload());
+    d.park_denial(SIG_IO, payload());
     d.record_mint(payload());
     d.discharge();
     assert!(d.bodyless().is_none());
@@ -101,17 +127,74 @@ fn a_discharge_leaves_no_funding() {
     );
 }
 
+// -- the undelivered park: the record a boundary reads --
+
+/// The record names the payload the park's escape retain was taken on, so the
+/// boundary that ends the park releases the right region. Both bits and payload
+/// travel: the io arm reads the bits before it dereferences anything.
+#[test]
+fn a_park_records_the_payload_its_retain_was_taken_on() {
+    let mut d = Delivery::new();
+    d.park_primitive(SIG_IO, payload());
+    let taken = d.take_undelivered().expect("the park is recorded");
+    assert_eq!(taken.0, SIG_IO, "the park's bits travel with its payload");
+    assert!(taken.1.bit_identical(payload()));
+}
+
+/// The crossing consumes the delivery: the resumer read the payload out and its
+/// own release of the resume result takes the retain. Counter-factual: a record
+/// surviving the crossing lets a later boundary release a reference the resumer
+/// already consumed, freeing the payload under the reader that still holds it.
+#[test]
+fn the_crossing_leaves_no_park_for_a_boundary_to_claim() {
+    let mut d = Delivery::new();
+    d.park_primitive(SIG_YIELD, payload());
+    d.take_resume_funding();
+    assert!(
+        d.take_undelivered().is_none(),
+        "a park a resumer read is delivered — the retain has its consumer",
+    );
+}
+
+/// An `Emit` node's park records the retain and no resume funding: the compiler
+/// balances that continuation itself. Counter-factual: routing it through
+/// `park_primitive` would mint a `ResumeDelivery` reference nothing consumes.
+#[test]
+fn an_emit_park_records_the_retain_and_owes_no_resume_mint() {
+    let mut d = Delivery::new();
+    d.park_emit(SIG_YIELD, payload());
+    assert!(
+        d.take_undelivered().is_some(),
+        "the emit's escape retain is a delivery a boundary may have to release",
+    );
+    assert!(
+        !d.take_resume_funding(),
+        "an `Emit` node's continuation is funded by its own decref_point",
+    );
+}
+
+/// Taking the record IS the receipt: a second boundary over the same fiber
+/// finds nothing. Counter-factual: a non-consuming read releases the same
+/// reference once per boundary.
+#[test]
+fn the_park_record_is_taken_so_a_second_boundary_claims_nothing() {
+    let mut d = Delivery::new();
+    d.park_emit(SIG_YIELD, payload());
+    d.take_undelivered();
+    assert!(d.take_undelivered().is_none());
+}
+
 /// The net for a new park shape wired without a consume seam: parking over an
 /// unconsumed park means some route ended the previous park without passing
-/// `take_resume_funding`, `install_abort`, or `discharge` — a leak of one
-/// region per cycle in release builds, a panic here.
+/// `take_resume_funding`, `install_abort`, `displace`, or `discharge` — a leak
+/// of one region per cycle in release builds, a panic here.
 #[test]
 #[should_panic(expected = "unconsumed")]
 #[cfg(debug_assertions)]
 fn a_second_park_over_an_unconsumed_one_panics() {
     let mut d = Delivery::new();
-    d.park_primitive();
-    d.park_primitive();
+    d.park_primitive(SIG_IO, payload());
+    d.park_primitive(SIG_IO, payload());
 }
 
 #[test]
@@ -119,6 +202,38 @@ fn a_second_park_over_an_unconsumed_one_panics() {
 #[cfg(debug_assertions)]
 fn a_denial_park_over_an_unconsumed_one_panics() {
     let mut d = Delivery::new();
-    d.park_primitive();
-    d.park_denial(payload());
+    d.park_primitive(SIG_IO, payload());
+    d.park_denial(SIG_IO, payload());
+}
+
+/// The net does NOT cover the park record, and must not: an `Emit` park owes no
+/// resume mint, so a route that ends one without clearing the record leaves
+/// nothing owed — the record is payload-named and its consumer compares it
+/// bit-wise, exactly as the denial record's does. Asserting on it instead would
+/// panic on a park some host abandoned, where nothing is wrong.
+#[test]
+#[cfg(debug_assertions)]
+fn a_park_over_a_stale_park_record_is_fine() {
+    let mut d = Delivery::new();
+    d.park_emit(SIG_YIELD, payload());
+    d.park_emit(SIG_YIELD, other());
+    assert_eq!(
+        d.take_undelivered().map(|(_, v)| v.bit_identical(other())),
+        Some(true),
+        "the later park's record replaces the stale one",
+    );
+}
+
+/// An IMMEDIATE payload records no park, because the escape retain was a no-op
+/// on a value living in no region. Counter-factual: recording it puts the net
+/// above in the way of a park that owes nothing — every `(emit :yield 1)` would
+/// have to reach a consume seam that has nothing to consume.
+#[test]
+fn an_immediate_park_records_nothing() {
+    let mut d = Delivery::new();
+    d.park_emit(SIG_YIELD, immediate());
+    assert!(
+        d.take_undelivered().is_none(),
+        "a payload in no region took no retain, so no seam owes it a release",
+    );
 }

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -341,7 +341,10 @@ impl VM {
         if squelched.is_empty() {
             return false;
         }
-        let err = self.squelch_violation(squelched);
+        // The park this boundary ends is the fiber's own live signal here: every
+        // site reaching the boundary through this predicate is still holding it
+        // (the two that are not pass their own — see `squelch_violation`).
+        let err = self.squelch_violation(squelched, self.fiber.signal);
         self.fiber.signal = Some((crate::value::SIG_ERROR, err));
         true
     }
@@ -353,7 +356,18 @@ impl VM {
     /// delivers it differently — the interpreter sets `fiber.signal`, the
     /// `compile/run-on` entry returns it as the call's result. `squelched` must
     /// be non-empty, the answer `signals::squelched_bits` gives.
-    pub(crate) fn squelch_violation(&mut self, squelched: SignalBits) -> Value {
+    ///
+    /// `parked` is the signal whose park this boundary ends, named by the site
+    /// rather than read from `fiber.signal`: two sites reach here through
+    /// `invoke_closure_jit`, which restores the CALLER's signal before it asks
+    /// the boundary's question and holds the parked one in a local. What the
+    /// park owed is released against it (docs/impl/region/owner.md § "A boundary
+    /// ends a park with no reader and no install").
+    pub(crate) fn squelch_violation(
+        &mut self,
+        squelched: SignalBits,
+        parked: Option<(SignalBits, Value)>,
+    ) -> Value {
         let squelched_str = crate::signals::registry::format_bits(squelched);
         let err = self.escaping_error(
             "signal-violation",
@@ -363,7 +377,7 @@ impl VM {
         // the payload the discard's own releases must leave standing — built in a
         // fresh region of its own, so in practice it exempts nothing and the
         // abandoned frames' tables run in full.
-        self.discard_suspended_frames(err);
+        self.discard_suspended_frames(err, parked);
         err
     }
 
@@ -401,18 +415,35 @@ impl VM {
     /// the activation that catches the squelch. Those regions stay leaked on this
     /// path until an ownership cut adopts them (UAF-safe, bounded per discard).
     ///
+    /// A fourth reading answers for the PARK rather than for the frames, and it
+    /// is the delivery ledger's: this exit is neither the reader that consumes a
+    /// park's delivery retain nor the install that releases a runtime-built
+    /// payload, so both are owed here (docs/impl/region/owner.md § "A boundary
+    /// ends a park with no reader and no install").
+    ///
     /// `payload` is the value the exit leaves with — the boundary's own
     /// `signal-violation` error — whose region no release here may take, on the
     /// same reading the abandoned-frame walk makes
     /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
-    /// still owes").
-    pub(crate) fn discard_suspended_frames(&mut self, payload: Value) {
+    /// still owes"). `parked` is the signal whose park this ends, named by the
+    /// enforcement site (see `squelch_violation`).
+    pub(crate) fn discard_suspended_frames(
+        &mut self,
+        payload: Value,
+        parked: Option<(SignalBits, Value)>,
+    ) {
         if let Some(frames) = self.fiber.suspended.take() {
             let dues = crate::value::fiber::ParkedDues::of(frames);
             let protect = Some(payload).filter(|v| !self.fiber.delivery.mint_names(*v));
             let heap = unsafe { &mut *self.heap_ptr };
             crate::vm::fiber::release_parked_dues(heap, dues, protect, None);
         }
+        // The park's own references run after the tables above, which still find
+        // the payload's region live: a body-allocated payload's own release is
+        // one of those entries, and the delivery retain dropped here is what
+        // keeps it from being the region's last.
+        let heap = unsafe { &mut *self.heap_ptr };
+        crate::vm::fiber::release_abandoned_park(heap, &mut self.fiber.delivery, parked);
         // The abandoned park's funding has no consumer — the delivery funnel
         // that would have taken it will never run for these frames.
         self.fiber.delivery.discharge();

--- a/src/vm/dispatch.rs
+++ b/src/vm/dispatch.rs
@@ -74,6 +74,14 @@ impl VM {
             // releases it still owes").
             if signal_bits.intersects(SIG_ERROR) {
                 self.fiber.delivery.record_mint(value);
+            } else {
+                // A SUSPENDING emit records the park instead: this retain is the
+                // delivery, and a `squelch`/`attune` boundary ends the park with
+                // no reader to consume it (docs/impl/region/owner.md § "A
+                // boundary ends a park with no reader and no install"). The two
+                // arms partition what reaches here, the halt having taken no
+                // retain to account for.
+                self.fiber.delivery.park_emit(signal_bits, value);
             }
         }
 

--- a/src/vm/fiber.rs
+++ b/src/vm/fiber.rs
@@ -51,8 +51,8 @@ mod borrow_tests;
 pub(crate) use owned::{kill_fiber, release_fiber_owned, release_parked_dues, take_fiber_owned};
 use refcount::{incref_signal_region, release_discarded_signal};
 pub(crate) use refcount::{
-    is_terminal_signal, release_displaced_denial_payload, release_displaced_io_request,
-    release_displaced_terminal_signal,
+    is_terminal_signal, release_abandoned_park, release_displaced_denial_payload,
+    release_displaced_io_request, release_displaced_terminal_signal,
 };
 // Re-exported for the WASM resume path (`crate::vm::fiber::record_terminal_signal_park`),
 // the only external caller; `owned::kill_fiber` reaches it by module path. Unused

--- a/src/vm/fiber/refcount.rs
+++ b/src/vm/fiber/refcount.rs
@@ -246,6 +246,67 @@ pub(crate) fn release_displaced_io_request(
     }
 }
 
+/// Release everything a park is left with when a `squelch`/`attune` boundary
+/// ends it — the one end of a park that is neither a resume nor an install
+/// (docs/impl/region/owner.md § "A boundary ends a park with no reader and no
+/// install, so it owes both references").
+///
+/// Two references stand on a park's payload and each answers to a seam this exit
+/// cuts. The **delivery** — the `EmitEscape` / `SuspendEscape` retain the park
+/// took — is consumed by the resumer's release of the resume result, and no
+/// resumer ever reads a squelched park's payload out of `fiber.signal`. The
+/// second is whatever a displacing install would have owed: for a payload the
+/// RUNTIME built (a yielding io op's `IoRequest`, a capability denial's struct)
+/// the reference its allocation left, since no `decref_point` names its region;
+/// for a body-allocated payload the body's own, which the abandoned frames'
+/// release tables run instead. So this releases the delivery for every park and
+/// the install's half for the two runtime-built shapes, reusing the readings the
+/// installs share so the three sites cannot come to disagree about which parks
+/// are which.
+///
+/// Two records decide it together, because neither answers on its own. The
+/// LEDGER says the park's delivery retain has no reader — a fact only the site
+/// that took the retain knows, and one no reading of a signal slot recovers. The
+/// enforcement site says which park this exit ends, and it must, because the
+/// slot cannot be read for it: two sites reach the boundary through
+/// `invoke_closure_jit`, which restores the CALLER's signal first and holds the
+/// parked one in a local. Releasing on the ledger alone would need every route
+/// out of a park to clear the record; comparing the two bit-wise needs no such
+/// argument, and a record left over from a park some other route ended names a
+/// payload this exit is not looking at (the gate `release_displaced_denial_payload`
+/// makes for the same reason). Taking the record is the second receipt, so two
+/// boundaries over one park release one set of references.
+///
+/// Order matters within the payload's own accounting: the io arm dereferences
+/// the parked value to reach its verdict, so it runs before either decref that
+/// could be the region's last. A no-op for a fiber with no live park, and for an
+/// exit whose signal the ledger does not name.
+pub(crate) fn release_abandoned_park(
+    heap: &mut crate::value::fiberheap::FiberHeap,
+    delivery: &mut crate::value::fiber::Delivery,
+    live: Option<(SignalBits, Value)>,
+) {
+    let Some(parked) = delivery.take_undelivered() else {
+        return;
+    };
+    let (_, payload) = parked;
+    if !live.is_some_and(|(_, v)| v.bit_identical(payload)) {
+        return;
+    }
+    // What the install would have owed, in the two readings the installs use.
+    release_displaced_io_request(heap, Some(parked));
+    if let Some(recorded) = delivery
+        .take_bodyless()
+        .filter(|r| r.bit_identical(payload))
+    {
+        let region = crate::value::arena::region_of(heap, recorded);
+        crate::value::arena::decref_region(heap, region);
+    }
+    // What the reader would have consumed.
+    let region = crate::value::arena::region_of(heap, payload);
+    crate::value::arena::decref_region(heap, region);
+}
+
 /// The region a park's `IoRequest` lives in, or `None` where the park owes this
 /// accounting nothing — no park at all, a payload some other holder answers for,
 /// or an immediate. One reading of "which parks are io parks", so the release and

--- a/src/vm/fiber/refcount/tests.rs
+++ b/src/vm/fiber/refcount/tests.rs
@@ -57,7 +57,7 @@ fn parked_fiber(bits: SignalBits, parked: Value, record: Option<Value>) -> Fiber
     handle.with_mut(|f| {
         f.signal = Some((bits, parked));
         if let Some(payload) = record {
-            f.delivery.park_denial(payload);
+            f.delivery.park_denial(bits, payload);
         }
     });
     handle
@@ -236,6 +236,140 @@ fn a_non_io_park_is_answered_without_dereferencing_its_payload() {
     crate::value::arena::decref_region(&mut heap, Some(rid));
 
     release_displaced_io_request(&mut heap, Some((SIG_YIELD, p)));
+}
+
+// -- release_abandoned_park: the boundary owes what no seam consumed --
+
+/// A boundary ends a park with no reader and no install, so both of the park's
+/// references are its to release: the delivery retain the park took, and the one
+/// the runtime's own allocation left. Counter-factual: running only the install's
+/// reading — which is what a boundary reusing `release_displaced_io_request`
+/// alone would do — leaves the request's region at rc 1 for good, one region and
+/// one object per squelched io op (elle-lisp/elle#1031).
+#[test]
+fn a_boundary_releases_both_of_an_io_parks_references() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (request, rid) = io_request(&mut heap);
+    crate::value::arena::incref_region(&mut heap, Some(rid));
+    let mut delivery = crate::value::fiber::Delivery::new();
+    let live = Some((SIG_IO, request));
+    delivery.park_primitive(SIG_IO, request);
+    let before = region_rc(&heap, rid);
+
+    release_abandoned_park(&mut heap, &mut delivery, live);
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before - 2,
+        "the allocation's reference and the delivery retain are both owed here",
+    );
+}
+
+/// A body-allocated payload owes the boundary ONE reference. Its own is the
+/// abandoned frames' release tables' to run, so a second decref here would free
+/// the value under the frame whose table is about to name it.
+#[test]
+fn a_boundary_releases_one_reference_of_a_body_allocated_park() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (p, rid) = payload(&mut heap);
+    crate::value::arena::incref_region(&mut heap, Some(rid));
+    let mut delivery = crate::value::fiber::Delivery::new();
+    let live = Some((SIG_YIELD, p));
+    delivery.park_emit(SIG_YIELD, p);
+    let before = region_rc(&heap, rid);
+
+    release_abandoned_park(&mut heap, &mut delivery, live);
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before - 1,
+        "only the delivery retain has no consumer — the body's reference has one",
+    );
+}
+
+/// A denial park is runtime-built like an io request, and its second reference
+/// is named by the ledger's own record rather than by the payload's type. The
+/// record is TAKEN, so the io arm and this one cannot both claim it.
+#[test]
+fn a_boundary_releases_both_of_a_denial_parks_references() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (p, rid) = payload(&mut heap);
+    crate::value::arena::incref_region(&mut heap, Some(rid));
+    let mut delivery = crate::value::fiber::Delivery::new();
+    let live = Some((SIG_IO, p));
+    delivery.park_denial(SIG_IO, p);
+    let before = region_rc(&heap, rid);
+
+    release_abandoned_park(&mut heap, &mut delivery, live);
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        before - 2,
+        "a denial's struct has no body reference either — the record names it",
+    );
+}
+
+/// The receipt: taking the record is what keeps a second boundary over the same
+/// fiber from releasing the same references again.
+#[test]
+fn a_second_boundary_over_the_same_fiber_releases_nothing() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (request, rid) = io_request(&mut heap);
+    crate::value::arena::incref_region(&mut heap, Some(rid));
+    let mut delivery = crate::value::fiber::Delivery::new();
+    let live = Some((SIG_IO, request));
+    delivery.park_primitive(SIG_IO, request);
+
+    release_abandoned_park(&mut heap, &mut delivery, live);
+    let after_first = region_rc(&heap, rid);
+    release_abandoned_park(&mut heap, &mut delivery, live);
+
+    assert_eq!(
+        region_rc(&heap, rid),
+        after_first,
+        "one park, one set of releases, however many boundaries the fiber meets",
+    );
+}
+
+/// A boundary that ends no park releases nothing. This is the ordinary case —
+/// most violations catch a raise rather than a suspension.
+#[test]
+fn a_boundary_with_no_park_releases_nothing() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (p, rid) = payload(&mut heap);
+    let live = Some((SIG_YIELD, p));
+    let mut delivery = crate::value::fiber::Delivery::new();
+    let before = region_rc(&heap, rid);
+
+    release_abandoned_park(&mut heap, &mut delivery, live);
+
+    assert_eq!(region_rc(&heap, rid), before);
+    assert!(p.as_heap_ptr().is_some(), "the payload is untouched");
+}
+
+/// The gate the ledger alone cannot supply: a record left over from a park some
+/// other route already ended names a value this exit is not looking at, and
+/// releasing it would drop a reference that park's own end already consumed.
+/// A host that refuses a suspension it cannot resume leaves exactly that
+/// (`VM::abandon_hosted_park`'s subject), and no route-completeness argument is
+/// needed once the two are compared.
+#[test]
+fn a_record_that_does_not_name_the_exits_park_releases_nothing() {
+    let mut heap = crate::value::fiberheap::FiberHeap::new();
+    let (stale, stale_rid) = payload(&mut heap);
+    let (live_payload, _) = payload(&mut heap);
+    let mut delivery = crate::value::fiber::Delivery::new();
+    delivery.park_emit(SIG_YIELD, stale);
+    let before = region_rc(&heap, stale_rid);
+
+    release_abandoned_park(&mut heap, &mut delivery, Some((SIG_YIELD, live_payload)));
+
+    assert_eq!(
+        region_rc(&heap, stale_rid),
+        before,
+        "the decref is owed by the park the exit is ending, not by whatever the \
+         ledger last recorded",
+    );
 }
 
 // -- the shared region exempts no install --

--- a/src/vm/run_on/jit.rs
+++ b/src/vm/run_on/jit.rs
@@ -159,7 +159,9 @@ impl VM {
             let yield_bits = post_signal.map_or(crate::value::SIG_YIELD, |(bits, _)| bits);
             let squelched = crate::signals::squelched_bits(yield_bits, closure.squelch_mask);
             if !squelched.is_empty() {
-                return (SIG_ERROR, self.squelch_violation(squelched));
+                // …and the park it ends is `post_signal` for the same reason:
+                // `fiber.signal` holds the caller's by here.
+                return (SIG_ERROR, self.squelch_violation(squelched, post_signal));
             }
 
             if let Some((bits, val)) = post_signal {
@@ -188,7 +190,7 @@ impl VM {
             // reason for not routing through `enforce_squelch`.
             let squelched = crate::signals::squelched_bits(bits, closure.squelch_mask);
             if !squelched.is_empty() {
-                return (SIG_ERROR, self.squelch_violation(squelched));
+                return (SIG_ERROR, self.squelch_violation(squelched, post_signal));
             }
             if !bits.is_empty() {
                 return (bits, val);

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -135,8 +135,12 @@ impl VM {
                 // the code after the Call, including the call's own result
                 // release — is funded by the delivery instead of by a `Return`
                 // mint (docs/impl/region/owner.md § "A delivery into a replayed
-                // frame carries one owning reference").
-                self.fiber.delivery.park_primitive();
+                // frame carries one owning reference"). The payload rides the
+                // record too: the retain above has no consumer where a boundary
+                // ends the park, and the boundary cannot read the signal slot
+                // for it (§ "A boundary ends a park with no reader and no
+                // install").
+                self.fiber.delivery.park_primitive(bits, value);
                 let saved_stack: Vec<Value> = self.fiber.stack.drain(..).collect();
                 let activation_region_map = self
                     .fiber
@@ -225,8 +229,9 @@ impl VM {
                 // unwinds to parks one — so the obligation rides the fiber until
                 // the delivery. The frame that driver parks resumes into the
                 // post-`TailCall` block, whose result release the missing `Return`
-                // mint would have funded.
-                self.fiber.delivery.park_primitive();
+                // mint would have funded. The payload rides the record too (see
+                // the Call-position arm).
+                self.fiber.delivery.park_primitive(bits, value);
                 self.fiber.signal = Some((bits, value));
                 bits
             }
@@ -281,8 +286,10 @@ impl VM {
         // owes, and the payload whose release the displacing install owes —
         // because only this classifier can tell a denial from an `(emit …)`
         // under the same withheld bits (docs/impl/region/owner.md § "Park/unpark
-        // symmetry").
-        self.fiber.delivery.park_denial(payload);
+        // symmetry"), and the payload once more as the park whose delivery
+        // retain a boundary would have to release (§ "A boundary ends a park
+        // with no reader and no install").
+        self.fiber.delivery.park_denial(blocked, payload);
 
         // Save the stack and build a suspended frame (same as suspending signals)
         let saved_stack: Vec<Value> = self.fiber.stack.drain(..).collect();
@@ -338,8 +345,8 @@ impl VM {
         );
         // Tail-position mirror of the Call-position denial park (see
         // `handle_capability_denial`), delivery obligation and left-over payload
-        // reference alike.
-        self.fiber.delivery.park_denial(payload);
+        // reference alike, the boundary's reading included.
+        self.fiber.delivery.park_denial(blocked, payload);
         self.fiber.signal = Some((blocked, payload));
         blocked
     }

--- a/tests/elle/region-boundary-park-uaf.lisp
+++ b/tests/elle/region-boundary-park-uaf.lisp
@@ -1,0 +1,158 @@
+(elle/epoch 12)
+# Soundness complement of region-boundary-park.lisp
+# (docs/impl/region/owner.md § "A boundary ends a park with no reader and no
+# install, so it owes both references"). Run under `--trace=guardfree` by the
+# subprocess pin `region_boundary_park_uaf` in tests/integration/elle_scripts.rs.
+#
+# A `squelch`/`attune` boundary now releases two references a park was left
+# with: the delivery retain no reader consumed, and — for a payload the runtime
+# built — the one its allocation left. Both are decrefs that never ran before,
+# and the fiber SURVIVES the boundary, so what has to be whole afterwards is
+# everything that still names the payload or shares its region.
+#
+# Six faces.
+#
+# 1. The payload the BODY allocated. Its own reference belongs to the abandoned
+#    frame's release table; only the delivery retain is the boundary's, so the
+#    value must still be readable through every holder that outlives the park.
+# 2. A payload the body STORED somewhere longer-lived before parking. The store
+#    took a counted reference, so the boundary's decrefs must not reach it.
+# 3. A payload the body BORROWED rather than allocated — a module-level binding
+#    it emits. The compiler mints the body's reference for exactly this shape,
+#    and an over-release here frees the binding under the whole program.
+# 4. REPETITION over the io machinery. The scheduler and its backend are reused
+#    across boundaries, so a region drained by one over-release surfaces within
+#    a few iterations; each subject runs in a loop and reads afterwards.
+# 5. A park some other host ended. `compile/run-on` rejects a suspension, and
+#    the ledger record outlives it; a boundary later in the same fiber must not
+#    release a park that is already over.
+# 6. The park that was NOT abandoned. An ordinary io call after every boundary
+#    proves the install path still owns its own release — the boundary must not
+#    have taken a reference the resume was going to need.
+#
+# Every read below happens AFTER the boundary ran, so an over-release faults at
+# the deref (guardfree) or trips the generation check.
+
+# ── 1. a body-allocated emit payload ─────────────────────────────────────────
+# The squelched body allocates the payload and keeps its own binding live past
+# the emit. The boundary drops the delivery retain; the frame's release table
+# drops the body's. A third decref would free `s` under the binding.
+
+(def emit-body
+  (squelch (fn []
+             (let [s (string "payload-" 1)]
+               (begin
+                 (emit :yield s)
+                 (length s)))) :yield))
+
+(defn emit-across [tag]
+  (let [held (string "held-" tag)]
+    (let [[ok e] (protect (emit-body))]
+      [(length held) ok (get e :error)])))
+
+(var i 0)
+(while (< i 40)
+  (let [r (emit-across i)]
+    (assert (< 0 (get r 0)) "the catching frame's own value must be whole")
+    (assert (= (get r 1) false) "the boundary must raise")
+    (assert (= (get r 2) :signal-violation)
+            "the violation must be readable after the boundary's releases"))
+  (assign i (+ i 1)))
+
+# ── 2. a payload stored somewhere longer-lived ───────────────────────────────
+# `sink` outlives every call and holds a counted reference to the very value the
+# body then emits. The boundary's decrefs answer for the park's references, not
+# for the store's.
+
+(def sink @[])
+
+(def store-emit-body
+  (squelch (fn []
+             (let [s (string "kept-" 1)]
+               (begin
+                 (push sink s)
+                 (emit :yield s)
+                 (length s)))) :yield))
+
+(assign i 0)
+(while (< i 40)
+  (protect (store-emit-body))
+  (assign i (+ i 1)))
+
+(assert (= (length sink) 40) "every stored payload must have reached the sink")
+(var n 0)
+(while (< n (length sink))
+  (assert (= (type-of (get sink n)) :string)
+          "a payload the sink holds must outlive the boundary")
+  (assign n (+ n 1)))
+
+# ── 3. a BORROWED payload: a module-level binding the body emits ─────────────
+# The body allocates nothing — it emits a value the module owns — so the only
+# reference the boundary may take is the one the compiler minted for the park.
+# Reading `shared` after every boundary is where an over-release surfaces.
+
+(def shared (string "shared-" 1))
+
+(def borrow-emit-body (squelch (fn [] (emit :yield shared)) :yield))
+
+(assign i 0)
+(while (< i 40)
+  (begin
+    (protect (borrow-emit-body))
+    (assert (= shared "shared-1")
+            "a borrowed payload must survive the boundary that ended its park"))
+  (assign i (+ i 1)))
+
+# ── 4. io parks, repeatedly ──────────────────────────────────────────────────
+# The request is the runtime's value, so BOTH its references are the boundary's.
+# A drained region shows up in the io machinery behind the next call, which is
+# why the writes below run after each boundary rather than only at the end.
+
+(def io-body (attune |:error| (fn [] (println ""))))
+(def sleep-body (attune |:error| (fn [] (ev/sleep 0))))
+
+(assign i 0)
+(while (< i 40)
+  (begin
+    (protect (io-body))
+    (protect (sleep-body))
+    (assert (= (type-of (string "probe-" i)) :string)
+            "allocation must go on working after the boundary's releases"))
+  (assign i (+ i 1)))
+
+# ── 5. a park some other host ended is no longer the boundary's to claim ─────
+# `compile/run-on :jit` cannot host a suspension, so it rejects the park and the
+# ledger record outlives it. The boundary below ends no park at all (a squelched
+# raise), so what keeps it off that stale record is the identity gate: the exit
+# names the park it is ending, and a record that does not name it is skipped.
+# Anything released here would be the stale record's.
+
+(def escaped (string "escaped-" 1))
+(defn yielder []
+  (yield escaped))
+(protect (compile/run-on :jit yielder))
+
+(def raise-body (squelch (fn [] (error "boom")) :error))
+
+(assign i 0)
+(while (< i 40)
+  (begin
+    (protect (raise-body))
+    (assert (= escaped "escaped-1")
+            "a boundary must not claim a park its host already abandoned"))
+  (assign i (+ i 1)))
+
+# ── 6. the install path still owns its own release ───────────────────────────
+# An ordinary io call after all of the above: its park ends at a resume, whose
+# install releases the request itself. If the boundary had taken a reference the
+# install needed, the shared io machinery would already be gone.
+
+(println "region-boundary-park-uaf: io still works")
+
+# And a fresh fiber round-trip, for the emit side of the same question.
+(def coro (fiber/new (fn [] (yield (string "round" 1))) |:yield|))
+(fiber/resume coro nil)
+(assert (= (type-of (fiber/value coro)) :string)
+        "a delivered park must still reach its resumer intact")
+
+(println "region-boundary-park-uaf: ok")

--- a/tests/elle/region-boundary-park.lisp
+++ b/tests/elle/region-boundary-park.lisp
@@ -1,0 +1,135 @@
+(elle/epoch 12)
+# A boundary ends a park with no reader and no install
+# (docs/impl/region/owner.md § "A boundary ends a park with no reader and no
+# install, so it owes both references").
+#
+# A `squelch`/`attune` violation is the third way a park can end. The other two
+# each consume one of the park's two references: a resumer reads the payload out
+# of `fiber.signal` and releases it there (the delivery reference the escape
+# retain minted), and the install that replaces the payload releases what a
+# RUNTIME-built payload's allocation left. A boundary is neither, so both
+# references are its to release — and a body-allocated payload's own reference
+# stays the abandoned frames' release tables' to run.
+#
+# This file is the LEAK gauge — `arena/count` and `arena/region-count` deltas
+# over a fixed window, BOUNDED for every subject. The soundness complement is
+# region-boundary-park-uaf.lisp.
+#
+# The trap: an `(emit :yield 1)` under a boundary reads bounded whatever this
+# mechanism does, because an immediate payload lives in no region at all. That
+# is the shape region-squelch-unwind.lisp already gauges, so this class hid
+# behind a green neighbour — every subject below carries a HEAP payload.
+
+(def window 300)
+
+(defn measure [thunk warm window]
+  (var i 0)
+  (while (%lt i warm)
+    (thunk)
+    (assign i (%add i 1)))
+  (def objects (arena/count))
+  (def regions (arena/region-count))
+  (var j 0)
+  (while (%lt j window)
+    (thunk)
+    (assign j (%add j 1)))
+  [(%sub (arena/count) objects) (%sub (arena/region-count) regions)])
+
+(defn caught [f]
+  (fn []
+    (try
+      (f)
+      (catch e nil))))
+
+# subjects ─────────────────────────────────────────────────────────────────────
+
+# (a) an IO park: the request is the runtime's value, so nothing the body ever
+# named holds it and the frames' release tables can name nothing either. Both
+# references are the boundary's — the allocation's and the delivery retain's.
+(def io-body (attune |:error| (fn [] (println ""))))
+
+# (b) the portless io op, reached through the complementary mask. The rate is
+# per park, not per port.
+(def sleep-body (attune |:error| (fn [] (ev/sleep 0))))
+
+# (c) the same io park behind a `squelch` of `:io` rather than an `attune`:
+# one boundary, two spellings.
+(def squelch-io-body (squelch (fn [] (println "")) :io))
+
+# (d) an `Emit` node's park with a HEAP payload. The body allocated it, so its
+# own reference is the release table's and only the delivery retain is owed.
+(def emit-body (squelch (fn [] (emit :yield (string "y" 1))) :yield))
+
+# (e) the same park reached through the emit PRIMITIVE, whose first argument the
+# compiler cannot read as a keyword set. A different park site, the same debt.
+(def dynamic-emit-body
+  (squelch (fn [] (fiber/emit :yield (string "y" 1))) :yield))
+
+# controls ─────────────────────────────────────────────────────────────────────
+
+# (f) an IMMEDIATE emit payload. It lives in no region, so the boundary owes it
+# nothing — and a subject built this way would read bounded before the fix.
+(def immediate-body (squelch (fn [] (emit :yield 1)) :yield))
+
+# (g) the same io call with NO boundary: the resume consumes the delivery and
+# the install releases the request, so this pins that the subjects measure the
+# boundary and not the io op.
+(defn no-boundary []
+  (println ""))
+
+# (h) the same squelched body that never violates: the ordinary releases run.
+(def clean-body (squelch (fn [] (string "y" 1)) :yield))
+
+# (i) a RAISE at a boundary rather than a park. An error emit takes the same
+# escape retain but parks nothing, and its delivery is the raise's own mint —
+# recorded in the ledger, which withdraws the payload exemption so the frames'
+# tables reclaim it. A regression here is the boundary claiming a raise.
+(def raise-body (squelch (fn [] (error (string "y" 1))) :error))
+
+# measurement ──────────────────────────────────────────────────────────────────
+
+(def d-io (measure (caught io-body) 20 window))
+(def d-sleep (measure (caught sleep-body) 20 window))
+(def d-squelch-io (measure (caught squelch-io-body) 20 window))
+(def d-emit (measure (caught emit-body) 20 window))
+(def d-dynamic (measure (caught dynamic-emit-body) 20 window))
+(def d-immediate (measure (caught immediate-body) 20 window))
+(def d-none (measure no-boundary 20 window))
+(def d-clean (measure (caught clean-body) 20 window))
+(def d-raise (measure (caught raise-body) 20 window))
+
+(println "region-boundary-park over " window " iters [objects regions]:")
+(println "  io-park          " d-io)
+(println "  sleep-park       " d-sleep)
+(println "  squelch-io-park  " d-squelch-io)
+(println "  emit-park        " d-emit)
+(println "  dynamic-emit     " d-dynamic)
+(println "  immediate        " d-immediate " (control)")
+(println "  no-boundary      " d-none " (control)")
+(println "  no-violation     " d-clean " (control)")
+(println "  raise            " d-raise " (control)")
+
+(def slack 50)
+
+(defn bounded [label delta]
+  (let [objects (get delta 0)
+        regions (get delta 1)]
+    (begin
+      (assert (< objects slack)
+              (concat label ": objects grew, delta=" (number->string objects)))
+      (assert (< regions slack)
+              (concat label ": regions grew, delta=" (number->string regions))))))
+
+(bounded "control: an immediate payload crosses no region" d-immediate)
+(bounded "control: an io park with no boundary reclaims normally" d-none)
+(bounded "control: a squelched body that never violates reclaims normally"
+         d-clean)
+(bounded "control: a raise at a boundary is not a park" d-raise)
+
+(bounded "an io park's request is released by the boundary that ends it" d-io)
+(bounded "a portless io park owes the same two references" d-sleep)
+(bounded "a squelch of :io ends the park exactly as an attune does" d-squelch-io)
+(bounded "an emit park's delivery retain has no reader at a boundary" d-emit)
+(bounded "the emit primitive's park owes the same delivery" d-dynamic)
+
+(println "region-boundary-park: ok")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -831,6 +831,25 @@ fn region_squelch_unwind_uaf() {
     );
 }
 
+// Guard — a squelch/attune boundary ends a park with no reader and no install,
+// so it releases both of the park's references (docs/impl/region/owner.md § "A
+// boundary ends a park with no reader and no install"). Each is a decref that
+// never ran before, and the fiber SURVIVES, so what must be whole afterwards is
+// everything that still names the payload: a body-allocated one the emitting
+// frame's own binding holds, one a longer-lived CONTAINER took a counted
+// reference to, a BORROWED module-level binding the compiler minted the body's
+// reference for, the io machinery behind 80 boundaries, and a park the install
+// path still owns — resumed after all of them. Every read happens after the
+// boundary ran, so an over-release faults there — SIGSEGV under guardfree. The
+// leak face is `region-boundary-park.lisp`.
+#[test]
+fn region_boundary_park_uaf() {
+    run_elle_script_with_args(
+        "region-boundary-park-uaf",
+        &["--jit=adaptive", "--mlir=off", "--trace=guardfree"],
+    );
+}
+
 // Guard — a deferred tail-call release runs at every end its activation can
 // reach, not only the clean break (docs/impl/region/owner.md § "A deferred
 // tail-call release has the node's life"). Each is a decref the activation


### PR DESCRIPTION
Closes #1031.

## The reading

A `squelch`/`attune` violation is the **third** way a park can end, and it is
neither of the two the park's accounting was written for.

- No resumer reads the payload out of `fiber.signal`, so the **delivery**
  reference — the `EmitEscape`/`SuspendEscape` retain the park took — has no
  consumer at all. A fiber torn down while parked did have one: its park crossed
  to a resumer first, by the one route out of the driving loop that a boundary
  cuts.
- No install replaces the payload in the slot, so a payload the **runtime** built
  keeps the reference its allocation left.

So the boundary owes two decrefs where each neighbouring seam owes one, and it
runs the installs' own readings to tell them apart. A body-allocated payload's
own reference stays the abandoned frames' release tables' to run.

## What was leaking

The issue's subject is the io half: an `IoRequest` reaching
`VM::discard_suspended_frames` with two references and losing neither. Running
`release_displaced_io_request` there moves the rate by 0, because that arm
answers for the allocation's reference and the delivery retain is the other one.

The **emit** half had no gauge at all. `region-squelch-unwind.lisp` carries an
immediate payload in every one of its emits, so a heap `(emit …)` under a
boundary read bounded while stranding a region per op just as the io request did.

Measured before, per op, 300-op window, debug interpreter:

| shape | objects | regions |
|---|---:|---:|
| `(attune \|:error\| (fn [] (println "")))` | 1 | 1 |
| `(attune \|:error\| (fn [] (ev/sleep 0)))` | 1 | 1 |
| `(squelch (fn [] (println "")) :io)` | 1 | 1 |
| `(squelch (fn [] (emit :yield (string "y" 1))) :yield)` | 1 | 1 |
| `(squelch (fn [] (fiber/emit :yield (string "y" 1))) :yield)` | 1 | 1 |
| four controls (immediate payload, no boundary, no violation, a raise) | 0 | 0 |

All five read 0 after.

## Naming the park

The issue's constraint holds: the chokepoint cannot read `fiber.signal` for the
park, because two of the six enforcement sites reach `squelch_violation` through
`invoke_closure_jit`, which restores the CALLER's signal first and holds the
parked one in a local.

Two records decide it together, because neither answers on its own.

- The **delivery ledger** says the retain has no reader — a fact only the site
  that took the retain knows, so that site writes the payload beside it
  (`park_primitive` / `park_denial` / `park_emit`, next to the `bodyless` record
  already there).
- The **enforcement site** says which park this exit ends, and passes it down.

Comparing the two bit-wise is what makes the release safe with no claim about
every route out of a park: a record left over from a park some other host ended
names a payload this exit is not looking at, and the next park overwrites it.
That is the gate `release_displaced_denial_payload` already makes for the same
reason.

## Gauges

- `tests/elle/region-boundary-park.lisp` — the leak face: five park shapes
  against four controls, each subject at 1 object and 1 region per op before.
- `tests/elle/region-boundary-park-uaf.lisp` — the soundness face under
  `--trace=guardfree`: a body-allocated payload, one a container holds, a
  **borrowed** module-level binding, the io machinery across 80 boundaries, a
  park some other host ended, and a park the install path still owns.
- `runtime::tests::ownership::discard_runs_the_abandoned_frames_release_tables`
  drives the chokepoint; `vm::fiber::refcount::tests` pins the per-shape counts;
  `value::fiber::delivery::tests` pins the record's lifecycle.

Ran: `oracle: ok` (0 open / 5 by-design), `plumb: ok` (0 open / 2 by-design),
the 101 `region_*` guardfree pins, `cargo test -p elle --lib` (2489), `make qa`.

## Known: the corpus smoke is red, and not from this branch

`make smoke-elle` fails on one batch with

```
thread 'main' panicked at src/vm/stack.rs:6:25:
index out of bounds: the len is 4 but the index is 262
```

— a stale `CodePayload` read (`handle_load_const`) inside macro expansion during
`compile_whole_module`. It is **pre-existing**: a binary built from `origin/main`
crashes on the same explicit file list 2 runs in 3.

```sh
./target/profiling/elle test \
  tests/elle/{macros,tls,unwind-suspend,jit-bytes-push,region-squelch-nested,\
param-frame-balance,ev-run-error-teardown,compile-extract,jit-double-import-uaf,\
region-break-skip-uaf,h2-headers-in-process}.lisp
```

Every one of those eleven files is required — dropping any one makes it pass, so
it is a cumulative page-recycling threshold rather than a property of one file.
It needs the JIT (`--jit=off` never crashes) and does not reproduce under
`--trace=scrub` or `--trace=guardfree`. Disabling the payload cache's sweep does
not help.

This branch does not cause it: with `release_abandoned_park` disabled the crash
still reproduces 9 runs in 10. What the branch does is add two corpus files,
which re-deals `make smoke-elle`'s hash-ordered batches and produces the 25-file
group that hits it — `origin/main`'s own `make smoke-elle` passes because its
deal never forms that group.
