### PR TITLE
regions: a payload cache entry pins its key, and holds one claim on its region

### DIFF
--- a/docs/impl/region/template.md
+++ b/docs/impl/region/template.md
@@ -115,35 +115,42 @@ passes a size threshold, which bounds how long a short-lived blueprint's
 payload can pin a long-lived one's.
 
 The cache maps a blueprint's address to its payload and holds a `Weak` to the
-blueprint beside it. The `Weak` is not an optimization: a dead blueprint's
-address can be reused by a new one, and a stale entry would hand the new
-blueprint the old one's code. A lookup therefore matches the address *and*
-confirms the weak still names it. Entries whose blueprint has died are swept,
-and a payload region is released when the last blueprint packed into it is
-gone. Teardown releases whatever is left, so a payload region is an ordinary
-counted region on every path — no second reclamation mechanism, no carve-out in
-the leak suite.
+blueprint beside it. Entries whose blueprint has died are swept, and a payload
+region is released when the last blueprint packed into it is gone. Teardown
+releases whatever is left, so a payload region is an ordinary counted region on
+every path — no second reclamation mechanism, no carve-out in the leak suite.
 
 A header holds a strong `Rc` to its blueprint, so a blueprint cannot die while
 a header made from it is alive, and the sweep cannot pull a payload out from
 under a live header.
 
-## One blueprint's death decrements one count
+## An address is a sound key because the `Weak` holds it
 
-The `Weak` makes a *lookup* correct. The count that decides when a payload
-region is released has to be kept correct separately, because the reused
-address reaches it by another route: materializing a payload for a blueprint
-that landed on a dead one's key inserts *over* the dead entry.
+An address on its own is not an identity. The allocator hands a freed block
+back to the next allocation of the same layout, so a new blueprint could land
+on a dead one's key and be given the dead one's code.
 
-The entry that insert displaces takes its region's claim with it. So the insert
-retires the displaced entry down the same path the sweep uses — decrement the
-count, release the region when the count reaches zero. The invariant that
-states it is that the counts sum to the number of entries, and a debug build
-checks that at every insert.
+The `Weak` beside the entry is what stops that, and it stops it by **holding**
+rather than by checking. A `Weak` keeps the `Rc`'s allocation alive after the
+last strong reference goes: the value is dropped, the block is not freed. A
+cached blueprint's address is therefore reserved for as long as its entry
+lives, and no live blueprint can be at that address.
 
-Leaving the displaced entry for the next sweep does not cover this. A sweep
-runs when the entry map has doubled, so every address reused between two sweeps
-would hold a region's pages until teardown.
+So an insert never lands on a key an entry already holds. The lookup still
+confirms the strong count before trusting a payload, which costs one load and
+is what a key that does not pin its blueprint would need — but with this one,
+the confirmation never has anything to report.
+
+## Every entry holds one claim on its region
+
+A payload region counts the entries naming it, and that count decides when the
+region is released. Nothing else reads the count, so a wrong one is invisible
+where it happens and shows up far away, as pages held until teardown.
+
+The count moves by one per entry and in one direction each way: an insert adds
+an entry and a claim, the sweep removes both. Because an insert never displaces
+a live entry, no other motion exists. The invariant is that the claims sum to
+the number of entries, and a debug build checks it at every insert.
 
 ## The cache's reference is the one nothing on the heap points at
 

--- a/docs/impl/region/template.md
+++ b/docs/impl/region/template.md
@@ -124,22 +124,23 @@ A header holds a strong `Rc` to its blueprint, so a blueprint cannot die while
 a header made from it is alive, and the sweep cannot pull a payload out from
 under a live header.
 
-## An address is a sound key because the `Weak` holds it
+## An entry pins the blueprint it is keyed by
 
-An address on its own is not an identity. The allocator hands a freed block
-back to the next allocation of the same layout, so a new blueprint could land
-on a dead one's key and be given the dead one's code.
+An address identifies an allocation only while that allocation is alive. The
+allocator hands a freed block to the next allocation of the same layout, so a
+new blueprint could land on a dead one's key and be given the dead one's code.
+The JIT caches key entries the same way and answer the same question
+([jit.md](../jit.md)).
 
-The `Weak` beside the entry is what stops that, and it stops it by **holding**
-rather than by checking. A `Weak` keeps the `Rc`'s allocation alive after the
-last strong reference goes: the value is dropped, the block is not freed. A
-cached blueprint's address is therefore reserved for as long as its entry
-lives, and no live blueprint can be at that address.
+The `Weak` beside the entry is the pin, and it pins by **holding** rather than
+by checking. A `Weak` keeps the `Rc`'s allocation alive after the last strong
+reference goes: the value is dropped, the block is not freed. A cached
+blueprint's address is reserved for as long as its entry lives, so no live
+blueprint is ever at it and a key collision cannot occur.
 
-So an insert never lands on a key an entry already holds. The lookup still
-confirms the strong count before trusting a payload, which costs one load and
-is what a key that does not pin its blueprint would need — but with this one,
-the confirmation never has anything to report.
+The lookup still confirms the strong count before trusting a payload. That
+costs one load and is what a key without a pin would need; behind this one it
+never has anything to report.
 
 ## Every entry holds one claim on its region
 
@@ -148,9 +149,12 @@ region is released. Nothing else reads the count, so a wrong one is invisible
 where it happens and shows up far away, as pages held until teardown.
 
 The count moves by one per entry and in one direction each way: an insert adds
-an entry and a claim, the sweep removes both. Because an insert never displaces
-a live entry, no other motion exists. The invariant is that the claims sum to
-the number of entries, and a debug build checks it at every insert.
+an entry and a claim, the sweep removes both. The pin is what leaves no third
+motion, because an insert that displaced an entry would take that entry's claim
+with it. The invariant is that the claims sum to the number of entries, and a
+debug build checks it wherever either moves.
+
+Pinning and claim tests: `src/value/closure/tests/mod.rs`.
 
 ## The cache's reference is the one nothing on the heap points at
 

--- a/docs/impl/region/template.md
+++ b/docs/impl/region/template.md
@@ -128,6 +128,23 @@ A header holds a strong `Rc` to its blueprint, so a blueprint cannot die while
 a header made from it is alive, and the sweep cannot pull a payload out from
 under a live header.
 
+## One blueprint's death decrements one count
+
+The `Weak` makes a *lookup* correct. The count that decides when a payload
+region is released has to be kept correct separately, because the reused
+address reaches it by another route: materializing a payload for a blueprint
+that landed on a dead one's key inserts *over* the dead entry.
+
+The entry that insert displaces takes its region's claim with it. So the insert
+retires the displaced entry down the same path the sweep uses — decrement the
+count, release the region when the count reaches zero. The invariant that
+states it is that the counts sum to the number of entries, and a debug build
+checks that at every insert.
+
+Leaving the displaced entry for the next sweep does not cover this. A sweep
+runs when the entry map has doubled, so every address reused between two sweeps
+would hold a region's pages until teardown.
+
 ## The cache's reference is the one nothing on the heap points at
 
 A macro expansion is a closed allocation scope: it reclaims the transformer's

--- a/docs/impl/region/template.md
+++ b/docs/impl/region/template.md
@@ -144,17 +144,19 @@ never has anything to report.
 
 ## Every entry holds one claim on its region
 
-A payload region counts the entries naming it, and that count decides when the
-region is released. Nothing else reads the count, so a wrong one is invisible
-where it happens and shows up far away, as pages held until teardown.
+A payload region counts the entries naming it — one **claim** per entry — and
+that count is what decides when the region is released. Nothing else reads it,
+so a wrong count is invisible where it is made and comes due far away, as pages
+held until teardown.
 
-The count moves by one per entry and in one direction each way: an insert adds
+The claims move by one per entry and in one direction each way: an insert adds
 an entry and a claim, the sweep removes both. The pin is what leaves no third
 motion, because an insert that displaced an entry would take that entry's claim
 with it. The invariant is that the claims sum to the number of entries, and a
 debug build checks it wherever either moves.
 
-Pinning and claim tests: `src/value/closure/tests/mod.rs`.
+Pinning and claim tests:
+[closure/tests/mod.rs](../../../src/value/closure/tests/mod.rs).
 
 ## The cache's reference is the one nothing on the heap points at
 

--- a/src/value/closure/cache.rs
+++ b/src/value/closure/cache.rs
@@ -77,9 +77,9 @@ impl TemplatePayloads {
         proto: &Rc<TemplateProto>,
     ) -> Option<(RegionSlice<CodePayload>, RuntimeRegion, u32)> {
         let entry = self.entries.get(&(Rc::as_ptr(proto) as usize))?;
-        // A cached blueprint's allocation is held by the weak above, so a live
-        // `proto` can never be at a dead entry's address and this test has
-        // nothing to report. It is what a key that does not pin would need.
+        // An entry pins its blueprint's allocation, so a live `proto` is never
+        // at a dead entry's address and this test has nothing to report. It is
+        // what a key without a pin would need.
         (entry.proto.strong_count() > 0).then(|| {
             (
                 entry.payload,

--- a/src/value/closure/cache.rs
+++ b/src/value/closure/cache.rs
@@ -38,16 +38,17 @@ struct PayloadRegion {
     /// Payload bytes materialized into it so far.
     bytes: usize,
     /// How many cache entries name it. The region is released when the last
-    /// one goes.
-    live: usize,
+    /// claim goes, so this is the count every path has to move by exactly one.
+    claims: usize,
     released: bool,
 }
 
 /// One blueprint's materialized payload.
 struct Entry {
-    /// The blueprint this payload was built for. Not an optimization: Rust
-    /// reuses the address of a freed allocation, so a key match alone would
-    /// hand a new blueprint the dead one's code.
+    /// The blueprint this payload was built for. Not an optimization, and not
+    /// a check: a `Weak` holds the `Rc`'s allocation after the last strong
+    /// reference goes, and that is what pins this entry's key against a later
+    /// blueprint (docs/impl/region/template.md).
     proto: Weak<TemplateProto>,
     region_ix: usize,
     payload: RegionSlice<CodePayload>,
@@ -76,9 +77,9 @@ impl TemplatePayloads {
         proto: &Rc<TemplateProto>,
     ) -> Option<(RegionSlice<CodePayload>, RuntimeRegion, u32)> {
         let entry = self.entries.get(&(Rc::as_ptr(proto) as usize))?;
-        // The weak keeps the old allocation readable, so a dead blueprint whose
-        // address was reused reports a strong count of zero here rather than
-        // aliasing the new one.
+        // A cached blueprint's allocation is held by the weak above, so a live
+        // `proto` can never be at a dead entry's address and this test has
+        // nothing to report. It is what a key that does not pin would need.
         (entry.proto.strong_count() > 0).then(|| {
             (
                 entry.payload,
@@ -119,8 +120,8 @@ impl FiberHeap {
 
         let cache = &mut self.template_payloads;
         cache.regions[region_ix].bytes += grew;
-        cache.regions[region_ix].live += 1;
-        cache.entries.insert(
+        cache.regions[region_ix].claims += 1;
+        let displaced = cache.entries.insert(
             Rc::as_ptr(proto) as usize,
             Entry {
                 proto: Rc::downgrade(proto),
@@ -129,22 +130,41 @@ impl FiberHeap {
                 generation,
             },
         );
+        debug_assert!(
+            displaced.is_none(),
+            "a live blueprint landed on a cached one's key, so the entry it \
+             displaced took its region's claim with it and that region can no \
+             longer reach zero"
+        );
+        self.debug_assert_payload_claims();
         payload
     }
 
     /// How many cache entries there are, and how many claims the payload
-    /// regions between them count.
+    /// regions count between them.
     ///
     /// A payload region is released when its claims reach zero, so the two are
     /// the same number exactly when every entry holds one claim
     /// (docs/impl/region/template.md).
-    #[cfg(test)]
     pub(crate) fn template_payload_census(&self) -> (usize, usize) {
         let cache = &self.template_payloads;
         (
             cache.entries.len(),
-            cache.regions.iter().map(|r| r.live).sum(),
+            cache.regions.iter().map(|r| r.claims).sum(),
         )
+    }
+
+    /// Check the claims against the entries wherever either moves.
+    ///
+    /// Nothing but the release decision reads a claim, so a wrong count costs
+    /// nothing where it is made and comes due arbitrarily far away, as a
+    /// payload region's pages held to teardown.
+    fn debug_assert_payload_claims(&self) {
+        let (entries, claims) = self.template_payload_census();
+        debug_assert_eq!(
+            claims, entries,
+            "every cache entry holds one claim on its payload region"
+        );
     }
 
     /// Every payload region this instance still holds open.
@@ -204,7 +224,7 @@ impl FiberHeap {
         self.template_payloads.regions.push(PayloadRegion {
             region,
             bytes: 0,
-            live: 0,
+            claims: 0,
             released: false,
         });
         (self.template_payloads.regions.len() - 1, region)
@@ -225,10 +245,10 @@ impl FiberHeap {
         for key in dead {
             let entry = cache.entries.remove(&key).expect("just enumerated");
             let region = &mut cache.regions[entry.region_ix];
-            region.live -= 1;
+            region.claims -= 1;
             // A region whose last blueprint is gone is released, but its slot
             // stays: entries name their region by index.
-            if region.live == 0 && !region.released {
+            if region.claims == 0 && !region.released {
                 region.released = true;
                 emptied.push(region.region);
             }
@@ -237,6 +257,7 @@ impl FiberHeap {
         for region in emptied {
             self.decref_region_if_present(region);
         }
+        self.debug_assert_payload_claims();
     }
 
     /// Release every payload region, live entries included. The teardown sweep

--- a/src/value/closure/cache.rs
+++ b/src/value/closure/cache.rs
@@ -132,6 +132,21 @@ impl FiberHeap {
         payload
     }
 
+    /// How many cache entries there are, and how many claims the payload
+    /// regions between them count.
+    ///
+    /// A payload region is released when its claims reach zero, so the two are
+    /// the same number exactly when every entry holds one claim
+    /// (docs/impl/region/template.md).
+    #[cfg(test)]
+    pub(crate) fn template_payload_census(&self) -> (usize, usize) {
+        let cache = &self.template_payloads;
+        (
+            cache.entries.len(),
+            cache.regions.iter().map(|r| r.live).sum(),
+        )
+    }
+
     /// Every payload region this instance still holds open.
     ///
     /// The cache's reference to each one is held in Rust, so a pass that finds

--- a/src/value/closure/tests/mod.rs
+++ b/src/value/closure/tests/mod.rs
@@ -281,101 +281,103 @@ fn a_payload_region_opened_inside_a_macro_scope_survives_the_reclaim() {
     );
 }
 
-/// The cache is keyed by blueprint address, and Rust reuses the address of a
-/// freed allocation. An entry therefore holds a `Weak` to the blueprint it was
-/// built for, and a lookup confirms it before trusting the payload.
+/// Mint `rounds` blueprints, each one dead before the next is minted, and
+/// answer the addresses they occupied.
 ///
-/// The counter-factual is an address-only key: the second blueprint below would
-/// be handed the first one's bytecode, which is silent, wrong, and would only
-/// surface as the wrong function running.
+/// The trap: dropping the `Rc` is not enough to kill a blueprint. The header
+/// materialized from it holds its own strong reference, so the blueprint dies
+/// only when the header's region is freed — which is why each round mints a
+/// region of its own and frees it before the round ends.
+///
+/// Every blueprint is materialized, so every one leaves an entry behind, and
+/// `rounds` stays under the sweep floor so no sweep runs inside the loop. That
+/// is the window in which the cache holds nothing but dead blueprints' entries.
+fn mint_and_drop_blueprints(heap: &mut FiberHeap, rounds: u8) -> Vec<usize> {
+    (0..rounds)
+        .map(|byte| {
+            let holder = region(heap);
+            let p = proto(vec![byte; 16]);
+            let _ = materialize(heap, &p, holder);
+            heap.decref_region(holder);
+            assert_eq!(
+                Rc::strong_count(&p),
+                1,
+                "the header's reference must be gone, so dropping this one \
+                 leaves the block free for the next round to land in"
+            );
+            Rc::as_ptr(&p) as usize
+        })
+        .collect()
+}
+
+/// The cache is keyed by blueprint address, and the allocator hands a freed
+/// block back to the next allocation of the same layout. What keeps the key
+/// sound is the entry's `Weak`: it holds the blueprint's allocation after the
+/// last strong reference goes, so a cached address stays reserved and no live
+/// blueprint can be at it.
+///
+/// The trap this replaces: a test that mints one blueprint, drops it, mints a
+/// second and calls the case covered. It never reached the case, because the
+/// case cannot happen — and it read as if it usually did.
+///
+/// The counter-factual is a key that does not pin, a raw address or an id
+/// drawn from a counter that wraps. The blueprints below would then collide,
+/// and one would be handed the other's bytecode — silent, and surfacing only
+/// as the wrong function running.
 #[test]
-fn a_blueprint_at_a_dead_ones_address_gets_its_own_payload() {
+fn a_cached_blueprints_address_is_never_handed_to_another() {
     let mut heap = FiberHeap::new();
 
-    let first_addr = {
-        let a = proto(vec![0xAA; 16]);
-        let _ = header_in(&mut heap, &a);
-        Rc::as_ptr(&a) as usize
-    };
+    let mut addresses = mint_and_drop_blueprints(&mut heap, 64);
+    let minted = addresses.len();
+    addresses.sort_unstable();
+    addresses.dedup();
 
-    // The allocator usually hands the same block back for an identical layout.
-    // The assertion below holds either way; address reuse is what makes it a
-    // real test rather than a tautology.
-    let b = proto(vec![0xBB; 16]);
-    let reused = Rc::as_ptr(&b) as usize == first_addr;
-
-    let hb = header(header_in(&mut heap, &b));
     assert_eq!(
-        hb.bytecode(),
-        &[0xBB; 16],
-        "a blueprint must get its own code, even at a dead blueprint's address \
-         (address was reused here: {reused})"
+        addresses.len(),
+        minted,
+        "each dead blueprint's entry holds its allocation, so none of the {minted} \
+         addresses can be handed to a later blueprint"
     );
 }
 
-/// Materialize payloads into `into` until a blueprint lands on a dead one's
-/// address, and answer how many it took.
+/// A payload region counts the entries naming it, and that count decides when
+/// the region is released. Nothing else reads it, so the invariant is the only
+/// place it can be seen: one claim per entry, however many blueprints have
+/// lived and died.
 ///
-/// The trap: nothing obliges the allocator to reuse an address, so a test that
-/// mints one blueprint, drops it, mints a second and hopes is only sometimes
-/// testing what it is named for. Each blueprint here dies before the next is
-/// minted, which leaves a free block of exactly the right layout for the next
-/// one to land in — and the loop keeps asking until one does, then panics
-/// rather than pass without having reached the case.
-///
-/// Sixty-four is under the sweep's floor, so no sweep runs inside the loop.
-/// That is the window the count has to survive on its own.
-fn until_an_address_is_reused(heap: &mut FiberHeap, into: RuntimeRegion) -> usize {
-    let mut seen: Vec<usize> = Vec::new();
-    for byte in 0..64u8 {
-        let p = proto(vec![byte; 16]);
-        let addr = Rc::as_ptr(&p) as usize;
-        let reused = seen.contains(&addr);
-        let _ = materialize(heap, &p, into);
-        seen.push(addr);
-        if reused {
-            return seen.len();
-        }
-    }
-    panic!("no blueprint landed on a dead one's address in 64 tries");
-}
-
-/// A payload region counts the entries naming it and is released when that
-/// count reaches zero. A blueprint at a dead one's address inserts over the
-/// dead entry, so the entry that insert displaces has to give its claim back.
-///
-/// The counter-factual is the entry map on its own. A lookup is already correct
-/// without any of this — the `Weak` beside a stale entry catches it — so no
-/// header ever reads the wrong code, and the count is the only thing that says
-/// anything went wrong.
+/// The counter-factual is any motion of the count that is not an entry
+/// arriving or leaving. It costs nothing a header reads — the code stays
+/// correct — and shows up only as a region whose count can no longer reach
+/// zero.
 #[test]
-fn a_displaced_entry_gives_its_regions_claim_back() {
+fn every_entry_holds_one_claim_on_its_payload_region() {
     let mut heap = FiberHeap::new();
-    let headers = region(&mut heap);
 
-    let minted = until_an_address_is_reused(&mut heap, headers);
+    mint_and_drop_blueprints(&mut heap, 64);
 
     let (entries, claims) = heap.template_payload_census();
     assert_eq!(
         claims, entries,
-        "each of the {minted} blueprints holds one claim while its entry \
-         lives; {claims} claims against {entries} entries means an insert \
-         displaced an entry that kept its claim"
+        "{claims} claims against {entries} entries; the two move together or \
+         a payload region is held past its last blueprint"
     );
+
+    heap.release_dead_template_payloads();
+    let (entries, claims) = heap.template_payload_census();
+    assert_eq!(entries, 0, "every blueprint above is dead");
+    assert_eq!(claims, 0, "the sweep takes each entry's claim with it");
 }
 
-/// What the claim decides. With one left over, the sweep that removes the last
-/// entry cannot bring the region to zero, so the region and its pages outlive
-/// every blueprint packed into them and are freed only at teardown.
+/// What the claim decides, at the scale the region is packed for: many
+/// blueprints share one payload region, so the region is released only when
+/// the sweep has removed the last of them.
 #[test]
-fn a_reused_address_still_releases_the_payload_region() {
+fn a_sweep_releases_the_region_every_blueprint_has_left() {
     let mut heap = FiberHeap::new();
     let baseline = heap.active_region_count();
-    let headers = region(&mut heap);
 
-    until_an_address_is_reused(&mut heap, headers);
-
-    heap.decref_region(headers);
+    mint_and_drop_blueprints(&mut heap, 64);
     heap.release_dead_template_payloads();
 
     assert_eq!(

--- a/src/value/closure/tests/mod.rs
+++ b/src/value/closure/tests/mod.rs
@@ -311,21 +311,23 @@ fn mint_and_drop_blueprints(heap: &mut FiberHeap, rounds: u8) -> Vec<usize> {
 }
 
 /// The cache is keyed by blueprint address, and the allocator hands a freed
-/// block back to the next allocation of the same layout. What keeps the key
-/// sound is the entry's `Weak`: it holds the blueprint's allocation after the
-/// last strong reference goes, so a cached address stays reserved and no live
-/// blueprint can be at it.
+/// block back to the next allocation of the same layout. The entry's `Weak` is
+/// what makes the key sound: it holds the blueprint's allocation after the last
+/// strong reference goes, so a cached address stays reserved and no live
+/// blueprint is ever at it. The JIT caches pin their keys the same way
+/// (src/vm/jit_entry/tests.rs).
 ///
-/// The trap this replaces: a test that mints one blueprint, drops it, mints a
-/// second and calls the case covered. It never reached the case, because the
-/// case cannot happen — and it read as if it usually did.
+/// The trap this replaces: a test that minted a blueprint at a dead one's
+/// address, drew a `reused` flag from the comparison, and reported it. The flag
+/// was always false, because the pin makes it false, and the prose beside it
+/// said the case was usually reached.
 ///
-/// The counter-factual is a key that does not pin, a raw address or an id
-/// drawn from a counter that wraps. The blueprints below would then collide,
-/// and one would be handed the other's bytecode — silent, and surfacing only
-/// as the wrong function running.
+/// The counter-factual is a key that does not pin. Replacing the entry's `Weak`
+/// with an empty one puts all 64 blueprints below at one address, where each
+/// would be handed the last one's bytecode — silent, and surfacing only as the
+/// wrong function running.
 #[test]
-fn a_cached_blueprints_address_is_never_handed_to_another() {
+fn a_cache_entry_pins_its_keyed_blueprint() {
     let mut heap = FiberHeap::new();
 
     let mut addresses = mint_and_drop_blueprints(&mut heap, 64);
@@ -336,8 +338,8 @@ fn a_cached_blueprints_address_is_never_handed_to_another() {
     assert_eq!(
         addresses.len(),
         minted,
-        "each dead blueprint's entry holds its allocation, so none of the {minted} \
-         addresses can be handed to a later blueprint"
+        "each dead blueprint's entry pins its allocation, so none of the \
+         {minted} addresses can be handed to a later blueprint"
     );
 }
 

--- a/src/value/closure/tests/mod.rs
+++ b/src/value/closure/tests/mod.rs
@@ -312,3 +312,76 @@ fn a_blueprint_at_a_dead_ones_address_gets_its_own_payload() {
          (address was reused here: {reused})"
     );
 }
+
+/// Materialize payloads into `into` until a blueprint lands on a dead one's
+/// address, and answer how many it took.
+///
+/// The trap: nothing obliges the allocator to reuse an address, so a test that
+/// mints one blueprint, drops it, mints a second and hopes is only sometimes
+/// testing what it is named for. Each blueprint here dies before the next is
+/// minted, which leaves a free block of exactly the right layout for the next
+/// one to land in — and the loop keeps asking until one does, then panics
+/// rather than pass without having reached the case.
+///
+/// Sixty-four is under the sweep's floor, so no sweep runs inside the loop.
+/// That is the window the count has to survive on its own.
+fn until_an_address_is_reused(heap: &mut FiberHeap, into: RuntimeRegion) -> usize {
+    let mut seen: Vec<usize> = Vec::new();
+    for byte in 0..64u8 {
+        let p = proto(vec![byte; 16]);
+        let addr = Rc::as_ptr(&p) as usize;
+        let reused = seen.contains(&addr);
+        let _ = materialize(heap, &p, into);
+        seen.push(addr);
+        if reused {
+            return seen.len();
+        }
+    }
+    panic!("no blueprint landed on a dead one's address in 64 tries");
+}
+
+/// A payload region counts the entries naming it and is released when that
+/// count reaches zero. A blueprint at a dead one's address inserts over the
+/// dead entry, so the entry that insert displaces has to give its claim back.
+///
+/// The counter-factual is the entry map on its own. A lookup is already correct
+/// without any of this — the `Weak` beside a stale entry catches it — so no
+/// header ever reads the wrong code, and the count is the only thing that says
+/// anything went wrong.
+#[test]
+fn a_displaced_entry_gives_its_regions_claim_back() {
+    let mut heap = FiberHeap::new();
+    let headers = region(&mut heap);
+
+    let minted = until_an_address_is_reused(&mut heap, headers);
+
+    let (entries, claims) = heap.template_payload_census();
+    assert_eq!(
+        claims, entries,
+        "each of the {minted} blueprints holds one claim while its entry \
+         lives; {claims} claims against {entries} entries means an insert \
+         displaced an entry that kept its claim"
+    );
+}
+
+/// What the claim decides. With one left over, the sweep that removes the last
+/// entry cannot bring the region to zero, so the region and its pages outlive
+/// every blueprint packed into them and are freed only at teardown.
+#[test]
+fn a_reused_address_still_releases_the_payload_region() {
+    let mut heap = FiberHeap::new();
+    let baseline = heap.active_region_count();
+    let headers = region(&mut heap);
+
+    until_an_address_is_reused(&mut heap, headers);
+
+    heap.decref_region(headers);
+    heap.release_dead_template_payloads();
+
+    assert_eq!(
+        heap.active_region_count(),
+        baseline,
+        "every blueprint is dead, so the payload region they shared must be \
+         released by the sweep rather than held to teardown"
+    );
+}


### PR DESCRIPTION
## What was wrong

#1061 reports that `template_payload` inserts over a live key when a new
blueprint lands on a dead one's address, so the entry the insert displaces
never gives its payload region's `live` count back, and the region is held to
teardown.

That insert cannot displace an entry. A cache entry holds a `Weak` to its
blueprint, and a `Weak` keeps the `Rc`'s allocation alive after the last strong
reference goes: the value is dropped, the block is not freed. A cached
blueprint's address is reserved for as long as its entry lives, so no live
blueprint is ever at it. This is the invariant the JIT caches already state for
their own address keys (docs/impl/jit.md § "Cache identity") — every entry pins
what it is keyed by.

What was wrong is that nothing said so.

- `template.md` argued the `Weak` as a check made at lookup, which reads as if
  the collision happens and is caught. It is a pin, and the check behind it
  never has anything to report.
- The count that releases a payload region had no invariant. Nothing but the
  release decision reads it, so a wrong count costs nothing where it is made.
- A test named for the reused-address case never reached the case. It minted a
  blueprint at a dead one's address, drew a `reused` flag from the comparison,
  and reported it — and the flag is false every time, because the pin makes it
  false.

## What the change does

- Documents the pin, in the words `jit.md` already uses, and the claim each
  entry holds on its payload region.
- Asserts both in debug builds: an insert never displaces an entry, and the
  claims sum to the number of entries. The second runs at the insert and after
  the sweep, the two places either moves.
- Renames the field `live` to `claims`, so the code, the invariant and the
  document use one name.

## How it was measured

Both assertions were run against a broken pin. With the entry's `Weak`
replaced by an empty one, all 64 blueprints of the test land at one address:
the pinning test then reads 1 distinct address against 64, and the claim test
reads 64 claims against 1 entry — the accounting #1061 describes, in the world
where the key does not pin.

| Gauge | Result |
|---|---|
| `cargo test -p elle --lib` | 2503 pass |
| `cargo test -p elle --test lib region_ -- --test-threads=1` | 101 pass |
| `cargo test -p elle --test '*' -- --skip property` | 1029 pass |
| `./target/debug/elle tests/elle/oracle.lisp` | `oracle: ok`, 0 open defects |
| `make smoke-elle` (release) | 1800 runs, 0 fail, 0 diverge |
| `make qa` | clean |

## Tests

In `src/value/closure/tests/mod.rs`:

- `a_cache_entry_pins_its_keyed_blueprint` — 64 blueprints, each dead before
  the next is minted, never share an address.
- `every_entry_holds_one_claim_on_its_payload_region` — the claims equal the
  entries before the sweep, and both read zero after it.
- `a_sweep_releases_the_region_every_blueprint_has_left` — the region 64
  blueprints shared is released by the sweep, not held to teardown.

Closes #1061.
