### PR TITLE
typeinfer: a self-recursive call's result is the previous pass's body type

### DIFF
--- a/docs/impl/AGENTS.md
+++ b/docs/impl/AGENTS.md
@@ -26,6 +26,7 @@ Up: [..](../AGENTS.md)
 - [stdlib-cache.md](stdlib-cache.md) — **Standard Library Disk Cache** `stdlib.lisp` (~2850 lines) is recompiled on every process start.
 - [symbol.md](symbol.md) — **Symbols and keywords — identity is the name hash** A `SymbolId` is the 64-bit FNV-1a hash of the symbol's name.
 - [syntax.md](syntax.md) — **Syntax — a region-native immutable tree** The pre-analysis tree the reader produces, the expander rewrites, and the analyzer consumes.
+- [typeinfer.md](typeinfer.md) — **Type inference: the ascent, and what a call proves** Where the types come from: an ascent from below whose limit is the least fixpoint, and what each kind of call contributes to it.
 - [values.md](values.md) — **Values** Every Elle value is a 16-byte tagged union: an 8-byte tag and an 8-byte payload.
 - [vm.md](vm.md) — **VM** The VM is a stack-machine interpreter that executes bytecode.
 - [wasm.md](wasm.md) — **WASM Backend** The WASM backend compiles Elle programs to WebAssembly and runs them under Wasmtime, over the same front end the bytecode VM uses.

--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -16,14 +16,14 @@ and leaves that environment behind. The next pass walks the same tree over the
 environment the last one left. The passes stop when one of them changes
 nothing.
 
-The start is Bottom, not Top. Every parameter a complete enumeration of call
-sites can prove — the binding is used only as a callee, the parameter is not
-mutated — is seeded at Bottom, so a recursion that passes its own argument
-through contributes nothing on the way up instead of pinning the parameter at
-Top. A parameter whose callers are not all visible is left absent, and an
-absent entry reads as Top.
+The start is Bottom, not Top. A parameter is seeded at Bottom when a complete
+enumeration of call sites can prove it: the binding is used only as a callee,
+and the parameter is not mutated. A recursion that passes its own argument
+through then contributes nothing on the way up, rather than pinning the
+parameter at Top. A parameter whose callers are not all visible is left absent,
+and an absent entry reads as Top.
 
-A pass re-derives, it never accumulates. Each parameter's type is **replaced**
+A pass re-derives; it never accumulates. Each parameter's type is **replaced**
 at pass end by that pass's complete join over the call sites, and each lambda's
 body type is replaced by what its body computed on that pass. A join that only
 grows can never come back down, so one early reading of an unfinished estimate
@@ -43,11 +43,11 @@ estimate rises, and the limit of the ascent is the least fixpoint.
 
 **A self-recursive call is a call.** It reads the body-type map that every
 other call reads, and takes no exception of its own. On the first pass the
-callee's body has not been walked yet, so the map holds no entry for it and an
-absent entry is Bottom — which is what the recursive contribution to a
-return-type join is worth, the base cases. Every later pass reads the estimate
-the pass before it computed, exactly as a mutual recursion does through the
-same map.
+callee's body has not been walked yet, so the map holds no entry for it, and an
+absent entry is Bottom. Bottom is what the recursive contribution to a
+return-type join is worth: the base cases. Every later pass reads the estimate
+the pass before it computed, exactly as a mutual recursion does through the same
+map.
 
 `fib` settles on the second pass:
 
@@ -85,8 +85,8 @@ entry and the widening terminates.
 
 Widening costs precision, and only for a program that outran the budget: a
 `%`-intrinsic whose operand a widened entry feeds no longer proves, and
-prove-or-reject rejects that site. The whole corpus converges in five passes or
-fewer, so no program in it pays.
+prove-or-reject rejects that site. The whole corpus converges in six passes or
+fewer — the deepest is `demos/nqueens` at six — so no program in it widens.
 
 ## What still does not prove
 

--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -1,0 +1,117 @@
+# Type inference: the ascent, and what a call proves
+
+<!-- audited: 2026-09-08 -->
+
+Where the types come from: an ascent from below whose limit is the least
+fixpoint, and what each kind of call contributes to it.
+
+[intrinsics.md](../intrinsics.md) says what each `%`-intrinsic contract needs.
+This file says where the types that discharge it are computed, and what happens
+when the computation does not settle. The pass is `src/hir/typeinfer/`.
+
+## The ascent
+
+One pass walks the whole tree, records a type for every node and every binding,
+and leaves that environment behind. The next pass walks the same tree over the
+environment the last one left. The passes stop when one of them changes
+nothing.
+
+The start is Bottom, not Top. Every parameter a complete enumeration of call
+sites can prove — the binding is used only as a callee, the parameter is not
+mutated — is seeded at Bottom, so a recursion that passes its own argument
+through contributes nothing on the way up instead of pinning the parameter at
+Top. A parameter whose callers are not all visible is left absent, and an
+absent entry reads as Top.
+
+A pass re-derives, it never accumulates. Each parameter's type is **replaced**
+at pass end by that pass's complete join over the call sites, and each lambda's
+body type is replaced by what its body computed on that pass. A join that only
+grows can never come back down, so one early reading of an unfinished estimate
+would hold every later pass at Top.
+
+This is Kleene iteration: every pass reads strictly more than the last, the
+estimate rises, and the limit of the ascent is the least fixpoint.
+
+## What a call contributes
+
+| Callee | The call's type |
+|---|---|
+| a lambda binding this unit defines | that lambda's body type, as the previous pass left it |
+| a registered primitive | its declared `RetType`, read from the primitive tables |
+| a stdlib arithmetic wrapper (`+`, `abs`, `min`, …) | Number — the wrapper raises on everything else |
+| anything else | Top |
+
+**A self-recursive call is a call.** It reads the body-type map that every
+other call reads, and takes no exception of its own. On the first pass the
+callee's body has not been walked yet, so the map holds no entry for it and an
+absent entry is Bottom — which is what the recursive contribution to a
+return-type join is worth, the base cases. Every later pass reads the estimate
+the pass before it computed, exactly as a mutual recursion does through the
+same map.
+
+`fib` settles on the second pass:
+
+```lisp
+(defn fib [n]
+  (if (%lt n 2) n (%add (fib (%sub n 1)) (fib (%sub n 2)))))
+```
+
+Pass 1 reads Bottom for both self-calls, so the `%add` is Bottom and the body
+is `Int ⊔ ⊥ = Int`. Pass 2 reads Int for both, so the `%add` is Int and the
+body is Int again. Nothing moves, and the ascent is over.
+
+The proof the second pass adds is what the backends spend: an `%add` of two
+proven ints carries `:int` into LIR, which is `AddInt` on the bytecode tier and
+a tag-check-free fast path on the JIT ([lir.md](lir.md)).
+
+## An exhausted budget widens
+
+The budget is ten passes, and nothing guarantees the ascent fits in it.
+Information travels one call at a time in walk order, so a caller walked before
+its callee learns the callee's type one pass late. Eleven such functions in a
+row outrun the budget.
+
+An estimate that is still moving sits **below** the least fixpoint, and below
+is the dangerous side. An entry still at Bottom discharges every contract that
+asks a subtype question, so a program whose ascent was cut short compiles
+`(%bit-and (g1) 1)` for a `g1` that returns a string.
+
+So an exhausted budget widens. Every entry that moved on the last pass is
+pinned at Top, and the ascent runs again over the pinned environment. Top is
+above the fixpoint, so no site reads a proof out of an estimate that never
+settled. A pinned entry cannot move again, so each round pins at least one more
+entry and the widening terminates.
+
+Widening costs precision, and only for a program that outran the budget: a
+`%`-intrinsic whose operand a widened entry feeds no longer proves, and
+prove-or-reject rejects that site. The whole corpus converges in five passes or
+fewer, so no program in it pays.
+
+## What still does not prove
+
+- **A mutated binding.** An `assign` gives a binding flow that a per-pass
+  recomputation cannot see, so a mutated parameter never receives call-site
+  proofs and keeps whatever a guard proves of it. The loop-accumulator spelling
+  of a numeric kernel is unproven for this reason, where the recursive spelling
+  of the same kernel proves.
+- **A binding used as a value.** One use outside callee position — stored,
+  passed to a higher-order function, returned, exported — means callers this
+  unit cannot enumerate, so the call-site join over the visible ones proves
+  nothing about the parameters.
+
+## Pinning tests
+
+- `hir::typeinfer::tests::recursion::self_recursive_call_result_is_the_body_type`
+  — the `fib` ascent: the `%add` over two self-calls is Int, not Bottom.
+- `…::a_self_recursive_result_proves_a_callee_parameter` — the same result
+  carried one call further, into the parameters of a helper that adds it.
+- `…::a_float_base_case_does_not_prove_an_int_recursive_result` — the
+  over-narrowing guard, and the soundness half: while a self-call was pinned at
+  Bottom, a body whose base case is a float typed its `%add` Int and let a
+  bitwise op read a float's payload.
+- `…::a_three_member_recursion_proves_through_the_cycle` and
+  `…::a_cycle_whose_members_disagree_proves_nothing` — mutual recursion, which
+  converges by the same iteration and must keep doing so.
+- `…::a_chain_deeper_than_the_budget_proves_nothing` — the widening: eleven
+  functions in reverse walk order outrun the ten passes, and the site that
+  reads the unsettled entry is rejected rather than compiled.

--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -54,6 +54,7 @@ same map.
 ```lisp
 (defn fib [n]
   (if (%lt n 2) n (%add (fib (%sub n 1)) (fib (%sub n 2)))))
+(assert (= (fib 10) 55) "the recursive results prove the addition")
 ```
 
 Pass 1 reads Bottom for both self-calls, so the `%add` is Bottom and the body
@@ -115,3 +116,6 @@ fewer, so no program in it pays.
 - `…::a_chain_deeper_than_the_budget_proves_nothing` — the widening: eleven
   functions in reverse walk order outrun the ten passes, and the site that
   reads the unsettled entry is rejected rather than compiled.
+- `tests/elle/typed-int-ops.lisp` — the corpus peer, on every tier: a
+  self-recursive integer `fib` emits `AddInt` and computes with it, and a float
+  base case is refused at compile time.

--- a/docs/intrinsics.md
+++ b/docs/intrinsics.md
@@ -1,6 +1,6 @@
 # Intrinsics
 
-<!-- audited: 2026-09-07 -->
+<!-- audited: 2026-09-08 -->
 
 Intrinsics are silent bytecode operations prefixed with `%`. A `%`-intrinsic
 in **call position** is a compile-time type-checked request for the fast
@@ -65,6 +65,9 @@ Inference discharges contracts from:
 
 - **literals** and expressions with known types (`(%add 1 2)` compiles);
 - **primitive return types** flowing forward (`(%length (->array c))`);
+- **a called function's return type** — a call to a function this unit
+  defines carries what that function's body was proven to return, a
+  recursive call included (see [impl/typeinfer.md](impl/typeinfer.md));
 - **`match (type-of x)` keyword arms** — inside a `:@array` arm, `x` *is* a
   mutable array, authoritatively;
 - **diverging type guards** — after

--- a/src/hir/typeinfer.rs
+++ b/src/hir/typeinfer.rs
@@ -1,11 +1,12 @@
-// audited: 2026-09-07
-// docs/impl/hir.md
+// audited: 2026-09-08
+// docs/impl/typeinfer.md
 // docs/intrinsics.md
 //! Bidirectional type inference and the intrinsic operand proofs.
 //!
 //! Post-functionalize pass that:
 //! 1. Infers types from literals, known return types, and type guards
-//! 2. Propagates types through call sites (forward flow)
+//! 2. Propagates types through call sites (forward flow — the ascent in
+//!    `infer/fixpoint.rs`)
 //! 3. Checks every call-position %-intrinsic against its operand contract
 //!    (prove-or-reject; `contract.rs`)
 //! 4. Narrows signals on primitive calls with provably typed args
@@ -45,8 +46,6 @@ pub struct TypeInfo {
     pub hir_types: HashMap<HirId, TyId>,
 }
 
-const MAX_ITERS: usize = 10;
-
 /// Run type inference and stdlib-to-intrinsic rewriting on functionalized HIR.
 ///
 /// `Err` is the intrinsic operand proof obligation firing (see
@@ -60,80 +59,11 @@ pub fn infer_and_rewrite(
 ) -> Result<TypeInfo, String> {
     let interner = TypeInterner::new();
 
-    let mut binding_types: HashMap<Binding, TyId> = HashMap::new();
-    let mut hir_types: HashMap<HirId, TyId> = HashMap::new();
-    let mut binding_min_length: HashMap<Binding, usize> = HashMap::new();
-
-    // Collect parameter info for lambdas: which bindings are params of which lambda
-    let mut lambda_params: HashMap<Binding, Vec<Binding>> = HashMap::new();
-    let mut lambda_body_type: HashMap<Binding, TyId> = HashMap::new();
-    collect_lambda_info(hir, arena, &mut lambda_params);
-    // A parameter mutated in its body has flow the per-pass recomputation
-    // cannot see; it never receives call-site proofs (guards only).
-    let mutated_params = collect_mutated_bindings(hir);
-    // Bindings read anywhere but callee position — their param joins are
-    // not proofs (see `collect_value_position_uses`).
-    let mut value_used = std::collections::HashSet::new();
-    collect_value_position_uses(hir, &mut value_used);
-    // Immutable let-bound aliases of `(type-of a)` → subject `a`, so the
-    // `(let [ta (type-of a)] (match ta …))` idiom narrows `a` like the inline
-    // dispatch (`collect_typeof_aliases`).
-    let mut typeof_aliases: HashMap<Binding, Binding> = HashMap::new();
-    collect_typeof_aliases(hir, arena, &mut typeof_aliases);
-    // Kleene start: every parameter that CAN be proven by complete call-site
-    // enumeration (callee-only binding, unmutated param) begins at BOTTOM, so
-    // an identity-passed argument in a self/mutual recursion contributes
-    // nothing on the way up instead of reading the Top default and pinning
-    // itself there. Parameters of value-used bindings stay ABSENT (read as
-    // Top): their callers are not enumerable, so optimism there would let the
-    // checker pass on ⊥. A never-called callee-only function's params stay ⊥
-    // — its %-sites can never execute, so nothing unsound compiles.
-    for (b, params) in &lambda_params {
-        if value_used.contains(b) {
-            continue;
-        }
-        for p in params {
-            if !mutated_params.contains(p) {
-                binding_types.insert(*p, TypeInterner::BOTTOM);
-            }
-        }
-    }
-
-    // Inference to a fixpoint. Convergence is judged on the whole type
-    // environment, not the root node's type: a call site visited late in a
-    // pass joins into a callee parameter whose occurrences were recorded
-    // earlier, so the refinement only reaches them on the next pass.
-    for _ in 0..MAX_ITERS {
-        let before_hir = hir_types.clone();
-        let before_bindings = binding_types.clone();
-        let mut param_joins: HashMap<Binding, TyId> = HashMap::new();
-        infer_types(
-            hir,
-            &interner,
-            arena,
-            &mut binding_types,
-            &mut hir_types,
-            &lambda_params,
-            &mut lambda_body_type,
-            &mut binding_min_length,
-            &value_used,
-            &typeof_aliases,
-            &mut param_joins,
-        );
-        // REPLACE each contributed parameter's type with this pass's complete
-        // join (Top included). A `(numeric!)` declaration floors the result at
-        // Number (meet: callers can refine to Int/Float, never widen past the
-        // declared contract); a mutated parameter never receives proofs.
-        for (param, joined) in param_joins {
-            if mutated_params.contains(&param) {
-                continue;
-            }
-            binding_types.insert(param, declared_floor(param, joined, arena, &interner));
-        }
-        if before_hir == hir_types && before_bindings == binding_types {
-            break;
-        }
-    }
+    // The ascent (docs/impl/typeinfer.md): one context collects the unit's
+    // program facts, then iterates the transfer function until the type
+    // environment stops moving.
+    let mut infer = Infer::new(hir, arena);
+    infer.solve(hir);
 
     // Collapse container-dispatch wrapper calls (`(put s :x j)` with `s` a proven
     // concrete container → `(%put-struct-mut s :x j)`) so the multi-arm dispatch and
@@ -143,23 +73,31 @@ pub fn infer_and_rewrite(
     // selected it.
     monomorphize::monomorphize_dispatch_wrappers(
         hir,
-        &hir_types,
+        &infer.hir_types,
         arena,
-        &typeof_aliases,
+        &infer.typeof_aliases,
         dispatch_wrappers,
     );
 
     // The prove-or-reject gate: every call-position %-intrinsic must discharge
     // its operand contract from the (narrowed, per-occurrence) inferred types.
-    contract::check_intrinsic_operand_proofs(hir, &hir_types, arena)?;
+    contract::check_intrinsic_operand_proofs(hir, &infer.hir_types, arena)?;
 
     // Signal narrowing: strip SIG_ERROR from calls with provably typed args
-    super::narrow::narrow_signals(hir, &interner, arena, &hir_types, &binding_min_length);
+    super::narrow::narrow_signals(
+        hir,
+        &interner,
+        arena,
+        &infer.hir_types,
+        &infer.binding_min_length,
+    );
 
     // Signal re-propagation: recompute parent signals bottom-up
     super::narrow::repropagate_signals(hir);
 
-    Ok(TypeInfo { hir_types })
+    Ok(TypeInfo {
+        hir_types: infer.hir_types,
+    })
 }
 
 /// Extract the binding from a callee expression.

--- a/src/hir/typeinfer/infer.rs
+++ b/src/hir/typeinfer/infer.rs
@@ -26,7 +26,7 @@ use std::collections::HashSet;
 
 mod collect;
 mod facts;
-mod fixpoint;
+pub(in crate::hir::typeinfer) mod fixpoint;
 mod node;
 mod subject;
 

--- a/src/hir/typeinfer/infer.rs
+++ b/src/hir/typeinfer/infer.rs
@@ -1,9 +1,17 @@
-//! Forward type-inference pass, split by concern:
+// audited: 2026-09-08
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! The inference pass and the environment it carries: one context owns every
+//! map a pass reads and rewrites, so each per-node rule names only what it uses.
 //!
-//! - `collect`  — the pre-passes that build the info maps `infer_node` reads
-//!   (lambda params, mutated bindings, value-position uses, `type-of` aliases).
-//! - `node`     — the fixpoint driver `infer_types` and the per-node `infer_node`
-//!   transfer function that is the heart of the pass.
+//! - `fixpoint` — the ascent: passes over the whole tree until the environment
+//!   stops moving (docs/impl/typeinfer.md).
+//! - `collect`  — the pre-passes that build the program facts `Infer::new`
+//!   reads (lambda params, mutated bindings, value-position uses, `type-of`
+//!   aliases).
+//! - `node`     — the per-node transfer function that is the heart of the pass,
+//!   with the binding forms in `node::binder`, the branching forms in
+//!   `node::branch`, and the call rules in `node::call`.
 //! - `subject`  — the `(type-of x)` scrutinee discrimination and the small
 //!   `Var`/ANF/keyword helpers that feed match-arm narrowing.
 //! - `facts`    — apply/restore of guard-derived narrowing facts on the binding
@@ -13,8 +21,12 @@
 //! `contract.rs` (`check_intrinsic_operand_proofs`) — the generalization of the
 //! monomorphic-container obligation to every %-intrinsic in call position.
 
+use super::*;
+use std::collections::HashSet;
+
 mod collect;
 mod facts;
+mod fixpoint;
 mod node;
 mod subject;
 
@@ -23,5 +35,95 @@ mod subject;
 // parent's `use infer::*` and prune.rs's `super::infer::{…}` both depend on it.
 pub(super) use collect::*;
 pub(super) use facts::*;
-pub(super) use node::*;
 pub(super) use subject::*;
+
+/// The inference pass: the program facts one compilation unit yields, and the
+/// type environment the ascent rewrites over them.
+pub(super) struct Infer<'a> {
+    /// The lattice. Owned, so a per-node rule joins without being handed one.
+    interner: TypeInterner,
+    arena: &'a BindingArena,
+
+    // ── the program's facts: collected once, never rewritten ──
+    /// Which bindings are lambdas, and what their parameters are.
+    lambda_params: HashMap<Binding, Vec<Binding>>,
+    /// Bindings written by `Assign`/`SetCell`. A parameter in this set has flow
+    /// the per-pass recomputation cannot see, so it never receives call-site
+    /// proofs (guards only).
+    mutated_params: HashSet<Binding>,
+    /// Bindings with at least one value-position use
+    /// (`collect_value_position_uses`): their callers are not all visible, so
+    /// call-site joins must not prove their parameters.
+    value_used: HashSet<Binding>,
+    /// Immutable let-bound aliases of `(type-of a)`, mapped to their subject
+    /// `a` (`collect_typeof_aliases`), so a match on such an alias narrows `a`.
+    pub(super) typeof_aliases: HashMap<Binding, Binding>,
+
+    // ── the environment: what a pass reads, and what it leaves behind ──
+    binding_types: HashMap<Binding, TyId>,
+    pub(super) hir_types: HashMap<HirId, TyId>,
+    /// Each lambda binding's body type, as the last pass computed it. Every
+    /// call reads its result here, a self-recursive call included.
+    lambda_body_type: HashMap<Binding, TyId>,
+    pub(super) binding_min_length: HashMap<Binding, usize>,
+    /// This pass's call-site contributions to parameter types. RECOMPUTED per
+    /// pass (the ascent replaces each contributed parameter's binding type
+    /// wholesale at pass end): a join that only ever accumulates can never come
+    /// back down, so unknown-typed call sites would have to be skipped — and a
+    /// skipped unknown is exactly the unsound "typed callers alone prove the
+    /// parameter" hole. Here Top contributes honestly.
+    param_joins: HashMap<Binding, TyId>,
+    /// The letrec lambdas whose own bodies are currently being walked, so a
+    /// binder knows which body it is inside. A traversal stack, not
+    /// environment: it is empty at the start and end of every pass.
+    selfrec: Vec<Binding>,
+}
+
+impl<'a> Infer<'a> {
+    /// Collect one unit's program facts and seed the ascent's start.
+    pub(super) fn new(hir: &Hir, arena: &'a BindingArena) -> Self {
+        let mut lambda_params: HashMap<Binding, Vec<Binding>> = HashMap::new();
+        collect_lambda_info(hir, arena, &mut lambda_params);
+        let mutated_params = collect_mutated_bindings(hir);
+        let mut value_used = HashSet::new();
+        collect_value_position_uses(hir, &mut value_used);
+        let mut typeof_aliases: HashMap<Binding, Binding> = HashMap::new();
+        collect_typeof_aliases(hir, arena, &mut typeof_aliases);
+
+        // Kleene start: every parameter that CAN be proven by complete
+        // call-site enumeration (callee-only binding, unmutated param) begins
+        // at BOTTOM, so an identity-passed argument in a self/mutual recursion
+        // contributes nothing on the way up instead of reading the Top default
+        // and pinning itself there. Parameters of value-used bindings stay
+        // ABSENT (read as Top): their callers are not enumerable, so optimism
+        // there would let the checker pass on ⊥. A never-called callee-only
+        // function's params stay ⊥ — its %-sites can never execute, so nothing
+        // unsound compiles.
+        let mut binding_types: HashMap<Binding, TyId> = HashMap::new();
+        for (b, params) in &lambda_params {
+            if value_used.contains(b) {
+                continue;
+            }
+            for p in params {
+                if !mutated_params.contains(p) {
+                    binding_types.insert(*p, TypeInterner::BOTTOM);
+                }
+            }
+        }
+
+        Infer {
+            interner: TypeInterner::new(),
+            arena,
+            lambda_params,
+            mutated_params,
+            value_used,
+            typeof_aliases,
+            binding_types,
+            hir_types: HashMap::new(),
+            lambda_body_type: HashMap::new(),
+            binding_min_length: HashMap::new(),
+            param_joins: HashMap::new(),
+            selfrec: Vec::new(),
+        }
+    }
+}

--- a/src/hir/typeinfer/infer.rs
+++ b/src/hir/typeinfer/infer.rs
@@ -73,10 +73,10 @@ pub(super) struct Infer<'a> {
     /// skipped unknown is exactly the unsound "typed callers alone prove the
     /// parameter" hole. Here Top contributes honestly.
     param_joins: HashMap<Binding, TyId>,
-    /// The letrec lambdas whose own bodies are currently being walked, so a
-    /// binder knows which body it is inside. A traversal stack, not
-    /// environment: it is empty at the start and end of every pass.
-    selfrec: Vec<Binding>,
+    /// The entries the ascent gave up on: an estimate still moving when the
+    /// pass budget ran out is held at Top for the rest of the run, so nothing
+    /// reads a proof out of it (`fixpoint.rs`).
+    widened: HashSet<Binding>,
 }
 
 impl<'a> Infer<'a> {
@@ -123,7 +123,7 @@ impl<'a> Infer<'a> {
             lambda_body_type: HashMap::new(),
             binding_min_length: HashMap::new(),
             param_joins: HashMap::new(),
-            selfrec: Vec::new(),
+            widened: HashSet::new(),
         }
     }
 }

--- a/src/hir/typeinfer/infer.rs
+++ b/src/hir/typeinfer/infer.rs
@@ -2,7 +2,7 @@
 // src/hir/AGENTS.md
 // docs/impl/typeinfer.md
 //! The inference pass and the environment it carries: one context owns every
-//! map a pass reads and rewrites, so each per-node rule names only what it uses.
+//! map a pass reads and rewrites. Each per-node rule names only what it uses.
 //!
 //! - `fixpoint` — the ascent: passes over the whole tree until the environment
 //!   stops moving (docs/impl/typeinfer.md).

--- a/src/hir/typeinfer/infer/collect.rs
+++ b/src/hir/typeinfer/infer/collect.rs
@@ -1,4 +1,9 @@
-use super::super::*;
+// audited: 2026-09-08
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! The pre-passes: the program facts one walk of the tree yields, which every
+//! later pass reads without recomputing them.
+
 use super::*;
 
 /// A binding initializer with any capture-cell wrapper peeled off: a

--- a/src/hir/typeinfer/infer/fixpoint.rs
+++ b/src/hir/typeinfer/infer/fixpoint.rs
@@ -8,7 +8,7 @@ use super::*;
 
 /// How many passes one ascent may take. Information travels one call at a time
 /// in walk order, so the count a program needs is the depth of its call chains
-/// rather than their size; the whole corpus settles in five or fewer.
+/// rather than their size; the whole corpus settles in six or fewer.
 pub(in crate::hir::typeinfer) const MAX_ITERS: usize = 10;
 
 impl Infer<'_> {

--- a/src/hir/typeinfer/infer/fixpoint.rs
+++ b/src/hir/typeinfer/infer/fixpoint.rs
@@ -9,7 +9,7 @@ use super::*;
 /// How many passes one ascent may take. Information travels one call at a time
 /// in walk order, so the count a program needs is the depth of its call chains
 /// rather than their size; the whole corpus settles in five or fewer.
-const MAX_ITERS: usize = 10;
+pub(in crate::hir::typeinfer) const MAX_ITERS: usize = 10;
 
 impl Infer<'_> {
     /// Run the transfer function over `hir` until the environment stops moving.

--- a/src/hir/typeinfer/infer/fixpoint.rs
+++ b/src/hir/typeinfer/infer/fixpoint.rs
@@ -12,21 +12,72 @@ use super::*;
 pub(in crate::hir::typeinfer) const MAX_ITERS: usize = 10;
 
 impl Infer<'_> {
-    /// Run the transfer function over `hir` until the environment stops moving.
+    /// Run the transfer function over `hir` until the environment stops moving,
+    /// widening whatever is still moving when the budget runs out.
+    pub(in crate::hir::typeinfer) fn solve(&mut self, hir: &Hir) {
+        while let Some(moving) = self.ascend(hir) {
+            // A round that pins nothing new has pinned everything there is, so
+            // the environment is already Top throughout and proves nothing.
+            // Stopping there is what bounds the widening.
+            if !self.widen(moving) {
+                return;
+            }
+        }
+    }
+
+    /// Passes until the environment settles or the budget runs out. `None` is
+    /// convergence; `Some` names every binding the last pass was still moving.
     ///
     /// Convergence is judged on the whole type environment, not the root node's
     /// type: a call site visited late in a pass joins into a callee parameter
     /// whose occurrences were recorded earlier, so the refinement only reaches
     /// them on the next pass.
-    pub(in crate::hir::typeinfer) fn solve(&mut self, hir: &Hir) {
+    fn ascend(&mut self, hir: &Hir) -> Option<Vec<Binding>> {
+        let mut moving = Vec::new();
         for _ in 0..MAX_ITERS {
             let before_hir = self.hir_types.clone();
             let before_bindings = self.binding_types.clone();
+            let before_bodies = self.lambda_body_type.clone();
             self.pass(hir);
-            if before_hir == self.hir_types && before_bindings == self.binding_types {
-                return;
+            if before_hir == self.hir_types
+                && before_bindings == self.binding_types
+                && before_bodies == self.lambda_body_type
+            {
+                return None;
             }
+            moving = moved(&before_bindings, &self.binding_types)
+                .chain(moved(&before_bodies, &self.lambda_body_type))
+                .collect();
         }
+        Some(moving)
+    }
+
+    /// Hold every entry the last pass was still moving at Top, and report
+    /// whether that pinned anything new.
+    ///
+    /// An ascent that ran out of budget left the environment BELOW the least
+    /// fixpoint, which is the side that proves things that are not true: an
+    /// entry still at Bottom discharges every subtype contract that asks about
+    /// it. Top is above the fixpoint, so a pinned entry proves nothing. Pinning
+    /// also freezes the entry, so each round pins strictly more than the last
+    /// and the widening terminates.
+    fn widen(&mut self, moving: Vec<Binding>) -> bool {
+        let before = self.widened.len();
+        self.widened.extend(moving);
+        if self.widened.len() == before {
+            // Nothing a binding carries moved, so the movement is in the node
+            // types alone. Hold the whole environment at Top: a pass over a
+            // frozen environment is a function of the tree alone, so the pass
+            // after it changes nothing.
+            let all: Vec<Binding> = self
+                .binding_types
+                .keys()
+                .chain(self.lambda_body_type.keys())
+                .copied()
+                .collect();
+            self.widened.extend(all);
+        }
+        self.widened.len() > before
     }
 
     /// One pass: infer every node from the environment the last pass left, then
@@ -36,7 +87,6 @@ impl Infer<'_> {
     /// contract); a mutated parameter never receives proofs.
     fn pass(&mut self, hir: &Hir) {
         self.param_joins.clear();
-        self.selfrec.clear();
         let ty = self.infer(hir);
         self.hir_types.insert(hir.id, ty);
         for (param, joined) in std::mem::take(&mut self.param_joins) {
@@ -46,5 +96,26 @@ impl Infer<'_> {
             let floored = declared_floor(param, joined, self.arena, &self.interner);
             self.binding_types.insert(param, floored);
         }
+        // Anything widened is held at Top for the rest of the ascent, over
+        // whatever this pass computed for it.
+        for b in &self.widened {
+            self.binding_types.insert(*b, TypeInterner::TOP);
+            if self.lambda_params.contains_key(b) {
+                self.lambda_body_type.insert(*b, TypeInterner::TOP);
+            }
+        }
     }
+}
+
+/// The keys whose type differs between two snapshots of one map. An entry is
+/// only ever inserted or refined, so a key the later snapshot lacks is not a
+/// move.
+fn moved<'m>(
+    before: &'m HashMap<Binding, TyId>,
+    after: &'m HashMap<Binding, TyId>,
+) -> impl Iterator<Item = Binding> + 'm {
+    after
+        .iter()
+        .filter(|(b, ty)| before.get(*b) != Some(*ty))
+        .map(|(b, _)| *b)
 }

--- a/src/hir/typeinfer/infer/fixpoint.rs
+++ b/src/hir/typeinfer/infer/fixpoint.rs
@@ -1,0 +1,50 @@
+// audited: 2026-09-08
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! The ascent: passes over the whole tree until the type environment stops
+//! moving, each one reading strictly more than the last.
+
+use super::*;
+
+/// How many passes one ascent may take. Information travels one call at a time
+/// in walk order, so the count a program needs is the depth of its call chains
+/// rather than their size; the whole corpus settles in five or fewer.
+const MAX_ITERS: usize = 10;
+
+impl Infer<'_> {
+    /// Run the transfer function over `hir` until the environment stops moving.
+    ///
+    /// Convergence is judged on the whole type environment, not the root node's
+    /// type: a call site visited late in a pass joins into a callee parameter
+    /// whose occurrences were recorded earlier, so the refinement only reaches
+    /// them on the next pass.
+    pub(in crate::hir::typeinfer) fn solve(&mut self, hir: &Hir) {
+        for _ in 0..MAX_ITERS {
+            let before_hir = self.hir_types.clone();
+            let before_bindings = self.binding_types.clone();
+            self.pass(hir);
+            if before_hir == self.hir_types && before_bindings == self.binding_types {
+                return;
+            }
+        }
+    }
+
+    /// One pass: infer every node from the environment the last pass left, then
+    /// REPLACE each contributed parameter's type with this pass's complete join
+    /// (Top included). A `(numeric!)` declaration floors the result at Number
+    /// (meet: callers can refine to Int/Float, never widen past the declared
+    /// contract); a mutated parameter never receives proofs.
+    fn pass(&mut self, hir: &Hir) {
+        self.param_joins.clear();
+        self.selfrec.clear();
+        let ty = self.infer(hir);
+        self.hir_types.insert(hir.id, ty);
+        for (param, joined) in std::mem::take(&mut self.param_joins) {
+            if self.mutated_params.contains(&param) {
+                continue;
+            }
+            let floored = declared_floor(param, joined, self.arena, &self.interner);
+            self.binding_types.insert(param, floored);
+        }
+    }
+}

--- a/src/hir/typeinfer/infer/node.rs
+++ b/src/hir/typeinfer/infer/node.rs
@@ -1,576 +1,144 @@
-use super::super::*;
+// audited: 2026-09-08
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! The transfer function: one node's type, given the environment the ascent has
+//! built so far. The binding forms, the branching forms and the call rules are
+//! each a submodule; what stays here is the dispatch and the leaves.
+
 use super::*;
 
-/// Forward type inference pass. Returns true if any types changed.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn infer_types(
-    hir: &Hir,
-    interner: &TypeInterner,
-    arena: &BindingArena,
-    binding_types: &mut HashMap<Binding, TyId>,
-    hir_types: &mut HashMap<HirId, TyId>,
-    lambda_params: &HashMap<Binding, Vec<Binding>>,
-    lambda_body_type: &mut HashMap<Binding, TyId>,
-    binding_min_length: &mut HashMap<Binding, usize>,
-    value_used: &std::collections::HashSet<Binding>,
-    typeof_aliases: &HashMap<Binding, Binding>,
-    param_joins: &mut HashMap<Binding, TyId>,
-) -> bool {
-    let ty = infer_node(
-        hir,
-        interner,
-        arena,
-        binding_types,
-        hir_types,
-        lambda_params,
-        lambda_body_type,
-        binding_min_length,
-        &mut Vec::new(),
-        value_used,
-        typeof_aliases,
-        param_joins,
-    );
-    let old = hir_types.insert(hir.id, ty);
-    old != Some(ty)
-}
+mod binder;
+mod branch;
+mod call;
 
-/// Infer the type of a single HIR node.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn infer_node(
-    hir: &Hir,
-    interner: &TypeInterner,
-    arena: &BindingArena,
-    binding_types: &mut HashMap<Binding, TyId>,
-    hir_types: &mut HashMap<HirId, TyId>,
-    lambda_params: &HashMap<Binding, Vec<Binding>>,
-    lambda_body_type: &mut HashMap<Binding, TyId>,
-    binding_min_length: &mut HashMap<Binding, usize>,
-    // The letrec lambdas whose own bodies are currently being inferred. A
-    // call to one of these from within its own body contributes BOTTOM to
-    // the type flow (the recursive contribution to a return-type join is
-    // exactly the base cases — Kleene iteration from below), which is what
-    // keeps a self-recursive body from poisoning itself with Top before any
-    // call site has forwarded its parameter types.
-    selfrec: &mut Vec<Binding>,
-    // Bindings with at least one value-position use (`collect_value_position_uses`):
-    // their callers are not all visible, so call-site joins must not prove
-    // their parameters.
-    value_used: &std::collections::HashSet<Binding>,
-    // Immutable let-bound aliases of `(type-of a)`, mapped to their subject `a`
-    // (`collect_typeof_aliases`), so a match on such an alias narrows `a`.
-    typeof_aliases: &HashMap<Binding, Binding>,
-    // This pass's call-site contributions to parameter types. RECOMPUTED per
-    // pass (the driver replaces each contributed parameter's binding type
-    // wholesale at pass end): a join that only ever accumulates can never
-    // come back down, so unknown-typed call sites would have to be skipped —
-    // and a skipped unknown is exactly the unsound "typed callers alone prove
-    // the parameter" hole. Here Top contributes honestly.
-    param_joins: &mut HashMap<Binding, TyId>,
-) -> TyId {
-    macro_rules! recurse {
-        ($e:expr) => {
-            infer_node(
-                $e,
-                interner,
-                arena,
-                binding_types,
-                hir_types,
-                lambda_params,
-                lambda_body_type,
-                binding_min_length,
-                selfrec,
-                value_used,
-                typeof_aliases,
-                param_joins,
-            )
-        };
-    }
+impl Infer<'_> {
+    /// Infer the type of a single HIR node.
+    pub(super) fn infer(&mut self, hir: &Hir) -> TyId {
+        match &hir.kind {
+            // Literals
+            HirKind::Nil => TypeInterner::NIL,
+            HirKind::Bool(_) => TypeInterner::BOOL,
+            HirKind::Int(_) => TypeInterner::INT,
+            HirKind::Float(_) => TypeInterner::FLOAT,
+            HirKind::String(_) => TypeInterner::STRING,
+            HirKind::Keyword(_) => TypeInterner::KEYWORD,
+            HirKind::EmptyList => TypeInterner::EMPTY_LIST,
 
-    match &hir.kind {
-        // Literals
-        HirKind::Nil => TypeInterner::NIL,
-        HirKind::Bool(_) => TypeInterner::BOOL,
-        HirKind::Int(_) => TypeInterner::INT,
-        HirKind::Float(_) => TypeInterner::FLOAT,
-        HirKind::String(_) => TypeInterner::STRING,
-        HirKind::Keyword(_) => TypeInterner::KEYWORD,
-        HirKind::EmptyList => TypeInterner::EMPTY_LIST,
-
-        // Variable reference
-        HirKind::Var(binding) => binding_types
-            .get(binding)
-            .copied()
-            .unwrap_or(TypeInterner::TOP),
-
-        // Intrinsic operations — known return types
-        HirKind::Intrinsic { op, args } => {
-            for arg in args {
-                let ty = recurse!(arg);
-                hir_types.insert(arg.id, ty);
-            }
-            intrinsic_return_type(*op, args, interner, hir_types)
-        }
-
-        // Let/Letrec — seed binding types from init values
-        HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
-            for (binding, init) in bindings {
-                let is_lambda_init = matches!(&unwrap_make_cell(init).kind, HirKind::Lambda { .. });
-                if is_lambda_init {
-                    selfrec.push(*binding);
-                }
-                let ty = recurse!(init);
-                if is_lambda_init {
-                    selfrec.pop();
-                }
-                hir_types.insert(init.id, ty);
-                // For lambda bindings (possibly cell-wrapped when
-                // self-recursive/captured), track their body's return type.
-                // REPLACE, don't join: on the first pass a self-recursive
-                // body reads its own parameters before any call site has
-                // forwarded them, so it computes Top — and a join can never
-                // come back down from Top on the later passes that know
-                // better. Each pass re-derives the body type from strictly
-                // more information; the last pass's value is the answer.
-                if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(init).kind {
-                    let body_ty = hir_types
-                        .get(&lam_body.id)
-                        .copied()
-                        .unwrap_or(TypeInterner::TOP);
-                    lambda_body_type.insert(*binding, body_ty);
-                } else {
-                    let old = binding_types
-                        .get(binding)
-                        .copied()
-                        .unwrap_or(TypeInterner::BOTTOM);
-                    let joined = interner.join(old, ty);
-                    // A `(numeric!)`-declared binding keeps its floor here: this is
-                    // the form a kernel parameter takes once HOF fusion has spliced
-                    // its body into a loop (`(let [x (get coll i)] BODY)`), where
-                    // the init's own type carries no proof.
-                    binding_types
-                        .insert(*binding, declared_floor(*binding, joined, arena, interner));
-                    // Track min_length for array constructor bindings
-                    if ty == TypeInterner::MUTABLE_ARRAY || ty == TypeInterner::ARRAY {
-                        if let Some(len) = unwrap_to_call(init) {
-                            binding_min_length.insert(*binding, len);
-                        }
-                    }
-                }
-            }
-            let body_ty = recurse!(body);
-            hir_types.insert(body.id, body_ty);
-            body_ty
-        }
-
-        // Lambda — infer body type and track return type
-        HirKind::Lambda { params, body, .. } => {
-            // A `(numeric!)` declaration is the programmer's numeric contract for
-            // the whole body (the GPU-eligibility gate holds the lowered code to
-            // it), so it proves every parameter ⊑ Number for the operand contracts
-            // — the declared analog of a call-site join. It is read from the
-            // parameter bindings, the single place it is recorded. An undeclared
-            // parameter is left ALONE — absence from the environment is meaningful
-            // (the driver's Kleene start: an unproven parameter reads as Top, a
-            // provable one is seeded at Bottom).
-            for p in params.iter().filter(|p| arena.get(**p).declared_numeric) {
-                let old = binding_types.get(p).copied().unwrap_or(TypeInterner::TOP);
-                binding_types.insert(*p, declared_floor(*p, old, arena, interner));
-            }
-            let body_ty = recurse!(body);
-            hir_types.insert(body.id, body_ty);
-            // We return Top for the lambda value itself — it's a closure
-            TypeInterner::TOP
-        }
-
-        // If — join branches, with guard narrowing on both sides: the
-        // then-branch gets the condition's truthy facts (`(%int? x)` refines
-        // x to Int), the else-branch its falsy facts (`(%not (number? b))`
-        // false means b IS a number). `meet` because a predicate refines a
-        // union (`Number ∧ Int = Int`) rather than fully determining the type
-        // (contrast the authoritative `match (type-of x)` override below).
-        HirKind::If {
-            cond,
-            then_branch,
-            else_branch,
-        } => {
-            let _cond_ty = recurse!(cond);
-            hir_types.insert(cond.id, _cond_ty);
-
-            let facts = super::super::guard::cond_facts(cond, arena);
-
-            let saved = apply_type_facts(&facts.when_true, binding_types, interner);
-            let then_ty = recurse!(then_branch);
-            hir_types.insert(then_branch.id, then_ty);
-            restore_type_facts(saved, binding_types);
-
-            let saved = apply_type_facts(&facts.when_false, binding_types, interner);
-            let else_ty = recurse!(else_branch);
-            hir_types.insert(else_branch.id, else_ty);
-            restore_type_facts(saved, binding_types);
-
-            interner.join(then_ty, else_ty)
-        }
-
-        // Match — the type-discriminating sibling of `If`. When the scrutinee is
-        // `(type-of <var>)`, a keyword-literal arm (`:@array`/`:@struct`/…) proves
-        // <var>'s concrete type+mutability inside that arm's body — the static
-        // proof a monomorphic data op (`%push-array-mut`, …) needs to lower as a
-        // silent opcode (pinned by the `match_typeof_narrows_*` tests). Children are
-        // visited exactly as `for_each_child` (value, then each guard+body); the
-        // narrowing is saved/restored per arm so it never leaks to a sibling — the
-        // same discipline as the `If` then/else branches above. The Match node's
-        // own type is the join of its arm bodies: a type-dispatch helper that
-        // returns the same type from every arm (the stdlib `compare`'s `rank`,
-        // all-Int) carries that type to its callers, which is what proves the
-        // downstream intrinsic operands.
-        HirKind::Match { value, arms } => {
-            let val_ty = recurse!(value);
-            hir_types.insert(value.id, val_ty);
-
-            let subject = typeof_subject_binding(value, arena, typeof_aliases);
-            let mut arm_join = TypeInterner::BOTTOM;
-            for (pat, guard, body) in arms {
-                if let Some(g) = guard {
-                    let g_ty = recurse!(g);
-                    hir_types.insert(g.id, g_ty);
-                }
-                // Narrow the scrutinee's binding to the arm's proven container
-                // type for the duration of the body, then restore. The narrowing
-                // **overrides** the binding's accumulated type rather than `meet`ing
-                // with it: a `(type-of x)` arm is *authoritative* — the runtime
-                // dispatch guarantees `x`'s concrete type whenever the arm runs, so
-                // within the body `x` simply IS the arm's keyword type, regardless of
-                // what the forward flow widened the binding to across all call sites.
-                // `meet` would be wrong here: if the binding accumulated a *disjoint*
-                // concrete type (a parameter called elsewhere with a different
-                // container — exactly the stdlib `push`/`put` shape), `meet` collapses
-                // to `Bottom`, leaving an immutable-arm container "unproven" and its
-                // silent monomorphic op a spurious compile error on an arm that only
-                // ever runs for that very type (pinned by
-                // `match_typeof_arm_narrows_authoritatively_over_a_called_param`). This
-                // differs from the `If` type-guard above, which `meet`s because a
-                // predicate like `(%int? x)` *refines* a union (`Number ∧ Int = Int`)
-                // rather than fully determining the type. Override is sound because
-                // the container keyword types are flat — the keyword is the most
-                // precise type, never a supertype of the accumulated one.
-                let saved = subject
-                    .zip(pattern_type_keyword(pat))
-                    .map(|(b, narrow_ty)| {
-                        let prev = binding_types.get(&b).copied();
-                        binding_types.insert(b, narrow_ty);
-                        (b, prev)
-                    });
-                let body_ty = recurse!(body);
-                hir_types.insert(body.id, body_ty);
-                arm_join = interner.join(arm_join, body_ty);
-                if let Some((b, prev)) = saved {
-                    match prev {
-                        Some(t) => {
-                            binding_types.insert(b, t);
-                        }
-                        None => {
-                            binding_types.remove(&b);
-                        }
-                    }
-                }
-            }
-            if arms.is_empty() {
-                TypeInterner::TOP
-            } else {
-                arm_join
-            }
-        }
-
-        // Call — forward arg types to callee params; result = callee return type
-        HirKind::Call { func, args, .. } => {
-            let _func_ty = recurse!(func);
-            hir_types.insert(func.id, _func_ty);
-
-            let arg_types: Vec<TyId> = args
-                .iter()
-                .map(|a| {
-                    let ty = recurse!(&a.expr);
-                    hir_types.insert(a.expr.id, ty);
-                    ty
-                })
-                .collect();
-
-            // Forward arg types to callee params.
-            // Handle both Var(b) and DerefCell { Var(b) } (letrec recursive calls).
-            // Forwarding is a complete proof only for a callee used EXCLUSIVELY
-            // in call position — a single value-position use (stored, passed,
-            // returned, exported) means invisible callers exist, so the joins
-            // must not prove its parameters.
-            let callee_binding = unwrap_callee_binding(func);
-            if let Some(callee_binding) = callee_binding {
-                if let Some(params) = lambda_params
-                    .get(&callee_binding)
-                    .filter(|_| !value_used.contains(&callee_binding))
-                {
-                    for (i, param) in params.iter().enumerate() {
-                        if let Some(&arg_ty) = arg_types.get(i) {
-                            // Top contributes honestly: an unknown-typed call
-                            // site makes the parameter unprovable (the driver
-                            // REPLACES the binding type from this map at pass
-                            // end, so recursion converges from below instead
-                            // of needing a Top skip).
-                            let old = param_joins
-                                .get(param)
-                                .copied()
-                                .unwrap_or(TypeInterner::BOTTOM);
-                            param_joins.insert(*param, interner.join(old, arg_ty));
-                        }
-                    }
-                }
-                // A call to a lambda whose own body is being inferred (a
-                // recursive call) contributes BOTTOM — the recursive
-                // contribution to a return-type join is exactly the base
-                // cases (Kleene iteration from below). It must NOT read the
-                // running estimate: on the first pass that is Top (the body
-                // was walked before any call site forwarded its parameters),
-                // and Top can never come back down through a join. Argument
-                // forwarding above still runs — a self-call is usually the
-                // sole source of its own parameters' step types.
-                if selfrec.contains(&callee_binding) {
-                    return TypeInterner::BOTTOM;
-                }
-                // Return type = whatever the callee's body returns.
-                // Only use BOTTOM for known lambdas (in lambda_params) where the
-                // body type hasn't been computed yet. For unknown callees (primitives,
-                // imports), return TOP to avoid unsound rewrites.
-                if lambda_params.contains_key(&callee_binding) {
-                    let ret_ty = lambda_body_type
-                        .get(&callee_binding)
-                        .copied()
-                        .unwrap_or(TypeInterner::BOTTOM);
-                    return ret_ty;
-                }
-
-                // Primitive return type inference for unresolved callees
-                let callee_sym = arena.get(callee_binding).name;
-                let prim_ty = primitive_return_type(callee_sym, &arg_types, interner);
-                if prim_ty != TypeInterner::TOP {
-                    return prim_ty;
-                }
-            }
-
-            TypeInterner::TOP
-        }
-
-        // Begin/Block — type is last expression. Flow-through guard
-        // narrowing: a one-armed diverging guard statement —
-        // `(when (%not (number? b)) (error …))` — proves its fall-through
-        // facts for every statement after it (the stdlib wrapper shape: the
-        // guard that raises the wrapper's :error is the same fact that
-        // discharges the intrinsic's contract downstream). Facts are scoped
-        // to the sequence and restored on exit.
-        HirKind::Begin(exprs) => {
-            let mut ty = TypeInterner::NIL;
-            let mut saved = Vec::new();
-            for expr in exprs {
-                ty = recurse!(expr);
-                hir_types.insert(expr.id, ty);
-                let facts = super::super::guard::facts_after_statement(expr, arena);
-                saved.extend(apply_type_facts(&facts, binding_types, interner));
-            }
-            restore_type_facts(saved, binding_types);
-            ty
-        }
-        HirKind::Block { body, .. } => {
-            let mut ty = TypeInterner::NIL;
-            let mut saved = Vec::new();
-            for expr in body {
-                ty = recurse!(expr);
-                hir_types.insert(expr.id, ty);
-                let facts = super::super::guard::facts_after_statement(expr, arena);
-                saved.extend(apply_type_facts(&facts, binding_types, interner));
-            }
-            restore_type_facts(saved, binding_types);
-            ty
-        }
-
-        // Cond — sequential If chain: each clause body gets its test's truthy
-        // facts; each later clause (and the else) additionally knows every
-        // earlier test was falsy. Result is the join of all bodies.
-        HirKind::Cond {
-            clauses,
-            else_branch,
-        } => {
-            let mut ty = TypeInterner::BOTTOM;
-            let mut fallthrough_saved = Vec::new();
-            for (test, body) in clauses {
-                let test_ty = recurse!(test);
-                hir_types.insert(test.id, test_ty);
-                let facts = super::super::guard::cond_facts(test, arena);
-                let saved = apply_type_facts(&facts.when_true, binding_types, interner);
-                let body_ty = recurse!(body);
-                hir_types.insert(body.id, body_ty);
-                restore_type_facts(saved, binding_types);
-                ty = interner.join(ty, body_ty);
-                fallthrough_saved.extend(apply_type_facts(
-                    &facts.when_false,
-                    binding_types,
-                    interner,
-                ));
-            }
-            if let Some(els) = else_branch {
-                let else_ty = recurse!(els);
-                hir_types.insert(els.id, else_ty);
-                ty = interner.join(ty, else_ty);
-            }
-            restore_type_facts(fallthrough_saved, binding_types);
-            ty
-        }
-
-        // And/Or — conservative: Top
-        // `and`/`or` evaluate to one of their operands — `and` the first falsy
-        // (else the last), `or` the first truthy (else the last) — so the result
-        // type is the JOIN of the operand types, exactly as `If` joins its
-        // branches. Join is sound (a returned value is always ⊑ its operand's
-        // type) and lets a homogeneous `(or a b)`/`(and a b)` of proven numbers
-        // discharge a downstream `%`-intrinsic; a heterogeneous one widens and
-        // correctly fails to prove. (Empty `and`/`or` never reach here — the
-        // analyzer emits a Bool literal for them.)
-        HirKind::And(exprs) | HirKind::Or(exprs) => {
-            let mut join = TypeInterner::BOTTOM;
-            for child in exprs {
-                let ty = recurse!(child);
-                hir_types.insert(child.id, ty);
-                join = interner.join(join, ty);
-            }
-            join
-        }
-
-        // Loop — recurse into body
-        HirKind::Loop { bindings, body } => {
-            for (binding, init) in bindings {
-                let ty = recurse!(init);
-                hir_types.insert(init.id, ty);
-                let old = binding_types
-                    .get(binding)
-                    .copied()
-                    .unwrap_or(TypeInterner::BOTTOM);
-                binding_types.insert(*binding, interner.join(old, ty));
-            }
-            let body_ty = recurse!(body);
-            hir_types.insert(body.id, body_ty);
-            body_ty
-        }
-
-        // Assign/Define — update binding type. A Define whose value is a
-        // lambda (the in-function `defn` idiom — a letrec*-semantics local)
-        // records its return type exactly like a Let/Letrec lambda binding,
-        // with the same selfrec discipline; `collect_lambda_info` records its
-        // params.
-        HirKind::Assign { target, value }
-        | HirKind::Define {
-            binding: target,
-            value,
-        } => {
-            let is_lambda_init = matches!(&unwrap_make_cell(value).kind, HirKind::Lambda { .. });
-            if is_lambda_init {
-                selfrec.push(*target);
-            }
-            let ty = recurse!(value);
-            if is_lambda_init {
-                selfrec.pop();
-                if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(value).kind {
-                    let body_ty = hir_types
-                        .get(&lam_body.id)
-                        .copied()
-                        .unwrap_or(TypeInterner::TOP);
-                    lambda_body_type.insert(*target, body_ty);
-                }
-            }
-            hir_types.insert(value.id, ty);
-            let old = binding_types
-                .get(target)
+            // Variable reference
+            HirKind::Var(binding) => self
+                .binding_types
+                .get(binding)
                 .copied()
-                .unwrap_or(TypeInterner::BOTTOM);
-            binding_types.insert(*target, interner.join(old, ty));
-            // Track min_length for array constructor bindings
-            if ty == TypeInterner::MUTABLE_ARRAY || ty == TypeInterner::ARRAY {
-                if let Some(call) = unwrap_to_call(value) {
-                    binding_min_length.insert(*target, call);
+                .unwrap_or(TypeInterner::TOP),
+
+            // Intrinsic operations — known return types
+            HirKind::Intrinsic { op, args } => {
+                for arg in args {
+                    let ty = self.infer(arg);
+                    self.hir_types.insert(arg.id, ty);
                 }
+                intrinsic_return_type(*op, args, &self.interner, &self.hir_types)
             }
-            ty
-        }
 
-        // Quoted compound data has the type its template's outermost node
-        // materializes to — a quoted proper list IS a pair chain, which is
-        // what proves `(%first '(a b c))`.
-        HirKind::QuoteConst(template) => {
-            use crate::value::ConstTemplate;
-            match template {
-                ConstTemplate::Pair(_, _) => TypeInterner::PAIR,
-                ConstTemplate::Array(_) => TypeInterner::ARRAY,
-                ConstTemplate::ArrayMut(_) => TypeInterner::MUTABLE_ARRAY,
-                ConstTemplate::String(_) => TypeInterner::STRING,
-                ConstTemplate::StringMut(_) => TypeInterner::MUTABLE_STRING,
-                ConstTemplate::EmptyList => TypeInterner::EMPTY_LIST,
-                ConstTemplate::Int(_) => TypeInterner::INT,
-                ConstTemplate::Float(_) => TypeInterner::FLOAT,
-                ConstTemplate::Bool(_) => TypeInterner::BOOL,
-                ConstTemplate::Keyword(_) => TypeInterner::KEYWORD,
-                ConstTemplate::Symbol(_) => TypeInterner::SYMBOL,
-                ConstTemplate::Nil => TypeInterner::NIL,
-                _ => TypeInterner::TOP,
+            // Binding forms — `binder.rs`
+            HirKind::Let { bindings, body } | HirKind::Letrec { bindings, body } => {
+                self.infer_let(bindings, body)
             }
-        }
+            HirKind::Assign { target, value }
+            | HirKind::Define {
+                binding: target,
+                value,
+            } => self.infer_define(*target, value),
+            HirKind::Loop { bindings, body } => self.infer_loop(bindings, body),
+            HirKind::MakeCell { value } => self.infer_make_cell(value),
+            HirKind::DerefCell { cell } => self.infer_deref_cell(cell),
+            HirKind::SetCell { cell, value } => self.infer_set_cell(cell, value),
 
-        // Return — the function-return ownership boundary is region-only and
-        // type-transparent: the result is the same value. Without this arm a
-        // lambda's body type (wrapped in Return by wrap_tail_returns) would
-        // read Top and no callee return type would ever flow to callers.
-        HirKind::Return { value } => {
-            let ty = recurse!(value);
-            hir_types.insert(value.id, ty);
-            ty
-        }
+            // Branching forms — `branch.rs`
+            HirKind::If {
+                cond,
+                then_branch,
+                else_branch,
+            } => self.infer_if(cond, then_branch, else_branch),
+            HirKind::Match { value, arms } => self.infer_match(value, arms),
+            HirKind::Cond {
+                clauses,
+                else_branch,
+            } => self.infer_cond(clauses, else_branch.as_deref()),
+            HirKind::Begin(exprs) => self.infer_sequence(exprs),
+            HirKind::Block { body, .. } => self.infer_sequence(body),
+            HirKind::And(exprs) | HirKind::Or(exprs) => self.infer_shortcircuit(exprs),
 
-        // MakeCell — propagate inner value type
-        HirKind::MakeCell { value } => {
-            let ty = recurse!(value);
-            hir_types.insert(value.id, ty);
-            ty
-        }
+            // Call — `call.rs`
+            HirKind::Call { func, args, .. } => self.infer_call(func, args),
 
-        // DerefCell — return binding type if cell is Var(b)
-        HirKind::DerefCell { cell } => {
-            let ty = recurse!(cell);
-            hir_types.insert(cell.id, ty);
-            if let HirKind::Var(b) = &cell.kind {
-                binding_types.get(b).copied().unwrap_or(TypeInterner::TOP)
-            } else {
+            // Lambda — infer body type; the lambda value itself is a closure
+            HirKind::Lambda { params, body, .. } => {
+                // A `(numeric!)` declaration is the programmer's numeric contract for
+                // the whole body (the GPU-eligibility gate holds the lowered code to
+                // it), so it proves every parameter ⊑ Number for the operand contracts
+                // — the declared analog of a call-site join. It is read from the
+                // parameter bindings, the single place it is recorded. An undeclared
+                // parameter is left ALONE — absence from the environment is meaningful
+                // (the ascent's Kleene start: an unproven parameter reads as Top, a
+                // provable one is seeded at Bottom).
+                for p in params
+                    .iter()
+                    .filter(|p| self.arena.get(**p).declared_numeric)
+                {
+                    let old = self
+                        .binding_types
+                        .get(p)
+                        .copied()
+                        .unwrap_or(TypeInterner::TOP);
+                    let floored = declared_floor(*p, old, self.arena, &self.interner);
+                    self.binding_types.insert(*p, floored);
+                }
+                let body_ty = self.infer(body);
+                self.hir_types.insert(body.id, body_ty);
                 TypeInterner::TOP
             }
-        }
 
-        // SetCell — widen binding type
-        HirKind::SetCell { cell, value } => {
-            let cell_ty = recurse!(cell);
-            hir_types.insert(cell.id, cell_ty);
-            let val_ty = recurse!(value);
-            hir_types.insert(value.id, val_ty);
-            // Widen the binding's type with the new value
-            if let HirKind::Var(b) = &cell.kind {
-                let old = binding_types
-                    .get(b)
-                    .copied()
-                    .unwrap_or(TypeInterner::BOTTOM);
-                binding_types.insert(*b, interner.join(old, val_ty));
+            // Return — the function-return ownership boundary is region-only and
+            // type-transparent: the result is the same value. Without this arm a
+            // lambda's body type (wrapped in Return by wrap_tail_returns) would
+            // read Top and no callee return type would ever flow to callers.
+            HirKind::Return { value } => {
+                let ty = self.infer(value);
+                self.hir_types.insert(value.id, ty);
+                ty
             }
-            val_ty
-        }
 
-        // Everything else — recurse and return Top
-        _ => {
-            hir.for_each_child(|child| {
-                let ty = recurse!(child);
-                hir_types.insert(child.id, ty);
-            });
-            TypeInterner::TOP
+            // Quoted compound data has the type its template's outermost node
+            // materializes to — a quoted proper list IS a pair chain, which is
+            // what proves `(%first '(a b c))`.
+            HirKind::QuoteConst(template) => {
+                use crate::value::ConstTemplate;
+                match template {
+                    ConstTemplate::Pair(_, _) => TypeInterner::PAIR,
+                    ConstTemplate::Array(_) => TypeInterner::ARRAY,
+                    ConstTemplate::ArrayMut(_) => TypeInterner::MUTABLE_ARRAY,
+                    ConstTemplate::String(_) => TypeInterner::STRING,
+                    ConstTemplate::StringMut(_) => TypeInterner::MUTABLE_STRING,
+                    ConstTemplate::EmptyList => TypeInterner::EMPTY_LIST,
+                    ConstTemplate::Int(_) => TypeInterner::INT,
+                    ConstTemplate::Float(_) => TypeInterner::FLOAT,
+                    ConstTemplate::Bool(_) => TypeInterner::BOOL,
+                    ConstTemplate::Keyword(_) => TypeInterner::KEYWORD,
+                    ConstTemplate::Symbol(_) => TypeInterner::SYMBOL,
+                    ConstTemplate::Nil => TypeInterner::NIL,
+                    _ => TypeInterner::TOP,
+                }
+            }
+
+            // Everything else — recurse and return Top
+            _ => {
+                hir.for_each_child(|child| {
+                    let ty = self.infer(child);
+                    self.hir_types.insert(child.id, ty);
+                });
+                TypeInterner::TOP
+            }
         }
     }
 }

--- a/src/hir/typeinfer/infer/node/binder.rs
+++ b/src/hir/typeinfer/infer/node/binder.rs
@@ -1,8 +1,9 @@
 // audited: 2026-09-08
 // src/hir/AGENTS.md
 // docs/impl/typeinfer.md
-//! What a binder records: the type a `let`, a `def`, a loop binding or a cell
-//! write leaves in the environment for every later read of that binding.
+//! What a binder records: the type a `let`, a `def` or a cell write leaves for
+//! every later read of that binding. A lambda init also records its body type,
+//! which is what the binding's callers read.
 
 use super::*;
 

--- a/src/hir/typeinfer/infer/node/binder.rs
+++ b/src/hir/typeinfer/infer/node/binder.rs
@@ -10,23 +10,15 @@ impl Infer<'_> {
     /// Let/Letrec — seed binding types from init values.
     pub(super) fn infer_let(&mut self, bindings: &[(Binding, Hir)], body: &Hir) -> TyId {
         for (binding, init) in bindings {
-            let is_lambda_init = matches!(&unwrap_make_cell(init).kind, HirKind::Lambda { .. });
-            if is_lambda_init {
-                self.selfrec.push(*binding);
-            }
             let ty = self.infer(init);
-            if is_lambda_init {
-                self.selfrec.pop();
-            }
             self.hir_types.insert(init.id, ty);
             // For lambda bindings (possibly cell-wrapped when
-            // self-recursive/captured), track their body's return type.
-            // REPLACE, don't join: on the first pass a self-recursive
-            // body reads its own parameters before any call site has
-            // forwarded them, so it computes Top — and a join can never
-            // come back down from Top on the later passes that know
-            // better. Each pass re-derives the body type from strictly
-            // more information; the last pass's value is the answer.
+            // self-recursive/captured), record their body's return type:
+            // this is what every call to the binding reads, a self-call
+            // included (docs/impl/typeinfer.md).
+            // REPLACE, don't join: each pass re-derives the body type from
+            // strictly more information, and a join could never come back
+            // down from the estimate an earlier pass computed with less.
             if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(init).kind {
                 let body_ty = self
                     .hir_types
@@ -62,25 +54,17 @@ impl Infer<'_> {
 
     /// Assign/Define — update binding type. A Define whose value is a
     /// lambda (the in-function `defn` idiom — a letrec*-semantics local)
-    /// records its return type exactly like a Let/Letrec lambda binding,
-    /// with the same selfrec discipline; `collect_lambda_info` records its
-    /// params.
+    /// records its return type exactly like a Let/Letrec lambda binding;
+    /// `collect_lambda_info` records its params.
     pub(super) fn infer_define(&mut self, target: Binding, value: &Hir) -> TyId {
-        let is_lambda_init = matches!(&unwrap_make_cell(value).kind, HirKind::Lambda { .. });
-        if is_lambda_init {
-            self.selfrec.push(target);
-        }
         let ty = self.infer(value);
-        if is_lambda_init {
-            self.selfrec.pop();
-            if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(value).kind {
-                let body_ty = self
-                    .hir_types
-                    .get(&lam_body.id)
-                    .copied()
-                    .unwrap_or(TypeInterner::TOP);
-                self.lambda_body_type.insert(target, body_ty);
-            }
+        if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(value).kind {
+            let body_ty = self
+                .hir_types
+                .get(&lam_body.id)
+                .copied()
+                .unwrap_or(TypeInterner::TOP);
+            self.lambda_body_type.insert(target, body_ty);
         }
         self.hir_types.insert(value.id, ty);
         let old = self

--- a/src/hir/typeinfer/infer/node/binder.rs
+++ b/src/hir/typeinfer/infer/node/binder.rs
@@ -1,0 +1,159 @@
+// audited: 2026-09-08
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! What a binder records: the type a `let`, a `def`, a loop binding or a cell
+//! write leaves in the environment for every later read of that binding.
+
+use super::*;
+
+impl Infer<'_> {
+    /// Let/Letrec — seed binding types from init values.
+    pub(super) fn infer_let(&mut self, bindings: &[(Binding, Hir)], body: &Hir) -> TyId {
+        for (binding, init) in bindings {
+            let is_lambda_init = matches!(&unwrap_make_cell(init).kind, HirKind::Lambda { .. });
+            if is_lambda_init {
+                self.selfrec.push(*binding);
+            }
+            let ty = self.infer(init);
+            if is_lambda_init {
+                self.selfrec.pop();
+            }
+            self.hir_types.insert(init.id, ty);
+            // For lambda bindings (possibly cell-wrapped when
+            // self-recursive/captured), track their body's return type.
+            // REPLACE, don't join: on the first pass a self-recursive
+            // body reads its own parameters before any call site has
+            // forwarded them, so it computes Top — and a join can never
+            // come back down from Top on the later passes that know
+            // better. Each pass re-derives the body type from strictly
+            // more information; the last pass's value is the answer.
+            if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(init).kind {
+                let body_ty = self
+                    .hir_types
+                    .get(&lam_body.id)
+                    .copied()
+                    .unwrap_or(TypeInterner::TOP);
+                self.lambda_body_type.insert(*binding, body_ty);
+            } else {
+                let old = self
+                    .binding_types
+                    .get(binding)
+                    .copied()
+                    .unwrap_or(TypeInterner::BOTTOM);
+                let joined = self.interner.join(old, ty);
+                // A `(numeric!)`-declared binding keeps its floor here: this is
+                // the form a kernel parameter takes once HOF fusion has spliced
+                // its body into a loop (`(let [x (get coll i)] BODY)`), where
+                // the init's own type carries no proof.
+                let floored = declared_floor(*binding, joined, self.arena, &self.interner);
+                self.binding_types.insert(*binding, floored);
+                // Track min_length for array constructor bindings
+                if ty == TypeInterner::MUTABLE_ARRAY || ty == TypeInterner::ARRAY {
+                    if let Some(len) = unwrap_to_call(init) {
+                        self.binding_min_length.insert(*binding, len);
+                    }
+                }
+            }
+        }
+        let body_ty = self.infer(body);
+        self.hir_types.insert(body.id, body_ty);
+        body_ty
+    }
+
+    /// Assign/Define — update binding type. A Define whose value is a
+    /// lambda (the in-function `defn` idiom — a letrec*-semantics local)
+    /// records its return type exactly like a Let/Letrec lambda binding,
+    /// with the same selfrec discipline; `collect_lambda_info` records its
+    /// params.
+    pub(super) fn infer_define(&mut self, target: Binding, value: &Hir) -> TyId {
+        let is_lambda_init = matches!(&unwrap_make_cell(value).kind, HirKind::Lambda { .. });
+        if is_lambda_init {
+            self.selfrec.push(target);
+        }
+        let ty = self.infer(value);
+        if is_lambda_init {
+            self.selfrec.pop();
+            if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(value).kind {
+                let body_ty = self
+                    .hir_types
+                    .get(&lam_body.id)
+                    .copied()
+                    .unwrap_or(TypeInterner::TOP);
+                self.lambda_body_type.insert(target, body_ty);
+            }
+        }
+        self.hir_types.insert(value.id, ty);
+        let old = self
+            .binding_types
+            .get(&target)
+            .copied()
+            .unwrap_or(TypeInterner::BOTTOM);
+        let joined = self.interner.join(old, ty);
+        self.binding_types.insert(target, joined);
+        // Track min_length for array constructor bindings
+        if ty == TypeInterner::MUTABLE_ARRAY || ty == TypeInterner::ARRAY {
+            if let Some(call) = unwrap_to_call(value) {
+                self.binding_min_length.insert(target, call);
+            }
+        }
+        ty
+    }
+
+    /// Loop — recurse into body.
+    pub(super) fn infer_loop(&mut self, bindings: &[(Binding, Hir)], body: &Hir) -> TyId {
+        for (binding, init) in bindings {
+            let ty = self.infer(init);
+            self.hir_types.insert(init.id, ty);
+            let old = self
+                .binding_types
+                .get(binding)
+                .copied()
+                .unwrap_or(TypeInterner::BOTTOM);
+            let joined = self.interner.join(old, ty);
+            self.binding_types.insert(*binding, joined);
+        }
+        let body_ty = self.infer(body);
+        self.hir_types.insert(body.id, body_ty);
+        body_ty
+    }
+
+    /// MakeCell — propagate inner value type.
+    pub(super) fn infer_make_cell(&mut self, value: &Hir) -> TyId {
+        let ty = self.infer(value);
+        self.hir_types.insert(value.id, ty);
+        ty
+    }
+
+    /// DerefCell — return binding type if cell is Var(b).
+    pub(super) fn infer_deref_cell(&mut self, cell: &Hir) -> TyId {
+        let ty = self.infer(cell);
+        self.hir_types.insert(cell.id, ty);
+        if let HirKind::Var(b) = &cell.kind {
+            self.binding_types
+                .get(b)
+                .copied()
+                .unwrap_or(TypeInterner::TOP)
+        } else {
+            TypeInterner::TOP
+        }
+    }
+
+    /// SetCell — widen binding type.
+    pub(super) fn infer_set_cell(&mut self, cell: &Hir, value: &Hir) -> TyId {
+        let cell_ty = self.infer(cell);
+        self.hir_types.insert(cell.id, cell_ty);
+        let val_ty = self.infer(value);
+        self.hir_types.insert(value.id, val_ty);
+        // Widen the binding's type with the new value
+        if let HirKind::Var(b) = &cell.kind {
+            let old = self
+                .binding_types
+                .get(b)
+                .copied()
+                .unwrap_or(TypeInterner::BOTTOM);
+            let joined = self.interner.join(old, val_ty);
+            self.binding_types.insert(*b, joined);
+        }
+        val_ty
+    }
+}

--- a/src/hir/typeinfer/infer/node/branch.rs
+++ b/src/hir/typeinfer/infer/node/branch.rs
@@ -1,0 +1,181 @@
+// audited: 2026-09-08
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! What a branch proves: the join over the arms a form can take, and the facts
+//! each arm knows because control reached it.
+
+use super::*;
+use crate::hir::pattern::HirPattern;
+
+impl Infer<'_> {
+    /// If — join branches, with guard narrowing on both sides: the
+    /// then-branch gets the condition's truthy facts (`(%int? x)` refines
+    /// x to Int), the else-branch its falsy facts (`(%not (number? b))`
+    /// false means b IS a number). `meet` because a predicate refines a
+    /// union (`Number ∧ Int = Int`) rather than fully determining the type
+    /// (contrast the authoritative `match (type-of x)` override below).
+    pub(super) fn infer_if(&mut self, cond: &Hir, then_branch: &Hir, else_branch: &Hir) -> TyId {
+        let cond_ty = self.infer(cond);
+        self.hir_types.insert(cond.id, cond_ty);
+
+        let facts = guard::cond_facts(cond, self.arena);
+
+        let saved = apply_type_facts(&facts.when_true, &mut self.binding_types, &self.interner);
+        let then_ty = self.infer(then_branch);
+        self.hir_types.insert(then_branch.id, then_ty);
+        restore_type_facts(saved, &mut self.binding_types);
+
+        let saved = apply_type_facts(&facts.when_false, &mut self.binding_types, &self.interner);
+        let else_ty = self.infer(else_branch);
+        self.hir_types.insert(else_branch.id, else_ty);
+        restore_type_facts(saved, &mut self.binding_types);
+
+        self.interner.join(then_ty, else_ty)
+    }
+
+    /// Match — the type-discriminating sibling of `If`. When the scrutinee is
+    /// `(type-of <var>)`, a keyword-literal arm (`:@array`/`:@struct`/…) proves
+    /// `<var>`'s concrete type+mutability inside that arm's body — the static
+    /// proof a monomorphic data op (`%push-array-mut`, …) needs to lower as a
+    /// silent opcode (pinned by the `match_typeof_narrows_*` tests). Children are
+    /// visited exactly as `for_each_child` (value, then each guard+body); the
+    /// narrowing is saved/restored per arm so it never leaks to a sibling — the
+    /// same discipline as the `If` then/else branches above. The Match node's
+    /// own type is the join of its arm bodies: a type-dispatch helper that
+    /// returns the same type from every arm (the stdlib `compare`'s `rank`,
+    /// all-Int) carries that type to its callers, which is what proves the
+    /// downstream intrinsic operands.
+    pub(super) fn infer_match(
+        &mut self,
+        value: &Hir,
+        arms: &[(HirPattern, Option<Hir>, Hir)],
+    ) -> TyId {
+        let val_ty = self.infer(value);
+        self.hir_types.insert(value.id, val_ty);
+
+        let subject = typeof_subject_binding(value, self.arena, &self.typeof_aliases);
+        let mut arm_join = TypeInterner::BOTTOM;
+        for (pat, guard, body) in arms {
+            if let Some(g) = guard {
+                let g_ty = self.infer(g);
+                self.hir_types.insert(g.id, g_ty);
+            }
+            // Narrow the scrutinee's binding to the arm's proven container
+            // type for the duration of the body, then restore. The narrowing
+            // **overrides** the binding's accumulated type rather than `meet`ing
+            // with it: a `(type-of x)` arm is *authoritative* — the runtime
+            // dispatch guarantees `x`'s concrete type whenever the arm runs, so
+            // within the body `x` simply IS the arm's keyword type, regardless of
+            // what the forward flow widened the binding to across all call sites.
+            // `meet` would be wrong here: if the binding accumulated a *disjoint*
+            // concrete type (a parameter called elsewhere with a different
+            // container — exactly the stdlib `push`/`put` shape), `meet` collapses
+            // to `Bottom`, leaving an immutable-arm container "unproven" and its
+            // silent monomorphic op a spurious compile error on an arm that only
+            // ever runs for that very type (pinned by
+            // `match_typeof_arm_narrows_authoritatively_over_a_called_param`). This
+            // differs from the `If` type-guard above, which `meet`s because a
+            // predicate like `(%int? x)` *refines* a union (`Number ∧ Int = Int`)
+            // rather than fully determining the type. Override is sound because
+            // the container keyword types are flat — the keyword is the most
+            // precise type, never a supertype of the accumulated one.
+            let saved = subject
+                .zip(pattern_type_keyword(pat))
+                .map(|(b, narrow_ty)| {
+                    let prev = self.binding_types.get(&b).copied();
+                    self.binding_types.insert(b, narrow_ty);
+                    (b, prev)
+                });
+            let body_ty = self.infer(body);
+            self.hir_types.insert(body.id, body_ty);
+            arm_join = self.interner.join(arm_join, body_ty);
+            if let Some((b, prev)) = saved {
+                match prev {
+                    Some(t) => {
+                        self.binding_types.insert(b, t);
+                    }
+                    None => {
+                        self.binding_types.remove(&b);
+                    }
+                }
+            }
+        }
+        if arms.is_empty() {
+            TypeInterner::TOP
+        } else {
+            arm_join
+        }
+    }
+
+    /// Cond — sequential If chain: each clause body gets its test's truthy
+    /// facts; each later clause (and the else) additionally knows every
+    /// earlier test was falsy. Result is the join of all bodies.
+    pub(super) fn infer_cond(&mut self, clauses: &[(Hir, Hir)], else_branch: Option<&Hir>) -> TyId {
+        let mut ty = TypeInterner::BOTTOM;
+        let mut fallthrough_saved = Vec::new();
+        for (test, body) in clauses {
+            let test_ty = self.infer(test);
+            self.hir_types.insert(test.id, test_ty);
+            let facts = guard::cond_facts(test, self.arena);
+            let saved = apply_type_facts(&facts.when_true, &mut self.binding_types, &self.interner);
+            let body_ty = self.infer(body);
+            self.hir_types.insert(body.id, body_ty);
+            restore_type_facts(saved, &mut self.binding_types);
+            ty = self.interner.join(ty, body_ty);
+            fallthrough_saved.extend(apply_type_facts(
+                &facts.when_false,
+                &mut self.binding_types,
+                &self.interner,
+            ));
+        }
+        if let Some(els) = else_branch {
+            let else_ty = self.infer(els);
+            self.hir_types.insert(els.id, else_ty);
+            ty = self.interner.join(ty, else_ty);
+        }
+        restore_type_facts(fallthrough_saved, &mut self.binding_types);
+        ty
+    }
+
+    /// Begin/Block — type is last expression. Flow-through guard
+    /// narrowing: a one-armed diverging guard statement —
+    /// `(when (%not (number? b)) (error …))` — proves its fall-through
+    /// facts for every statement after it (the stdlib wrapper shape: the
+    /// guard that raises the wrapper's :error is the same fact that
+    /// discharges the intrinsic's contract downstream). Facts are scoped
+    /// to the sequence and restored on exit.
+    pub(super) fn infer_sequence(&mut self, exprs: &[Hir]) -> TyId {
+        let mut ty = TypeInterner::NIL;
+        let mut saved = Vec::new();
+        for expr in exprs {
+            ty = self.infer(expr);
+            self.hir_types.insert(expr.id, ty);
+            let facts = guard::facts_after_statement(expr, self.arena);
+            saved.extend(apply_type_facts(
+                &facts,
+                &mut self.binding_types,
+                &self.interner,
+            ));
+        }
+        restore_type_facts(saved, &mut self.binding_types);
+        ty
+    }
+
+    /// And/Or — `and`/`or` evaluate to one of their operands — `and` the first
+    /// falsy (else the last), `or` the first truthy (else the last) — so the
+    /// result type is the JOIN of the operand types, exactly as `If` joins its
+    /// branches. Join is sound (a returned value is always ⊑ its operand's
+    /// type) and lets a homogeneous `(or a b)`/`(and a b)` of proven numbers
+    /// discharge a downstream `%`-intrinsic; a heterogeneous one widens and
+    /// correctly fails to prove. (Empty `and`/`or` never reach here — the
+    /// analyzer emits a Bool literal for them.)
+    pub(super) fn infer_shortcircuit(&mut self, exprs: &[Hir]) -> TyId {
+        let mut join = TypeInterner::BOTTOM;
+        for child in exprs {
+            let ty = self.infer(child);
+            self.hir_types.insert(child.id, ty);
+            join = self.interner.join(join, ty);
+        }
+        join
+    }
+}

--- a/src/hir/typeinfer/infer/node/call.rs
+++ b/src/hir/typeinfer/infer/node/call.rs
@@ -2,7 +2,7 @@
 // src/hir/AGENTS.md
 // docs/impl/typeinfer.md
 //! What a call proves: the arguments it forwards to the callee's parameters,
-//! and the type its own result carries away (docs/impl/typeinfer.md).
+//! and the type its own result carries away.
 
 use super::*;
 use crate::hir::expr::CallArg;

--- a/src/hir/typeinfer/infer/node/call.rs
+++ b/src/hir/typeinfer/infer/node/call.rs
@@ -1,0 +1,89 @@
+// audited: 2026-09-08
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! What a call proves: the arguments it forwards to the callee's parameters,
+//! and the type its own result carries away (docs/impl/typeinfer.md).
+
+use super::*;
+use crate::hir::expr::CallArg;
+
+impl Infer<'_> {
+    /// Call — forward arg types to callee params; result = callee return type.
+    pub(super) fn infer_call(&mut self, func: &Hir, args: &[CallArg]) -> TyId {
+        let func_ty = self.infer(func);
+        self.hir_types.insert(func.id, func_ty);
+
+        let arg_types: Vec<TyId> = args
+            .iter()
+            .map(|a| {
+                let ty = self.infer(&a.expr);
+                self.hir_types.insert(a.expr.id, ty);
+                ty
+            })
+            .collect();
+
+        // Forward arg types to callee params.
+        // Handle both Var(b) and DerefCell { Var(b) } (letrec recursive calls).
+        // Forwarding is a complete proof only for a callee used EXCLUSIVELY
+        // in call position — a single value-position use (stored, passed,
+        // returned, exported) means invisible callers exist, so the joins
+        // must not prove its parameters.
+        let callee_binding = unwrap_callee_binding(func);
+        if let Some(callee_binding) = callee_binding {
+            if let Some(params) = self
+                .lambda_params
+                .get(&callee_binding)
+                .filter(|_| !self.value_used.contains(&callee_binding))
+            {
+                for (i, param) in params.iter().enumerate() {
+                    if let Some(&arg_ty) = arg_types.get(i) {
+                        // Top contributes honestly: an unknown-typed call
+                        // site makes the parameter unprovable (the ascent
+                        // REPLACES the binding type from this map at pass
+                        // end, so recursion converges from below instead
+                        // of needing a Top skip).
+                        let old = self
+                            .param_joins
+                            .get(param)
+                            .copied()
+                            .unwrap_or(TypeInterner::BOTTOM);
+                        let joined = self.interner.join(old, arg_ty);
+                        self.param_joins.insert(*param, joined);
+                    }
+                }
+            }
+            // A call to a lambda whose own body is being inferred (a
+            // recursive call) contributes BOTTOM — the recursive
+            // contribution to a return-type join is exactly the base
+            // cases (Kleene iteration from below). It must NOT read the
+            // running estimate: on the first pass that is Top (the body
+            // was walked before any call site forwarded its parameters),
+            // and Top can never come back down through a join. Argument
+            // forwarding above still runs — a self-call is usually the
+            // sole source of its own parameters' step types.
+            if self.selfrec.contains(&callee_binding) {
+                return TypeInterner::BOTTOM;
+            }
+            // Return type = whatever the callee's body returns.
+            // Only use BOTTOM for known lambdas (in lambda_params) where the
+            // body type hasn't been computed yet. For unknown callees (primitives,
+            // imports), return TOP to avoid unsound rewrites.
+            if self.lambda_params.contains_key(&callee_binding) {
+                return self
+                    .lambda_body_type
+                    .get(&callee_binding)
+                    .copied()
+                    .unwrap_or(TypeInterner::BOTTOM);
+            }
+
+            // Primitive return type inference for unresolved callees
+            let callee_sym = self.arena.get(callee_binding).name;
+            let prim_ty = primitive_return_type(callee_sym, &arg_types, &self.interner);
+            if prim_ty != TypeInterner::TOP {
+                return prim_ty;
+            }
+        }
+
+        TypeInterner::TOP
+    }
+}

--- a/src/hir/typeinfer/infer/node/call.rs
+++ b/src/hir/typeinfer/infer/node/call.rs
@@ -52,22 +52,20 @@ impl Infer<'_> {
                     }
                 }
             }
-            // A call to a lambda whose own body is being inferred (a
-            // recursive call) contributes BOTTOM — the recursive
-            // contribution to a return-type join is exactly the base
-            // cases (Kleene iteration from below). It must NOT read the
-            // running estimate: on the first pass that is Top (the body
-            // was walked before any call site forwarded its parameters),
-            // and Top can never come back down through a join. Argument
-            // forwarding above still runs — a self-call is usually the
-            // sole source of its own parameters' step types.
-            if self.selfrec.contains(&callee_binding) {
-                return TypeInterner::BOTTOM;
-            }
-            // Return type = whatever the callee's body returns.
-            // Only use BOTTOM for known lambdas (in lambda_params) where the
-            // body type hasn't been computed yet. For unknown callees (primitives,
-            // imports), return TOP to avoid unsound rewrites.
+            // Return type = whatever the callee's body returns, as the
+            // previous pass left it.
+            //
+            // A SELF-recursive call takes no exception here: it reads the map
+            // every other call reads. On the first pass the callee's own body
+            // has not been walked yet, so the map holds no entry for it, and
+            // BOTTOM is exactly what the recursive contribution to a
+            // return-type join is worth — the base cases. Every later pass
+            // reads the estimate the pass before it computed, which is Kleene
+            // iteration from below and converges on the least fixpoint
+            // (docs/impl/typeinfer.md § "What a call contributes").
+            //
+            // For unknown callees (primitives, imports) TOP, to avoid unsound
+            // rewrites.
             if self.lambda_params.contains_key(&callee_binding) {
                 return self
                     .lambda_body_type

--- a/src/hir/typeinfer/tests.rs
+++ b/src/hir/typeinfer/tests.rs
@@ -1,22 +1,24 @@
-// audited: 2026-09-07
+// audited: 2026-09-08
 // src/hir/AGENTS.md
-// docs/impl/hir.md
-//! The inference pass's unit tests, and the three helpers every one of them
+// docs/impl/typeinfer.md
+//! The inference pass's unit tests, and the four helpers every one of them
 //! compiles through.
 //!
 //! One module per subject: `narrow` for what a guard or a dispatch arm proves,
-//! `rettype` for what an op's result proves, `prune` for dead-arm removal,
-//! `contract` for prove-or-reject, `monomorphize` for wrapper collapse.
+//! `rettype` for what an op's result proves, `recursion` for what a recursive
+//! call's result proves, `prune` for dead-arm removal, `contract` for
+//! prove-or-reject, `monomorphize` for wrapper collapse.
 
 use super::infer_and_rewrite;
 use crate::hir::types::TyId;
-use crate::hir::{BindingArena, Hir};
+use crate::hir::{BindingArena, Hir, HirId, HirKind};
 use crate::symbol::SymbolTable;
 
 mod contract;
 mod monomorphize;
 mod narrow;
 mod prune;
+mod recursion;
 mod rettype;
 
 /// Compile a source file to canonical (functionalized) HIR, mirroring the
@@ -35,6 +37,45 @@ fn inferred_types(src: &str) -> Vec<TyId> {
     let (mut hir, arena) = compile_fhir(src, &mut symbols);
     let info = infer_and_rewrite(&mut hir, &arena, &mut Default::default()).expect("infer");
     info.hir_types.values().copied().collect()
+}
+
+/// The inferred type of every `%`-intrinsic node named `op` in `src`, in the
+/// order the walk reaches them.
+///
+/// Sharper than `inferred_types`, which reports every node's type at once: over
+/// int literals the operands put `Int` into that set themselves, so an op's own
+/// result rule can only be read off the op's own node.
+fn intrinsic_result_types(src: &str, op: &str) -> Vec<TyId> {
+    fn find(h: &Hir, op: &str, found: &mut Vec<HirId>) {
+        if let HirKind::Intrinsic { op: this, .. } = &h.kind {
+            if this.name() == op {
+                found.push(h.id);
+            }
+        }
+        h.for_each_child(|c| find(c, op, found));
+    }
+    let mut symbols = SymbolTable::new();
+    let (mut hir, arena) = compile_fhir(src, &mut symbols);
+    let info = infer_and_rewrite(&mut hir, &arena, &mut Default::default()).expect("infer");
+    let mut found = Vec::new();
+    find(&hir, op, &mut found);
+    assert!(!found.is_empty(), "{src} compiled to no {op} node");
+    found
+        .into_iter()
+        .map(|id| {
+            info.hir_types
+                .get(&id)
+                .copied()
+                .unwrap_or_else(|| panic!("an {op} node in {src} carries no inferred type"))
+        })
+        .collect()
+}
+
+/// The inferred type of the one `%`-intrinsic node named `op` in `src`.
+fn intrinsic_result_type(src: &str, op: &str) -> TyId {
+    let found = intrinsic_result_types(src, op);
+    assert_eq!(found.len(), 1, "{src} holds more than one {op} node");
+    found[0]
 }
 
 /// Compile `src` through the file front end (which runs `infer_and_rewrite`),

--- a/src/hir/typeinfer/tests/recursion.rs
+++ b/src/hir/typeinfer/tests/recursion.rs
@@ -1,0 +1,122 @@
+// audited: 2026-09-08
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! What a recursive call's result proves, and what an ascent that never settled
+//! proves — nothing.
+
+use super::{compile_result, intrinsic_result_type, intrinsic_result_types};
+use crate::hir::typeinfer::infer::fixpoint::MAX_ITERS;
+use crate::hir::types::TypeInterner;
+
+/// `fib`, the shape the whole subject turns on. Pass 1 reads Bottom for the two
+/// self-calls and computes the body `Int ⊔ ⊥ = Int`; pass 2 reads Int for them,
+/// so the `%add` over two recursive results is Int.
+///
+/// The counter-factual: while a self-call returned Bottom unconditionally, this
+/// node inferred Bottom on every pass. No `:int` reached LIR, so the bytecode
+/// tier emitted the polymorphic `Add` and the JIT kept its tag-check diamond in
+/// the hot path of a function whose body is two subtractions and a compare.
+#[test]
+fn self_recursive_call_result_is_the_body_type() {
+    let src = "(defn fib [n] \
+                 (if (%lt n 2) n (%add (fib (%sub n 1)) (fib (%sub n 2))))) \
+               (fib 6)";
+    assert_eq!(
+        intrinsic_result_type(src, "%add"),
+        TypeInterner::INT,
+        "the %add over two self-recursive results must be Int"
+    );
+}
+
+/// The result travels: hoisting the addition into a helper keeps the proof,
+/// because the helper's parameters are the join over its call sites and that
+/// join is now Int rather than Bottom.
+///
+/// The counter-factual: Bottom flowed into the helper's parameters, so the
+/// helper's own `%add` was unproven too — no spelling of the same arithmetic
+/// recovered it.
+#[test]
+fn a_self_recursive_result_proves_a_callee_parameter() {
+    let src = "(defn combine [a b] (%add a b)) \
+               (defn fib [n] \
+                 (if (%lt n 2) n (combine (fib (%sub n 1)) (fib (%sub n 2))))) \
+               (fib 6)";
+    assert_eq!(
+        intrinsic_result_type(src, "%add"),
+        TypeInterner::INT,
+        "the helper's %add over two forwarded recursive results must be Int"
+    );
+}
+
+/// The over-narrowing guard, and the soundness half of the same rule: a base
+/// case that returns a float makes the recursive result a Number, which no
+/// bitwise op accepts.
+///
+/// The counter-factual: while a self-call returned Bottom, `(%add ⊥ 1)` joined
+/// to Int, this compiled, and the bitwise opcode read the float 2.5's payload
+/// as an integer.
+#[test]
+fn a_float_base_case_does_not_prove_an_int_recursive_result() {
+    let src = "(defn f [n] \
+                 (if (%lt n 2) 1.5 (%bit-and (%add (f (%sub n 1)) 1) 3))) \
+               (f 4)";
+    let err = compile_result(src).expect_err("a float base case must not prove an int result");
+    assert!(
+        err.contains("%bit-and"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+}
+
+/// Mutual recursion reads the same body-type map and must keep converging: a
+/// three-member cycle proves Int at every member, one pass per level.
+#[test]
+fn a_three_member_recursion_proves_through_the_cycle() {
+    let src = "(defn a3 [n] (if (%lt n 1) 0 (%add (b3 (%sub n 1)) 1))) \
+               (defn b3 [n] (if (%lt n 1) 0 (%add (c3 (%sub n 1)) 1))) \
+               (defn c3 [n] (if (%lt n 1) 0 (%add (a3 (%sub n 1)) 1))) \
+               (a3 5)";
+    let types = intrinsic_result_types(src, "%add");
+    assert_eq!(types.len(), 3, "one %add per member of the cycle");
+    assert!(
+        types.iter().all(|t| *t == TypeInterner::INT),
+        "every member of an int cycle must prove Int; got {types:?}"
+    );
+}
+
+/// A cycle whose members genuinely disagree has no int to prove: one member
+/// returns a string, the join is Top, and an `%add` reading it is rejected.
+/// The pin against an ascent that mistakes "settled" for "proven".
+#[test]
+fn a_cycle_whose_members_disagree_proves_nothing() {
+    let src = "(defn ping [n] (if (%lt n 1) 0 (pong (%sub n 1)))) \
+               (defn pong [n] (if (%lt n 1) \"done\" (ping (%sub n 1)))) \
+               (%add (ping 4) 1)";
+    let err = compile_result(src).expect_err("a cycle that can return a string proves no Number");
+    assert!(
+        err.contains("%add"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+}
+
+/// The widening. Information travels one call per pass in walk order, so a
+/// chain of callers each walked before its callee outruns the pass budget by
+/// one link. What the last pass left is below the least fixpoint — the chain's
+/// head still reads Bottom — and Bottom discharges every subtype contract.
+///
+/// The counter-factual: this exact program compiled, and `(%bit-and (g1) 1)`
+/// ran the integer opcode over the string "s", printing 0.
+#[test]
+fn a_chain_deeper_than_the_budget_proves_nothing() {
+    let links = MAX_ITERS + 1;
+    let mut src = String::new();
+    for i in 1..links {
+        src.push_str(&format!("(defn g{i} [] (g{})) ", i + 1));
+    }
+    src.push_str(&format!("(defn g{links} [] \"s\") "));
+    src.push_str("(%bit-and (g1) 1)");
+    let err = compile_result(&src).expect_err("an ascent that never settled proves nothing");
+    assert!(
+        err.contains("%bit-and"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+}

--- a/src/hir/typeinfer/tests/rettype.rs
+++ b/src/hir/typeinfer/tests/rettype.rs
@@ -1,39 +1,11 @@
-// audited: 2026-09-07
+// audited: 2026-09-08
 // src/hir/AGENTS.md
 // docs/intrinsics.md
 //! What an op's result proves: every `%`-intrinsic and every constructor has a
 //! result type, and that type is the next op's proof.
 
-use super::{compile_fhir, compile_result, infer_and_rewrite, inferred_types};
-use crate::hir::types::{TyId, TypeInterner};
-use crate::hir::{Hir, HirId, HirKind};
-use crate::symbol::SymbolTable;
-
-/// The inferred type of the `%`-intrinsic node named `op` in `src`.
-///
-/// Sharper than `inferred_types`, which reports every node's type at once: over
-/// int literals the operands put `Int` into that set themselves, so a family
-/// member's own result rule can only be read off the op's own node.
-fn intrinsic_result_type(src: &str, op: &str) -> TyId {
-    fn find(h: &Hir, op: &str, found: &mut Option<HirId>) {
-        if let HirKind::Intrinsic { op: this, .. } = &h.kind {
-            if this.name() == op {
-                *found = Some(h.id);
-            }
-        }
-        h.for_each_child(|c| find(c, op, found));
-    }
-    let mut symbols = SymbolTable::new();
-    let (mut hir, arena) = compile_fhir(src, &mut symbols);
-    let info = infer_and_rewrite(&mut hir, &arena, &mut Default::default()).expect("infer");
-    let mut found = None;
-    find(&hir, op, &mut found);
-    let id = found.unwrap_or_else(|| panic!("{src} compiled to no {op} node"));
-    info.hir_types
-        .get(&id)
-        .copied()
-        .unwrap_or_else(|| panic!("the {op} node in {src} carries no inferred type"))
-}
+use super::{compile_result, inferred_types, intrinsic_result_type};
+use crate::hir::types::TypeInterner;
 
 /// Every member of the div family: `%add` and `%sub` and `%mul` share their
 /// result rule with `%div`, `%rem` and `%mod`, so each row below runs over all

--- a/tests/elle/typed-int-ops.lisp
+++ b/tests/elle/typed-int-ops.lisp
@@ -1,5 +1,5 @@
 (elle/epoch 12)
-# audited: 2026-09-07
+# audited: 2026-09-08
 # The operand proof, end to end.
 #
 # A %-intrinsic whose operands the front end proved are integers emits the
@@ -7,7 +7,8 @@
 # Both compute the same answer, on every tier this file runs on.
 #
 # A proven op's result carries a type of its own, so the proof reaches the next
-# op in the chain — and a float operand denies it there.
+# op in the chain — and a float operand denies it there. A call's result carries
+# one too, a recursive call included.
 # docs/impl/lir.md
 # docs/intrinsics.md
 
@@ -115,6 +116,36 @@
 
 (assert (= (mask 33) 1) "a guard-proven remainder discharges %bit-and")
 (assert (= (mask 255) 15) "and holds at the mask's top value")
+
+# ── A recursive call's result proves the next operation ──────────
+
+(defn fib-int [n]
+  "The recursion's own result is the addition's proof: a self-call reads the
+   body type the previous pass of the ascent computed."
+  (when (%not (int? n))
+    (error {:error :type-error :message "fib-int: int required"}))
+  (if (%lt n 2)
+    n
+    (%add (fib-int (%sub n 1)) (fib-int (%sub n 2)))))
+
+# The counter-factual: while a self-recursive call returned Bottom, this %add
+# read two unproven operands and kept the polymorphic Add. No spelling of an
+# integer recursion emitted the integer opcode, and the JIT kept a tag-check
+# diamond in the hot path of a body that is two subtractions and a compare.
+(assert (string/contains? (disasm-text fib-int) "AddInt")
+        "%add over two self-recursive int results emits AddInt")
+(assert (= (fib-int 10) 55) "AddInt computes the recursion")
+(assert (= (fib-int 0) 0) "and the base case returns its argument")
+
+# The proof follows the body, not the shape: a base case that returns a float
+# makes the recursive result a Number, which the bitwise contract refuses.
+(let [r (protect (compile/barrier-module (string "(defn f [n] "
+                 "  (if (%lt n 2) 1.5 (%bit-and (%add (f (%sub n 1)) 1) 3))) "
+                 "(f 4)") "<typed-int-ops>"))]
+  (assert (not (get r 0)) "a float base case must not prove an int result")
+  (assert (string/contains? (get (get r 1) :message) "%bit-and")
+          (string "the diagnostic must name the refusing op, got "
+                  (get (get r 1) :message))))
 
 # ── A float operand proves nothing to a bitwise op ───────────────
 


### PR DESCRIPTION
Closes #1077.

## What was wrong

A call to the lambda whose body was being walked returned `BOTTOM`,
unconditionally and on every pass, so nothing downstream of a recursive call
ever proved. `fib`'s `%add` inferred Bottom, carried no `:int` into LIR, and
paid for it on every tier: the polymorphic `Add` on the bytecode tier, and a
tag-check diamond with its slow path and merge phi on the JIT. Bottom flowed
into let bindings and callee parameters, so hoisting the addition into a helper
did not recover the proof, and `meet(⊥, _) = ⊥`, so no runtime guard could lift
it either. There was no spelling of a self-recursive integer function whose
recursive results proved.

## What the change does

**A self-call is a call.** It reads the body-type map that every other call
reads. The map holds no entry for a body that has not been walked yet, which is
Bottom on the first pass — the base cases, the same value the pin returned — and
the previous pass's estimate on every pass after that. This is the Kleene
iteration the pass already ran for its parameters and for mutual recursion, in
one more dimension. `fib` settles on the second pass: pass 1 computes the body
`Int ⊔ ⊥ = Int`, pass 2 reads Int for both self-calls and the `%add` is Int.

**An ascent that did not settle now widens.** Reading an estimate across passes
gives convergence a job it did not have before. The environment a
budget-exhausted pass leaves sits below the least fixpoint, which is the side
that proves things that are not true, so every entry still moving is pinned at
Top and the ascent runs again; a pinned entry cannot move, so the widening
terminates. This closes a hole that predates the change: eleven functions in a
chain outrun the ten-pass budget, and

```lisp
(defn g1 [] (g2)) … (defn g11 [] "s")
(%bit-and (g1) 1)
```

compiled and ran the integer opcode over a string, printing 0. It now rejects.
The cost is precision for a program that outruns the budget: proofs that would
have settled in an eleventh pass are refused rather than believed.

**One preparatory commit.** Eleven arguments were threaded through every node of
the transfer function. An `Infer` context owns them instead, which is what let
the transfer function split by subject into files inside the reading budget.
No behavior change in that commit.

## How it was measured

The proof itself, on `(defn fib [n] (if (%lt n 2) n (%add (fib (%sub n 1)) (fib (%sub n 2)))))`:

```
$ elle --dump=lir fib.lisp          # before          # after
    r9  ← r7 - r8 :int                  same              same
    r16 ← r14 - r15 :int                same              same
    r20 ← r12 + r19                 ← no proof        r20 ← r12 + r19 :int
```

and in the bytecode, the only instruction that changes: `Add` → `AddInt`.

What it buys, on a quiet machine, comparing two release binaries that differ by
the implementation commit alone. `perf stat -e instructions` over nine in-process
rounds of `fib(32)`, with `time/elapsed`'s best round beside it:

| tier | before | after | |
|---|---|---|---|
| JIT (`--jit=eager`), instructions | 31.90 G | 31.47 G | **−1.4 %** |
| JIT, best round | 0.159 s | 0.157 s | −1.7 %, at the edge of the noise |
| bytecode, instructions (`fib(30)`×7) | 91.327 G | 91.299 G | −0.03 % |

The JIT number is the tag-check diamond, its slow path and its merge phi leaving
the hot path: about 7 instructions per call, against a per-call cost that is
dominated by the activation and its region accounting. The bytecode number is
the one extra `if let` the polymorphic `Add` runs before its int fast path.

Compile cost is unchanged: the same `perf stat` over `--dump=lir` of
`demos/nqueens/nqueens.lisp` and `tests/elle/oracle.lisp` moves −0.08 %. Counting
every ascent over `tests/elle`, `lib` and `demos` — each run compiles the stdlib
and then the file — 233 settle in 2 passes, 481 in 3, 747 in 4, 22 in 5 and 2 in
6, against a budget of 10. The widening never fires.

## Tests

- `hir::typeinfer::tests::recursion` — six tests: the `fib` result, the same
  result carried into a helper's parameters, the float base case that must
  refuse a bitwise op, two mutual-recursion pins, and the chain that outruns the
  budget (its length read from the budget, so raising the budget keeps the test
  honest). Four were red before the implementation commit.
- `tests/elle/typed-int-ops.lisp` — the corpus peer, on every tier: a
  self-recursive integer `fib` emits `AddInt` and computes, and a float base
  case is refused at compile time.
