### PR TITLE
regions: a branch merge inherits the points that covered its entry

### DIFF
--- a/docs/impl/region/mechanism.md
+++ b/docs/impl/region/mechanism.md
@@ -1480,14 +1480,47 @@ followed by one the tail call's path may not be a predecessor of at all, and a
 release replicated into an unreachable point is a release added on a path that
 never owed it.
 
+**A merge inherits what covered the branch's ENTRY as well.** The arms are one of
+the two sources, not the whole of it. A branch is entered from one position, and
+whatever points covered that position cover the merge too — the merge is reached
+only through the branch, so the paths that arrive at it are exactly the paths that
+arrived at the entry, minus the ones an arm's own tail call took away. Reading the
+arms alone loses a point at the boundary the arms never touch: the condition
+block, which closes like any other and clears what it was carrying, so a branch
+that follows an earlier branch starts life covering nothing. Every release after
+the second branch is then emitted at a merge the first branch's tail-calling arm
+does not reach, with no replica to run it there — one region per call, plus its
+cascade.
+
+That is not a corner shape. **Functionalization inserts a branch of its own** for
+every mutable a branch arm reassigns: the two versions of the name have to meet,
+and they meet in an `If` on the same condition, emitted after the arm that already
+carries the tail call. So a body whose tail is `(if p (begin … (assign i …) …
+(f x)) …)` compiles to two branches, and the enclosing scope's releases land past
+the second one. A loop is the everyday spelling of it, `while` and `each` alike
+carrying an `assign` over their induction variable — which is why an `each` over an
+empty sequence, whose body never runs, still strands what the scope around it
+holds.
+
+The two sources are collected separately because they are sealed differently. An
+arm's own points name a block the arm just closed and are sealed AT that close; the
+inherited ones are already sealed when the branch begins, and are read there —
+`Finished` points only, a point still naming the open block dying with it exactly as
+before. Neither source can double-count the other: a point handed to the merge from
+the entry was never in an arm's `tail_exit_hoist` to be sealed, the block boundary
+between the two having cleared it.
+
 The residual is unchanged in kind: a holder escape marks by a facet no edge at
 the point replaces.
 
 Pinned by `tests/elle/region-tail-frame-exit.lisp` (the reclamation, with the
 argument-move and callee exemptions, the per-arm faces, the captured-holder faces,
 the non-self-cancelling boundary, the env-cell faces, the
-handed-back-through-the-callee faces, the forward-cell faces, and the
-id-routed letrec closure whose body's tail is a branch, driven as rows),
+handed-back-through-the-callee faces, the forward-cell faces, the
+id-routed letrec closure whose body's tail is a branch, and the merge that
+inherits its points from the branch's entry — the `if`, `when`, `cond` and loop
+faces of the branch functionalization inserts for a reassigned local — driven as
+rows),
 the `tail-frame-exit-unused` /
 `tail-frame-exit-moved` / `tail-frame-exit-arms` / `tail-frame-exit-captured` /
 `tail-frame-exit-handback` / `tail-frame-exit-fold-driver` /

--- a/src/lir/lower/AGENTS.md
+++ b/src/lir/lower/AGENTS.md
@@ -172,7 +172,14 @@ other is structural ownership-location, NOT escape:
   and the callee takes over the leaf rather than the source, so such an argument
   keeps the exemption only where the call passes the slot the region's own
   release route loads (`drop_named_only_arg_exemptions`, mechanism.md § "A leaf
-  is a part, not the whole").
+  is a part, not the whole"). A point survives the block it was opened in through
+  a branch: `begin_branch_arms` reads both the points the branch's arms will seal
+  and the ones already covering the position the branch is entered at, and
+  `open_branch_merge` hands the merge the union. The entry half is what a branch
+  following an earlier branch needs — the condition block clears what it carries
+  like any other, and functionalization puts a second branch after the first for
+  every mutable an arm reassigns (mechanism.md § "A merge inherits what covered
+  the branch's ENTRY as well").
   And the region must be frame-held
   (`RegionInfo::frame_held_regions`), because a tail callee also reaches
   its CAPTURED environment, which no argument names. A region escaping by the

--- a/src/lir/lower/control.rs
+++ b/src/lir/lower/control.rs
@@ -494,11 +494,11 @@ impl<'a> Lowerer<'a> {
         // the block"). The no-match block makes no tail call, so it contributes
         // none — which costs nothing, since a point is only ever a licence to
         // replicate, never an obligation to.
-        let saved_arm_hoists = self.begin_branch_arms();
+        let branch_hoists = self.begin_branch_arms();
 
         if any_guard_yields {
             self.lower_match_sequential(arms, scrutinee_slot, result_slot, result_reg, done_label)?;
-            self.open_branch_merge(saved_arm_hoists);
+            self.open_branch_merge(branch_hoists);
             return Ok(result_reg);
         }
 
@@ -520,7 +520,7 @@ impl<'a> Lowerer<'a> {
 
         // Done block: reload result
         self.current_block = BasicBlock::new(done_label);
-        self.open_branch_merge(saved_arm_hoists);
+        self.open_branch_merge(branch_hoists);
         self.emit(LirInstr::LoadLocal {
             dst: result_reg,
             slot: result_slot,

--- a/src/lir/lower/emitops.rs
+++ b/src/lir/lower/emitops.rs
@@ -302,14 +302,52 @@ impl<'a> Lowerer<'a> {
         self.current_func.blocks.push(block);
     }
 
-    /// Start collecting the relocation points of a branch's arms, returning the
-    /// enclosing branch's collection for `open_branch_merge` to restore.
+    /// Start collecting the relocation points of a branch's arms, returning what
+    /// [`Self::open_branch_merge`] needs to hand the merge block: the enclosing
+    /// branch's collection to restore, and the points already covering the
+    /// position this branch is entered at.
     ///
     /// The three branch lowerings bracket their arms with this pair; a branch
     /// nested inside an arm therefore collects into its own list and hands its
     /// union up as that arm's contribution.
-    pub(super) fn begin_branch_arms(&mut self) -> Vec<super::TailExitHoist> {
-        std::mem::take(&mut self.arm_exit_hoists)
+    ///
+    /// The **inherited** half is the merge's second source. A merge is reached
+    /// only through the branch, so the paths that arrive at it are the paths that
+    /// arrived at the entry, minus the ones an arm's own tail call took away — and
+    /// a point that covered the entry covers the merge for the same reason it
+    /// covered the entry (docs/impl/region/mechanism.md § "A merge inherits what
+    /// covered the branch's ENTRY as well"). Without it a branch that follows an
+    /// earlier branch starts life covering nothing: the condition block closes like
+    /// any other and clears what it was carrying.
+    ///
+    /// Read here rather than sealed later, because this runs while the branch's own
+    /// entry block is the one still open — the position the points describe. Only
+    /// the [`super::HoistBlock::Finished`] ones are taken: a point still naming the
+    /// open block dies with that block exactly as before, having no closed
+    /// instruction list to be spliced into.
+    ///
+    /// The points are MOVED out rather than copied, so the branch holds the only
+    /// record of each. A point is mutable state — every replica spliced into its
+    /// block advances its `at` past what it inserted — so two records of one point
+    /// diverge, and the stale one then splices into the middle of the run the
+    /// current one already put there. What that costs is the position between here
+    /// and the branch's own first block boundary: a `cond`'s first clause test and a
+    /// `match`'s first pattern test are lowered into the entry block and emit their
+    /// releases plainly. That is the conservative baseline this whole mechanism
+    /// improves on, never a mis-free.
+    pub(super) fn begin_branch_arms(&mut self) -> super::BranchHoists {
+        let mut inherited = Vec::new();
+        self.tail_exit_hoist.retain(|h| match h.block {
+            super::HoistBlock::Finished(_) => {
+                inherited.push(h.clone());
+                false
+            }
+            super::HoistBlock::Current(_) => true,
+        });
+        super::BranchHoists {
+            saved: std::mem::take(&mut self.arm_exit_hoists),
+            inherited,
+        }
     }
 
     /// Seal the relocation points of the arm-final block into the branch's
@@ -337,14 +375,20 @@ impl<'a> Lowerer<'a> {
         self.arm_exit_hoists.extend(sealed);
     }
 
-    /// Hand the merge block just opened the points its arms sealed, and restore
-    /// the enclosing branch's collection.
+    /// Hand the merge block just opened the points its arms sealed and the points
+    /// that covered the branch's entry, and restore the enclosing branch's
+    /// collection.
     ///
-    /// Every path into a merge arrives through one of the arms, so these points
-    /// together cover the merge — which is what licenses replicating a release
-    /// emitted here back into each of them.
-    pub(super) fn open_branch_merge(&mut self, saved: Vec<super::TailExitHoist>) {
+    /// Every path into a merge arrives through one of the arms, and every path
+    /// into the branch arrived at its entry, so the two sets together cover the
+    /// merge — which is what licenses replicating a release emitted here back into
+    /// each of them. Neither can double-count the other: a point handed over from
+    /// the entry was never in an arm's `tail_exit_hoist` to be sealed, the block
+    /// boundary between the two having cleared it.
+    pub(super) fn open_branch_merge(&mut self, hoists: super::BranchHoists) {
+        let super::BranchHoists { saved, inherited } = hoists;
         self.tail_exit_hoist = std::mem::replace(&mut self.arm_exit_hoists, saved);
+        self.tail_exit_hoist.extend(inherited);
     }
 
     /// Open the relocation point a frame-replacing tail call leaves behind: the
@@ -612,6 +656,24 @@ impl<'a> Lowerer<'a> {
                 continue;
             }
             let at = self.tail_exit_hoist[i].at;
+            // A point's `at` names its `TailCall`, and each replica spliced ahead
+            // of that call advances it past what it inserted — so the invariant is
+            // that ONE record of each point exists (`begin_branch_arms` moves them
+            // rather than copying). A second record keeps a stale index, which
+            // splices into the middle of the run the live one already put there and
+            // leaves the operand stack of a block that still passes every other
+            // check misshapen. Asserting the index still names the call turns that
+            // into a panic here rather than an out-of-bounds stack read at runtime.
+            debug_assert!(
+                matches!(
+                    self.current_func.blocks[block].instructions.get(at),
+                    Some(SpannedInstr {
+                        instr: LirInstr::TailCall { .. } | LirInstr::TailCallArrayMut { .. },
+                        ..
+                    })
+                ),
+                "a relocation point's index must still name its tail call: block={block} at={at}"
+            );
             self.tail_exit_hoist[i].at += copy.len();
             self.current_func.blocks[block]
                 .instructions

--- a/src/lir/lower/expr/block.rs
+++ b/src/lir/lower/expr/block.rs
@@ -24,6 +24,18 @@ impl<'a> Lowerer<'a> {
         let else_label = self.fresh_label();
         let merge_label = self.fresh_label();
 
+        // Each arm seals whatever relocation point it ends on, so a release
+        // emitted past the merge can be replicated back into the arms that leave
+        // through a frame-replacing tail call (docs/impl/region/mechanism.md
+        // § "The relocation point outlives the block"). Read BEFORE the condition
+        // block closes, because the merge's other source is the set of points
+        // already covering this position, and `finish_block` clears them
+        // (§ "A merge inherits what covered the branch's ENTRY as well"). `cond`
+        // is lowered above, so nothing of this branch's own is lost by reading
+        // here; `lower_cond` and `lower_match` reach the same moment with their
+        // entry block still open.
+        let branch_hoists = self.begin_branch_arms();
+
         // Terminate current block with branch
         self.terminate(Terminator::Branch {
             cond: cond_reg,
@@ -31,12 +43,6 @@ impl<'a> Lowerer<'a> {
             else_label,
         });
         self.finish_block();
-
-        // Each arm seals whatever relocation point it ends on, so a release
-        // emitted past the merge can be replicated back into the arms that leave
-        // through a frame-replacing tail call (docs/impl/region/mechanism.md
-        // § "The relocation point outlives the block").
-        let saved_arm_hoists = self.begin_branch_arms();
 
         // Then block: store result to slot, jump to merge
         self.current_block = BasicBlock::new(then_label);
@@ -62,7 +68,7 @@ impl<'a> Lowerer<'a> {
 
         // Merge block: load result from slot
         self.current_block = BasicBlock::new(merge_label);
-        self.open_branch_merge(saved_arm_hoists);
+        self.open_branch_merge(branch_hoists);
         self.emit(LirInstr::LoadLocal {
             dst: result_reg,
             slot: result_slot,

--- a/src/lir/lower/expr/loops.rs
+++ b/src/lir/lower/expr/loops.rs
@@ -222,7 +222,7 @@ impl<'a> Lowerer<'a> {
         // inherit (docs/impl/region/mechanism.md § "The relocation point outlives
         // the block"). A `cond` with no `else` contributes an empty-handed nil
         // path, which simply carries no point.
-        let saved_arm_hoists = self.begin_branch_arms();
+        let branch_hoists = self.begin_branch_arms();
 
         // Process each clause
         for (i, (test, body)) in clauses.iter().enumerate() {
@@ -284,7 +284,7 @@ impl<'a> Lowerer<'a> {
 
         // Done block (continue here)
         self.current_block = BasicBlock::new(done_label);
-        self.open_branch_merge(saved_arm_hoists);
+        self.open_branch_merge(branch_hoists);
         self.emit(LirInstr::LoadLocal {
             dst: result_reg,
             slot: cond_result_slot,

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -96,11 +96,12 @@ struct BlockLowerContext {
 /// the same single release, relocated), and is legal for every region the call
 /// itself cannot reach.
 ///
-/// A branch merge inherits the points of the arms that reach it, so a point also
-/// outlives its own block (§ "The relocation point outlives the block"). There
-/// the release is emitted at the merge *and* replicated at each point, which is
-/// sound only for a self-cancelling run — one that nil-stamps the slot it read,
-/// so the copy a path reaches second no-ops.
+/// A branch merge inherits the points of the arms that reach it AND the points
+/// that already covered the branch's entry, so a point outlives its own block
+/// (§ "The relocation point outlives the block"). There the release is emitted at
+/// the merge *and* replicated at each point, which is sound only for a
+/// self-cancelling run — one that nil-stamps the slot it read, so the copy a path
+/// reaches second no-ops.
 struct TailExitHoist {
     /// Index of the `TailCall` in its block's instruction list. A hoisted
     /// release is spliced in here, ahead of the frame replacement, and the index
@@ -429,10 +430,11 @@ pub struct Lowerer<'a> {
     /// emission position (see [`TailExitHoist`]). Either a single
     /// [`HoistBlock::Current`] entry — a frame-replacing tail call emitted into
     /// this very block, which dominates everything after it — or the
-    /// [`HoistBlock::Finished`] points a branch merge inherited from its arms.
-    /// Set by `lower_call`'s tail arm and by the branch lowerings, cleared at
-    /// every other block boundary, and saved/restored across lambda boundaries
-    /// like every other per-function slot map.
+    /// [`HoistBlock::Finished`] points a branch merge inherited, from its arms
+    /// and from the position the branch was entered at. Set by `lower_call`'s
+    /// tail arm and by the branch lowerings, cleared at every other block
+    /// boundary, and saved/restored across lambda boundaries like every other
+    /// per-function slot map.
     tail_exit_hoist: Vec<TailExitHoist>,
     /// Points sealed from the arms of the branch currently being lowered, which
     /// `open_branch_merge` hands to its merge block. Saved and restored around

--- a/src/lir/lower/mod.rs
+++ b/src/lir/lower/mod.rs
@@ -102,6 +102,7 @@ struct BlockLowerContext {
 /// the merge *and* replicated at each point, which is sound only for a
 /// self-cancelling run — one that nil-stamps the slot it read, so the copy a path
 /// reaches second no-ops.
+#[derive(Clone)]
 struct TailExitHoist {
     /// Index of the `TailCall` in its block's instruction list. A hoisted
     /// release is spliced in here, ahead of the frame replacement, and the index
@@ -122,6 +123,23 @@ struct TailExitHoist {
     /// argument's is the ownership move the calling convention rests on, and the
     /// callee's belongs to the activation that takes it over.
     exempt: rustc_hash::FxHashSet<crate::hir::region::Region>,
+}
+
+/// What a branch lowering holds across its arms, so `open_branch_merge` can hand
+/// the merge block everything that covers it.
+///
+/// Two sources, collected at different moments because they are sealed
+/// differently: an arm's own points name a block the arm just closed and are
+/// sealed at that close (`seal_arm_hoists`), while the points covering the
+/// branch's ENTRY are already sealed when the branch begins and are read there
+/// (docs/impl/region/mechanism.md § "A merge inherits what covered the branch's
+/// ENTRY as well").
+struct BranchHoists {
+    /// The enclosing branch's `arm_exit_hoists`, restored at the merge so a
+    /// nested branch's arms never leak into it.
+    saved: Vec<TailExitHoist>,
+    /// The points that already covered the position the branch was entered at.
+    inherited: Vec<TailExitHoist>,
 }
 
 /// Where a relocation point lives, and with it which of the two placements

--- a/tests/elle/h2-stress-scoped.lisp
+++ b/tests/elle/h2-stress-scoped.lisp
@@ -63,8 +63,8 @@
 # delta must fit under. Shrink-only — see "The pins" above.
 (def residue-small 10)
 (def residue-large 30)
-(def max-objects-per-request 9)
-(def max-regions-per-request 9)
+(def max-objects-per-request 2)
+(def max-regions-per-request 2)
 
 # ── Helpers ──────────────────────────────────────────────────────────
 

--- a/tests/elle/region-tail-frame-exit-uaf.lisp
+++ b/tests/elle/region-tail-frame-exit-uaf.lisp
@@ -318,6 +318,33 @@
         m (e17-arm v false)]
     (%add n (%add m (length (first v))))))
 
+# (e18) the merge a branch inherits from its ENTRY rather than from its arms
+# (docs/impl/region/mechanism.md § "A merge inherits what covered the branch's
+# ENTRY as well"). Functionalization inserts a second branch to merge the two
+# versions of the mutable this arm reassigns, so the scrutinee's release is
+# emitted past it and replicated ahead of the arm's `TailCall`. The scrutinee is a
+# pair built around a list the CALLER owns, so freeing it cascades one decref
+# along the funnel's counted edge — which must drop that edge and no more. The
+# caller drives both arms with one list and reads it afterwards, so an
+# over-cascade faults on the second call or on the final read.
+(defn e18-pair (v)
+  [v 1])
+(defn e18-arm (v t)
+  (let [[a b] (e18-pair v)
+        g (fn () (length (first a)))]
+    (if t
+      (let [_ (begin
+                (def @i 0)
+                (assign i (%add i 1))
+                i)]
+        (g))
+      5)))
+(defn e18-read (i)
+  (let [v (list (string "ag" i) i)
+        n (e18-arm v true)
+        m (e18-arm v false)]
+    (%add n (%add m (length (first v))))))
+
 # (e4) the capturing closure is RETURNED, so it outlives the frame and carries `x`
 # with it — on the funnel's counted edge, which is what the frame's release must
 # leave standing. The caller invokes the closure afterwards and reads through it.
@@ -566,6 +593,7 @@
 (var e16 0)
 (var e16b 0)
 (var e17 0)
+(var e18 0)
 (var e4 0)
 (var f 0)
 (var g 0)
@@ -605,6 +633,7 @@
   (assign e16 (e16-read i))
   (assign e16b (e16b-read i))
   (assign e17 (e17-read i))
+  (assign e18 (e18-read i))
   (assign e4 (e4-read i))
   (assign f (f-read i))
   (assign g (g-return i))
@@ -658,6 +687,9 @@
 (assert (%gt e17 0)
         "a letrec closure's replicated release freed more than the frame's own \
          reference under a branch body tail")
+(assert (%gt e18 0)
+        "a scrutinee's replicated release freed more than the frame's own \
+         reference at a merge inherited from the branch's entry")
 (assert (> e4 0) "value freed under a closure that escaped holding it")
 (assert (%gt f 0) "stranded value freed after being stored into a container")
 (assert (%gt g 0) "returned value freed under the caller's read")

--- a/tests/elle/region-tail-frame-exit.lisp
+++ b/tests/elle/region-tail-frame-exit.lisp
@@ -36,6 +36,14 @@
 # value-routed release nil-stamps the slot it read, so the copy a path reaches
 # second loads `nil` and no-ops.
 #
+# The arms are one of two sources. A merge also inherits what covered the
+# position the branch was ENTERED at, because the merge is reached only through
+# the branch (§ "A merge inherits what covered the branch's ENTRY as well"). That
+# is what a branch following an earlier branch needs, and functionalization
+# writes one for every mutable a branch arm reassigns — so a loop or an `assign`
+# inside an arm puts the enclosing scope's releases past a merge the first
+# branch's tail-calling arm never arrives at.
+#
 # An ENV CELL's release leaves no such stamp, so it takes the other route to the
 # same place: the relocation keeps it in the arm whose tail call it was placed in,
 # and the sibling arm takes branch compensation's per-arm release — the HEAD one
@@ -378,6 +386,82 @@
     (go n)
     (if t (tail-sink) 5)))
 
+# (d22) the release lands past a SECOND branch. A merge inherits the relocation
+# points of the arms that reach it AND the points that already covered the
+# position the branch was entered at — the merge is reached only through the
+# branch, so the paths arriving at it are the paths that arrived at the entry
+# (docs/impl/region/mechanism.md § "A merge inherits what covered the branch's
+# ENTRY as well"). Read from the arms alone, a branch following an earlier branch
+# starts life covering nothing, and every release after it is emitted where the
+# earlier branch's tail-calling arm never arrives.
+#
+# The second branch is not written here: functionalization inserts one for every
+# mutable a branch arm reassigns, an `If` on the same condition merging the two
+# versions of the name after the arm that already carries the tail call. The
+# scrutinee's own region is what these rows measure — the branch tests a value
+# read out of it, so its release lands at the branch and, with the second one
+# inserted, past that instead.
+(defn mk-ok ()
+  [true 7])
+(defn mk-not ()
+  [false 7])
+(defn phi-when (p)
+  (let [[ok? n] (p)]
+    (when ok?
+      (let [_ (begin
+                (def @i 0)
+                (assign i (%add i 1))
+                i)]
+        (tail-sink)))))
+
+# (d22b) both arms, the sibling FALLING THROUGH to the merge, where the release
+# is still emitted. Exactly one release runs per path, the arm's replica or the
+# merge's copy.
+(defn phi-if (p)
+  (let [[ok? n] (p)]
+    (if ok?
+      (let [_ (begin
+                (def @i 0)
+                (assign i (%add i 1))
+                i)]
+        (tail-sink))
+      5)))
+
+# (d22c) the reassignment inside a LOOP, which is how ordinary code writes it:
+# `while` and `each` both carry an `assign` over an induction variable, so a walk
+# in a branch arm inserts the merge whether or not its body ever runs. This one's
+# never does.
+(defn phi-loop (p)
+  (let [[ok? n] (p)]
+    (when ok?
+      (let [_ (begin
+                (def @i 0)
+                (while (%lt i 0) (assign i (%add i 1))))]
+        (tail-sink)))))
+
+# (d22d) a `cond` clause body carrying the reassignment, with the else body
+# leaving through its own callee. Both bodies are driven.
+(defn phi-cond (p)
+  (let [[ok? n] (p)]
+    (cond
+      ok?
+        (let [_ (begin
+                  (def @i 0)
+                  (assign i (%add i 1))
+                  i)]
+          (tail-sink))
+      (tail-sink2))))
+
+# (d22e) control: the same arm with no reassignment, so functionalization inserts
+# no second branch and the arm's own point is the one the release reads.
+(defn phi-none (p)
+  (let [[ok? n] (p)]
+    (when ok?
+      (let [_ (begin
+                (def i 0)
+                (%add i 1))]
+        (tail-sink)))))
+
 # (d18) the `def` face of the same three bodies. A `def` has no scope NODE, so the
 # analysis leaves its closure region's demise where the binding chain put it — the
 # binding's last use — and a use as a CALLEE resolves through `last_use` to the node
@@ -595,6 +679,13 @@
   (measure (fn () (arm-selfrec-partial 3 true)) 200 window))
 (def arm-selfrec-partial-f-d
   (measure (fn () (arm-selfrec-partial 3 false)) 200 window))
+(def phi-when-d (measure (fn () (phi-when mk-ok)) 200 window))
+(def phi-if-t-d (measure (fn () (phi-if mk-ok)) 200 window))
+(def phi-if-f-d (measure (fn () (phi-if mk-not)) 200 window))
+(def phi-loop-d (measure (fn () (phi-loop mk-ok)) 200 window))
+(def phi-cond-t-d (measure (fn () (phi-cond mk-ok)) 200 window))
+(def phi-cond-f-d (measure (fn () (phi-cond mk-not)) 200 window))
+(def phi-none-d (measure (fn () (phi-none mk-ok)) 200 window))
 (def callee-letrec-member-d
   (measure (fn () (callee-letrec-member 3)) 200 window))
 (def callee-member-plain-d (measure (fn () (callee-member-plain 3)) 200 window))
@@ -661,6 +752,9 @@
          arm-selfrec-f-d "  cond " arm-selfrec-cond-0-d "/" arm-selfrec-cond-2-d
          "  inner " arm-selfrec-inner-t-d "/" arm-selfrec-inner-f-d "  partial "
          arm-selfrec-partial-t-d "/" arm-selfrec-partial-f-d)
+(println "  merge inheriting the branch's entry: when " phi-when-d "  if "
+         phi-if-t-d "/" phi-if-f-d "  loop " phi-loop-d "  cond " phi-cond-t-d
+         "/" phi-cond-f-d "  control " phi-none-d)
 (println "  def binder: arg-call " def-arg-call-d "  nontail " def-nontail-d
          "  stmt " def-stmt-d "  tail " def-tail-d)
 (println "  letrec member callee: arg-call " callee-letrec-member-d "  plain "
@@ -766,6 +860,15 @@
 (bounded? def-stmt-d "the same `def` called for effect")
 (bounded? def-tail-d "control: the `def` whose body tail-calls the binding")
 
+(bounded? phi-when-d
+          "a release past the merge functionalization inserts for a reassigned local")
+(bounded? phi-if-t-d "the tail-calling arm of the same shape's two-armed face")
+(bounded? phi-if-f-d "the sibling arm, which falls through to the merge")
+(bounded? phi-loop-d "the same where a loop carries the reassignment")
+(bounded? phi-cond-t-d "the same under a cond clause body")
+(bounded? phi-cond-f-d "the cond else body, which leaves through its own callee")
+(bounded? phi-none-d "control: the same arm with no reassignment to merge")
+
 (bounded? callee-letrec-member-d
           "the letrec member the body tail-calls, released at the letrec scope end")
 (bounded? callee-member-plain-d
@@ -814,6 +917,14 @@
 (assert (= (arm-selfrec-inner 3 false) 1) "inner-recursion sibling arm lost")
 (assert (= (arm-selfrec-partial 3 false) 5)
         "partial branch-tail fall-through result lost")
+(assert (= (phi-when mk-ok) 0) "phi merge when result lost")
+(assert (nil? (phi-when mk-not)) "phi merge when sibling arm lost")
+(assert (= (phi-if mk-ok) 0) "phi merge if result lost")
+(assert (= (phi-if mk-not) 5) "phi merge if fall-through result lost")
+(assert (= (phi-loop mk-ok) 0) "phi merge loop result lost")
+(assert (= (phi-cond mk-ok) 0) "phi merge cond clause result lost")
+(assert (= (phi-cond mk-not) 1) "phi merge cond else result lost")
+(assert (= (phi-none mk-ok) 0) "control: no-reassignment arm result lost")
 (assert (= (callee-letrec-member 3) 1) "callee-letrec-member result lost")
 (assert (= (callee-member-plain 3) 2) "callee-member-plain result lost")
 (assert (= (callee-member-capture member-src) 4)


### PR DESCRIPTION
A relocation point licenses replicating a release into a block a frame-replacing
tail call already left. A branch merge collected the points its **arms** sealed
and nothing else, so a branch entered from a position that already carried points
started life covering none of them — and every release after that branch was
emitted at a merge the earlier branch's tail-calling arm never arrives at.

That is not a corner shape, because the second branch is usually not written by
hand. **Functionalization inserts one for every mutable a branch arm reassigns**:
the two versions of the name have to meet, and they meet in an `If` on the same
condition, emitted after the arm that already carries the tail call. A loop is the
everyday spelling — `while` and `each` both carry an `assign` over an induction
variable — so a walk inside a branch arm strands what the enclosing scope holds,
whether or not the walk's body ever runs.

`lib/http2/server.lisp`'s `handle-server-request` is that shape:

```lisp
_ (each k in (keys resp-headers)
    (push h-pairs [(string k) (string (get resp-headers k))]))
```

The test handler returns no `:headers`, so `resp-headers` is `{}` and the loop
body never executes. What it strands is not what the loop allocates: the value the
handler returned, the bytes inside it, and the `protect` pair that carried it out
— all bound before the loop, all released past the merge functionalization put
after it.

## What the fix is

`begin_branch_arms` now reads the relocation points already covering the position
the branch is entered at, alongside the collection its arms seal into, and
`open_branch_merge` hands the merge the union. A merge is reached only through the
branch, so the paths arriving at it are the paths that arrived at the entry, minus
the ones an arm's own tail call took away — the same argument that licenses the
arms' own points.

The entry half is read while the branch's entry block is still open, so `lower_if`
asks for it before terminating that block; `lower_cond` and `lower_match` already
reached that moment. Only `Finished` points are taken — one still naming the open
block has no closed instruction list to be spliced into and dies with it, as
before. The points are **moved** rather than copied: a point is mutable state,
each replica advancing its index past what it inserted, so two records of one
point would diverge and the stale one would splice into the middle of the run the
live one already placed. A `debug_assert` now pins that a point's index still
names its tail call.

## Measured

| drive | before | after |
|---|---:|---:|
| h2 server request, `POST` with a body | 9 objects / 9 regions | **2 / 2** |
| h2 server request, `GET` | 8 / 8 | **0 / 0** |
| the same, client half | 0 / 0 | 0 / 0 |

`tests/elle/h2-stress-scoped.lisp`'s per-request ceilings fall from 9 to 2, at
both of its request counts.

## Tests

`tests/elle/region-tail-frame-exit.lisp` gains the rows: the `when`, two-armed,
loop and `cond` faces of the branch functionalization inserts for a reassigned
local, beside a control with no reassignment. Each read one region per call
before this change and zero after; the control read zero throughout.

`tests/elle/region-tail-frame-exit-uaf.lisp` gains the soundness witness — a
scrutinee built around a list the caller owns, whose replicated release must
cascade one decref along the counted edge and no further, driven on both arms and
read afterwards.

Closes #1053. What that issue named as the request body's share of the rate is
#1055, measured at 2 objects and 2 regions per request and pinned there by
`tests/elle/h2-stress-scoped.lisp`.
