### PR TITLE
typeinfer: bottom is not a proof, so the pass hands out none

### DIFF
--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -124,17 +124,34 @@ exempt it, and only in the spelling with a form after it: the same definition
 alone in a file is the file's result, so `f` reads in value position, its
 parameters read as Top, and the site was rejected already.
 
-### The declaration still floors
+### A fact refines the start
 
-`(numeric!)` proves Number for a parameter no call site has reached, so the
-floor lands **on** the Kleene start rather than meeting with it. `meet(⊥,
-Number)` is ⊥, which sits below the contract the author wrote, and a floor that
-returns something below itself is not a floor.
+A guard and a `(numeric!)` declaration are both proofs about a binding that owe
+nothing to a call site. Both reach the environment by meeting with the type the
+ascent has accumulated, and `meet(⊥, fact)` is ⊥, so the start erases them.
+While Bottom discharged every row that erasure cost nothing, and nothing found
+it.
 
-A Bottom the meet **produces** is the opposite fact: a caller passing a string
-to a declared-numeric parameter, where `meet(String, Number)` is ⊥. That one
-stays unproven, so the declaring body's `%`-sites reject rather than compute
-over the string.
+A fact meeting the start **is** the fact. Nothing has contributed to the
+binding, so the guard or the declaration is the whole of what is known:
+
+```lisp
+(defn g [b]
+  (when (%not (%int? b)) (error :not-int))
+  (%mul 2 b))
+```
+
+`b` is an int in everything after the guard, whether or not this unit calls
+`g`. `(numeric!)` reads the same way: it floors **on** the start rather than
+meeting with it, and a floor that returns something below itself is not a
+floor.
+
+A Bottom the meet **produces** is the opposite fact — the accumulated type and
+the fact are disjoint, so no value reaches the site the fact governs.
+`meet(String, Number)` is ⊥ for a caller passing a string to a declared-numeric
+parameter, and `meet(String, Int)` is ⊥ inside the `(%int? x)` branch of a
+function only ever called with a string. Both are left alone, so those sites
+reject rather than compute.
 
 ## What still does not prove
 
@@ -165,9 +182,10 @@ over the string.
   functions in reverse walk order outrun the ten passes, and the site that
   reads the unsettled entry is rejected rather than compiled.
 - `hir::typeinfer::tests::bottom::*` — Bottom is not a proof: one rejection per
-  contract row that asks a subtype question, the `(numeric!)` floor over the
-  Kleene start and over a caller that contradicts it, and the postcondition
-  that the map the pass hands out carries no Bottom.
+  contract row that asks a subtype question, a guard and a `(numeric!)`
+  declaration each refining the Kleene start and each meeting a fact that
+  contradicts it, and the postcondition that the map the pass hands out carries
+  no Bottom.
 - `tests/elle/typed-int-ops.lisp` — the corpus peer, on every tier: a
   self-recursive integer `fib` emits `AddInt` and computes with it, and a float
   base case is refused at compile time.

--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -115,7 +115,7 @@ read a proof out of Bottom. The first two ask with `subtype`, and did.
 
 A definition is therefore checked where it is written:
 
-```lisp
+```text
 (defn f [x] (%mul x x))
 ```
 
@@ -139,6 +139,7 @@ binding, so the guard or the declaration is the whole of what is known:
 (defn g [b]
   (when (%not (%int? b)) (error :not-int))
   (%mul 2 b))
+(assert (= (g 5) 10) "the guard proves b, and this unit calls g nowhere else")
 ```
 
 `b` is an int in everything after the guard, whether or not this unit calls

--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -1,6 +1,6 @@
 # Type inference: the ascent, and what a call proves
 
-<!-- audited: 2026-09-08 -->
+<!-- audited: 2026-09-09 -->
 
 Where the types come from: an ascent from below whose limit is the least
 fixpoint, and what each kind of call contributes to it.
@@ -88,6 +88,54 @@ Widening costs precision, and only for a program that outran the budget: a
 prove-or-reject rejects that site. The whole corpus converges in six passes or
 fewer — the deepest is `demos/nqueens` at six — so no program in it widens.
 
+## Bottom is not a proof
+
+Widening treats an unsettled entry, and a settled Bottom needs the same answer
+for the same reason. `subtype(⊥, b)` holds for every `b`, so a Bottom operand
+discharges every contract row that asks a subtype question — Numbers,
+DivFamily, Ints, Ordered, and the `%get` index — and the silent opcode lowers
+over a value of any type.
+
+Two different facts wear that one lattice element:
+
+- **No value reaches here.** A function this unit defines and never calls has
+  parameters no call site contributes to, so they keep the Kleene start.
+- **Nothing has contributed yet.** A `(numeric!)` parameter carries the start
+  until a pass walks a call site that refines it.
+
+Neither says what type a value arriving at the site has. So the pass hands out
+no Bottom: at the ascent's limit, every Bottom left in the node map settles to
+Top, which is above the fixpoint and proves nothing.
+
+That one rule covers every consumer, because they all read that one map — the
+operand contracts (`contract.rs`), the signal narrowing (`narrow.rs`), the
+wrapper monomorphization (`monomorphize.rs`), and the LIR operand proof
+(`src/lir/lower/expr/intrinsic.rs`). The last two ask with equality and never
+read a proof out of Bottom. The first two ask with `subtype`, and did.
+
+A definition is therefore checked where it is written:
+
+```lisp
+(defn f [x] (%mul x x))
+```
+
+That is a compile error whether or not a later form calls `f`. Bottom used to
+exempt it, and only in the spelling with a form after it: the same definition
+alone in a file is the file's result, so `f` reads in value position, its
+parameters read as Top, and the site was rejected already.
+
+### The declaration still floors
+
+`(numeric!)` proves Number for a parameter no call site has reached, so the
+floor lands **on** the Kleene start rather than meeting with it. `meet(⊥,
+Number)` is ⊥, which sits below the contract the author wrote, and a floor that
+returns something below itself is not a floor.
+
+A Bottom the meet **produces** is the opposite fact: a caller passing a string
+to a declared-numeric parameter, where `meet(String, Number)` is ⊥. That one
+stays unproven, so the declaring body's `%`-sites reject rather than compute
+over the string.
+
 ## What still does not prove
 
 - **A mutated binding.** An `assign` gives a binding flow that a per-pass
@@ -116,6 +164,10 @@ fewer — the deepest is `demos/nqueens` at six — so no program in it widens.
 - `…::a_chain_deeper_than_the_budget_proves_nothing` — the widening: eleven
   functions in reverse walk order outrun the ten passes, and the site that
   reads the unsettled entry is rejected rather than compiled.
+- `hir::typeinfer::tests::bottom::*` — Bottom is not a proof: one rejection per
+  contract row that asks a subtype question, the `(numeric!)` floor over the
+  Kleene start and over a caller that contradicts it, and the postcondition
+  that the map the pass hands out carries no Bottom.
 - `tests/elle/typed-int-ops.lisp` — the corpus peer, on every tier: a
   self-recursive integer `fib` emits `AddInt` and computes with it, and a float
   base case is refused at compile time.

--- a/docs/intrinsics.md
+++ b/docs/intrinsics.md
@@ -1,6 +1,6 @@
 # Intrinsics
 
-<!-- audited: 2026-09-08 -->
+<!-- audited: 2026-09-09 -->
 
 Intrinsics are silent bytecode operations prefixed with `%`. A `%`-intrinsic
 in **call position** is a compile-time type-checked request for the fast
@@ -82,7 +82,9 @@ Inference discharges contracts from:
   chain of them;
 - **a `(numeric!)` declaration** — it floors *every parameter of the
   enclosing function* at Number, so a whole numeric kernel proves at once
-  without a per-parameter guard.
+  without a per-parameter guard. A caller that contradicts the declaration
+  does not discharge it: pass a string to a declared-numeric parameter and
+  the declaring body's `%`-sites are rejected.
 
 ```lisp
 (def half
@@ -105,6 +107,12 @@ stays unknown, so `(fn [x] (%mul x x))` does not compile — write
 `(fn [x] (* x x))` (the wrapper), guard the parameter, or declare
 `(numeric!)`. This is the point of the design: the programmer states the
 fact once, visibly, and the compiler holds it.
+
+**A definition is checked where it is written.** A function nobody calls has
+no proven call sites, so `(defn f [x] (%mul x x))` is the same compile error
+whether or not the rest of the file calls `f`. "Nothing reaches this
+parameter" is a claim about reachability, and no contract row asks that
+question (see [impl/typeinfer.md](impl/typeinfer.md)).
 
 The declaration is recorded on the parameter **bindings** it constrains, not
 on the function node, so it survives a rewrite that dissolves the function:

--- a/src/hir/typeinfer/contract/check.rs
+++ b/src/hir/typeinfer/contract/check.rs
@@ -1,12 +1,31 @@
-//! Discharging a single call-position site: match its op's contract row
-//! against the inferred operand types (and the nonzero-divisor facts), and
-//! either lower silently or reject with a diagnostic.
+// audited: 2026-09-09
+// src/hir/AGENTS.md
+// docs/intrinsics.md
+//! Discharging one call-position site: its op's contract row, against the
+//! operand types the inference proved.
+//!
+//! A row that holds lets the site lower silently. A row that does not is a
+//! compile error naming the op, the operand, and what was inferred there. The
+//! div family carries the nonzero-divisor facts on top of its types.
 
 use super::*;
 
 /// The inferred type of an operand occurrence (post-narrowing, per occurrence).
+///
+/// Never Bottom: `subtype(⊥, b)` holds for every `b`, so a Bottom operand would
+/// discharge Numbers, DivFamily, Ints, Ordered and the `%get` index alike, and
+/// the silent opcode would lower over a value of any type. The ascent raises
+/// every settled Bottom to Top before it hands this map over
+/// (`Infer::settle`), and the assertion is what keeps that true of a later
+/// producer of one.
 fn ty_of(h: &Hir, hir_types: &HashMap<HirId, TyId>) -> TyId {
-    hir_types.get(&h.id).copied().unwrap_or(TypeInterner::TOP)
+    let ty = hir_types.get(&h.id).copied().unwrap_or(TypeInterner::TOP);
+    debug_assert_ne!(
+        ty,
+        TypeInterner::BOTTOM,
+        "an operand type reaching the contract gate is Bottom, which proves nothing"
+    );
+    ty
 }
 
 /// Is this operand provably ≠ 0 on the current path?

--- a/src/hir/typeinfer/infer.rs
+++ b/src/hir/typeinfer/infer.rs
@@ -1,4 +1,4 @@
-// audited: 2026-09-08
+// audited: 2026-09-09
 // src/hir/AGENTS.md
 // docs/impl/typeinfer.md
 //! The inference pass and the environment it carries: one context owns every
@@ -96,9 +96,12 @@ impl<'a> Infer<'a> {
         // contributes nothing on the way up instead of reading the Top default
         // and pinning itself there. Parameters of value-used bindings stay
         // ABSENT (read as Top): their callers are not enumerable, so optimism
-        // there would let the checker pass on ⊥. A never-called callee-only
-        // function's params stay ⊥ — its %-sites can never execute, so nothing
-        // unsound compiles.
+        // there would let the checker pass on ⊥.
+        //
+        // The start is not a proof, and a never-called function's parameters
+        // never leave it. Reaching the limit still at ⊥ says only that nothing
+        // contributed, so `Infer::settle` raises those to Top before the map
+        // leaves the pass (docs/impl/typeinfer.md § "Bottom is not a proof").
         let mut binding_types: HashMap<Binding, TyId> = HashMap::new();
         for (b, params) in &lambda_params {
             if value_used.contains(b) {

--- a/src/hir/typeinfer/infer/facts.rs
+++ b/src/hir/typeinfer/infer/facts.rs
@@ -1,4 +1,34 @@
+// audited: 2026-09-09
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! The declared floor, and the guard-derived narrowing facts a branching form
+//! applies to the binding environment and then restores.
+
 use super::super::*;
+
+/// Refine a binding's accumulated type with a fact proven about the binding —
+/// a type guard's narrowing, or a `(numeric!)` declaration's floor.
+///
+/// A fact meeting the ascent's start IS the fact. `meet(⊥, fact)` is ⊥, so
+/// meeting there would erase a proof that owes nothing to a call site: a guard
+/// holds in the branch it governs, and a declaration holds through the body,
+/// whether or not this unit calls the enclosing function
+/// (docs/impl/typeinfer.md § "Bottom is not a proof").
+///
+/// A Bottom the meet PRODUCES is the opposite reading — the accumulated type
+/// and the fact are disjoint, so no value reaches the site the fact governs —
+/// and it is left alone, because it proves nothing either.
+///
+/// The two are one `TyId`, so a Bottom an enclosing disjoint fact produced
+/// reads here as the start and the fact re-proves the binding. That costs
+/// precision and nothing else: reaching it takes two mutually exclusive guards
+/// around the site, so the code the fact proves is code no value reaches.
+fn refine(interner: &TypeInterner, accumulated: TyId, fact: TyId) -> TyId {
+    if accumulated == TypeInterner::BOTTOM {
+        return fact;
+    }
+    interner.meet(accumulated, fact)
+}
 
 /// Apply a binding's `(numeric!)` declaration to a type it is being bound with.
 /// The declaration floors the binding at Number — callers may refine it to
@@ -19,15 +49,15 @@ pub(crate) fn declared_floor(
     interner: &TypeInterner,
 ) -> TyId {
     if arena.get(binding).declared_numeric {
-        interner.meet(ty, TypeInterner::NUMBER)
+        refine(interner, ty, TypeInterner::NUMBER)
     } else {
         ty
     }
 }
 
-/// Apply the `TypeIs` facts to the binding environment (meet with the
-/// accumulated type), returning the saved prior entries for `restore_type_facts`.
-/// `Nonzero` facts are the contract checker's flow, not a type — skipped here.
+/// Apply the `TypeIs` facts to the binding environment, returning the saved
+/// prior entries for `restore_type_facts`. `Nonzero` facts are the contract
+/// checker's flow, not a type — skipped here.
 pub(crate) fn apply_type_facts(
     facts: &[super::super::guard::Fact],
     binding_types: &mut HashMap<Binding, TyId>,
@@ -43,7 +73,7 @@ pub(crate) fn apply_type_facts(
             .get(binding)
             .copied()
             .unwrap_or(TypeInterner::TOP);
-        binding_types.insert(*binding, interner.meet(old, *narrow_ty));
+        binding_types.insert(*binding, refine(interner, old, *narrow_ty));
     }
     saved
 }

--- a/src/hir/typeinfer/infer/fixpoint.rs
+++ b/src/hir/typeinfer/infer/fixpoint.rs
@@ -1,4 +1,4 @@
-// audited: 2026-09-08
+// audited: 2026-09-09
 // src/hir/AGENTS.md
 // docs/impl/typeinfer.md
 //! The ascent: passes over the whole tree until the type environment stops
@@ -13,14 +13,38 @@ pub(in crate::hir::typeinfer) const MAX_ITERS: usize = 10;
 
 impl Infer<'_> {
     /// Run the transfer function over `hir` until the environment stops moving,
-    /// widening whatever is still moving when the budget runs out.
+    /// widening whatever is still moving when the budget runs out, then settle
+    /// what the ascent hands out.
     pub(in crate::hir::typeinfer) fn solve(&mut self, hir: &Hir) {
         while let Some(moving) = self.ascend(hir) {
             // A round that pins nothing new has pinned everything there is, so
             // the environment is already Top throughout and proves nothing.
             // Stopping there is what bounds the widening.
             if !self.widen(moving) {
-                return;
+                break;
+            }
+        }
+        self.settle();
+    }
+
+    /// Raise every Bottom the ascent settled on to Top, so the node map this
+    /// pass hands out carries none.
+    ///
+    /// Bottom is the start, and `subtype(⊥, b)` holds for every `b` — so a
+    /// Bottom operand discharges every contract row that asks a subtype
+    /// question. What a settled Bottom records is that nothing contributed to
+    /// the entry: the parameters of a function this unit never calls, or the
+    /// body type of a cycle with no base case. Neither says what type a value
+    /// arriving at the site has, and Top is the answer that proves nothing
+    /// (docs/impl/typeinfer.md § "Bottom is not a proof").
+    ///
+    /// One raise serves every consumer, because they all read this one map: the
+    /// operand contracts, the signal narrowing, the wrapper monomorphization,
+    /// and the LIR operand proof.
+    fn settle(&mut self) {
+        for ty in self.hir_types.values_mut() {
+            if *ty == TypeInterner::BOTTOM {
+                *ty = TypeInterner::TOP;
             }
         }
     }
@@ -82,9 +106,9 @@ impl Infer<'_> {
 
     /// One pass: infer every node from the environment the last pass left, then
     /// REPLACE each contributed parameter's type with this pass's complete join
-    /// (Top included). A `(numeric!)` declaration floors the result at Number
-    /// (meet: callers can refine to Int/Float, never widen past the declared
-    /// contract); a mutated parameter never receives proofs.
+    /// (Top included). A `(numeric!)` declaration floors the result at Number —
+    /// callers can refine to Int/Float, never widen past the declared contract
+    /// (`declared_floor`); a mutated parameter never receives proofs.
     fn pass(&mut self, hir: &Hir) {
         self.param_joins.clear();
         let ty = self.infer(hir);

--- a/src/hir/typeinfer/tests.rs
+++ b/src/hir/typeinfer/tests.rs
@@ -1,4 +1,4 @@
-// audited: 2026-09-08
+// audited: 2026-09-09
 // src/hir/AGENTS.md
 // docs/impl/typeinfer.md
 //! The inference pass's unit tests, and the four helpers every one of them
@@ -6,14 +6,16 @@
 //!
 //! One module per subject: `narrow` for what a guard or a dispatch arm proves,
 //! `rettype` for what an op's result proves, `recursion` for what a recursive
-//! call's result proves, `prune` for dead-arm removal, `contract` for
-//! prove-or-reject, `monomorphize` for wrapper collapse.
+//! call's result proves, `bottom` for what the lattice's start proves,
+//! `prune` for dead-arm removal, `contract` for prove-or-reject,
+//! `monomorphize` for wrapper collapse.
 
 use super::infer_and_rewrite;
 use crate::hir::types::TyId;
 use crate::hir::{BindingArena, Hir, HirId, HirKind};
 use crate::symbol::SymbolTable;
 
+mod bottom;
 mod contract;
 mod monomorphize;
 mod narrow;

--- a/src/hir/typeinfer/tests/bottom.rs
+++ b/src/hir/typeinfer/tests/bottom.rs
@@ -5,9 +5,10 @@
 //! element it starts from, and what it still discharges.
 //!
 //! `subtype(⊥, b)` holds for every `b`, so a Bottom operand would discharge
-//! every contract row that asks a subtype question. One reject per such row,
-//! the `(numeric!)` floor on both sides, and the postcondition that closes the
-//! whole class: the map the pass hands out carries no Bottom.
+//! every contract row that asks a subtype question. One reject per such row, a
+//! guard and a declaration each refining the start and each meeting a fact that
+//! contradicts it, and the postcondition that closes the whole class: the map
+//! the pass hands out carries no Bottom.
 
 use super::{compile_result, inferred_types};
 use crate::hir::types::TypeInterner;
@@ -81,30 +82,51 @@ fn a_call_that_never_returns_proves_nothing_about_its_result() {
     );
 }
 
-/// The declaration floors the Kleene start rather than meeting with it:
-/// `meet(⊥, Number)` is ⊥, and a floor that returns something below itself is
-/// not a floor. The over-rejection guard for the row above — refusing Bottom
-/// must not cost the declaration its proof.
+/// A fact meeting the Kleene start IS the fact. A guard and a `(numeric!)`
+/// declaration are both proofs about a binding that owe nothing to a call site,
+/// and both reach the environment by meeting with what the ascent accumulated —
+/// where `meet(⊥, fact)` is ⊥, which erases them.
+///
+/// The over-rejection guard for the rejections above. While Bottom discharged
+/// every row the erasure cost nothing and nothing found it; refusing Bottom is
+/// what makes these three sites depend on the fact.
 #[test]
-fn a_numeric_declaration_proves_a_parameter_no_call_site_has_reached() {
+fn a_fact_proves_a_parameter_no_call_site_has_reached() {
     compile_result("(defn sq [x] (numeric!) (%mul x x)) 1")
         .expect("the declaration proves the parameter of a function nobody calls");
+    compile_result("(defn g [b] (when (%not (%int? b)) (error :not-int)) (%mul 2 b)) 1")
+        .expect("the diverging guard proves b whether or not this unit calls g");
+    compile_result("(defn g [b] (if (%int? b) (%mul 2 b) 0)) 1")
+        .expect("the if-guard proves b in its then-branch on the same terms");
 }
 
-/// The soundness half of the same rule. `meet(String, Number)` is ⊥ too, and
-/// that Bottom is a caller contradicting the declaration — the opposite fact,
-/// and the one that must not discharge anything.
+/// The soundness half of the same rule, and what keeps the two Bottoms apart. A
+/// Bottom the meet PRODUCES says the accumulated type and the fact are
+/// disjoint, so no value reaches the site the fact governs — the opposite of a
+/// start nothing has contributed to, and not a proof either.
 ///
-/// The counter-factual: this compiled, `%bit-and` ran the integer opcode over
-/// the string "str", and the program printed 0.
+/// The counter-factual: the declared case compiled, `%bit-and` ran the integer
+/// opcode over the string "str", and the program printed 0.
 #[test]
-fn a_caller_that_contradicts_a_numeric_declaration_proves_nothing() {
-    let err = compile_result("(defn sq [x] (numeric!) (%bit-and x 1)) (sq \"str\")")
-        .expect_err("a string argument does not discharge a declared-numeric parameter");
-    assert!(
-        err.contains("%bit-and"),
-        "the error must name the op that could not prove; got: {err}"
-    );
+fn a_fact_that_contradicts_the_accumulated_type_proves_nothing() {
+    for (src, op) in [
+        // meet(String, Number): a caller contradicts the declaration.
+        (
+            "(defn sq [x] (numeric!) (%bit-and x 1)) (sq \"str\")",
+            "%bit-and",
+        ),
+        // meet(String, Int): the guarded branch of a function only ever called
+        // with a string.
+        (
+            "(defn g [b] (if (%int? b) (%bit-and b 1) 0)) (g \"str\")",
+            "%bit-and",
+        ),
+    ] {
+        let Err(err) = compile_result(src) else {
+            panic!("a fact disjoint from the accumulated type proves nothing: {src}");
+        };
+        assert!(err.contains(op), "the error must name {op}; got: {err}");
+    }
     compile_result("(defn sq [x] (numeric!) (%bit-and x 1)) (sq 7)")
         .expect("an int argument refines the declaration and still proves");
 }

--- a/src/hir/typeinfer/tests/bottom.rs
+++ b/src/hir/typeinfer/tests/bottom.rs
@@ -1,0 +1,132 @@
+// audited: 2026-09-09
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! Bottom is not a proof: what the ascent refuses to discharge with the lattice
+//! element it starts from, and what it still discharges.
+//!
+//! `subtype(⊥, b)` holds for every `b`, so a Bottom operand would discharge
+//! every contract row that asks a subtype question. One reject per such row,
+//! the `(numeric!)` floor on both sides, and the postcondition that closes the
+//! whole class: the map the pass hands out carries no Bottom.
+
+use super::{compile_result, inferred_types};
+use crate::hir::types::TypeInterner;
+
+/// The reject direction, one row per contract that asks a subtype question. A
+/// function this unit never calls has parameters no call site contributes to,
+/// so they keep the Kleene start — which says nothing about the type of a value
+/// that arrives, because no value does.
+///
+/// The counter-factual: every one of these compiled, and the silent opcode
+/// lowered over an operand of any type at all.
+#[test]
+fn a_never_called_function_proves_nothing_about_its_parameters() {
+    for (src, op) in [
+        ("(defn dead [x] (%add x 1)) 1", "%add"),
+        ("(defn dead [x] (%div x 2)) 1", "%div"),
+        ("(defn dead [x] (%bit-and x 1)) 1", "%bit-and"),
+        ("(defn dead [x] (%lt x 1)) 1", "%lt"),
+        ("(defn dead [i] (%get [1 2 3] i)) 1", "%get"),
+    ] {
+        let Err(err) = compile_result(src) else {
+            panic!("an uncalled function's parameter proves nothing: {src}");
+        };
+        assert!(err.contains(op), "error must name {op}; got: {err}");
+    }
+}
+
+/// Both spellings of one definition answer the same. A definition alone in a
+/// file is that file's result, so its binding reads in value position and its
+/// parameters read as Top; a form after it leaves the binding unused, which is
+/// where the Kleene start used to survive to the gate.
+///
+/// The counter-factual: the trailing `1` decided whether the same function
+/// compiled, and nothing in the source said so.
+#[test]
+fn a_trailing_form_does_not_decide_whether_a_definition_compiles() {
+    let alone = compile_result("(defn f [x] (%mul x x))")
+        .expect_err("an unproven parameter is rejected in the definition-as-result spelling");
+    let followed = compile_result("(defn f [x] (%mul x x)) 1")
+        .expect_err("and in the spelling with a form after it");
+    assert!(alone.contains("%mul"), "error must name %mul; got: {alone}");
+    assert!(
+        followed.contains("%mul"),
+        "error must name %mul; got: {followed}"
+    );
+}
+
+/// The over-rejection guard: a total op has no contract to discharge, so it
+/// compiles over an operand of any type — a parameter at the Kleene start
+/// included. Rejecting Bottom must cost only the rows that ask about a type.
+#[test]
+fn a_total_op_still_compiles_in_a_never_called_function() {
+    compile_result("(defn dead [x y] (%eq x y)) 1").expect("%eq is total");
+    compile_result("(defn dead [x] (%not x)) 1").expect("%not is truthiness negation, total");
+    compile_result("(defn dead [x] (%type-of x)) 1").expect("%type-of is total");
+}
+
+/// The other producer of a settled Bottom, and the one that owes nothing to how
+/// a recursive call is typed: a cycle with no base case returns from nowhere, so
+/// its body type is the start and stays there. A site reading that result has no
+/// proof, whatever the ascent decides about self-calls.
+///
+/// The counter-factual: `(%bit-and (a) 1)` compiled.
+#[test]
+fn a_call_that_never_returns_proves_nothing_about_its_result() {
+    let err = compile_result("(defn a [] (b)) (defn b [] (a)) (%bit-and (a) 1)")
+        .expect_err("a body type that never left the start proves no int");
+    assert!(
+        err.contains("%bit-and"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+}
+
+/// The declaration floors the Kleene start rather than meeting with it:
+/// `meet(⊥, Number)` is ⊥, and a floor that returns something below itself is
+/// not a floor. The over-rejection guard for the row above — refusing Bottom
+/// must not cost the declaration its proof.
+#[test]
+fn a_numeric_declaration_proves_a_parameter_no_call_site_has_reached() {
+    compile_result("(defn sq [x] (numeric!) (%mul x x)) 1")
+        .expect("the declaration proves the parameter of a function nobody calls");
+}
+
+/// The soundness half of the same rule. `meet(String, Number)` is ⊥ too, and
+/// that Bottom is a caller contradicting the declaration — the opposite fact,
+/// and the one that must not discharge anything.
+///
+/// The counter-factual: this compiled, `%bit-and` ran the integer opcode over
+/// the string "str", and the program printed 0.
+#[test]
+fn a_caller_that_contradicts_a_numeric_declaration_proves_nothing() {
+    let err = compile_result("(defn sq [x] (numeric!) (%bit-and x 1)) (sq \"str\")")
+        .expect_err("a string argument does not discharge a declared-numeric parameter");
+    assert!(
+        err.contains("%bit-and"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+    compile_result("(defn sq [x] (numeric!) (%bit-and x 1)) (sq 7)")
+        .expect("an int argument refines the declaration and still proves");
+}
+
+/// The postcondition that closes the class rather than one row of it. Every
+/// consumer downstream of the pass — the operand contracts, the signal
+/// narrowing, the wrapper monomorphization, the LIR operand proof — reads this
+/// one map, so a map with no Bottom in it leaves none of them a Bottom to read
+/// a proof out of.
+///
+/// The program compiles: `%eq` is total, so the uncalled function survives the
+/// gate and its parameter occurrences reach the map.
+#[test]
+fn the_map_the_pass_hands_out_carries_no_bottom() {
+    for src in [
+        "(defn dead [x y] (%eq x y)) 1",
+        "(defn a [] (b)) (defn b [] (a)) (%eq (a) 1)",
+        "(defn sq [x] (numeric!) (%mul x x)) 1",
+    ] {
+        assert!(
+            !inferred_types(src).contains(&TypeInterner::BOTTOM),
+            "the inferred map must hand out no Bottom; {src} did"
+        );
+    }
+}


### PR DESCRIPTION
`subtype(⊥, b)` holds for every `b`, so a Bottom operand discharged every
contract row that asks a subtype question — Numbers, DivFamily, Ints, Ordered
and the `%get` index — and the silent opcode lowered over a value of any type.

## What was wrong

Two producers of a settled Bottom reached the gate. The sharper one executes:

```lisp
(defn sq [x] (numeric!) (%bit-and x 1))
(print (sq "str"))                       ; => 0
```

`meet(String, Number)` is ⊥, ⊥ discharged Ints, and the integer opcode ran over
a string. No recursion and no dead code — that call happens.

The other is a function this unit never calls, whose parameters keep the Kleene
start. It made the same definition compile or reject depending on whether a
later form exists:

```lisp
(defn f [x] (%mul x x))                  ; rejected: f is the file's result
(defn f [x] (%mul x x)) 1                ; compiled: f is unused
```

A file's last binding reads in value position and its parameters read as Top; an
unused one keeps ⊥. Nothing in the source says so.

## What the change does

`Infer::settle` raises every Bottom the ascent settled on to Top before the node
map leaves the pass. One raise covers every consumer, because they all read that
one map: the operand contracts, the signal narrowing, the wrapper
monomorphization, and the LIR operand proof. The first two asked with `subtype`
and read a proof out of Bottom; the last two ask with equality and never did.

`refine` replaces the two places a fact met the binding environment. A guard and
a `(numeric!)` declaration are both proofs about a binding that owe nothing to a
call site, and `meet(⊥, fact)` is ⊥ — so the start erased them. While Bottom
discharged every row that erasure cost nothing and nothing found it. A fact
meeting the start is now the fact; a Bottom the meet *produces* is the disjoint
reading and is left alone, so a caller contradicting a declaration and a guarded
branch that cannot run both stay unproven.

`ty_of` carries a `debug_assert` that no operand type reaching the gate is
Bottom — at the gate the defect lived in, so a later producer of one trips it in
every debug build.

The cost is stated in the docs: a definition is checked where it is written, so
a function nobody calls is rejected like one that is called.

## How it was measured

The corpus, `make qa`, `make smoke` (vm, jit, doctest, embedding, nouring),
`cargo test --workspace --lib` (2549), and `cargo test --test '*'` (1044). The
corpus recorded 1291 pass, 15 skip, 0 fail, 0 diverge, 0 timeout. Every `.lisp`
file in the repository still compiles, checked one at a time.

The `tests/elle/oracle.lisp` region verdicts are unchanged, all thirteen
`tail-frame-exit-*` probes closed at rate 0.0.

## Tests

`src/hir/typeinfer/tests/bottom.rs`, each confirmed failing before the
implementation landed:

- one rejection per contract row that asks a subtype question, from a function
  this unit never calls;
- the trailing-form pin, which says the defect out loud;
- a cycle with no base case, whose body type never leaves the start — a producer
  that owes nothing to how a recursive call is typed;
- a guard and a declaration each proving a parameter no call site has reached,
  and each meeting a fact that contradicts it;
- a total op still compiling over the start, so refusing Bottom costs only the
  rows that ask about a type;
- the postcondition that closes the class: the map the pass hands out carries no
  Bottom.

Closes #1079.
