### PR TITLE
audit: a file that breaks a rule carries no stamp

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -29,8 +29,11 @@ already making.
   next reader holding two claims and no way to choose.
 - Delete what no longer describes the code. A deleted paragraph costs nothing
   to read.
-- When the repair is larger than your change, file an issue and cite it where
-  the claim sits.
+- Do the repair, however much larger it is than the change that found it. A
+  file past the reading budget is split; a section describing code that is gone
+  is deleted. Neither waits for somebody else.
+- File an issue for a defect in the code. Prose you have open is repaired here,
+  where the cost of reading it is already paid.
 - Audit against this file as it stands today, never against the version you
   remember.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -75,9 +75,14 @@ an HTML comment under the title.
 The date is ISO 8601. A file with no stamp is not audited yet, and it sorts to
 the front of the queue.
 
-Break a rule with no issue behind it, and remove the stamp. A file that cannot
-meet a rule yet stamps `audited: <date> (#N)`, which reads as audited with a
-known deviation, tracked where the work is scheduled.
+**A file that breaks a rule carries no stamp.** There is no form that records
+the break and keeps the stamp, and no way to hand the repair to somebody else
+and stamp the file anyway.
+
+The stamp is what takes a file out of the queue. So a stamp over a standing
+violation is exactly how that violation stops being anybody's work, and the
+file that most needs a reader is the one nothing will send a reader back to.
+Repair the file, or leave it unstamped where the queue can still reach it.
 
 ### The tree comes into policy one file at a time
 

--- a/docs/impl/audit.md
+++ b/docs/impl/audit.md
@@ -16,9 +16,9 @@ an HTML comment under the title.
 
 The date is ISO 8601. A file with no stamp has never been audited.
 
-A file that cannot meet a rule yet stamps `audited: <date> (#N)`, naming the
-issue that will fix it. A deviation with no issue behind it is a broken rule,
-and the file carries no stamp at all.
+A file that breaks a rule carries no stamp until the rule is met. Nothing
+records a deviation and keeps the stamp: the stamp is what removes a file from
+the queue, and a file with a standing violation is what the queue is for.
 
 ## Enforcement
 

--- a/scripts/audit
+++ b/scripts/audit
@@ -25,8 +25,8 @@ comment under its title:
   // audited: 2026-09-04
   <!-- audited: 2026-09-04 -->
 
-Apply DOCUMENTATION.md to a file, then stamp today's date. Break a rule with no
-issue behind it, and remove the stamp.
+Apply DOCUMENTATION.md to a file, then stamp today's date. A file that breaks a
+rule carries no stamp until the rule is met.
 EOF
 }
 
@@ -90,8 +90,7 @@ vendored() {
     return 1
 }
 
-# The stamp date on one file, or empty. It lives in the first few lines, and
-# `(#N)` after the date marks a tracked deviation that still counts as stamped.
+# The stamp date on one file, or empty. It lives in the first few lines.
 #
 # The `|| true` is required, not defensive: under `pipefail` an unstamped file
 # makes grep exit 1, which `set -e` turns into a silent early exit of the whole

--- a/tests/integration/audit.rs
+++ b/tests/integration/audit.rs
@@ -138,21 +138,6 @@ fn a_large_file_outranks_a_small_file_at_the_same_depth() {
 }
 
 #[test]
-fn a_stamp_naming_an_issue_counts_as_stamped() {
-    let t = Tree::new("deviation");
-    t.write("tracked.md", &doc(Some("2026-09-04 (#123)"), 400))
-        .write("bare.md", &doc(None, 400));
-
-    // `audited: <date> (#N)` reads as audited with a known deviation, tracked
-    // where the work is scheduled. Treating it as unstamped would push every
-    // deliberately-deferred file to the front of the queue forever.
-    assert!(
-        t.rank_of("bare.md") < t.rank_of("tracked.md"),
-        "a deviation with an issue behind it is not the same as never audited"
-    );
-}
-
-#[test]
 fn a_generated_index_carries_no_stamp_and_is_not_queued() {
     let t = Tree::new("generated");
     t.write(


### PR DESCRIPTION
The policy offered `audited: <date> (#N)` for a file that could not meet a rule. It read as audited with a known deviation, tracked where the work was scheduled. It removed the file from the audit queue.

## What was wrong

**It let a file leave the queue without meeting the rule it broke.** The queue is the only thing that sends anybody back to a file nobody is otherwise opening. `docs/impl/audit.md` § "Repair is the point" already said a fresh stamp over a standing violation is worse than no stamp, for exactly this reason. The deviation form was the same stamp with a number after it.

**It promised an exemption nothing honors.** `every_stamped_file_is_within_the_reading_budget` (`tests/integration/prose.rs`) checks every stamped file at 500 lines and never reads the parenthetical. A file stamped `audited: <date> (#N)` for being over budget still failed the build. The form bought a red build and a lost queue entry.

**Nothing parsed the number.** `stamp_of` (`scripts/audit`) greps `audited: [0-9]{4}-[0-9]{2}-[0-9]{2}` and cuts the date. Anything after the date was ignored, not understood. `a_stamp_naming_an_issue_counts_as_stamped` passed because its fixture date matched, so it pinned the date regex rather than the form it named.

## What changes

`DOCUMENTATION.md` and `docs/impl/audit.md` now say a file that breaks a rule carries no stamp until the rule is met, and that no form records the break and keeps the stamp. The test goes, and so does the comment over `stamp_of` claiming the script handled the syntax.

No behavior changes: nothing read the number before, so nothing reads it now.

## Tests

`cargo test --test lib audit` — 16 pass, one fewer than before, and the removed one is the one named above. `cargo test --test lib prose` — 7 pass. `make qa` — green.