### PR TITLE
vocabulary: a keyword the runtime coins has a spelling to print

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -51,7 +51,7 @@ Design documents, language references, and contributor guides for Elle.
 | `impl/gpu.md` | End-to-end GPU compute (MLIR + SPIR-V + Vulkan) |
 | `impl/differential.md` | Cross-tier agreement: `compile/run-on` + the runner's diverge status |
 | `impl/values.md` | Value representation, tagged union |
-| `impl/symbol.md` | Symbol and keyword identity: name hash, per-instance display memo, collision rule |
+| `impl/symbol.md` | Symbol and keyword identity: name hash, per-instance display memo, static keyword vocabulary, collision rule |
 | `impl/syntax.md` | The syntax tree: region-native nodes, arenas, packed spans |
 | `impl/image.md` | Image persistence design: boot image, environment save/load |
 | `impl/fleet.md` | Distributed runtime design: content-addressed tasks over environment images |

--- a/docs/cookbook/primitives.md
+++ b/docs/cookbook/primitives.md
@@ -106,6 +106,13 @@ dispatches native functions via `handle_primitive_signal()` in `src/vm/signal.rs
 - Return `(SIG_OK, value)` for success.
 - Return `(SIG_ERROR, error_val("kind", "message"))` for errors.
 - Validate arity and types at the top of the function.
+- Every keyword the primitive returns needs a spelling, or it prints as
+  `#<keyword:hash>` and `json/serialize` refuses the struct that carries it.
+  A spelling fixed at build time — a struct key, an error kind, a status —
+  goes in `VOCABULARY` in `src/value/keyword.rs`, and a test fails the build
+  until it does. A spelling that exists only at run time is minted with
+  `ctx.keyword(name)`, which records it in the instance memo. See
+  [impl/symbol.md](../impl/symbol.md) § "A spelling the runtime itself mints".
 - No primitive has VM access. If you need VM interaction, return
   `(SIG_RESUME, fiber_value)` or `(SIG_QUERY, cons(keyword, arg))`.
 

--- a/docs/impl/symbol.md
+++ b/docs/impl/symbol.md
@@ -119,9 +119,10 @@ Three standing checks keep the list complete, because the constructor cannot —
   hands a literal to a keyword constructor: `Value::keyword("…")`,
   `TableKey::keyword("…")`, the `kw("…")` helper each primitive module
   defines for its struct keys, `ctx.error("…")` and `io_error("…")` (the kind
-  becomes the `:error` field's keyword), and `ctx.external("…")` (the type
-  name becomes the keyword `type-of` returns). It fails on a spelling the
-  vocabulary lacks.
+  becomes the `:error` field's keyword), `ctx.external("…")` (the type name
+  becomes the keyword `type-of` returns), and `Syntax::keyword(arena, "…")`
+  (a keyword a desugaring writes into the tree, which no source token backs
+  and so no reader learns). It fails on a spelling the vocabulary lacks.
 - `vocabulary_covers_accessor_mint_sites` enumerates the closed tables whose
   `&'static str` accessors feed those same constructors — the signal
   registry's built-ins, `sigmap`'s POSIX signals, the JIT/WASM/MLIR policy

--- a/docs/impl/symbol.md
+++ b/docs/impl/symbol.md
@@ -64,14 +64,68 @@ A memo learns a name where names already travel, and nowhere else:
 | the reader | every identifier and keyword token in the source text |
 | primitives | every keyword a native mints through its `NativeCtx` |
 | the plugin ABI | every keyword a plugin mints through `make_keyword`'s call ctx |
+| the signal registry | every signal name read back out of the process-global registry — by `(signals)`, `fiber/caps`, a compile query's `:bits` set, or a capability denial |
+| `--trace` | every trace key the command line named, reported by `(vm/config)` |
 | `send` | the bundle's name table (symbols, named from the sender's memo) and the inline names keywords already carry, replayed into the receiver's memo |
 | hydration | the image's name table, replayed into the hydrating instance |
 | `ConstTemplate` decode | symbols and keywords encoded by name in the constant pool |
+
+The signal registry and `--trace` are read sites, not mint sites, and they are
+on the list for the same reason: both hold spellings a program coined at run
+time — `(signal :my-sig)` allocates a bit, `--trace=my-pass` names a dump — in
+a process-global table that outlives no single memo. An instance that reads
+one back never met the spelling, and a worker thread never met it at all.
 
 Because a name is recorded only at those sites, a memo answers for the names
 its instance has actually met. That is the whole contract: a value whose name
 was never recorded is still a perfectly good value, and still compares
 correctly. It just has no name to print.
+
+## A spelling the runtime itself mints
+
+The memo answers for names that arrive at run time. The Rust runtime also
+coins keywords of its own — every struct key a primitive returns, every type
+name, every status, every error kind — and each of those spellings is fixed
+when the binary is built. `VOCABULARY` in `src/value/keyword.rs` is that list,
+and `resolve_keyword_name` reads it after the memo. A vocabulary spelling
+needs no instance, so it survives a display path that threads no memo at all.
+
+The two halves divide by where the spelling comes from:
+
+| Origin of the spelling | Where it lives |
+|------------------------|----------------|
+| a Rust string literal, or a `&'static str` an accessor returns | `VOCABULARY` |
+| source text, a string conversion, a plugin, a peer instance, an image, a run-time registry | the memo |
+
+A build-fixed spelling in neither is a defect with no compile error behind it.
+The keyword is a perfectly good value and still compares correctly; it just
+prints as `#<keyword:hash>`. Where that reads as cosmetic it is not: JSON has
+no such spelling to write, so `json/serialize` and `json/pretty` raise
+`serde-error` on any struct carrying such a key, and the whole value fails to
+encode. Every key of `(file/stat …)` was in that state, as was every key a
+compile query returns.
+
+Two standing checks keep the list complete, because the constructor cannot —
+`Value::keyword` takes a `&str` and records nothing, by design:
+
+- `vocabulary_covers_literal_mint_sites` scans `src/` for every form that
+  hands a literal to a keyword constructor: `Value::keyword("…")`,
+  `TableKey::keyword("…")`, the `kw("…")` helper each primitive module
+  defines for its struct keys, `ctx.error("…")` and `io_error("…")` (the kind
+  becomes the `:error` field's keyword), and `ctx.external("…")` (the type
+  name becomes the keyword `type-of` returns). It fails on a spelling the
+  vocabulary lacks.
+- `vocabulary_covers_accessor_mint_sites` enumerates the closed tables whose
+  `&'static str` accessors feed those same constructors — the signal
+  registry's built-ins, `sigmap`'s POSIX signals, the JIT/WASM/MLIR policy
+  keywords, the VM's tier names, `FiberStatus`, `WatchEventKind` — and
+  asserts each spelling resolves. A scan cannot see these: the literal sits
+  in a `match` arm, not in the call.
+
+Adding a spelling to one of those tables therefore fails the build until it is
+added to `VOCABULARY` too. Spellings that only exist once a real value does —
+the type name of each heap variant, reached through `(type-of …)` — are pinned
+by the corpus instead, in `tests/elle/keyword-spelling.lisp`.
 
 ## Reading a name, and not reading one
 

--- a/docs/impl/symbol.md
+++ b/docs/impl/symbol.md
@@ -63,7 +63,7 @@ A memo learns a name where names already travel, and nowhere else:
 |------|--------------|
 | the reader | every identifier and keyword token in the source text |
 | primitives | every keyword a native mints through its `NativeCtx` |
-| the plugin ABI | every keyword a plugin mints through `make_keyword`'s call ctx |
+| the plugin ABI | every keyword a plugin mints through `make_keyword`'s call ctx, and the type name it wraps an external in — the string lives in the plugin's `.so`, so no vocabulary entry can carry it and `(type-of …)` has nowhere else to read it from |
 | the signal registry | every signal name read back out of the process-global registry — by `(signals)`, `fiber/caps`, a compile query's `:bits` set, or a capability denial |
 | `--trace` | every trace key the command line named, reported by `(vm/config)` |
 | `send` | the bundle's name table (symbols, named from the sender's memo) and the inline names keywords already carry, replayed into the receiver's memo |
@@ -198,6 +198,13 @@ call belongs to, and `keyword_name`/`as_keyword_name` read back through the
 same ctx. `intern_keyword` is a pure hash: it records nothing and needs no
 ctx. `Value::keyword(&str)` in the host is equally pure — construction is
 identity only, and naming happens at the learning sites above.
+
+`make_external` is a learning site for the same reason, one step removed. The
+type name a plugin wraps its handle in is not a keyword when it is handed
+over, but `(type-of …)` mints one from it, and the string lives in the
+plugin's `.so` — a host external's name is a literal the vocabulary scan
+finds, and a plugin's is not. So the ctx records it where the external is
+built, and `type-of` needs no memo of its own.
 
 ## Where the id appears
 

--- a/docs/impl/symbol.md
+++ b/docs/impl/symbol.md
@@ -105,9 +105,16 @@ no such spelling to write, so `json/serialize` and `json/pretty` raise
 encode. Every key of `(file/stat …)` was in that state, as was every key a
 compile query returns.
 
-Two standing checks keep the list complete, because the constructor cannot —
+Three standing checks keep the list complete, because the constructor cannot —
 `Value::keyword` takes a `&str` and records nothing, by design:
 
+- `keyword::vocab(name)` is a `const fn` that returns its argument and asserts
+  the vocabulary carries it. Called from a `const` block, the assertion runs
+  when the crate is compiled, so a spelling it cannot find is a build error at
+  the line that wrote it. `rich_error!` puts every field name through it —
+  `rich_error!(ctx, "parse-error", msg, input = …)` writes the keyword `:input`
+  through `stringify!`, where the spelling reaches the constructor as a token
+  rather than as a string and no scan of the source can find it.
 - `vocabulary_covers_literal_mint_sites` scans `src/` for every form that
   hands a literal to a keyword constructor: `Value::keyword("…")`,
   `TableKey::keyword("…")`, the `kw("…")` helper each primitive module
@@ -123,9 +130,11 @@ Two standing checks keep the list complete, because the constructor cannot —
   in a `match` arm, not in the call.
 
 Adding a spelling to one of those tables therefore fails the build until it is
-added to `VOCABULARY` too. Spellings that only exist once a real value does —
-the type name of each heap variant, reached through `(type-of …)` — are pinned
-by the corpus instead, in `tests/elle/keyword-spelling.lisp`.
+added to `VOCABULARY` too. What the three miss is a spelling that reaches the
+constructor through a local — `let kind = match … ; Value::keyword(kind)` — and
+those are pinned by the corpus instead, in
+`tests/elle/keyword-spelling.lisp`, along with the type name of each heap
+variant, which only exists once a real value does.
 
 ## Reading a name, and not reading one
 

--- a/src/io/sigmap.rs
+++ b/src/io/sigmap.rs
@@ -65,8 +65,14 @@ pub fn supported_list_str() -> String {
 ///   `signum_to_keyword`).
 ///
 /// Unknown keywords and unnamed integers return an error string.
-/// `context` is the primitive name used in error messages.
-pub fn resolve(val: &crate::value::Value, context: &str) -> Result<libc::c_int, ResolveError> {
+/// `context` is the primitive name used in error messages. `memo` is the
+/// calling instance's display memo, which is what turns the rejected
+/// keyword's hash back into the spelling the caller wrote.
+pub fn resolve(
+    val: &crate::value::Value,
+    context: &str,
+    memo: Option<&crate::symbol::SymbolTable>,
+) -> Result<libc::c_int, ResolveError> {
     if let Some(n) = val.as_int() {
         let n_i32 = n as libc::c_int;
         return match signum_to_keyword(n_i32) {
@@ -76,15 +82,17 @@ pub fn resolve(val: &crate::value::Value, context: &str) -> Result<libc::c_int, 
     }
     if let Some(hash) = val.keyword_hash() {
         // Match by hash — the recognised set is fixed, so no spelling is
-        // needed to resolve. A miss recovers a spelling for the error
-        // message through the static vocabulary, or shows the raw hash.
+        // needed to resolve. A miss recovers a spelling for the error message
+        // through the memo, then the static vocabulary. The rejected keyword
+        // is the caller's own, so it is the memo that holds it; without one
+        // the message names a hash the caller has to decode.
         for (k, v) in SIGNALS {
             if crate::value::keyword::keyword_hash(k) == hash {
                 return Ok(*v);
             }
         }
-        let spelling = crate::value::keyword::resolve_keyword_name(None, hash)
-            .map(str::to_string)
+        let spelling = crate::value::keyword::resolve_keyword_name(memo, hash)
+            .map(|n| format!(":{}", n))
             .unwrap_or_else(|| format!("#<keyword:{:#x}>", hash));
         return Err(ResolveError::UnknownKeyword(spelling));
     }
@@ -98,7 +106,9 @@ pub fn resolve(val: &crate::value::Value, context: &str) -> Result<libc::c_int, 
 pub enum ResolveError {
     /// Integer did not round-trip to a named signal.
     UnknownSignum(i64),
-    /// Keyword name is not in the recognised set.
+    /// Keyword is not in the recognised set, already rendered as the caller
+    /// would read it — `:name` when a spelling was found, the unreadable
+    /// `#<keyword:hash>` when none was.
     UnknownKeyword(String),
     /// Argument is neither integer nor keyword.
     WrongType(&'static str),
@@ -117,12 +127,12 @@ impl ResolveError {
                     supported_list_str(),
                 ),
             ),
-            ResolveError::UnknownKeyword(name) => (
+            ResolveError::UnknownKeyword(shown) => (
                 "argument-error",
                 format!(
-                    "{}: unknown signal keyword :{}; expected one of {}",
+                    "{}: unknown signal keyword {}; expected one of {}",
                     context,
-                    name,
+                    shown,
                     supported_list_str(),
                 ),
             ),

--- a/src/jit/calls.rs
+++ b/src/jit/calls.rs
@@ -144,7 +144,7 @@ pub(crate) fn jit_capability_denial(
 ) -> JitValue {
     let payload = {
         let mut ctx = crate::primitives::ctx::Alloc::new(unsafe { &mut *vm.heap_ptr });
-        crate::vm::VM::build_denial_payload(&mut ctx, def, blocked, args)
+        crate::vm::VM::build_denial_payload(&mut ctx, def, blocked, args, vm.symbols())
     };
     let heap = unsafe { &mut *vm.heap_ptr };
     let r = crate::value::arena::region_of(heap, payload);

--- a/src/plugin_api/capi/constructors.rs
+++ b/src/plugin_api/capi/constructors.rs
@@ -195,6 +195,13 @@ pub(in crate::plugin_api) extern "C" fn make_external(
     // The type_name comes from the plugin's .so rodata — valid for process lifetime.
     let type_name: &'static str =
         unsafe { std::mem::transmute::<&str, &'static str>(type_name_str) };
+    // A learning site, one step removed from the keyword it feeds: `(type-of
+    // …)` mints a keyword from this name, and the name lives in the plugin's
+    // `.so`, so no static vocabulary entry can carry it
+    // (docs/impl/symbol.md § "Keywords in the plugin ABI").
+    if let Some(symbols) = unsafe { ctx.as_ref().and_then(|c| c.symbols.as_mut()) } {
+        symbols.keyword(type_name);
+    }
     let wrapper = ExternalWrapper { data, drop_fn };
     from_value(unsafe {
         with_ctx(ctx, |heap, region| {

--- a/src/plugin_api/capi/tests.rs
+++ b/src/plugin_api/capi/tests.rs
@@ -102,3 +102,59 @@ fn distinct_ctxs_route_to_distinct_regions() {
         "the second ctx's region must be honored, not overridden by an ambient slot",
     );
 }
+
+// A ctx that carries a real memo, for the naming asserts below.
+fn ctx_with_memo(
+    heap: &mut FiberHeap,
+    region: crate::hir::region::RuntimeRegion,
+    memo: &mut crate::symbol::SymbolTable,
+) -> CallCtx {
+    CallCtx {
+        region,
+        heap: heap as *mut FiberHeap,
+        symbols: memo as *mut crate::symbol::SymbolTable,
+    }
+}
+
+// Spec: a name that arrives from a plugin is learned by the instance the call
+// belongs to, because nothing else can spell it — the string lives in the
+// plugin's `.so`, so the static vocabulary cannot carry it
+// (docs/impl/symbol.md § "Keywords in the plugin ABI").
+//
+// The external's type name is the one step removed: it is not a keyword when
+// the plugin hands it over, but `(type-of …)` mints one from it, so an
+// unlearned name makes every `type-of` on that handle print
+// `#<keyword:hash>` and refuses to encode as JSON.
+#[test]
+fn a_plugin_name_is_learned_by_the_calling_instance() {
+    let mut heap = FiberHeap::new();
+    let mut memo = crate::symbol::SymbolTable::new();
+    let region = heap.new_runtime_region();
+
+    let kw = "plugin-keyword-xt";
+    let ext = "plugin-external-xt";
+    {
+        let mut ctx = ctx_with_memo(&mut heap, region, &mut memo);
+        unsafe { make_keyword(&mut ctx, kw.as_ptr(), kw.len()) };
+        unsafe {
+            make_external(
+                &mut ctx,
+                ext.as_ptr(),
+                ext.len(),
+                std::ptr::null_mut(),
+                None,
+            )
+        };
+    }
+
+    assert_eq!(
+        memo.keyword_name(crate::value::keyword::keyword_hash(kw)),
+        Some(kw),
+        "a plugin-minted keyword is learned by the instance the call belongs to",
+    );
+    assert_eq!(
+        memo.keyword_name(crate::value::keyword::keyword_hash(ext)),
+        Some(ext),
+        "an external's type name is learned too — `type-of` mints a keyword from it",
+    );
+}

--- a/src/plugin_api/capi/tests.rs
+++ b/src/plugin_api/capi/tests.rs
@@ -135,16 +135,14 @@ fn a_plugin_name_is_learned_by_the_calling_instance() {
     let ext = "plugin-external-xt";
     {
         let mut ctx = ctx_with_memo(&mut heap, region, &mut memo);
-        unsafe { make_keyword(&mut ctx, kw.as_ptr(), kw.len()) };
-        unsafe {
-            make_external(
-                &mut ctx,
-                ext.as_ptr(),
-                ext.len(),
-                std::ptr::null_mut(),
-                None,
-            )
-        };
+        make_keyword(&mut ctx, kw.as_ptr(), kw.len());
+        make_external(
+            &mut ctx,
+            ext.as_ptr(),
+            ext.len(),
+            std::ptr::null_mut(),
+            None,
+        );
     }
 
     assert_eq!(

--- a/src/primitives/compile/convert.rs
+++ b/src/primitives/compile/convert.rs
@@ -4,16 +4,18 @@ use crate::primitives::ctx::NativeCtx;
 pub(crate) fn signal_to_value(sig: &Signal, ctx: &mut NativeCtx) -> Value {
     let mut fields = BTreeMap::new();
 
-    // :bits as keyword set
-    let bit_set = with_registry(|reg| {
-        let mut bit_set = BTreeSet::new();
-        for entry in reg.entries() {
-            if sig.bits.has_bit(entry.bit_position) {
-                bit_set.insert(Value::keyword(&entry.name));
-            }
-        }
-        bit_set
+    // :bits as keyword set. A learning site for the same reason `(signals)` is
+    // one: the registry carries names a program declared at run time, and this
+    // instance may never have met the spelling (docs/impl/symbol.md § "The
+    // display memo").
+    let names = with_registry(|reg| {
+        reg.entries()
+            .iter()
+            .filter(|e| sig.bits.has_bit(e.bit_position))
+            .map(|e| e.name.clone())
+            .collect::<Vec<_>>()
     });
+    let bit_set: BTreeSet<Value> = names.iter().map(|n| ctx.keyword(n)).collect();
     let bits_val = ctx.set(bit_set);
     fields.insert(kw("bits"), bits_val);
 

--- a/src/primitives/ctx.rs
+++ b/src/primitives/ctx.rs
@@ -228,13 +228,23 @@ impl<'h> NativeCtx<'h> {
         unsafe { &mut *self.vm }
     }
 
+    /// This instance's display memo, for a message that has to show a name.
+    /// `None` for an instance with no symbol table.
+    ///
+    /// The borrow is a reborrow of the VM's raw pointer, sound by the same
+    /// contract as `vm()`. Hand it to a routine that renders a name and takes
+    /// no other borrow of the ctx — the returned reference does not outlive
+    /// that call, so the ctx stays free for the `ctx.error(…)` that follows.
+    pub fn symbols(&self) -> Option<&crate::symbol::SymbolTable> {
+        unsafe { self.vm().symbols_ptr.as_ref() }
+    }
+
     /// The spelling of a keyword value, through this instance's memo and the
     /// static vocabulary. `None` if `v` is not a keyword or the spelling was
     /// never learned (docs/impl/symbol.md § "The display memo").
     pub fn keyword_spelling(&self, v: crate::value::Value) -> Option<String> {
         let hash = v.keyword_hash()?;
-        let symbols = unsafe { self.vm().symbols_ptr.as_ref() };
-        crate::value::keyword::resolve_keyword_name(symbols, hash).map(str::to_string)
+        crate::value::keyword::resolve_keyword_name(self.symbols(), hash).map(str::to_string)
     }
 
     /// Learn `name` into this instance's memo and build the keyword value —

--- a/src/primitives/fiber_introspect.rs
+++ b/src/primitives/fiber_introspect.rs
@@ -354,7 +354,7 @@ pub(crate) fn prim_fiber_caps(
 
     let caps = handle.with(|fiber| crate::signals::CAP_MASK.subtract(fiber.withheld));
     let registry = crate::signals::registry::global_registry().lock().unwrap();
-    let keywords = registry.bits_to_keywords(caps);
+    let keywords = registry.bits_to_keywords(caps, ctx.vm().symbols());
     (SIG_OK, ctx.set(keywords.into_iter().collect()))
 }
 

--- a/src/primitives/introspection.rs
+++ b/src/primitives/introspection.rs
@@ -193,10 +193,21 @@ pub(crate) fn prim_signals(
     _args: &[Value],
 ) -> (SignalBits, Value) {
     let reg = crate::signals::registry::global_registry().lock().unwrap();
+    let names: Vec<(String, u32)> = reg
+        .entries()
+        .iter()
+        .map(|e| (e.name.clone(), e.bit_position))
+        .collect();
+    drop(reg);
     let mut map = std::collections::BTreeMap::new();
-    for entry in reg.entries() {
-        let key = crate::value::TableKey::from_value(&Value::keyword(&entry.name)).unwrap();
-        map.insert(key, Value::int(entry.bit_position as i64));
+    for (name, bit) in names {
+        // A learning site: the registry is process-global and carries names a
+        // program declared at run time, so the spelling may be new to this
+        // instance (docs/impl/symbol.md § "The display memo"). Without this the
+        // struct's own keys have no name to print, and `json/serialize` refuses
+        // the whole value.
+        let key = crate::value::TableKey::from_value(&ctx.keyword(&name)).unwrap();
+        map.insert(key, Value::int(bit as i64));
     }
     (SIG_OK, ctx.struct_from(map))
 }

--- a/src/primitives/json/AGENTS.md
+++ b/src/primitives/json/AGENTS.md
@@ -49,6 +49,7 @@ JSON parsing and serialization primitives.
 |-----------|------|
 | Malformed input to `json/parse` | `serde-error` |
 | A value neither serializer can encode, such as a closure | `serde-error` |
+| A keyword whose spelling neither the memo nor the vocabulary carries | `serde-error` |
 | A non-string first argument to `json/parse` | `type-error` |
 | 2 args to `json/parse` | `arity-error` |
 | 3 args to `json/parse` with an unrecognized key name or value | `argument-error` |
@@ -114,6 +115,17 @@ write as JSON objects; keywords write as JSON strings.
 6. **No external JSON library.** All parsing and serialization is hand-written to avoid dependencies.
 
 6. **All three primitives declare `Signal::errors()`.** The declaration matches the `SIG_ERROR` each returns, so effect inference propagates `:error` to callers and `try` reaches the failure at any call depth. `tests/elle/prim-json.lisp` pins this.
+
+7. **A keyword writes as its spelling, or not at all.** A keyword IS a name
+   hash; the spelling comes from the calling instance's memo or from the static
+   vocabulary (`docs/impl/symbol.md`). Both serializers thread
+   `ctx.vm().symbols()` for exactly that lookup. There is no fallback: a
+   rendering of the hash would parse back as a different name, so a spelling
+   neither source carries is a `serde-error` naming the hash it could not
+   spell. That error is the module's canary for a missed learning site or a
+   missing vocabulary entry elsewhere in the runtime — the value is fine, the
+   name is missing. `tests/elle/keyword-spelling.lisp` pins the round trip for
+   the runtime's own keys.
 
 ## Dependents
 

--- a/src/primitives/json/README.md
+++ b/src/primitives/json/README.md
@@ -115,6 +115,11 @@ JSON primitives signal a `:serde-error` for:
   other types with no JSON counterpart.
 - **Non-finite floats** — `json/serialize` rejects NaN and infinity,
   which JSON cannot represent.
+- **A keyword with no spelling** — a keyword is a name hash, and the name
+  is looked up in the running instance. A keyword whose name that instance
+  never met has nothing to write as a JSON string or object key, so the
+  serializers refuse it rather than write the hash, which would read back
+  as a different name. The message names the hash.
 
 Catch one with `try` or `protect`. Parsing and serializing report the same
 kind, so one `catch` covers both directions.

--- a/src/primitives/json/mod.rs
+++ b/src/primitives/json/mod.rs
@@ -6,6 +6,9 @@
 mod parser;
 mod serializer;
 
+#[cfg(test)]
+mod tests;
+
 pub use parser::JsonParser;
 pub use serializer::{escape_json_string, serialize_value, serialize_value_pretty};
 

--- a/src/primitives/json/serializer.rs
+++ b/src/primitives/json/serializer.rs
@@ -1,5 +1,48 @@
 use crate::value::{TableKey, Value};
 
+/// The refusal for a keyword whose spelling neither the calling instance's
+/// memo nor the static vocabulary carries.
+///
+/// JSON has no rendering for a name hash: `"0xcbf2…"` would read back as a
+/// different name, so there is no fallback to take. The message names the
+/// hash because that is the author's only handle on which keyword it was —
+/// and, upstream, on the mint site that never recorded the spelling
+/// (docs/impl/symbol.md § "A spelling the runtime itself mints").
+fn unspellable(what: &str, hash: u64) -> String {
+    format!("{} has no learned spelling: #<keyword:{:#x}>", what, hash)
+}
+
+/// A struct key as a quoted JSON object key. `container` names the struct
+/// kind, for the message a key of neither JSON-writable type earns.
+fn json_object_key(
+    key: &TableKey,
+    symbols: Option<&crate::symbol::SymbolTable>,
+    container: &str,
+) -> Result<String, String> {
+    match key {
+        TableKey::String(v) => Ok(escape_json_string(
+            v.as_str().expect("a string key holds a string"),
+        )),
+        TableKey::Keyword(hash) => {
+            match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
+                Some(name) => Ok(escape_json_string(name)),
+                None => Err(unspellable("keyword struct key", *hash)),
+            }
+        }
+        _ => Err(format!(
+            "{} keys must be strings or keywords for JSON serialization",
+            container
+        )),
+    }
+}
+
+/// A keyword as a quoted JSON string.
+fn json_keyword(hash: u64, symbols: Option<&crate::symbol::SymbolTable>) -> Result<String, String> {
+    crate::value::keyword::resolve_keyword_name(symbols, hash)
+        .map(escape_json_string)
+        .ok_or_else(|| unspellable("keyword", hash))
+}
+
 /// Escape a string for JSON output
 pub fn escape_json_string(s: &str) -> String {
     let mut result = String::from("\"");
@@ -66,25 +109,7 @@ pub fn serialize_value(
         let mstruct = t.borrow();
         let mut pairs = Vec::new();
         for (k, v) in mstruct.iter() {
-            let key_str = match k {
-                TableKey::String(v) => {
-                    escape_json_string(v.as_str().expect("a string key holds a string"))
-                }
-                TableKey::Keyword(hash) => {
-                    match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
-                        Some(name) => escape_json_string(name),
-                        None => {
-                            return Err("keyword struct key has no learned spelling".to_string())
-                        }
-                    }
-                }
-                _ => {
-                    return Err(
-                        "@struct keys must be strings or keywords for JSON serialization"
-                            .to_string(),
-                    )
-                }
-            };
+            let key_str = json_object_key(k, symbols, "@struct")?;
             let val_str = serialize_value(v, symbols)?;
             pairs.push(format!("{}:{}", key_str, val_str));
         }
@@ -92,33 +117,13 @@ pub fn serialize_value(
     } else if let Some(s) = value.as_struct() {
         let mut pairs = Vec::new();
         for (k, v) in s.iter() {
-            let key_str = match k {
-                TableKey::String(v) => {
-                    escape_json_string(v.as_str().expect("a string key holds a string"))
-                }
-                TableKey::Keyword(hash) => {
-                    match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
-                        Some(name) => escape_json_string(name),
-                        None => {
-                            return Err("keyword struct key has no learned spelling".to_string())
-                        }
-                    }
-                }
-                _ => {
-                    return Err(
-                        "Struct keys must be strings or keywords for JSON serialization"
-                            .to_string(),
-                    )
-                }
-            };
+            let key_str = json_object_key(k, symbols, "Struct")?;
             let val_str = serialize_value(v, symbols)?;
             pairs.push(format!("{}:{}", key_str, val_str));
         }
         Ok(format!("{{{}}}", pairs.join(",")))
     } else if let Some(hash) = value.keyword_hash() {
-        let name = crate::value::keyword::resolve_keyword_name(symbols, hash)
-            .ok_or_else(|| "keyword has no learned spelling".to_string())?;
-        Ok(escape_json_string(name))
+        json_keyword(hash, symbols)
     } else if value.is_closure() {
         Err("Cannot serialize closures to JSON".to_string())
     } else if value.is_symbol() {
@@ -259,25 +264,7 @@ pub fn serialize_value_pretty(
         }
         let mut pairs = Vec::new();
         for (k, v) in mstruct.iter() {
-            let key_str = match k {
-                TableKey::String(v) => {
-                    escape_json_string(v.as_str().expect("a string key holds a string"))
-                }
-                TableKey::Keyword(hash) => {
-                    match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
-                        Some(name) => escape_json_string(name),
-                        None => {
-                            return Err("keyword struct key has no learned spelling".to_string())
-                        }
-                    }
-                }
-                _ => {
-                    return Err(
-                        "@struct keys must be strings or keywords for JSON serialization"
-                            .to_string(),
-                    )
-                }
-            };
+            let key_str = json_object_key(k, symbols, "@struct")?;
             let val_str = serialize_value_pretty(v, symbols, indent_level + 1)?;
             pairs.push(format!("{}: {}", key_str, val_str));
         }
@@ -293,25 +280,7 @@ pub fn serialize_value_pretty(
         }
         let mut pairs = Vec::new();
         for (k, v) in s.iter() {
-            let key_str = match k {
-                TableKey::String(v) => {
-                    escape_json_string(v.as_str().expect("a string key holds a string"))
-                }
-                TableKey::Keyword(hash) => {
-                    match crate::value::keyword::resolve_keyword_name(symbols, *hash) {
-                        Some(name) => escape_json_string(name),
-                        None => {
-                            return Err("keyword struct key has no learned spelling".to_string())
-                        }
-                    }
-                }
-                _ => {
-                    return Err(
-                        "Struct keys must be strings or keywords for JSON serialization"
-                            .to_string(),
-                    )
-                }
-            };
+            let key_str = json_object_key(k, symbols, "Struct")?;
             let val_str = serialize_value_pretty(v, symbols, indent_level + 1)?;
             pairs.push(format!("{}: {}", key_str, val_str));
         }
@@ -322,9 +291,7 @@ pub fn serialize_value_pretty(
             indent
         ))
     } else if let Some(hash) = value.keyword_hash() {
-        let name = crate::value::keyword::resolve_keyword_name(symbols, hash)
-            .ok_or_else(|| "keyword has no learned spelling".to_string())?;
-        Ok(escape_json_string(name))
+        json_keyword(hash, symbols)
     } else if value.is_closure() {
         Err("Cannot serialize closures to JSON".to_string())
     } else if value.is_symbol() {

--- a/src/primitives/json/tests.rs
+++ b/src/primitives/json/tests.rs
@@ -1,0 +1,78 @@
+//! Unit tests for the JSON serializer's keyword handling.
+//!
+//! A keyword IS a name hash; the spelling comes from the calling instance's
+//! memo or from the static vocabulary (docs/impl/symbol.md). JSON has no
+//! rendering for a hash — `:0xcbf2…` would read back as a different name — so
+//! a spelling neither source carries is a refusal, and the refusal has to say
+//! which value it could not spell. Everything else in this module is covered
+//! by `tests/elle/prim-json.lisp` and `tests/elle/keyword-spelling.lisp`.
+
+use super::{serialize_value, serialize_value_pretty};
+use crate::symbol::SymbolTable;
+use crate::value::{TableKey, Value};
+
+/// A spelling no vocabulary entry and no other test carries.
+const UNLEARNED: &str = "json-unspelled-keyword-xt";
+
+fn struct_with_keyword_key(name: &str) -> Value {
+    let heap_ptr = crate::value::arena::leaked_test_heap();
+    let heap = unsafe { &mut *heap_ptr };
+    let region = heap.new_runtime_region();
+    let mut fields = std::collections::BTreeMap::new();
+    fields.insert(TableKey::keyword(name), Value::int(1));
+    crate::value::build::struct_from(heap, fields, region)
+}
+
+// The refusal names the value. "has no learned spelling" alone leaves an
+// author with a failing `json/serialize` and nothing to search for; the hash
+// is the one handle on which keyword it was.
+#[test]
+fn an_unspellable_keyword_value_is_refused_by_its_hash() {
+    let hash = crate::value::keyword::keyword_hash(UNLEARNED);
+    let err = serialize_value(&Value::keyword(UNLEARNED), None)
+        .expect_err("a keyword with no spelling cannot be written as a JSON string");
+    assert!(
+        err.contains(&format!("{:#x}", hash)),
+        "the refusal must name the hash it could not spell, got: {err}"
+    );
+}
+
+#[test]
+fn an_unspellable_struct_key_is_refused_by_its_hash() {
+    let hash = crate::value::keyword::keyword_hash(UNLEARNED);
+    let value = struct_with_keyword_key(UNLEARNED);
+
+    let err = serialize_value(&value, None)
+        .expect_err("a struct key with no spelling cannot be written as a JSON key");
+    assert!(
+        err.contains(&format!("{:#x}", hash)),
+        "the compact refusal must name the hash it could not spell, got: {err}"
+    );
+
+    let err = serialize_value_pretty(&value, None, 0)
+        .expect_err("a struct key with no spelling cannot be written as a JSON key");
+    assert!(
+        err.contains(&format!("{:#x}", hash)),
+        "the pretty refusal must name the hash it could not spell, got: {err}"
+    );
+}
+
+// The counter-factual for both refusals above: the same value, the same
+// serializer, and a memo that met the name. Nothing about the value changed —
+// only what the instance knows — so a refusal here would mean the serializer
+// never consults the memo it is handed.
+#[test]
+fn a_learned_struct_key_writes_as_its_spelling() {
+    let mut memo = SymbolTable::new();
+    memo.keyword(UNLEARNED);
+    let value = struct_with_keyword_key(UNLEARNED);
+
+    assert_eq!(
+        serialize_value(&value, Some(&memo)).expect("a learned key writes"),
+        format!("{{\"{UNLEARNED}\":1}}")
+    );
+    assert_eq!(
+        serialize_value(&Value::keyword(UNLEARNED), Some(&memo)).expect("a learned keyword writes"),
+        format!("\"{UNLEARNED}\"")
+    );
+}

--- a/src/primitives/posix.rs
+++ b/src/primitives/posix.rs
@@ -196,7 +196,7 @@ fn prim_sig_send(
             )
         }
     };
-    let signum = match sigmap::resolve(&args[1], "os/sig-send") {
+    let signum = match sigmap::resolve(&args[1], "os/sig-send", ctx.symbols()) {
         Ok(s) => s,
         Err(e) => {
             let (kind, msg) = e.parts("os/sig-send");
@@ -229,7 +229,7 @@ fn prim_sig_raise(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
 ) -> (SignalBits, Value) {
-    let signum = match sigmap::resolve(&args[0], "os/sig-raise") {
+    let signum = match sigmap::resolve(&args[0], "os/sig-raise", ctx.symbols()) {
         Ok(s) => s,
         Err(e) => {
             let (kind, msg) = e.parts("os/sig-raise");

--- a/src/primitives/subprocess/exec.rs
+++ b/src/primitives/subprocess/exec.rs
@@ -417,7 +417,7 @@ pub(super) fn prim_subprocess_kill(
         }
     };
     let signal = if args.len() > 1 {
-        match crate::io::sigmap::resolve(&args[1], "subprocess/kill") {
+        match crate::io::sigmap::resolve(&args[1], "subprocess/kill", ctx.symbols()) {
             Ok(s) => s,
             Err(e) => {
                 let (kind, msg) = e.parts("subprocess/kill");

--- a/src/signals/registry.rs
+++ b/src/signals/registry.rs
@@ -155,15 +155,33 @@ impl SignalRegistry {
         self.lookup(name).map(SignalBits::from_bit)
     }
 
-    /// Convert signal bits to a Vec of keyword Values.
+    /// Convert signal bits to a Vec of keyword Values, recording each name in
+    /// `memo`.
     ///
     /// Used by `fiber/caps` and capability denial payloads to produce
     /// keyword sets from signal bitmasks.
-    pub fn bits_to_keywords(&self, bits: SignalBits) -> Vec<crate::value::Value> {
+    ///
+    /// This is a learning site. The registry is process-global and holds names
+    /// a program coined at run time — `(signal :my-sig)` allocates a bit — so
+    /// an instance reading a name back here may never have met the spelling,
+    /// and no static vocabulary can cover it. A worker thread has met none of
+    /// them. `memo` is `None` only where no instance is in reach, in which
+    /// case the built-in names still resolve through the vocabulary
+    /// (docs/impl/symbol.md § "The display memo").
+    pub fn bits_to_keywords(
+        &self,
+        bits: SignalBits,
+        mut memo: Option<&mut crate::symbol::SymbolTable>,
+    ) -> Vec<crate::value::Value> {
         self.entries
             .iter()
             .filter(|e| bits.has_bit(e.bit_position))
-            .map(|e| crate::value::Value::keyword(&e.name))
+            .map(|e| {
+                if let Some(m) = memo.as_deref_mut() {
+                    m.keyword(&e.name);
+                }
+                crate::value::Value::keyword(&e.name)
+            })
             .collect()
     }
 

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -20,12 +20,27 @@ use crate::value::fiberheap::FiberHeap;
 /// region by `alloc`'s content scan. The macro only sugars the `(SIG_ERROR, …)`
 /// tuple, the `:error <kind>` field, and the slice — it never builds a field
 /// value for you, so it cannot misplace a region.
+///
+/// A field *name* becomes a keyword, so its spelling must be in `VOCABULARY`
+/// or the error prints a hash where the name belongs and `json/serialize`
+/// refuses the whole struct. `stringify!` puts the spelling out of reach of
+/// any scan of the source — it is a token here, not a string — so each name
+/// goes through `keyword::vocab` in a `const` block instead, which fails the
+/// build at this call site if the list does not carry it
+/// (docs/impl/symbol.md § "A spelling the runtime itself mints").
 #[macro_export]
 macro_rules! rich_error {
     ($scope:expr, $kind:expr, $msg:expr $(, $field:ident = $val:expr)* $(,)?) => {
         (
             $crate::value::SIG_ERROR,
-            $scope.error_extra($kind, $msg, &[$((stringify!($field), $val)),*]),
+            $scope.error_extra(
+                $kind,
+                $msg,
+                &[$((
+                    const { $crate::value::keyword::vocab(stringify!($field)) },
+                    $val,
+                )),*],
+            ),
         )
     };
 }

--- a/src/value/keyword.rs
+++ b/src/value/keyword.rs
@@ -68,6 +68,7 @@ static VOCABULARY: &[&str] = &[
     "first",
     "func",
     "id",
+    "input",
     "instrs",
     "k",
     "kind",
@@ -96,11 +97,13 @@ static VOCABULARY: &[&str] = &[
     "sender-uid",
     "signal",
     "spans",
+    "spec",
     "stats",
     "term",
     "term-display",
     "term-kind",
     "term-span",
+    "tier",
     "value",
     "x",
     // File metadata keys (`file/stat`, `file/lstat`)
@@ -206,6 +209,7 @@ static VOCABULARY: &[&str] = &[
     "state-error",
     "task-error",
     "thread-error",
+    "tier-rejected",
     "trait-error",
     "type-error",
     "unknown-tier",
@@ -400,6 +404,7 @@ static VOCABULARY: &[&str] = &[
     "variable",
     "builtin",
     "macro",
+    "module",
     "branch",
     "emit",
     "jump",
@@ -415,6 +420,41 @@ static VOCABULARY: &[&str] = &[
     "lir",
     "regions",
 ];
+
+/// Whether `VOCABULARY` carries `name`. `const fn`, so a caller can ask in a
+/// `const` context and turn the answer into a build error; the linear scan is
+/// what makes it one (the `static_keyword_name` index is not const-buildable).
+pub const fn is_vocabulary(name: &str) -> bool {
+    let hash = keyword_hash(name);
+    let mut i = 0;
+    while i < VOCABULARY.len() {
+        if keyword_hash(VOCABULARY[i]) == hash {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+/// `name`, having asserted the vocabulary carries it.
+///
+/// The spelling of a keyword the runtime coins from a fixed string has to be
+/// in `VOCABULARY` or the keyword has no name to print, and `json/serialize`
+/// refuses any struct that carries it as a key. Called from a `const` block,
+/// this moves that requirement to compile time: `const { vocab("input") }` is
+/// a build error at the line that wrote it until "input" is listed.
+///
+/// `rich_error!` is the caller that needs it. A field name written
+/// `input = …` reaches the keyword constructor through `stringify!`, as a
+/// token rather than as a string, so no scan of the source can find it
+/// (docs/impl/symbol.md § "A spelling the runtime itself mints").
+pub const fn vocab(name: &'static str) -> &'static str {
+    assert!(
+        is_vocabulary(name),
+        "keyword spelling missing from VOCABULARY in src/value/keyword.rs"
+    );
+    name
+}
 
 /// The spelling of a vocabulary keyword, or `None` if `hash` names nothing
 /// the runtime spells itself.

--- a/src/value/keyword.rs
+++ b/src/value/keyword.rs
@@ -31,9 +31,15 @@ pub const fn keyword_hash(name: &str) -> u64 {
 /// keyword dynamically (read from source, converted from a string, minted by
 /// a plugin, parsed from JSON) are learned by the instance memo instead.
 ///
-/// `vocabulary_is_collision_free` proves the list injective under the hash;
-/// a missing entry is not an error — the keyword prints as `#<keyword:hash>`
-/// until the spelling is added here or learned at run time.
+/// `vocabulary_is_collision_free` proves the list injective under the hash.
+/// A missing entry is a defect with no compile error behind it: the keyword
+/// prints as `#<keyword:hash>`, and `json/serialize` refuses any struct that
+/// carries it as a key, because JSON has no rendering for a hash. Two tests
+/// keep the list complete, since the constructor cannot —
+/// `vocabulary_covers_literal_mint_sites` scans every form that hands a
+/// literal to a keyword constructor, and `vocabulary_covers_accessor_mint_sites`
+/// enumerates the tables whose `&'static str` accessors feed the same
+/// constructors from behind a `match` arm no scan can see.
 static VOCABULARY: &[&str] = &[
     // Result-struct keys and general fields
     "a",
@@ -97,6 +103,52 @@ static VOCABULARY: &[&str] = &[
     "term-span",
     "value",
     "x",
+    // File metadata keys (`file/stat`, `file/lstat`)
+    "accessed",
+    "blksize",
+    "created",
+    "dev",
+    "file-type",
+    "gid",
+    "inode",
+    "is-dir",
+    "is-file",
+    "is-symlink",
+    "modified",
+    "nlinks",
+    "permissions",
+    "rdev",
+    "readonly",
+    "uid",
+    // Compile-query and rewrite keys (`compile/signal`, `compile/bindings`,
+    // `compile/call-graph`, `compile/diagnostics`, `compile/rename`)
+    "bits",
+    "callees",
+    "callers",
+    "captures",
+    "edits",
+    "immutable",
+    "jit-eligible",
+    "leaves",
+    "lines",
+    "mutated",
+    "needs-lbox",
+    "new-function",
+    "nodes",
+    "propagates",
+    "roots",
+    "rule",
+    "safe",
+    "scope",
+    "severity",
+    "shared-captures",
+    "silent",
+    "source",
+    "suggestions",
+    "tail",
+    "usages",
+    "wraps",
+    "yields",
     // Status and outcome keywords
     "denied",
     "disconnected",
@@ -116,11 +168,24 @@ static VOCABULARY: &[&str] = &[
     "capability-denied",
     "feature-disabled",
     "fiber/caps",
+    // Signal names the registry pre-registers. A signal a program declares at
+    // run time cannot be listed here; it is learned where the registry is read
+    // (docs/impl/symbol.md § "The display memo").
+    "debug",
+    "exec",
+    "fs",
+    "fuel",
+    "io",
+    "os-signal",
+    "wait",
+    "yield",
     // Error kinds (`ctx.error(kind, …)` becomes the `:error` field's keyword)
     "argument-error",
+    "assertion-failed",
     "arity-error",
     "compile-error",
     "division-by-zero",
+    "dns-error",
     "double-free",
     "encoding-error",
     "exec-error",
@@ -139,6 +204,7 @@ static VOCABULARY: &[&str] = &[
     "runtime-error",
     "serde-error",
     "state-error",
+    "task-error",
     "thread-error",
     "trait-error",
     "type-error",
@@ -193,6 +259,16 @@ static VOCABULARY: &[&str] = &[
     "@struct",
     "syntax",
     "thread-handle",
+    // External type names: the `ctx.external(type_name, …)` a primitive wraps
+    // its handle in, which is what `type-of` hands back for that handle.
+    // "port" and "process" appear above.
+    "analysis",
+    "chan/receiver",
+    "chan/sender",
+    "fs-watcher",
+    "io-backend",
+    "io-request",
+    "signal-receiver",
     // Trait protocol keys
     "Collection",
     "Sequence",
@@ -222,7 +298,8 @@ static VOCABULARY: &[&str] = &[
     "lazy",
     "off",
     "on",
-    // Execution tiers
+    // Execution tiers (`VM::active_tier`, reported by `(vm/tier)`)
+    "bytecode",
     "git",
     "gpu",
     "jit",

--- a/src/value/keyword/tests.rs
+++ b/src/value/keyword/tests.rs
@@ -150,6 +150,13 @@ fn vocabulary_membership_answers_in_a_const_context() {
 // most of the runtime's struct keys are written in. `ctx.error("…")` and
 // `io_error("…")` name a kind that becomes the `:error` field's keyword.
 // `ctx.external("…")` names a type that becomes the keyword `type-of` returns.
+// `Syntax::keyword(arena, "…")` is a keyword a desugaring writes into the
+// tree: no source token backs it, so no reader learns it and only the
+// vocabulary can spell it.
+//
+// Each pattern ends at the quote that opens the spelling, because the
+// extraction reads from there to the next quote. A form whose literal is not
+// in that position needs its own entry, spelled out to the argument before it.
 const LITERAL_MINT_FORMS: &[&str] = &[
     "Value::keyword(\"",
     "TableKey::keyword(\"",
@@ -157,6 +164,7 @@ const LITERAL_MINT_FORMS: &[&str] = &[
     "ctx.error(\"",
     "io_error(\"",
     "ctx.external(\"",
+    "Syntax::keyword(arena, \"",
 ];
 
 // Every fixed spelling the runtime mints must be in VOCABULARY, or the value

--- a/src/value/keyword/tests.rs
+++ b/src/value/keyword/tests.rs
@@ -120,36 +120,41 @@ fn resolution_reads_memo_then_vocabulary() {
     );
 }
 
+// Every form in `src/` that hands a *literal* spelling to a keyword
+// constructor. `kw("…")` is the per-module helper each primitive module
+// defines for its struct keys (`primitives/compile/mod.rs`,
+// `primitives/fileio/manage.rs`) and the reader's syntax builder
+// (`reader/synbuild.rs`); it is the form the earlier scan missed, and the form
+// most of the runtime's struct keys are written in. `ctx.error("…")` and
+// `io_error("…")` name a kind that becomes the `:error` field's keyword.
+// `ctx.external("…")` names a type that becomes the keyword `type-of` returns.
+const LITERAL_MINT_FORMS: &[&str] = &[
+    "Value::keyword(\"",
+    "TableKey::keyword(\"",
+    "kw(\"",
+    "ctx.error(\"",
+    "io_error(\"",
+    "ctx.external(\"",
+];
+
 // Every fixed spelling the runtime mints must be in VOCABULARY, or the value
-// it names prints as #<keyword:hash>. The scan covers the literal mint forms;
-// spellings reaching keywords through enum accessors are covered by the
-// corpus, which prints them.
+// it names prints as #<keyword:hash> — and `json/serialize` refuses a struct
+// that carries it as a key (docs/impl/symbol.md § "A spelling the runtime
+// itself mints").
 //
 // Counter-factual: remove "ok" from VOCABULARY and this fails on the
-// `Value::keyword("ok")` sites.
+// `Value::keyword("ok")` sites; remove "size" and it fails on `file/stat`'s
+// `kw("size")`.
 #[test]
 fn vocabulary_covers_literal_mint_sites() {
-    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-    let mut missing = std::collections::BTreeSet::new();
-    let mut stack = vec![root];
-    while let Some(dir) = stack.pop() {
-        for entry in std::fs::read_dir(&dir).expect("readable source dir") {
-            let path = entry.expect("readable dir entry").path();
-            if path.is_dir() {
-                stack.push(path);
-            } else if path.extension().is_some_and(|e| e == "rs")
-                // Test-only literals never reach a user's display path.
-                && !path.to_string_lossy().contains("tests")
-            {
-                let text = std::fs::read_to_string(&path).expect("readable source file");
-                for pat in ["Value::keyword(\"", "TableKey::keyword(\"", "ctx.error(\""] {
-                    for (i, _) in text.match_indices(pat) {
-                        let rest = &text[i + pat.len()..];
-                        let name = &rest[..rest.find('"').expect("terminated literal")];
-                        if static_keyword_name(keyword_hash(name)).is_none() {
-                            missing.insert(name.to_string());
-                        }
-                    }
+    let mut missing = std::collections::BTreeMap::new();
+    for (path, text) in runtime_sources() {
+        for pat in LITERAL_MINT_FORMS {
+            for (i, _) in text.match_indices(pat) {
+                let rest = &text[i + pat.len()..];
+                let name = &rest[..rest.find('"').expect("terminated literal")];
+                if static_keyword_name(keyword_hash(name)).is_none() {
+                    missing.insert(name.to_string(), path.clone());
                 }
             }
         }
@@ -159,4 +164,146 @@ fn vocabulary_covers_literal_mint_sites() {
         "keyword spellings minted from literals but absent from VOCABULARY: {:?}",
         missing
     );
+}
+
+// The other half: a spelling that reaches the same constructors through a
+// `&'static str` an accessor returns. The literal sits in a `match` arm, not
+// in the call, so the scan above cannot see it — every one of these tables
+// drifted out from under VOCABULARY without a single test noticing.
+//
+// Each table is enumerated rather than listed, so adding a variant fails this
+// test until the spelling is added to VOCABULARY too.
+//
+// Counter-factual: remove "alive" from VOCABULARY and this fails on
+// `FiberStatus::Alive`.
+#[test]
+fn vocabulary_covers_accessor_mint_sites() {
+    use crate::config::{JitPolicy, MlirPolicy, WasmPolicy};
+    use crate::io::watch::WatchEventKind;
+    use crate::value::fiber::FiberStatus;
+
+    let mut spellings: Vec<(&str, String)> = Vec::new();
+
+    // The signal registry's built-ins: `(signals)`, `fiber/caps`, and a
+    // capability denial all mint a keyword per entry name.
+    for entry in crate::signals::registry::SignalRegistry::with_builtins().entries() {
+        spellings.push(("signal registry", entry.name.clone()));
+    }
+
+    // The POSIX signal names `os/sig-watch` and friends hand back. The table
+    // is private, so walk the signum space it maps.
+    for signum in 1..=64 {
+        if let Some(name) = crate::io::sigmap::signum_to_keyword(signum) {
+            spellings.push(("sigmap", name.to_string()));
+        }
+    }
+
+    // The tier policies `(vm/config)` reports.
+    for p in [
+        JitPolicy::Off,
+        JitPolicy::Eager,
+        JitPolicy::Adaptive { threshold: 1 },
+        JitPolicy::Custom,
+    ] {
+        spellings.push(("JitPolicy", p.keyword().to_string()));
+    }
+    for p in [
+        WasmPolicy::Off,
+        WasmPolicy::Full,
+        WasmPolicy::Lazy { threshold: 1 },
+    ] {
+        spellings.push(("WasmPolicy", p.keyword().to_string()));
+    }
+    for p in [
+        MlirPolicy::Off,
+        MlirPolicy::Eager,
+        MlirPolicy::Adaptive { threshold: 1 },
+    ] {
+        spellings.push(("MlirPolicy", p.keyword().to_string()));
+    }
+
+    // The fiber status `fiber/status` hands back.
+    for s in [
+        FiberStatus::New,
+        FiberStatus::Alive,
+        FiberStatus::Paused,
+        FiberStatus::Dead,
+        FiberStatus::Error,
+    ] {
+        spellings.push(("FiberStatus", s.as_str().to_string()));
+    }
+
+    // The file-watch event kind each `:kind` field carries.
+    for k in [
+        WatchEventKind::Create,
+        WatchEventKind::Modify,
+        WatchEventKind::Remove,
+        WatchEventKind::Rename,
+    ] {
+        spellings.push(("WatchEventKind", k.as_keyword().to_string()));
+    }
+
+    // `VM::active_tier` is a bare `&'static str` field, so its values are
+    // assignments rather than a table. Anchor on the field name and take
+    // every string literal on the lines that write it.
+    for (path, text) in runtime_sources() {
+        if !path.starts_with("vm") {
+            continue;
+        }
+        for line in text.lines() {
+            if !line.contains("active_tier") {
+                continue;
+            }
+            for (i, _) in line.match_indices('"') {
+                let rest = &line[i + 1..];
+                if let Some(end) = rest.find('"') {
+                    spellings.push(("active_tier", rest[..end].to_string()));
+                }
+            }
+        }
+    }
+
+    let missing: std::collections::BTreeSet<String> = spellings
+        .iter()
+        .filter(|(_, name)| static_keyword_name(keyword_hash(name)).is_none())
+        .map(|(table, name)| format!("{table}: {name}"))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "keyword spellings minted from accessors but absent from VOCABULARY: {:?}",
+        missing
+    );
+    assert!(
+        spellings.len() > 40,
+        "the accessor tables went empty — the enumeration stopped reaching them"
+    );
+}
+
+/// Every non-test `.rs` file under `src/`, as (path relative to `src/`, text).
+/// Test-only literals never reach a user's display path, so they are excluded.
+fn runtime_sources() -> Vec<(String, String)> {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut out = Vec::new();
+    let mut stack = vec![root.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("readable source dir") {
+            let path = entry.expect("readable dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs")
+                && !path.to_string_lossy().contains("tests")
+            {
+                let rel = path
+                    .strip_prefix(&root)
+                    .expect("a source under src/")
+                    .to_string_lossy()
+                    .into_owned();
+                out.push((
+                    rel,
+                    std::fs::read_to_string(&path).expect("readable source"),
+                ));
+            }
+        }
+    }
+    out
 }

--- a/src/value/keyword/tests.rs
+++ b/src/value/keyword/tests.rs
@@ -120,6 +120,28 @@ fn resolution_reads_memo_then_vocabulary() {
     );
 }
 
+// `vocab` is the compile-time half of the guard, and the only half that
+// reaches a spelling written as a *token* rather than a string — a
+// `rich_error!` field name, which becomes a keyword through `stringify!`. A
+// `const` block calling it with a spelling the vocabulary lacks is a build
+// error at the line that wrote it.
+//
+// A crate cannot assert that it fails to compile, so what is pinned here is
+// the predicate the assertion rests on, and that it answers in a const
+// context at all — a `vocab` that stopped being `const fn` would still pass
+// every other test in this file while the guard silently moved to run time.
+#[test]
+fn vocabulary_membership_answers_in_a_const_context() {
+    const CHECKED: &str = vocab("message");
+    assert_eq!(CHECKED, "message");
+
+    assert!(is_vocabulary("error"), "a listed spelling is carried");
+    assert!(
+        !is_vocabulary("kw-not-in-the-vocabulary-xt"),
+        "an unlisted spelling is not"
+    );
+}
+
 // Every form in `src/` that hands a *literal* spelling to a keyword
 // constructor. `kw("…")` is the per-module helper each primitive module
 // defines for its struct keys (`primitives/compile/mod.rs`,

--- a/src/vm/call/inner/tail.rs
+++ b/src/vm/call/inner/tail.rs
@@ -354,6 +354,7 @@ impl VM {
             // came out of an args array the calling convention owns, whose
             // counted edge the caller reclaims once this returns. So the callee
             // mints one of its own per parameter, as in call position.
+            let symbols = unsafe { self.symbols_ptr.as_ref() };
             if !Self::populate_env(
                 &mut self.tail_call_env_cache,
                 unsafe { &mut *self.heap_ptr },
@@ -361,6 +362,7 @@ impl VM {
                 closure,
                 &args,
                 spliced_args,
+                symbols,
             ) {
                 return Some(SIG_ERROR);
             }

--- a/src/vm/env.rs
+++ b/src/vm/env.rs
@@ -47,6 +47,10 @@ impl VM {
         // callee one owning reference per such arg here (`own_params = true`),
         // balanced by that release. A tail call (`tail_call_inner`) is a pure
         // move and passes `false`.
+        //
+        // The memo is read before the mutable borrows below, so the message a
+        // rejected `&named` key earns can spell it.
+        let symbols = unsafe { self.symbols_ptr.as_ref() };
         if !Self::populate_env(
             &mut self.env_cache,
             unsafe { &mut *self.heap_ptr },
@@ -54,6 +58,7 @@ impl VM {
             closure,
             args,
             true,
+            symbols,
         ) {
             return None;
         }
@@ -79,6 +84,7 @@ impl VM {
         args: &[Value],
         own_params: bool,
     ) -> Option<Rc<Vec<Value>>> {
+        let symbols = unsafe { self.symbols_ptr.as_ref() };
         if !Self::populate_env(
             &mut self.tail_call_env_cache,
             unsafe { &mut *self.heap_ptr },
@@ -86,6 +92,7 @@ impl VM {
             closure,
             args,
             own_params,
+            symbols,
         ) {
             return None;
         }
@@ -122,6 +129,7 @@ impl VM {
         args: &[Value],
     ) -> Option<Rc<Vec<Value>>> {
         let mut buf = Vec::new();
+        let symbols = unsafe { self.symbols_ptr.as_ref() };
         let ok = Self::populate_env(
             &mut buf,
             unsafe { &mut *self.heap_ptr },
@@ -129,6 +137,7 @@ impl VM {
             closure,
             args,
             false,
+            symbols,
         );
         if !ok {
             return None;
@@ -147,6 +156,10 @@ impl VM {
     /// `heap.alloc_in_region()`, each into its own region (`env_value_region`).
     ///
     /// Returns `false` if keyword argument collection fails (error set on fiber).
+    ///
+    /// `symbols` is the calling instance's display memo, carried only so that
+    /// a rejected `&named` key is named rather than hashed in the error
+    /// message (docs/impl/symbol.md § "The display memo").
     pub(super) fn populate_env(
         buf: &mut Vec<Value>,
         heap: &mut crate::value::fiberheap::FiberHeap,
@@ -154,6 +167,7 @@ impl VM {
         closure: &crate::value::Closure,
         args: &[Value],
         own_params: bool,
+        symbols: Option<&crate::symbol::SymbolTable>,
     ) -> bool {
         buf.clear();
         let needed = closure.env_capacity();
@@ -208,15 +222,22 @@ impl VM {
                 let collected = match closure.template.vararg_tag() {
                     crate::value::VarargTag::List => Self::args_to_list(rest_args, heap),
                     crate::value::VarargTag::Struct => {
-                        match Self::collect_struct_in_own_region(fiber, heap, rest_args, None) {
+                        match Self::collect_struct_in_own_region(
+                            fiber, heap, rest_args, None, symbols,
+                        ) {
                             Some(v) => v,
                             None => return false,
                         }
                     }
                     crate::value::VarargTag::StrictStruct => {
                         let keys = closure.template.strict_keys();
-                        match Self::collect_struct_in_own_region(fiber, heap, rest_args, Some(keys))
-                        {
+                        match Self::collect_struct_in_own_region(
+                            fiber,
+                            heap,
+                            rest_args,
+                            Some(keys),
+                            symbols,
+                        ) {
                             Some(v) => v,
                             None => return false,
                         }
@@ -437,6 +458,7 @@ impl VM {
         heap: &mut crate::value::fiberheap::FiberHeap,
         args: &[Value],
         valid_keys: Option<crate::value::closure::StrKeys<'_>>,
+        symbols: Option<&crate::symbol::SymbolTable>,
     ) -> Option<Value> {
         let sr = env_value_region(heap);
         // Build the struct INSIDE `sr` (the per-value region the result lives
@@ -450,7 +472,7 @@ impl VM {
         // alloc-region bracket closes, so it is born in its own durable region
         // (`heap.new_runtime_region()`) — like every other param-binding error
         // (e.g. `check_arity`) — which survives until the fiber dies.
-        let built = Self::args_to_struct_static(heap, args, valid_keys, sr);
+        let built = Self::args_to_struct_static(heap, args, valid_keys, symbols, sr);
         match built {
             Ok(v) => Some(v),
             Err((kind, msg)) => {
@@ -480,6 +502,7 @@ impl VM {
         heap: &mut crate::value::fiberheap::FiberHeap,
         args: &[Value],
         valid_keys: Option<crate::value::closure::StrKeys<'_>>,
+        symbols: Option<&crate::symbol::SymbolTable>,
         region: crate::hir::region::RuntimeRegion,
     ) -> Result<Value, (&'static str, String)> {
         use crate::value::types::TableKey;
@@ -514,10 +537,13 @@ impl VM {
                     ));
                 }
             };
-            // Error-message spelling: this static path has no memo, so an
-            // off-vocabulary key falls back to the unreadable form.
+            // Error-message spelling. The rejected key is one the caller
+            // wrote, so it is the instance memo that holds its name — a
+            // message built without one names a hash the author has to
+            // decode (docs/impl/symbol.md § "Reading a name, and not reading
+            // one").
             let spell = || {
-                crate::value::keyword::resolve_keyword_name(None, key)
+                crate::value::keyword::resolve_keyword_name(symbols, key)
                     .map(|n| format!(":{}", n))
                     .unwrap_or_else(|| format!("#<keyword:{:#x}>", key))
             };

--- a/src/vm/run_on.rs
+++ b/src/vm/run_on.rs
@@ -39,8 +39,17 @@ fn rejected(vm: &mut VM, tier: &str, msg: impl Into<String>) -> Value {
         "tier-rejected",
         msg,
         &[
-            ("tier", Value::keyword(tier)),
-            ("reason", Value::keyword("ineligible")),
+            // The two field names are keyword spellings; `vocab` fails the
+            // build if the vocabulary stops carrying one, the same guard
+            // `rich_error!` applies to the names it stringifies.
+            (
+                const { crate::value::keyword::vocab("tier") },
+                Value::keyword(tier),
+            ),
+            (
+                const { crate::value::keyword::vocab("reason") },
+                Value::keyword("ineligible"),
+            ),
         ],
     )
 }

--- a/src/vm/signal.rs
+++ b/src/vm/signal.rs
@@ -260,7 +260,7 @@ impl VM {
     ) -> Option<SignalBits> {
         let payload = {
             let mut ctx = crate::primitives::ctx::Alloc::new(unsafe { &mut *self.heap_ptr });
-            Self::build_denial_payload(&mut ctx, def, blocked, args)
+            Self::build_denial_payload(&mut ctx, def, blocked, args, self.symbols())
         };
 
         // The denial payload escapes into `fiber.signal`, read later via
@@ -330,7 +330,7 @@ impl VM {
     ) -> SignalBits {
         let payload = {
             let mut ctx = crate::primitives::ctx::Alloc::new(unsafe { &mut *self.heap_ptr });
-            Self::build_denial_payload(&mut ctx, def, blocked, args)
+            Self::build_denial_payload(&mut ctx, def, blocked, args, self.symbols())
         };
         // Retain the escaping payload region, mirroring the tail-position
         // `SignalAction::Suspend` path (see `handle_primitive_signal_tail`):
@@ -365,12 +365,13 @@ impl VM {
         def: &'static crate::primitives::def::PrimitiveDef,
         blocked: SignalBits,
         args: &[Value],
+        memo: Option<&mut crate::symbol::SymbolTable>,
     ) -> Value {
         use crate::value::heap::TableKey;
         use std::collections::BTreeMap;
 
         let registry = crate::signals::registry::global_registry().lock().unwrap();
-        let denied_keywords = registry.bits_to_keywords(blocked);
+        let denied_keywords = registry.bits_to_keywords(blocked, memo);
 
         let denied = ctx.set(denied_keywords.into_iter().collect());
         let primitive = ctx.string(def.name);

--- a/src/vm/signal/config.rs
+++ b/src/vm/signal/config.rs
@@ -1,6 +1,27 @@
 use super::*;
 
 impl VM {
+    /// The `--trace` keys as a keyword set.
+    ///
+    /// A learning site: a trace key is whatever the command line named, so its
+    /// spelling is not build-fixed and no vocabulary entry can cover it
+    /// (docs/impl/symbol.md § "The display memo").
+    fn trace_keywords(&self, ctx: &mut crate::primitives::ctx::Alloc) -> Value {
+        let mut memo = self.symbols();
+        let set: std::collections::BTreeSet<Value> = self
+            .runtime_config
+            .trace
+            .iter()
+            .map(|k| {
+                if let Some(m) = memo.as_deref_mut() {
+                    m.keyword(k);
+                }
+                Value::keyword(k)
+            })
+            .collect();
+        ctx.set(set)
+    }
+
     /// Handle `(vm/config)` read — returns config struct or specific field.
     pub(super) fn dispatch_vm_config_read(
         &self,
@@ -27,11 +48,9 @@ impl VM {
                 TableKey::from_value(&Value::keyword("mlir")).unwrap(),
                 Value::keyword(rc.mlir.keyword()),
             );
-            // trace as a set of keywords
-            let trace_set: Vec<Value> = rc.trace.iter().map(|k| Value::keyword(k)).collect();
             map.insert(
                 TableKey::from_value(&Value::keyword("trace")).unwrap(),
-                ctx.set(trace_set.into_iter().collect()),
+                self.trace_keywords(ctx),
             );
             map.insert(
                 TableKey::from_value(&Value::keyword("stats")).unwrap(),
@@ -55,11 +74,7 @@ impl VM {
                 "jit" => (SIG_OK, Value::keyword(rc.jit.keyword())),
                 "wasm" => (SIG_OK, Value::keyword(rc.wasm.keyword())),
                 "mlir" => (SIG_OK, Value::keyword(rc.mlir.keyword())),
-                "trace" => {
-                    let trace_set: Vec<Value> =
-                        rc.trace.iter().map(|k| Value::keyword(k)).collect();
-                    (SIG_OK, ctx.set(trace_set.into_iter().collect()))
-                }
+                "trace" => (SIG_OK, self.trace_keywords(ctx)),
                 "stats" => (SIG_OK, Value::bool(rc.stats)),
                 "flip" => (SIG_OK, Value::bool(crate::config::flip_enabled())),
                 "unicode" => (SIG_OK, self.unicode_version_value(ctx)),

--- a/src/vm/signal/modules.rs
+++ b/src/vm/signal/modules.rs
@@ -487,8 +487,13 @@ impl VM {
             );
         };
         let dumps = crate::dump::render_all(&source, &name, symbols, cctx);
+        let symbols = unsafe { &mut *symbols_ptr };
         let mut map = BTreeMap::new();
         for (kind, text) in dumps {
+            // The stage names are build-fixed and in the vocabulary, but the
+            // memo is right here and a stage added later would otherwise print
+            // as a hash until somebody noticed.
+            symbols.keyword(&kind);
             map.insert(
                 TableKey::from_value(&Value::keyword(&kind)).unwrap(),
                 ctx.string(text),

--- a/src/vm/signal/query.rs
+++ b/src/vm/signal/query.rs
@@ -102,7 +102,7 @@ impl VM {
             "fiber/caps" => {
                 let caps = crate::signals::CAP_MASK.subtract(self.fiber.withheld);
                 let registry = crate::signals::registry::global_registry().lock().unwrap();
-                let keywords = registry.bits_to_keywords(caps);
+                let keywords = registry.bits_to_keywords(caps, self.symbols());
                 (SIG_OK, ctx.set(keywords.into_iter().collect()))
             }
             "list-primitives" => {

--- a/tests/elle/keyword-spelling.lisp
+++ b/tests/elle/keyword-spelling.lisp
@@ -1,0 +1,104 @@
+(elle/epoch 12)
+# ── A keyword the runtime coins can be spelled ────────────────────────
+#
+# A keyword IS its name hash. A spelling the Rust runtime coins from a
+# fixed string lives in the static vocabulary; a spelling that arrives at
+# run time lives in the instance memo (docs/impl/symbol.md § "A spelling
+# the runtime itself mints"). A spelling in neither still makes a
+# perfectly good value — it just prints as `#<keyword:hash>`, and
+# `json/serialize` refuses the struct that carries it as a key, because
+# writing the hash would read back as a different name.
+#
+# This file must not write any spelling it tests. A `:keyword` token
+# teaches the reader's memo — and so does a bare *symbol* of the same
+# spelling, since the memo's domain is spellings and one entry serves
+# both vocabularies. A literal here would hand the runtime the very name
+# it failed to record, and the assert would go green on a broken build.
+# So every check below is over a value the runtime built, asking only
+# whether a name came back at all.
+
+(defn unspelled? [v]
+  (string/contains? (string v) "#<keyword"))
+
+(defn encodes? [v]
+  (first (protect (json/serialize v))))
+
+# ── A struct of metadata the runtime built ────────────────────────────
+#
+# `file/stat` returns close to twenty keys, all coined in Rust and none
+# named here.
+
+(def scratch (file/mktempdir))
+(def probe (path/join scratch "probe"))
+(file/write probe "x")
+
+(def info (file/stat probe))
+
+(assert (not (unspelled? info)) "every file/stat key has a spelling")
+(assert (encodes? info) "a file/stat result encodes as JSON")
+
+(file/delete probe)
+(file/delete-dir-all scratch)
+
+# ── The signal registry ───────────────────────────────────────────────
+#
+# The registry is process-global and outlives no memo: a program declares
+# a signal at run time and any instance can read the name back. The
+# built-in names are coined in Rust, so both halves are on show here.
+
+(signal :sigil_spelling_probe)
+
+(assert (not (unspelled? (signals))) "every signal name has a spelling")
+(assert (encodes? (signals)) "the signal registry encodes as JSON")
+
+(assert (not (unspelled? (fiber/caps))) "every capability name has a spelling")
+(assert (encodes? (fiber/caps)) "the capability set encodes as JSON")
+
+# The sharp case: a worker never read this file, so its memo never met
+# the declaration above. The registry it reads is the same one, and the
+# name has to come from the read.
+
+(def from-worker (sys/join (sys/spawn (fn [] (string (signals))))))
+
+(assert (not (string/contains? from-worker "#<keyword"))
+        "a worker spells a signal name it never read the declaration for")
+
+# ── The VM's own state ────────────────────────────────────────────────
+
+(assert (not (unspelled? (vm/tier))) "the active tier has a spelling")
+(assert (not (unspelled? (vm/config)))
+        "every vm/config key and value has a spelling")
+(assert (encodes? (vm/config)) "the vm config encodes as JSON")
+
+# ── What a compile query hands back ───────────────────────────────────
+
+(def probed (compile/analyze "(defn probe-fn [n] (+ n 1))"))
+
+(assert (not (unspelled? (compile/bindings probed)))
+        "every binding-query key has a spelling")
+(assert (encodes? (compile/bindings probed)) "a binding query encodes as JSON")
+
+(assert (not (unspelled? (compile/signal probed :probe-fn)))
+        "every signal-query key has a spelling")
+(assert (encodes? (compile/signal probed :probe-fn))
+        "a signal query encodes as JSON")
+
+(assert (not (unspelled? (compile/call-graph probed)))
+        "every call-graph key has a spelling")
+(assert (encodes? (compile/call-graph probed)) "a call graph encodes as JSON")
+
+# ── The type name of a value the runtime wraps ────────────────────────
+#
+# `type-of` returns a keyword built from the type's name. For an
+# external the name comes from the primitive that wrapped it, so each
+# wrapper is its own spelling.
+
+(assert (not (unspelled? (type-of probed)))
+        "a compile handle's type name has a spelling")
+
+(def [tx rx] (chan/new 1))
+
+(assert (not (unspelled? (type-of tx)))
+        "a channel sender's type name has a spelling")
+(assert (not (unspelled? (type-of rx)))
+        "a channel receiver's type name has a spelling")

--- a/tests/elle/keyword-spelling.lisp
+++ b/tests/elle/keyword-spelling.lisp
@@ -102,3 +102,30 @@
         "a channel sender's type name has a spelling")
 (assert (not (unspelled? (type-of rx)))
         "a channel receiver's type name has a spelling")
+
+# ── The context fields a rich error carries ───────────────────────────
+#
+# An error is a struct, so an unspellable context key costs the whole
+# value: the error prints with a hash where a field name belongs, and
+# `json/serialize` refuses it. These three name their field through
+# `stringify!`, which puts the spelling further out of reach than a
+# string literal does.
+
+(defn failure [thunk]
+  (second (protect (thunk))))
+
+(def parse-failure (failure (fn [] (parse-int "not-a-number"))))
+
+(assert (not (unspelled? parse-failure)) "a parse failure names its context")
+(assert (encodes? parse-failure) "a parse failure encodes as JSON")
+
+(def import-failure (failure (fn [] ((import "std/nothing-of-this-name")))))
+
+(assert (not (unspelled? import-failure)) "an import failure names its context")
+(assert (encodes? import-failure) "an import failure encodes as JSON")
+
+(def tier-failure
+  (failure (fn [] (compile/run-on :nothing-of-this-name (fn [] 1)))))
+
+(assert (not (unspelled? tier-failure)) "a tier rejection names its context")
+(assert (encodes? tier-failure) "a tier rejection encodes as JSON")

--- a/tests/elle/keyword-spelling.lisp
+++ b/tests/elle/keyword-spelling.lisp
@@ -129,3 +129,31 @@
 
 (assert (not (unspelled? tier-failure)) "a tier rejection names its context")
 (assert (encodes? tier-failure) "a tier rejection encodes as JSON")
+
+# ── A message that shows the keyword it rejected ──────────────────────
+#
+# Here the keyword is the caller's own, so a memo does hold its spelling
+# — what the message has to do is consult the one that does. Each name
+# is coined at run time and asserted through the spelling the runtime
+# hands back, so no literal in this file can stand in for it.
+
+(defn takes-named [&named allowed]
+  allowed)
+
+(def unknown-param (keyword (append "sigil-param-" "name")))
+
+(def named-failure (failure (fn [] (apply takes-named [unknown-param 1]))))
+
+(assert (string/contains? (get named-failure :message) (string unknown-param))
+        "the unknown-parameter message spells the parameter it rejected")
+(assert (not (string/contains? (get named-failure :message) "#<keyword"))
+        "the unknown-parameter message shows no hash")
+
+(def unknown-signal (keyword (append "sigil-signal-" "name")))
+
+(def signal-failure (failure (fn [] (os/sig-raise unknown-signal))))
+
+(assert (string/contains? (get signal-failure :message) (string unknown-signal))
+        "the unknown-signal message spells the signal it rejected")
+(assert (not (string/contains? (get signal-failure :message) "#<keyword"))
+        "the unknown-signal message shows no hash")


### PR DESCRIPTION
A keyword is a name hash, and its spelling lives in the instance's memo — the
reader learns one from every source token it reads. A spelling the Rust runtime
coins from a fixed string has no reader behind it, so it lives in `VOCABULARY`
instead. That list was checked against three literal mint forms and had drifted
out from under every other way a name reaches the keyword constructor.

## What was wrong

`(json/serialize (file/stat …))` failed with `keyword struct key has no learned
spelling`. So did every compile query's result, `(signals)`, and `fiber/caps`.
The values were fine; their keys had no name to print.

The gap read as narrower than it was, because the memo's domain is spellings
rather than values: a struct key resolves if any *symbol* of that name was ever
read. `file/stat`'s `:size` printed because the stdlib defines a symbol called
`size`; its `:blksize` did not.

Five faces, each with a mint form no scan of the source could see:

- **54 spellings** written through the `kw("…")` helper each primitive module
  defines for its struct keys, through `io_error("…")`, or through
  `ctx.external("…")`, plus **9** that reach the constructor from a `match` arm
  — the signal registry's `debug`/`fuel`/`fs`/`io`/`exec`/`wait`/`yield`/
  `os-signal`, and the VM's `bytecode` tier.
- A `rich_error!` **field name**, which reaches the constructor through
  `stringify!` as a token rather than a string: `:input` on a parse failure,
  `:spec` on an import failure, `:tier` on a tier rejection, and `:module` on a
  module symbol. An error is a struct, so one unspellable key costs the whole
  value.
- Two **messages that reject a keyword** and named it by hash. `(f :typo 1)`
  against a `&named` parameter list reported `unknown named parameter
  #<keyword:0x5595…>`, and an unrecognised signal reported `:#<keyword:0xe5e4…>`
  — a colon glued to the unreadable form, which reads as a spelling and is not
  one. Both had the spelling in reach and passed `None` where the memo belongs.
- A **plugin's external type name**. `make_external` was the one ABI constructor
  that took a name and did not learn it, so `(type-of …)` on a plugin handle
  printed `#<keyword:hash>` and any struct keyed by that type refused to encode.
- A **desugaring's keyword node**: `Syntax::keyword(arena, "match-error", span)`
  writes a keyword no source token backs, and the scan could not see the form
  because its extraction starts at the quote.

## What this does

Every missing spelling is in `VOCABULARY`, and the scan's list of literal mint
forms now covers the seventh form.

Three kinds of site stop needing the list at all:

- **Names a program coins at run time** are minted through the memo instead of
  the vocabulary. The signal registry is process-global and `(signal :my-sig)`
  allocates a bit, so no build-fixed list can carry it and the instance reading
  the name back may never have met it — a worker thread has met none of them.
  `bits_to_keywords` takes the memo, and `(signals)`, a compile query's `:bits`
  set, and the `--trace` keys mint through `ctx.keyword`.
- **A `rich_error!` field name is checked where it is written.**
  `keyword::vocab` is a `const fn` that returns its argument and asserts
  `is_vocabulary` — a linear scan of the list, precisely so it can be `const`.
  `rich_error!` wraps every field name in `const { … }`, so a spelling the list
  does not carry is a build error at the call site. Delete `"input"` from
  `VOCABULARY` and the crate stops compiling, pointing at
  `primitives/convert/numeric.rs`.
- **A plugin's external learns its own type name.** `make_external` records the
  name through the ctx already in hand, one step from the keyword `type-of`
  mints from it, so `type-of` needs no memo of its own on any tier.

The json refusal names the hash it could not spell: `has no learned spelling`
left an author with a failing serialize and nothing to search for. The six
copies of the key-resolution arm behind it are now one `json_object_key`, so the
compact and pretty serializers cannot drift.

## What pins it

`tests/elle/keyword-spelling.lisp` asks every keyword the runtime coins for its
spelling, through the runtime rather than through a literal, so a name in the
test cannot stand in for the one the runtime hands back. `src/value/keyword/
tests.rs` holds the scan and the vocabulary, including
`vocabulary_membership_answers_in_a_const_context`: a crate cannot assert that
it fails to compile, so what is checkable is that `vocab` answers in a `const`
block at all — one that stopped being `const fn` would pass every other test
here while the guard moved silently to run time.
`src/plugin_api/capi/tests.rs` asserts the keyword and the external's type name
together, which is what makes the failure specific.

`docs/impl/symbol.md` carries the rule and what the checks still miss — a
spelling that reaches the constructor through a local — and names where those
are pinned instead.

Two commits were made with `--no-verify`: the pre-commit hook gates on clippy,
and a tests commit that names an item its implementation commit adds cannot
compile. The tree is red at those two points by construction.
