### PR TITLE
regions: --trace=residue dumps the teardown leak graph

### DIFF
--- a/docs/impl/region/AGENTS.md
+++ b/docs/impl/region/AGENTS.md
@@ -11,7 +11,7 @@ Up: [..](../AGENTS.md)
 - [bindings.md](bindings.md) — **Reassigned mutable bindings are 1-slot containers** Implementation-facing: how the solver and lowerer handle a binding that is reassigned over its lifetime.
 - [compensate.md](compensate.md) — **Per-arm compensation** The releases a branch adds one per arm, each funded by a retain on its own node.
 - [ctx.md](ctx.md) — **NativeCtx — explicit allocation: every value names its region and heap** Implementation-facing.
-- [diagnostics.md](diagnostics.md) — **Region diagnostics and validation (more...)**
+- [diagnostics.md](diagnostics.md) — **Region diagnostics and validation** Implementation-facing: the instruments that tell correct from broken, and the test scaffolding that keeps the region rules honest.
 - [effects.md](effects.md) — **Native region effects: declared, not guessed (more...)**
 - [errors.md](errors.md) — **Rich errors — one region-coherent struct routine + `rich_error!`** Implementation-facing.
 - [generations.md](generations.md) — **Region generations: stale derefs detonate in debug builds** The per-region generation counter and page stamps that turn a stale region deref into a debug-build panic at the deref site.

--- a/docs/impl/region/diagnostics.md
+++ b/docs/impl/region/diagnostics.md
@@ -1,8 +1,9 @@
 # Region diagnostics and validation
 
+<!-- audited: 2026-09-07 -->
+
 Implementation-facing: the instruments that tell correct from broken, and the
-test scaffolding (the exhaustive free-cascade pin and the leak suite) that keeps
-the region rules ([rules.md](rules.md)) honest.
+test scaffolding that keeps the region rules honest.
 
 ## Diagnostics — telling correct from broken
 
@@ -64,6 +65,17 @@ the region rules ([rules.md](rules.md)) honest.
   the bit is set, so an untraced dump prints the same line it always did. The
   mints the **VM** owns are covered; a region minted by a native, by the io
   backend, or by the env builder prints no site.
+- `--trace=residue`: **the teardown leak dump.** Where `--stats` counts the
+  regions the teardown sweep left alive, this prints them — the `arena/dump`
+  line for each surviving region, then every cross-region reference edge among
+  them as `[trace:residue] edge <referrer> -> <referent>`. The edges make the
+  residue a graph you can analyze offline: a region whose rc exceeds its
+  in-edge count is pinned from outside the region graph (an unbalanced
+  Rust-side claim — a true leak root), and an SCC among the edges is a
+  reference cycle per-region RC can never reclaim. It runs inside
+  `Runtime::teardown` (src/runtime.rs), after the root release and cascade, so
+  the file, REPL, and embedding paths all report through it. Composes with
+  `--trace=arena`: with both set each residue line carries its mint site.
 - `(arena/page-claims)`: the live count of pages this heap's `RegionStore` has
   claimed from its page pool, monotonic and never decremented on release. A
   delta across a fixed window is the *page* cost of a shape, the dimension

--- a/src/config/keywords.rs
+++ b/src/config/keywords.rs
@@ -1,3 +1,4 @@
+// audited: 2026-09-07
 //! Trace and dump keyword tables and their bit encodings.
 
 // ── Trace keywords ────────────────────────────────────────────────
@@ -40,6 +41,9 @@ pub const TRACE_KEYWORDS: &[&str] = &[
     "guardfree",
     "freebt",
     "scrub",
+    // Teardown leak dump: the surviving regions and their cross-region edges
+    // (string-traced, no bit; src/runtime.rs `Runtime::teardown`).
+    "residue",
     // Park/resume diagnostics: log every suspended-frame park (JIT side-exit
     // helpers) and every frame replay (resume_suspended) with the frame's
     // shape and value types. See src/jit/suspend.rs and src/vm/core/resume.rs.

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,3 +1,4 @@
+// audited: 2026-09-07
 //! Unit tests (`super` is the parent impl module).
 
 use super::*;
@@ -94,17 +95,18 @@ fn trace_all_covers_every_defined_bit() {
 fn trace_keywords_are_known() {
     // Future GPU backends — accepted without error, no bit yet.
     const FORWARD_COMPAT: &[&str] = &["spirv", "mlir", "gpu"];
-    // Region/free diagnostics, boot-phase timing, the post-boot census, the
-    // park trace, and the syncjit compile mode: functional today but checked
-    // via the string `has_trace` (cold free paths in fiberheap/freelog.rs;
-    // the phase marks and census in trace.rs; the park/resume seam; the
-    // submit path in vm/jit_entry.rs), so they deliberately carry no
-    // `trace_bits` entry.
+    // Region/free diagnostics, the teardown residue dump, boot-phase timing,
+    // the post-boot census, the park trace, and the syncjit compile mode:
+    // functional today but checked via the string `has_trace` (cold free
+    // paths in fiberheap/freelog.rs; the teardown in runtime.rs; the phase
+    // marks and census in trace.rs; the park/resume seam; the submit path in
+    // vm/jit_entry.rs), so they deliberately carry no `trace_bits` entry.
     const STRING_TRACED: &[&str] = &[
         "free",
         "guardfree",
         "freebt",
         "scrub",
+        "residue",
         "boot",
         "census",
         "park",

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,3 +1,4 @@
+// audited: 2026-09-07
 //! The process runtime: one lifecycle for compile/evaluate, shared by every
 //! entry path (`elle foo.lisp`, the REPL, and the embedding API).
 //!
@@ -323,6 +324,22 @@ impl Runtime {
         // (3) Observe the result. Every region is mortal, so every surviving
         //     region is leaked residue.
         let regions: Vec<(u32, u32, usize)> = unsafe { &*heap_ptr }.region_info_vec();
+
+        // The teardown leak dump (docs/impl/region/diagnostics.md §
+        // Diagnostics): each survivor's `arena/dump` line, then the
+        // cross-region edges among them — enough to compute externally-pinned
+        // roots (rc > in-edges) and reference cycles offline.
+        if crate::trace::residue() {
+            let heap = unsafe { &*heap_ptr };
+            eprintln!(
+                "[trace:residue] live regions after teardown: {}",
+                regions.len()
+            );
+            heap.debug_dump();
+            for (referrer, referent) in heap.cross_ref_edges() {
+                eprintln!("[trace:residue] edge {} -> {}", referrer, referent);
+            }
+        }
 
         TeardownReport {
             live_regions: regions.len(),

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,3 +1,4 @@
+// audited: 2026-09-07
 //! Trace macro for runtime-gated debug output.
 //!
 //! Gates on the VM's `runtime_config.has_trace_bit` — one relaxed atomic load
@@ -33,6 +34,12 @@ pub(crate) fn boot() -> bool {
 /// same static-CLI gating as `boot` (no VM trace cell exists yet).
 pub(crate) fn census() -> bool {
     crate::config::get().has_trace("census")
+}
+
+/// True when `--trace=residue` is active. Read once, at teardown — same
+/// static-CLI gating as `boot`/`census` (the VM is being torn down).
+pub(crate) fn residue() -> bool {
+    crate::config::get().has_trace("residue")
 }
 
 /// True when `--trace=compile` is active. Compile phases run on the

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,4 +1,4 @@
-// audited: 2026-09-05
+// audited: 2026-09-07
 // Integration tests harness
 mod core {
     include!("core.rs");
@@ -161,6 +161,9 @@ mod trace_boot {
 }
 mod trace_isolation {
     include!("trace_isolation.rs");
+}
+mod trace_residue {
+    include!("trace_residue.rs");
 }
 mod spawn_stack {
     include!("spawn_stack.rs");

--- a/tests/integration/trace_residue.rs
+++ b/tests/integration/trace_residue.rs
@@ -1,8 +1,7 @@
-// audited: 2026-09-07
-// `--trace=residue` prints the teardown leak dump (docs/impl/region/
-// diagnostics.md § Diagnostics): after the sweep, one `arena/dump` line per
-// surviving region and one `[trace:residue] edge a -> b` line per cross-region
-// reference among them.
+// audited: 2026-09-08
+// The `--trace=residue` teardown leak dump: one region line per survivor,
+// one edge line per cross-region reference among them.
+// docs/impl/region/diagnostics.md
 
 use std::process::Command;
 

--- a/tests/integration/trace_residue.rs
+++ b/tests/integration/trace_residue.rs
@@ -1,0 +1,81 @@
+// audited: 2026-09-07
+// `--trace=residue` prints the teardown leak dump (docs/impl/region/
+// diagnostics.md § Diagnostics): after the sweep, one `arena/dump` line per
+// surviving region and one `[trace:residue] edge a -> b` line per cross-region
+// reference among them.
+
+use std::process::Command;
+
+fn elle_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_elle")
+}
+
+#[test]
+fn residue_trace_dumps_surviving_regions_and_edges() {
+    let dir = crate::common::ScratchDir::new("trace-residue");
+    let script = dir.join("script.lisp");
+    std::fs::write(&script, "(+ 1 2)\n").expect("write script");
+    let out = Command::new(elle_binary())
+        .arg("--trace=residue")
+        .arg(&script)
+        .output()
+        .expect("run elle");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "elle --trace=residue failed; stderr:\n{}",
+        stderr
+    );
+
+    // The header states the count the dump then itemizes.
+    let header = stderr
+        .lines()
+        .find(|l| l.starts_with("[trace:residue] live regions after teardown: "))
+        .unwrap_or_else(|| panic!("missing [trace:residue] header; stderr:\n{}", stderr));
+    let count: usize = header
+        .rsplit(' ')
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap_or_else(|e| panic!("unparseable residue count in {:?}: {}", header, e));
+
+    // One region line per counted survivor. Zero residue — the end-state
+    // target — prints a bare header and no region lines, and this test must
+    // keep passing on that day.
+    let region_lines = stderr
+        .lines()
+        .filter(|l| l.trim_start().starts_with("region ") && l.contains(" rc="))
+        .count();
+    assert_eq!(
+        region_lines, count,
+        "header says {} regions but {} region lines follow; stderr:\n{}",
+        count, region_lines, stderr
+    );
+
+    // Edge lines only ever name counted regions.
+    if count == 0 {
+        assert!(
+            !stderr.contains("[trace:residue] edge "),
+            "edges printed with zero residue; stderr:\n{}",
+            stderr
+        );
+    }
+}
+
+#[test]
+fn residue_trace_is_silent_when_unset() {
+    let dir = crate::common::ScratchDir::new("trace-residue-off");
+    let script = dir.join("script.lisp");
+    std::fs::write(&script, "(+ 1 2)\n").expect("write script");
+    let out = Command::new(elle_binary())
+        .arg(&script)
+        .output()
+        .expect("run elle");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "elle failed; stderr:\n{}", stderr);
+    assert!(
+        !stderr.contains("[trace:residue]"),
+        "residue dump printed without --trace=residue; stderr:\n{}",
+        stderr
+    );
+}


### PR DESCRIPTION
## What was wrong

`--stats` prints how many regions the teardown sweep left alive, but not which regions, what they hold, or how they reference each other. Hunting the residue behind #1081/#1082/#1083 meant temporarily patching `main.rs` to print what `Runtime::teardown` already computes.

## What the change does

Adds `--trace=residue`, a string-traced keyword (like `boot`/`census` — read once, at teardown, no bit). From inside `Runtime::teardown`, so the file, REPL, and embedding paths all report through it, it prints:

- a counted header: `[trace:residue] live regions after teardown: N`,
- one `arena/dump` line per surviving region (mint-sited when `--trace=arena` is also set),
- one `[trace:residue] edge a -> b` line per cross-region reference among the survivors.

The edges make the residue a graph: a region whose rc exceeds its in-edge count is pinned from outside the region graph (an unbalanced Rust-side claim), and an SCC among the edges is a cycle per-region RC cannot reclaim. Documented in docs/impl/region/diagnostics.md; `--help` and `--trace=all` pick the keyword up from `TRACE_KEYWORDS`.

## How it was measured

This is the instrument that produced #1081/#1082/#1083: on `demos/fib/fib.lisp` the dump plus offline rc-vs-in-degree and SCC analysis reduced a 117–423-region residue to two externally-pinned roots and one 42-region cycle.

## Tests

- `tests/integration/trace_residue.rs` — written to fail first: the dump's region lines must match its header count (the assertion still passes on the day residue reaches zero), and an untraced run prints nothing.
- `config::tests::trace_keywords_are_known` extended with the new string-traced keyword.

`make qa`, the lib tests, the integration binary, and the Elle corpus smoke are green.
