### PR TITLE
docs: authority rides the carrier, and the crossing asks the fiber

### DIFF
--- a/docs/impl/AGENTS.md
+++ b/docs/impl/AGENTS.md
@@ -13,7 +13,7 @@ Up: [..](../AGENTS.md)
 - [dissolution.md](dissolution.md) — **Dissolution — HOF loop fusion (more...)**
 - [escape.md](escape.md) — **Escape analysis — the authoritative true-escape pass (more...)**
 - [fleet.md](fleet.md) — **Fleet — adhoc distributed execution over images (more...)**
-- [gpu.md](gpu.md) — **GPU Compute (more...)**
+- [gpu.md](gpu.md) — **GPU Compute** How a plain Elle closure becomes a dispatched compute kernel, across the MLIR backend and the Vulkan plugin.
 - [hir.md](hir.md) — **HIR — High-level IR** The HIR pass converts expanded syntax trees into a typed intermediate representation.
 - [image.md](image.md) — **Images — regions hydrated at load** Design for image-style persistence.
 - [jit.md](jit.md) — **JIT** The JIT compiles hot functions from LIR to native code using Cranelift.

--- a/docs/impl/gpu.md
+++ b/docs/impl/gpu.md
@@ -1,12 +1,16 @@
 # GPU Compute
 
+<!-- audited: 2026-09-07 -->
+
+How a plain Elle closure becomes a dispatched compute kernel, across the
+MLIR backend and the Vulkan plugin.
+
 > **Feature-gated:** End-to-end GPU compute requires `--features mlir`
 > (for compiler-generated SPIR-V) and the `vulkan` plugin built and
 > loadable. Tested on AMD RADV; any Vulkan 1.0 + `Int64` driver should
 > work.
 
-The GPU pipeline turns a plain Elle closure into a dispatched compute
-kernel. Three layers cooperate:
+Three layers cooperate:
 
 ```text
 ┌──────────────────────────────────────────────────────────────┐
@@ -40,8 +44,8 @@ What happens:
    :dtype dtype}`; one output buffer of size `n * elem-size`.
 6. Dispatch: `(plugin:dispatch shader wg-count 1 1 bufs)` returns a
    handle.
-7. Suspend the fiber: `(plugin:wait handle)` blocks on the GPU fence
-   fd via `IoOp::Task` (no thread pool thread is held).
+7. Suspend the fiber: `(plugin:wait handle)` polls the GPU fence fd
+   through the scheduler (no thread pool thread is held).
 8. Decode: `(plugin:decode (plugin:collect handle) dtype)` produces
    an Elle array.
 
@@ -79,26 +83,27 @@ etc. See `lib/spirv.lisp` for the full opcode surface and
 
 `vulkan/init` creates `VkInstance` + `VkDevice` + queue (one of each;
 no multi-device support). The state is wrapped in
-`Arc<Mutex<VulkanState>>` so it can be cloned into Send closures for
-the thread pool.
+`Arc<Mutex<VulkanState>>`, which is what lets a shader hold the context
+it was built against and lock it again at dispatch.
 
 `vulkan/shader` accepts SPIR-V either as bytes (compiler-generated or
 loaded into Elle) or as a string path to a `.spv` file, then builds
 a `VkComputePipeline` with one storage buffer per binding.
 
-`vulkan/submit` is the only async primitive. It:
+`vulkan/dispatch` allocates the GPU buffers, uploads the input data,
+records the dispatch, and submits it to the queue. It returns a handle
+carrying the fence FD, and it does not wait.
 
-1. Takes an array of buffer specs.
-2. Builds a Send closure that allocates GPU buffers, uploads input
-   data, records the dispatch, submits to the queue, waits on a
-   fence FD.
-3. Returns `(SIG_IO, IoRequest::task(closure))` — the fiber suspends,
-   the thread pool runs the closure, the fiber resumes with the result
-   bytes.
+`vulkan/wait` is the only async primitive. It returns
+`SIG_YIELD | SIG_IO` with a poll request on the handle's fence FD, so the
+fiber suspends until the GPU signals the fence and no thread-pool thread
+is held.
 
-Numeric data is extracted from Elle arrays into `Vec<f32>` (or
-`Vec<i64>`, etc., per `dtype`) **before** the closure is built — the
-closure carries plain `Vec<T>` so it satisfies `Send`.
+`vulkan/collect` reads the result bytes once the fence has signalled.
+
+`vulkan/submit` does all three in one call. It blocks the calling thread
+on `wait_for_fences` rather than suspending the fiber, because the stable
+ABI exposes no `IoRequest::task` for a plugin to return.
 
 `vulkan/decode` parses the result-bytes envelope:
 
@@ -157,10 +162,19 @@ plugins/vulkan/src/decode.rs     Result bytes → Elle array
 | `vulkan/init` | errors | Create Vulkan context |
 | `vulkan/shader` | errors | Build a compute pipeline from SPIR-V |
 | `vulkan/dispatch` | errors | Submit a compute dispatch (returns handle) |
-| `vulkan/wait` | yields+io+errors | Block on the GPU fence |
+| `vulkan/wait` | yields+io+errors | Suspend on the GPU fence fd |
 | `vulkan/collect` | errors | Read result bytes |
 | `vulkan/decode` | errors | Bytes → Elle array (per dtype) |
-| `vulkan/submit` | yields+io+errors | One-shot dispatch + wait |
+| `vulkan/submit` | errors | One-shot dispatch + wait, blocking the thread |
+| `vulkan/f32-bits` | errors | IEEE 754 f32 bit pattern of a number |
+| `vulkan/persist` | errors | Create a persistent GPU buffer |
+| `vulkan/update` | errors | Re-upload data to a persistent GPU buffer |
+
+No primitive here declares `:gpu`, so denying that bit withholds none of
+them. The one primitive that declares `:gpu` is `git`, which compiles a
+closure to SPIR-V and dispatches nothing. What a capability for the GPU
+would have to ask instead is in
+[signals/authority.md](../signals/authority.md).
 
 ## Configuration
 

--- a/docs/signals/AGENTS.md
+++ b/docs/signals/AGENTS.md
@@ -6,6 +6,7 @@ Up: [..](../AGENTS.md)
 
 ## Documents
 
+- [authority.md](authority.md) — **Authority** What holds authority in a running program, and where the runtime asks whether a fiber may spend it.
 - [capabilities.md](capabilities.md) — **Capability enforcement** Capabilities flow down.
 - [design.md](design.md) — **Signal Design (more...)**
 - [emit.md](emit.md) — **emit** `emit` is the single mechanism for all signal emission in Elle.
@@ -15,5 +16,5 @@ Up: [..](../AGENTS.md)
 - [jit.md](jit.md) — **Signals and JIT (more...)**
 - [primitives.md](primitives.md) — **Fiber Primitives** User-facing fiber operations and patterns.
 - [protocol.md](protocol.md) — **Signal Protocol (more...)**
-- [questions.md](questions.md) — **Signal Questions (more...)**
+- [questions.md](questions.md) — **Signal Questions** What the signal design has not settled, and what it has.
 - [recovery.md](recovery.md) — **Signal Recovery (more...)**

--- a/docs/signals/authority.md
+++ b/docs/signals/authority.md
@@ -1,0 +1,165 @@
+# Authority
+
+<!-- audited: 2026-09-07 -->
+
+What holds authority in a running program, and where the runtime asks whether a
+fiber may spend it.
+
+## The question the check asks today
+
+A fiber carries a withheld set. Every native call tests the primitive's declared
+bits against that set, and an overlapping call does not run.
+[capabilities.md](capabilities.md) states the rule, the denial payload, and how a
+parent mediates.
+
+That check asks one question: **may this fiber name this primitive?** The call
+site asks it, and the primitive's declaration answers it.
+
+This document argues for a second question, asked in a different place: **may
+this fiber cause this effect?** The two differ whenever authority outlives the
+call that minted it, and whenever the effect leaves by a route the call site does
+not own.
+
+## The unit is the fiber
+
+An enforcement point needs something durable to sit on. A construct the compiler
+may erase enforces nothing, because the optimizer decides at build time whether
+the check survives into the program at all.
+
+A fiber is durable. It is a runtime object with identity, state, a parent, and
+the withheld set itself. Capabilities flow down it at creation and at resume, a
+denial parks it, and no pass rewrites it away.
+
+```lisp
+(let [outer (fiber/new
+              (fn []
+                (let [inner (fiber/new (fn [] (fiber/caps)) |:error| :deny |:ffi|)]
+                  (fiber/resume inner)))
+              |:error|
+              :deny |:fs|)]
+  (let [caps (fiber/resume outer)]
+    (assert (not (caps :fs)) "a child cannot regain a capability its parent withheld")
+    (assert (not (caps :ffi)) "a child keeps its own denial")
+    (assert (caps :io) "a child keeps what nobody withheld")))
+```
+
+### A closure does not survive
+
+The compiler dissolves closures. `(map f xs)` over a proven immutable array
+becomes an index-walk loop with the body of `f` inlined, and the closure stops
+existing — [dissolution.md](../impl/dissolution.md) describes the transform and
+every shape it covers.
+
+So a capability declared on a closure is one the optimizer may delete. Worse, it
+deletes the check silently and only for the programs where fusion applies, which
+makes enforcement depend on how hot a loop is.
+
+### A primitive call does not always happen
+
+Two constructs leave the dispatch path the check lives on. Arithmetic compiles to
+specialized instructions that run no capability test, which
+[capabilities.md](capabilities.md) states. `emit` is a bytecode instruction whose
+handler never reads the withheld set, which [emit.md](emit.md) states.
+
+A fiber therefore raises any signal bit it names, including one it does not hold.
+A parent that masks a bit to watch for an operation sees whatever the child
+chooses to raise, so a mask audits a cooperative child and not a hostile one.
+
+Neither construct is a mistake on its own. Together they say the call site cannot
+carry the whole check, because the language has more than one way to reach an
+effect.
+
+## Minting is not spending
+
+The check gates the primitive that **mints** authority. It does not gate the
+authority that primitive hands back.
+
+An `io-request` is an ordinary value, with `io-request?` as its public predicate.
+So is a port, and so is the module value an `import` of a native plugin returns.
+Each travels through a closure capture, a resume value, a channel, or a struct
+field exactly like any other value.
+
+A fiber that holds one spends it in full. The submission API — `io/backend`,
+`io/submit`, `io/wait`, `io/reap` and `io/cancel` — declares `:error` alone, so
+no denial reaches a request that arrives from somewhere else.
+
+This is the rule the model turns on: **a check on minting is not a check on
+spending.** A sandbox built from denial holds only while every capability-bearing
+value stays outside it, and nothing in the language marks which values those are.
+
+## Where a fiber's work crosses out
+
+An effect leaves a fiber by one of four routes. The table names them, and says
+what the runtime asks today.
+
+| Crossing | What crosses | Asked today |
+|---|---|---|
+| The scheduler | a request, submitted or emitted | nothing |
+| Native code | a primitive that acts without suspending | the call site's check |
+| A device | a fiber lowered and dispatched | nothing exists yet |
+| A child fiber or a thread | the withheld set itself | the transitive check |
+
+The child crossing is the one that already works, and it works because the
+requirement travels with the thing that crosses. A child cannot argue its way
+past a denial, because it inherits the set rather than consulting one.
+
+## The rule
+
+**A requirement rides the carrier that crosses, and the crossing asks the fiber
+that owns it.**
+
+The requirement is minted with the authority, so nothing can separate the two. A
+value that escapes a sandbox still carries what spending it costs, and the fiber
+that spends it is the fiber the crossing asks about.
+
+This holds where a declaration does not, for three reasons. No optimizer deletes
+it, because the record is data rather than a call site. No author forgets it,
+because the minting primitive already declares the bits and the carrier copies
+them. No plugin misstates it across the stable ABI, because the carrier records
+what the operation needs rather than what its author claimed.
+
+## What the model makes possible
+
+### A capability for the GPU
+
+A fiber that lowers through MLIR and runs on a device is a unit of work crossing
+out of the process. The question is whether **this fiber** may run there, and the
+dispatch is where the runtime asks it.
+
+That question has no closure in it, so no fusion pass can erase the answer. It
+has no plugin declaration in it either, so a device backend cannot grant itself
+authority by describing itself generously.
+
+An on-device region is the same shape one level down. A region that materializes
+on a device is authority held as a value, so it carries what spending it costs
+and the materialization asks the owning fiber. The carrier rule is what makes an
+automatically parallelized region safe to move, because moving it moves the
+requirement with it.
+
+### Mediation, and what it does not settle
+
+A parent that catches a denial can perform the operation and resume the child.
+The seam a mediator answers is whatever primitive the implementation reached, so
+a composed operation presents one seam for each helper it calls.
+
+Moving the check to the crossing does not change that count. A composed operation
+crosses once for each request it makes, so a mediator still answers at the
+granularity of the implementation rather than the operation.
+
+What the model does say is that denial retrofits a boundary onto ambient
+authority. The child names a global, and the runtime intercepts whatever that
+global reaches. A supervisor that hands the child an operation, rather than
+denying a global the child can already name, has a seam by construction — and
+the seam is the operation the supervisor wrote.
+
+Whether the standard library should also present one deniable seam for each
+composed operation stays open. The alternatives are a declaration on the
+operation, which this document argues against, and a supervisor-supplied API,
+which needs no runtime support at all.
+
+## See also
+
+- [capabilities.md](capabilities.md) — the enforcement reference: `:deny`,
+  `fiber/caps`, denial payloads, mediation and refusal
+- [emit.md](emit.md) — signal emission, and what it does not check
+- [protocol.md](protocol.md) — the signal protocol and the registry

--- a/docs/signals/capabilities.md
+++ b/docs/signals/capabilities.md
@@ -1,5 +1,7 @@
 # Capability enforcement
 
+<!-- audited: 2026-09-07 -->
+
 Capabilities flow down. A fiber's parent decides what the fiber is
 permitted to do. Operations the fiber can't perform become signals the
 parent can catch.
@@ -63,7 +65,7 @@ can deny nor what it can catch.
 `:yield` is not in this table. It is the cooperative suspension `(yield v)`
 raises, not a capability: an I/O request raises `|:io|` alone, so a
 generator masked `|:yield|` catches its own yields while its reads travel
-out to the scheduler. See `docs/signals/protocol.md`.
+out to the scheduler. See [protocol.md](protocol.md).
 
 | Keyword | Bit | Effect when denied | Dispatch |
 |---------|-----|--------------------|----------|
@@ -74,7 +76,7 @@ out to the scheduler. See `docs/signals/protocol.md`.
 | `:halt` | 8 | Blocks VM termination | yes |
 | `:io` | 9 | Blocks operations that reach the I/O scheduler | yes |
 | `:exec` | 11 | Blocks subprocess execution | no |
-| `:gpu` | 15 | Blocks GPU dispatch | no |
+| `:gpu` | 15 | Blocks compiling a closure to SPIR-V (`git`) | no |
 | `:os-signal` | 16 | Blocks POSIX signal send/raise | no |
 | `:fs` | 17 | Blocks filesystem access | no |
 
@@ -117,7 +119,7 @@ When a fiber calls a primitive whose declared signal bits overlap
 with the fiber's withheld capabilities, the primitive does not run.
 Instead, the fiber emits a signal with:
 
-- **Bits**: the blocked capability bits (e.g., `:io`)
+- **Bits**: the blocked capability bits, for example `:io`
 - **Payload**: a struct describing the denial
 
 ```text
@@ -129,6 +131,27 @@ Instead, the fiber emits a signal with:
 ```
 
 The parent catches this signal through the normal mask routing.
+
+## What a denial does not confine
+
+A denial gates the primitive that **mints** authority. It does not gate a
+capability-bearing value the fiber already holds.
+
+An `io-request`, a port, and the module value a native `import` returns are
+ordinary values. Each reaches a fiber through a closure capture, a resume
+value, a channel, or a struct field. A fiber that holds one uses it whatever
+its withheld set says, because `io/submit` and its siblings declare `:error`
+alone.
+
+So a sandbox built from `:deny` holds while every capability-bearing value
+stays outside it. Hand one in and no denial applies to it.
+[authority.md](authority.md) states the model this follows from, and the
+question the runtime would have to ask instead.
+
+`emit` is the same shape one level down. It is a bytecode instruction rather
+than a primitive call, so a fiber raises any bit it names — including one it
+does not hold. A mask therefore audits a cooperative child, not a hostile one.
+See [emit.md](emit.md).
 
 ## Introspection
 
@@ -253,6 +276,9 @@ blocks `length` but not `+`.
 
 ## Examples
 
+Each sandbox below holds while the fiber receives no capability-bearing value
+from outside it, for the reason the confinement section gives.
+
 ```text
 # Pure computation sandbox — no IO, no filesystem, no FFI, no subprocess
 (let [f (fiber/new compute |:io :fs :ffi :exec :error|
@@ -263,13 +289,19 @@ blocks `length` but not `+`.
 (let [f (fiber/new worker |:fs :error| :deny |:fs|)]
   (fiber/resume f))
 
-# Capability-check a plugin before running it
+# Watch what a plugin's init tries to do
 (let [f (fiber/new plugin-init |:error| :deny |:exec :ffi|)]
   (let [result (fiber/resume f)]
     (if (= (fiber/status f) :dead)
       result
       (do (println "plugin tried:" ((fiber/value f) :primitive))
           (fiber/cancel f)))))
+```
+
+Denying `:ffi` does not stop the fiber loading a native module. `import`
+declares `:fs`, so `:fs` is the bit that closes that route.
+
+```text
 
 # Nested sandbox: outer denies IO, inner denies errors
 (let [outer (fiber/new

--- a/docs/signals/index.md
+++ b/docs/signals/index.md
@@ -1,5 +1,7 @@
 # Signals
 
+<!-- audited: 2026-09-07 -->
+
 Elle's unified signal and capability system. Two directions:
 
 - **Signals flow up** — from callee to caller. Inferred at compile time,
@@ -13,6 +15,7 @@ Elle's unified signal and capability system. Two directions:
 |------|---------|
 | [emit](emit.md) | `emit` special form, yield/error macros, signal emission |
 | [capabilities](capabilities.md) | Capability enforcement, `:deny`, `fiber/caps` |
+| [authority](authority.md) | What holds authority, and where a fiber's right to spend it is asked |
 | [design](design.md) | Motivation, prior art, terminology, core insight |
 | [protocol](protocol.md) | Signal protocol, registry, user signals |
 | [inference](inference.md) | Compile-time verification, restrictions |

--- a/docs/signals/questions.md
+++ b/docs/signals/questions.md
@@ -1,5 +1,9 @@
 # Signal Questions
 
+<!-- audited: 2026-09-07 -->
+
+What the signal design has not settled, and what it has.
+
 ## Open Questions
 
 ### Signal bit allocation
@@ -23,28 +27,29 @@ and faster. Current implementation: flat.
 ## Resolved Questions
 
 - **Signal resumption**: Yes. Resume value is pushed onto the child's operand
-  stack. See `docs/fibers.md`.
+  stack. See [fibers.md](fibers.md).
 
 - **Error representation**: Errors are values — by convention a struct
   `{:error :keyword :message "..."}`, but any value works. No `Condition`
   type, no signal hierarchy. Pattern matching on the payload replaces hierarchy
-  checks. See the "Error Signalling" section below.
+  checks. See [recovery.md](recovery.md).
 
 - **Coroutine pattern**: `yield` works as a special form (emits
   `SIG_YIELD`). A generator fiber is `(fiber/new fn |:yield|)`, resumed
   with `(fiber/resume f val)`. `try`/`catch` is a prelude macro.
 
-- **Signal erasure**: Signal bits are stored on the `Closure` struct
-  (`SignalBits` = 4 bytes per closure). Acceptable cost.
+- **Signal erasure**: A `ClosureTemplate` carries the code's signal, and a
+  `Closure` carries the squelch mask that narrows it — `effective_signal()`
+  combines the two. `SignalBits` wraps a `u64`. Acceptable cost.
 
 - **Compound signals**: Functions routinely carry multiple signal bits.
   A function that does I/O and can error has bits `|:error :io|`. The
   compiler infers compound signals by unioning the bits of all callees.
-  Compound signals that include `:io` receive special treatment: a fiber
-  mask that catches `:error` but not `:io` will *not* catch a compound
-  `:error :io` signal. The signal remains uncaught until a handler that
-  catches `:io` is reached — the scheduler must see the `:io` bit to
-  submit the operation to the backend.
+  No bit is privileged: a mask catches a compound signal when the two share
+  any bit, so `|:error|` catches `|:error :io|`. The scheduler still sees
+  every request it must service, because an I/O request raises `|:io|` and
+  carries no `:yield` — so a `|:yield|` mask shares no bit with one and
+  cannot swallow it. See [capabilities.md](capabilities.md).
 
 ---
 


### PR DESCRIPTION
The capability system asks one question: **may this fiber name this primitive?** It asks at the call, and the primitive's declaration answers. Two consequences were undocumented, and a capability that gates a GPU depends on both.

**A check on minting is not a check on spending.** An `io-request`, a port, and the module value a native `import` returns are ordinary values with ordinary travel. The submission API declares `:error` alone, so a fiber spends whatever capability-bearing value reaches it. A fiber denying `|:io :exec :fs|` runs `/bin/sh` and writes a file (#1072).

**The call site cannot carry the whole check.** Arithmetic compiles to specialized instructions and `emit` is a bytecode instruction, so a fiber raises any bit it names (#1073). A mask audits a cooperative child, not a hostile one.

`docs/signals/authority.md` states the model both point at. The unit is the fiber, because a fiber is the one construct with runtime identity that the compiler cannot dissolve — a capability declared on a closure is one loop fusion may delete, and a check on a call site is one `emit` walks past. The rule: a requirement rides the carrier that crosses out of the fiber, and the crossing asks the fiber that owns it. The document names the four crossings, says what a capability for the GPU would ask under that rule, and says plainly what the model does not settle — mediation granularity (#930) is left open with its alternatives stated.

Documentation only. No code changes.

**Repairs found while auditing.** Each file I touched, read whole and stamped.

- `capabilities.md` promised a confinement it does not deliver. It also gave `:gpu` as blocking GPU dispatch, when the only primitive declaring `:gpu` is `git`, which dispatches nothing; and offered a plugin sandbox whose `:ffi` denial does not gate `import`, which declares `:fs` (#1074).
- `questions.md` said a mask catching `:error` but not `:io` will not catch a compound signal. `covers` has been plain overlap since #929, with `covers_privileges_no_bit_over_another` pinning it. It also placed the signal on the `Closure` at 4 bytes; the template carries it and `SignalBits` wraps a `u64`. Two dead references repaired, and a call-out added.
- `gpu.md` described `vulkan/submit` as the only async primitive, returning `(SIG_IO, IoRequest::task(closure))` run on the thread pool. The plugin says the stable ABI exposes no `IoRequest::task` and blocks the calling thread; `vulkan/wait` is the async one, polling the fence fd. Three primitives were missing from its table. A call-out added, so the index no longer lists it as uncalled.

**Verification.** Every document under `docs/signals/` and `docs/impl/` runs clean as a program. The new `lisp` fence in `authority.md` asserts capability transitivity; inverting one of its assertions fails the run, so the fence executes rather than being skipped. `scripts/audit --staged` passes on all seven files. `make agents` regenerated both indexes.

Filed rather than fixed here: #1072, #1073, #1074, #1075.
