### PR TITLE
primitives: the two diagnostic prints spell the names they show

### DIFF
--- a/docs/impl/symbol.md
+++ b/docs/impl/symbol.md
@@ -1,5 +1,7 @@
 # Symbols and keywords — identity is the name hash
 
+<!-- audited: 2026-09-09 -->
+
 A `SymbolId` is the 64-bit FNV-1a hash of the symbol's name. Nothing mints it
 and no table owns it: the same name yields the same id in every symbol table,
 every thread, every process, and every build.
@@ -159,6 +161,19 @@ value — the wrong one. `#<…>` is the codebase's marker for an object the
 printer cannot render faithfully, and here it doubles as a canary: every mint
 site is a learning site, so an unresolved form in user-facing output points at
 a missed one, or at a formatter that failed to thread the memo.
+
+`VM::show_value` is the one render of a value for a message a person reads. It
+threads the owning instance's memo, and every such message goes through it: the
+uncaught-error report, the "Cannot call" type error on each of the four call
+paths, the WASM tier's report, and the `debug/print` and `trace` prints. A site
+that formats a `Value` with a bare `{}` or `{:?}` instead threads no memo, so
+the author reads a hash where their own name should be.
+
+Because the unresolved form is a canary, one test answers for the whole class
+rather than for each render. `unresolved_names_reach_no_user_facing_surface`
+runs a program across every output surface and fails if either stream carries
+`#<symbol:` or `#<keyword:` at all. A render added later that forgets the memo
+fails there without anybody naming it.
 
 ## Collisions are fatal
 

--- a/src/primitives/debug.rs
+++ b/src/primitives/debug.rs
@@ -1,4 +1,7 @@
-//! Debug print, trace, and memory usage primitives
+// audited: 2026-09-09
+//! The debug primitives an author reaches for to see a running program. Two
+//! stderr prints, a process memory reading, and the count of spellings this
+//! instance's memo holds.
 
 use crate::primitives::def::RegionEffect;
 use crate::signals::Signal;
@@ -8,27 +11,33 @@ use crate::value::Value;
 
 /// Prints a value with debug information
 /// (debug-print value)
+///
+/// The value goes through `VM::show_value`, so it renders against this
+/// instance's memo. A bare `{:?}` threads no memo and spells every name outside
+/// the static vocabulary `#<symbol:hash>` (docs/impl/symbol.md).
 pub(crate) fn prim_debug_print(
-    _ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
+    ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
 ) -> (SignalBits, Value) {
-    eprintln!("[DEBUG] {:?}", args[0]);
+    eprintln!("[DEBUG] {}", ctx.vm().show_value(args[0]));
     (SIG_OK, args[0])
 }
 
 /// Traces execution with a label
 /// `(trace label value)` — prints `[TRACE] label: value` to stderr, returns value
 ///
-/// Label can be a string or symbol. Symbols are resolved to their
-/// name via the VM's symbol table (via `ctx.vm().symbols()`, same access
-/// pattern as string).
+/// The label can be a string or a symbol. Both halves of the line resolve
+/// against this instance's memo: the label through `SymbolTable::name`, the
+/// value through `VM::show_value` (docs/impl/symbol.md). Rendering only the
+/// label leaves a spelled label beside a hashed value on one line.
 pub(crate) fn prim_trace(
     ctx: &mut crate::primitives::ctx::NativeCtx<'_>,
     args: &[Value],
 ) -> (SignalBits, Value) {
+    let traced = ctx.vm().show_value(args[1]);
     if args[0]
         .with_string(|s| {
-            eprintln!("[TRACE] {}: {:?}", s, args[1]);
+            eprintln!("[TRACE] {}: {}", s, traced);
         })
         .is_some()
     {
@@ -40,7 +49,7 @@ pub(crate) fn prim_trace(
             .and_then(|s| s.name(sym_id))
             .map(|n| n.to_string())
             .unwrap_or_else(|| format!("#<symbol:{:#x}>", sym_id.0));
-        eprintln!("[TRACE] {}: {:?}", name, args[1]);
+        eprintln!("[TRACE] {}: {}", name, traced);
         (SIG_OK, args[1])
     } else {
         (

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -1,6 +1,6 @@
 # tests/integration
 
-<!-- audited: 2026-09-05 -->
+<!-- audited: 2026-09-09 -->
 
 Full-pipeline integration tests: end-to-end behavior verification.
 
@@ -73,7 +73,8 @@ Tests are organized by feature area in separate files:
 | `core.rs` | Basic arithmetic, conditionals, lists, functions |
 | `advanced.rs` | Closures, recursion, higher-order functions |
 | `concurrency.rs` | Fibers, thread transfer |
-| `error_reporting.rs` | Error messages with source locations |
+| `error_reporting.rs` | Error messages with source locations, and the names an uncaught error's report spells |
+| `diagnostics.rs` | What `debug/print` and `trace` write to stderr, and the unresolved-name canary over every output surface |
 | `repl_exit_codes.rs` | REPL exit code behavior |
 | ~~`coroutines.rs`~~ | Migrated to `tests/elle/coroutines.lisp` |
 | `lexical_scope.rs` | Lexical scoping and closures |

--- a/tests/integration/diagnostics.rs
+++ b/tests/integration/diagnostics.rs
@@ -1,0 +1,137 @@
+// audited: 2026-09-09
+// What the runtime writes for a person to read. The `debug/print` and `trace`
+// prints, and the unresolved-name canary over every surface a program reaches.
+// docs/impl/symbol.md
+//
+// A render that threads no symbol table spells a symbol `#<symbol:hash>` and a
+// keyword `#<keyword:hash>`. Those forms are deliberately unreadable, which
+// makes them a canary: one in user-facing output means a render dropped the
+// memo. The tests drive the binary, because the subject is what lands on the
+// terminal rather than what a primitive returns.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Run `input` through the binary's read-stdin path and return its
+/// `(stdout, stderr, exited-zero)`.
+fn run(input: &str) -> (String, String, bool) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_elle"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn elle");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin is piped")
+        .write_all(input.as_bytes())
+        .expect("write the program");
+    let out = child.wait_with_output().expect("wait for elle");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    )
+}
+
+/// The stderr of a program that must run cleanly.
+///
+/// Panics on a nonzero exit. A failed run never reaches the print under test,
+/// and an empty stderr satisfies none of the assertions below but explains
+/// nothing about why.
+fn stderr_of(input: &str) -> String {
+    let (_, stderr, ok) = run(input);
+    assert!(ok, "{input:?} must run cleanly, stderr:\n{stderr}");
+    stderr
+}
+
+#[test]
+fn debug_print_names_a_keyword_it_prints() {
+    // The counter-factual: probe with a keyword the static vocabulary already
+    // spells (`:timeout`, `:ok`, any error kind) and `resolve_keyword_name`
+    // answers from `VOCABULARY` whether or not the print threads the memo. Only
+    // a spelling this instance learned from source separates the two.
+    let err = stderr_of("(debug/print :probe-debug-keyword)\n");
+    assert!(
+        err.contains(":probe-debug-keyword"),
+        "debug/print must name the keyword it prints, got:\n{err}"
+    );
+}
+
+#[test]
+fn debug_print_names_a_symbol_it_prints() {
+    // A symbol has no vocabulary behind it, so an unthreaded print hashes every
+    // one of them.
+    let err = stderr_of("(debug/print (quote probe-debug-symbol))\n");
+    assert!(
+        err.contains("probe-debug-symbol"),
+        "debug/print must name the symbol it prints, got:\n{err}"
+    );
+}
+
+#[test]
+fn trace_names_the_keyword_it_traces() {
+    // The trap: `trace` resolves its LABEL through the memo already, so a test
+    // that checks the label alone passes while the value beside it on the same
+    // line reads `#<keyword:hash>`.
+    let err = stderr_of("(trace \"probe-label\" :probe-trace-keyword)\n");
+    assert!(
+        err.contains(":probe-trace-keyword"),
+        "trace must name the keyword it traces, got:\n{err}"
+    );
+}
+
+#[test]
+fn trace_names_a_keyword_nested_in_the_traced_value() {
+    // A traced value is usually a container. Threading the memo into the outer
+    // render but not through its recursion leaves every nested name hashed.
+    let err = stderr_of("(trace \"probe-label\" [1 :probe-nested-keyword])\n");
+    assert!(
+        err.contains(":probe-nested-keyword"),
+        "trace must name a keyword inside the value it traces, got:\n{err}"
+    );
+}
+
+/// Every surface a program's own names reach, in one program: the value the
+/// REPL echoes, `print`, `string`, the two diagnostic prints, the message of a
+/// type error, and the report of an error that reaches the root.
+///
+/// The last form raises, so the program exits nonzero. That is deliberate, and
+/// the test below reads both streams rather than the status.
+const EVERY_SURFACE: &str = concat!(
+    ":canary-echoed\n",
+    "(print [:canary-printed (quote canary-printed-sym)])\n",
+    "(print (string {:canary-stringified 1}))\n",
+    "(debug/print :canary-debugged)\n",
+    "(trace \"canary\" :canary-traced)\n",
+    "(print (protect ((quote canary-uncallable) 1)))\n",
+    "(error {:code :canary-raised :at (quote canary-raised-sym)})\n",
+);
+
+#[test]
+fn unresolved_names_reach_no_user_facing_surface() {
+    // The net for the whole class. The tests above say which name each print
+    // must spell; this one says no surface may carry the unreadable form at
+    // all, so a render added later that drops the memo fails here even though
+    // no test names it.
+    //
+    // The counter-factual: probe with names the vocabulary spells (`:ok`,
+    // `:timeout`, `:type-error`) and every one of them resolves with no memo
+    // threaded anywhere.
+    let (stdout, stderr, _) = run(EVERY_SURFACE);
+    for (stream, text) in [("stdout", &stdout), ("stderr", &stderr)] {
+        for form in ["#<keyword:", "#<symbol:"] {
+            assert!(
+                !text.contains(form),
+                "{stream} carries the unresolved form {form}, so a render dropped \
+                 the symbol memo:\n{text}"
+            );
+        }
+    }
+    // Guard the guard: an empty stream carries no unresolved form either.
+    assert!(
+        stdout.contains("canary-printed") && stderr.contains("canary-raised"),
+        "the probe must reach every surface it names:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -11,6 +11,9 @@ mod core {
 mod error_reporting {
     include!("error_reporting.rs");
 }
+mod diagnostics {
+    include!("diagnostics.rs");
+}
 mod repl_exit_codes {
     include!("repl_exit_codes.rs");
 }


### PR DESCRIPTION
## What was wrong

A symbol or keyword IS its name hash ([docs/impl/symbol.md](docs/impl/symbol.md)); the spelling lives in the per-instance memo. `Value`'s bare `Display`/`Debug` cannot thread that memo, because `fmt` takes only `&self` and a formatter, so a render that uses one prints `#<symbol:hash>`.

#1043 introduced `VM::show_value` as the one render of a value for a message a person reads, and routed the uncaught-error report, the four "Cannot call" paths and the WASM tier's report through it. It left the two diagnostic prints behind. On `main` today:

```
$ echo '(debug/print :probe) (trace "label" [1 :nested])' | elle
[DEBUG] #<keyword:0xbd448553e280c5f9>
[TRACE] label: [1 #<keyword:0x16ff70ef2aa17e75>]
```

`trace` is the sharper case: it resolved its label through the memo already, so one line held a spelled label beside a hashed value.

Only a name this instance learned shows the defect. `resolve_keyword_name` reads the static `VOCABULARY` after the memo, so `:timeout` or any error kind prints correctly whether or not the memo is threaded. That is what kept this looking narrow — the common keys read fine and the author's own read as hashes.

## What this does

Both prints render through `ctx.vm().show_value(…)`. `trace` resolves the value before it matches on the label, so its string and symbol arms print the same rendering.

[docs/impl/symbol.md](docs/impl/symbol.md) § "Reading a name, and not reading one" now states the `show_value` rule, which until this change lived only in a Rust doc comment. The section already described the unresolved form as a canary; it now also names the test that nets the class.

## How it was measured

`(debug/print …)` and `(trace …)` were run through the built binary before and after, on names coined in the probe's own source. The commit messages carry the before-output verbatim.

## Tests

`tests/integration/diagnostics.rs`, five tests, all of which fail on the parent commit:

- `debug_print_names_a_keyword_it_prints`, `debug_print_names_a_symbol_it_prints`
- `trace_names_the_keyword_it_traces`, `trace_names_a_keyword_nested_in_the_traced_value`
- `unresolved_names_reach_no_user_facing_surface` — the net for the class rather than for these two sites. One program crosses the REPL echo, `print`, `string`, both diagnostic prints, a type error's message and the root error report, and neither stream may carry `#<symbol:` or `#<keyword:` at all. A render added later that drops the memo fails there without anybody naming it.

Every probe uses a spelling read from the test's own source, never a vocabulary keyword, so none of them can pass over the defect. The tests drive the binary, because the subject is what lands on the terminal.

The canary program's last form raises, so it exits nonzero by design; that test reads both streams rather than the status, and a closing assertion pins that the probe reached both, because an empty stream carries no unresolved form either.

Green: `make qa`, `cargo test --lib` (2549), `cargo test --test lib` (1337), the corpus via `make smoke-elle` against the release binary, and the ten remaining test targets.
