### PR TITLE
vm: the scheduler entry thunk is born in a region of its own, and released

### DIFF
--- a/docs/impl/region/AGENTS.md
+++ b/docs/impl/region/AGENTS.md
@@ -23,7 +23,7 @@ Up: [..](../AGENTS.md)
 - [ownership.md](ownership.md) — **Adoption and subtree drop (the ownership forest) (more...)**
 - [relocate.md](relocate.md) — **A release past a frame-replacing tail call** Every release the lowerer emits after a `TailCall` is dead on the closure path, and what it costs to move one ahead of that call.
 - [replicate.md](replicate.md) — **The relocation point and its replicas** How a relocation point outlives its own block, so one release covers a merge and every path that leaves the frame before it.
-- [rules.md](rules.md) — **Region rules — the implementor's correctness obligations** This is implementation-facing: the exhaustive correctness contract the compiler and runtime must uphold.
+- [rules.md](rules.md) — **Region rules — the implementor's correctness obligations** The exhaustive correctness contract the compiler and runtime must uphold for regions.
 - [signalexit.md](signalexit.md) — **What a signal exit owes** A native tail call runs its fall-through block on normal completion alone, so a signal exit answers for the releases left in it.
 - [template.md](template.md) — **Code objects — a blueprint, a payload, and a header** A closure template is the code object of one lambda: its bytecode, constant pool, source locations, and the region tables its body needs.
 - [unwind.md](unwind.md) — **An abandoned frame runs the releases it still owes** The two tables naming what an abandoned frame still owed, and the exits that walk them.

--- a/docs/impl/region/rules.md
+++ b/docs/impl/region/rules.md
@@ -1,7 +1,11 @@
 # Region rules — the implementor's correctness obligations
 
-This is implementation-facing: the exhaustive correctness contract the
-compiler and runtime must uphold. Read it before touching the region code. The RC-instruction mechanism these
+<!-- audited: 2026-09-09 -->
+
+The exhaustive correctness contract the compiler and runtime must uphold for
+regions.
+
+Read this file before you touch the region code. The RC-instruction mechanism these
 rules constrain — value/slot resolution, coalescing, self-edge elimination, and
 the equivalence oracle — is in [mechanism.md](mechanism.md).
 For the consumer-facing model — how to write Elle that is sympathetic to the
@@ -91,7 +95,7 @@ is a correctness defect, not a tuning knob.
    When the target block is the function's **tail**, that anchor is the last
    point before the frame is handed back, so the broken value is also the
    *returned* value and takes the return mint — including through an enclosing
-   `Loop`/`While`, which a `break` jumps past (mechanism.md § "A break out of a
+   `Loop`/`While`, which a `break` jumps past ([mechanism.md](mechanism.md) § "A break out of a
    TAIL block carries the return mint"). The jump moves the anchor of every
    *other* region in the same window too: a release the break passes over is
    emitted into unreachable code, so a `decref_point` at or after a break site
@@ -99,7 +103,7 @@ is a correctness defect, not a tuning knob.
    nested loop or lambda, where the release must keep running once per iteration
    / once per activation, and except where a frame-replacing exit in the body
    means the block's own exit label is not a point every path reaches
-   (mechanism.md § "A release the break jumps over is not a release").
+   ([mechanism.md](mechanism.md) § "A release the break jumps over is not a release").
    A third class is a *borrowing node*: an **uncounted** container element read —
    the `%get`/`%first`/`%rest` opcodes — hands back a value that still lives
    **inside the container** (its own region for a pair's car, an interior member's
@@ -112,12 +116,12 @@ is a correctness defect, not a tuning knob.
    not this class: its dispatch takes the Rule 5 pass-through retain, so the reader
    holds its own reference and the container is free to die — what that retain
    cannot survive is adoption freezing the element's RC, which the ownership cut
-   handles at admission (adopt.md § "The lifetime obligation the root carries"). A
+   handles at admission ([adopt.md](adopt.md) § "The lifetime obligation the root carries"). A
    *remove* is neither: `%pop` extracts the element out of the container (and out of
    its Owned subtree, `extract_owned_region`), so the container keeps its own last
    use. A `Match` arm's pattern binding is a borrowing read of the **scrutinee**, so
    where its release lands is decided by the loop-containment test every binder's
-   scope node feeds (mechanism.md § "Every binder records its scope").
+   scope node feeds ([mechanism.md](mechanism.md) § "Every binder records its scope").
    It is *per
    activation*: each activation remaps its static region slots to fresh physical
    regions, so the same static `DecrefRegion` frees a different physical region
@@ -137,7 +141,7 @@ is a correctness defect, not a tuning knob.
    before the release
    that subtree-drops its **owner**. A member's own `DecrefRegion` is a no-op only
    while the member is still `Owned`; once the owner's drop has reclaimed it that
-   decref faults, so the member must come first (adopt.md § "The lifetime
+   decref faults, so the member must come first ([adopt.md](adopt.md) § "The lifetime
    obligation the root carries"). The same holds for a value that may BE, or live
    inside, another — a borrowing read's result, an opaque call's result, a funnel's
    pass-through result: each is released `DecrefValueRegion`-style, which resolves
@@ -196,7 +200,8 @@ is a correctness defect, not a tuning knob.
      owned-param callee (the caller's dead post-`TailCall` release *is* the
      transfer), so an arg the frame does NOT own is handed one fresh owning
      reference, consumed by the callee's owned-param release. The transfer is
-     what makes that block's deadness load-bearing for **arguments only**: a
+     what lets that block's deadness carry weight, and it does so for
+     **arguments only**: a
      release landing there for anything the call does not name has no such
      story and is carried back ahead of the `TailCall`
      ([mechanism.md](mechanism.md) § "A release past a frame-replacing tail
@@ -324,7 +329,7 @@ process-resident roots in the process-root registry; `Runtime`'s `Drop` (or an
 explicit `Runtime::teardown`) runs the sweep. One teardown routine, so the paths
 cannot drift.
 
-Two non-negotiable properties:
+Three non-negotiable properties:
 
 1. **RC-driven, never iterate-and-free.** The sweep releases the *roots* —
    decrefs each registered process-root region exactly once — and lets the
@@ -340,6 +345,19 @@ Two non-negotiable properties:
    number *is* the remaining work, not a tuning knob. `tests/elle/oracle.lisp`
    measures the same property as a per-op leak rate while a program runs;
    `tests/region_process_teardown` counts what survives the process.
+
+3. **No unexplained references.** A surviving region's RC is explained by the
+   in-edges other survivors point at it, and by nothing else. The remainder —
+   RC minus that in-degree, the quantity the macro scope balances below — is a
+   claim held outside the region graph, so no release the region system can
+   reach ever frees it. Zero regions carrying one is the claim, and
+   `tests/region_process_teardown` gates it.
+
+   The residue count and this one measure different defects. A reference cycle
+   keeps its members alive with every reference explained, so the residue stays
+   positive while this count is zero. An unexplained reference pins its region
+   and everything that region reaches, whatever the rest of the graph does, and
+   it survives every fix to the graph.
 
 Because the sweep is RC-driven, the residue equals the set of regions whose RC
 never reached zero — the true leaks — rather than being hidden by a blanket free.

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1,3 +1,9 @@
+// audited: 2026-09-09
+// The VM's execution entries: a blueprint, a code object at the root, and a
+// program under the async scheduler. The module list sits above them.
+// docs/impl/vm.md
+// docs/impl/region/rules.md
+
 pub mod arithmetic;
 pub mod call;
 pub mod capture;
@@ -380,12 +386,14 @@ impl VM {
             Instruction::Return as u8,
         ];
 
-        // `call_region` is the static slot baked into the synthetic Call above;
-        // it doubles as the physical region the entry thunk is born in (the
-        // static/runtime conflation flagged elsewhere — preserved here). The slot
-        // counter starts at 2, so nonzero.
-        let entry_region = crate::hir::region::RuntimeRegion::new(call_region_slot)
-            .expect("call_region slot nonzero");
+        // The entry thunk gets a runtime region of its own, minted from the heap.
+        // The static slot baked into the synthetic `Call` above is a compile-time
+        // name from a different id-space (docs/impl/region/model.md § id-spaces):
+        // read as a physical id it names whichever live region already answers to
+        // that number, so the thunk would land among another value's objects and
+        // the mint's creation claim would never be taken. A mint takes that claim
+        // here, and the release after the run balances it.
+        let entry_region = self.heap().new_runtime_region();
         // Build the entry thunk as an ordinary allocation into `entry_region`
         // (mortal) — reclaimed by the termination sweep. The synthetic
         // `(ev/run thunk)` bytecode has no MakeClosure of its own; the real
@@ -415,7 +423,16 @@ impl VM {
             crate::value::Arity::Exact(0),
             synthetic_constants,
         );
-        self.execute_proto(&Rc::new(wrapper), None)
+        let result = self.execute_proto(&Rc::new(wrapper), None);
+        // The run is over, so this is the entry thunk's point of demise (Rule 4,
+        // docs/impl/region/rules.md): the wrapper's hand-encoded bytecode carries
+        // no `DecrefRegion` to fire, so the balance for the mint above is here.
+        // The result of `(ev/run thunk)` lives in the fresh region that call
+        // minted, never in this one, so the release cannot reach the value being
+        // returned. It runs on the error exit too — a failed run owes the same
+        // balance as a completed one.
+        self.heap().decref_region(entry_region);
+        result
     }
 }
 

--- a/tests/region_process_teardown.rs
+++ b/tests/region_process_teardown.rs
@@ -1,3 +1,4 @@
+// audited: 2026-09-09
 //! Process-teardown contract (docs/impl/region/rules.md § "Teardown — every
 //! region frees").
 //!
@@ -47,37 +48,48 @@ fn census_with(mut rt: Runtime, src: Option<&str>) {
     report_census(rt.heap(), &report);
 }
 
-fn report_census(heap: &elle::value::fiberheap::FiberHeap, report: &elle::runtime::TeardownReport) {
-    eprintln!("census: {} regions survive teardown", report.live_regions);
-    // For every surviving region, count how many of its rc references are
-    // explained by another live region's contents (in-degree). The remainder
-    // (`rc - in_degree`) is an owner/escape reference that was never released —
-    // those regions are the *roots* of the leak graph; everything else is
-    // their cascade shadow. Group the roots by tag signature. Reads this
-    // instance's own heap (passed explicitly).
+/// The references a surviving region carries that no other survivor's contents
+/// explain: `(id, rc, in_degree)` for every region whose rc exceeds its
+/// in-degree. Each remainder is a claim held outside the region graph, so no
+/// release the region system reaches can ever balance it — the leak roots of
+/// docs/impl/region/rules.md § "Teardown — every region frees". Everything else
+/// in the residue is their cascade shadow.
+fn unexplained_references(
+    heap: &elle::value::fiberheap::FiberHeap,
+    report: &elle::runtime::TeardownReport,
+) -> Vec<(u32, u32, u32)> {
     let mut indegree: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
     for (_, to) in heap.cross_ref_edges() {
         *indegree.entry(to).or_insert(0) += 1;
     }
+    report
+        .regions
+        .iter()
+        .filter_map(|&(id, rc, _objs)| {
+            let ind = indegree.get(&id).copied().unwrap_or(0);
+            (rc > ind).then_some((id, rc, ind))
+        })
+        .collect()
+}
+
+/// One line per surviving region, plus the leak roots grouped by tag signature.
+fn report_census(heap: &elle::value::fiberheap::FiberHeap, report: &elle::runtime::TeardownReport) {
+    eprintln!("census: {} regions survive teardown", report.live_regions);
+    let roots = unexplained_references(heap, report);
+    let shadow = report.regions.len() - roots.len();
     let mut root_classes: std::collections::HashMap<String, (usize, u32)> =
         std::collections::HashMap::new();
-    let mut shadow = 0usize;
-    for &(id, rc, _objs) in &report.regions {
-        let ind = indegree.get(&id).copied().unwrap_or(0);
-        if rc > ind {
-            let mut tags: Vec<String> = heap
-                .region_tags(id)
-                .iter()
-                .map(|t| format!("{t:?}"))
-                .collect();
-            tags.sort();
-            tags.dedup();
-            let e = root_classes.entry(tags.join("+")).or_insert((0, 0));
-            e.0 += 1;
-            e.1 += rc - ind;
-        } else {
-            shadow += 1;
-        }
+    for &(id, rc, ind) in &roots {
+        let mut tags: Vec<String> = heap
+            .region_tags(id)
+            .iter()
+            .map(|t| format!("{t:?}"))
+            .collect();
+        tags.sort();
+        tags.dedup();
+        let e = root_classes.entry(tags.join("+")).or_insert((0, 0));
+        e.0 += 1;
+        e.1 += rc - ind;
     }
     let mut classes: Vec<_> = root_classes.into_iter().collect();
     classes.sort_by_key(|(_, (n, _))| std::cmp::Reverse(*n));

--- a/tests/region_process_teardown/census.rs
+++ b/tests/region_process_teardown/census.rs
@@ -1,3 +1,9 @@
+// audited: 2026-09-09
+// What one run leaves behind: the gates on the post-teardown residue, and the
+// per-shape censuses that name the classes it is made of.
+// docs/impl/region/rules.md
+// docs/impl/region/diagnostics.md
+
 use super::*;
 
 /// The sweep must be *observable* and *idempotent*. The residual live-region
@@ -34,6 +40,53 @@ fn process_teardown_is_observable_and_idempotent() {
         report.live_regions,
         again.live_regions
     );
+}
+
+/// Teardown leaves no reference the region graph cannot explain
+/// (docs/impl/region/rules.md § "Teardown — every region frees"). Every
+/// reference a surviving region carries comes from another survivor's contents;
+/// a remainder is a claim held outside the graph, and no release the region
+/// system reaches can ever balance it.
+///
+/// The counter-factual: the residue count alone cannot see this. A reference
+/// cycle keeps its members alive with every reference explained, so the count
+/// stays positive for a reason the graph shows, and an unbalanced Rust-side
+/// claim sits inside that number indistinguishable from the cycle's shadow.
+///
+/// The run goes through `execute_scheduled`, the path every entry point takes,
+/// so the scheduler wrapper's own allocations are inside the measurement.
+#[test]
+fn teardown_leaves_no_unexplained_references() {
+    for src in [
+        "(+ 1 2)",
+        "(def squares (map (fn [x] (* x x)) (list 1 2 3)))",
+    ] {
+        let mut rt = Runtime::new();
+        let value = {
+            let (vm, symbols, cctx) = rt.parts();
+            let result = compile_file(src, symbols, cctx, "<unexplained>").expect("compiles");
+            vm.execute_scheduled(&result.bytecode, cctx).expect("runs")
+        };
+        // The program value reaches the caller with one owning reference; route
+        // it through the process-root registry so the sweep consumes it, or it
+        // reports as an unexplained reference of the caller's own making.
+        elle::value::arena::register_process_root(rt.heap(), value);
+        let report = rt.teardown();
+        let heap = rt.heap();
+        let pinned: Vec<String> = unexplained_references(heap, &report)
+            .iter()
+            .map(|&(id, rc, ind)| {
+                format!(
+                    "region {id} rc={rc} in-edges={ind} tags={:?}",
+                    heap.region_tags(id)
+                )
+            })
+            .collect();
+        assert!(
+            pinned.is_empty(),
+            "{src}: regions pinned from outside the region graph: {pinned:#?}"
+        );
+    }
 }
 
 /// Diagnostic, not a gate: dump the post-teardown residue (id, rc, objs, tags)

--- a/tests/region_process_teardown/census.rs
+++ b/tests/region_process_teardown/census.rs
@@ -5,6 +5,7 @@
 // docs/impl/region/diagnostics.md
 
 use super::*;
+use elle::compiler::stdlib_cache::StdlibCache;
 
 /// The sweep must be *observable* and *idempotent*. The residual live-region
 /// count is the standing oracle: it is the set of regions whose RC never reached
@@ -54,14 +55,17 @@ fn process_teardown_is_observable_and_idempotent() {
 /// claim sits inside that number indistinguishable from the cycle's shadow.
 ///
 /// The run goes through `execute_scheduled`, the path every entry point takes,
-/// so the scheduler wrapper's own allocations are inside the measurement.
+/// so the scheduler wrapper's own allocations are inside the measurement. The
+/// stdlib is compiled rather than read from the disk cache, so every region in
+/// the residue was minted by this run and the verdict does not move with the
+/// state of a cache file.
 #[test]
 fn teardown_leaves_no_unexplained_references() {
     for src in [
         "(+ 1 2)",
         "(def squares (map (fn [x] (* x x)) (list 1 2 3)))",
     ] {
-        let mut rt = Runtime::new();
+        let mut rt = Runtime::with_stdlib_cache(StdlibCache::Off);
         let value = {
             let (vm, symbols, cctx) = rt.parts();
             let result = compile_file(src, symbols, cctx, "<unexplained>").expect("compiles");


### PR DESCRIPTION
`VM::execute_scheduled` wraps the program in a synthetic `(ev/run thunk)` entry.
It built that thunk into the region named by the synthetic `Call`'s static slot,
read as a physical region id. The two are different id-spaces, so the id names
whichever live region already answers to that number: the thunk lands among
another value's objects, and because that region already exists no creation
claim is taken. Where the id happens to name nothing, the allocation creates the
region at rc 1 and nothing ever balances it — the wrapper's hand-encoded
bytecode carries no `DecrefRegion`.

The change mints a runtime region for the thunk and releases it once the run
returns, on the error exit as well as the normal one. The result of
`(ev/run thunk)` lives in the fresh region that call minted, never in this one,
so the release cannot reach the value being returned.

## Measurement

`--trace=residue`, computing each surviving region's rc against its in-degree
over the dump's edges. `demos/fib/fib.lisp` under `--cache=`, before and after:

| | regions | pinned from outside the graph |
|---|---|---|
| before | 117 | 1 — `region 10432 rc=3 objs=2 tags=[ClosureTemplate, Closure]` |
| after | 117 | 0 |

The count does not move: the thunk's region is inside the scheduler's reference
cycle (#1081), so balancing the claim does not free it yet. What moves is that
every reference on every surviving region is now explained by another
survivor's contents.

## Tests

`census::teardown_leaves_no_unexplained_references`
(`tests/region_process_teardown`) asserts no surviving region's rc exceeds its
in-degree, over a run driven through `execute_scheduled`. It fails on the parent
commit and passes here. The residue count alone cannot see this class: a
reference cycle keeps its members alive with every reference explained, so an
unbalanced Rust-side claim hides inside that number looking like the cycle's
shadow.

`docs/impl/region/rules.md` § "Teardown — every region frees" gains the property
as the third the contract carries.

Closes #1083.