### PR TITLE
typeinfer: a written lambda binding's result is Top

### DIFF
--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -232,8 +232,9 @@ The pass has no flow, so it cannot order the write against a call.
 - `hir::typeinfer::tests::mutation::*` — a written lambda binding proves nothing
   about its result: the write after the call and the write before it, the write
   reached from inside another function, a write that stores the same type, the
-  branch a Bottom would have joined away, and two controls — the unwritten
-  binding, and the SSA-renamed function-local write that still proves.
+  loop that rewrites its own callee between two turns, the branch a Bottom would
+  have joined away, and two controls — the unwritten binding, and the
+  SSA-renamed function-local write that still proves.
 - `tests/elle/typed-int-ops.lisp` — the corpus peer, on every tier: a
   self-recursive integer `fib` emits `AddInt` and computes with it, a float
   base case is refused at compile time, and a reassigned local lambda binding

--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -154,13 +154,42 @@ parameter, and `meet(String, Int)` is ⊥ inside the `(%int? x)` branch of a
 function only ever called with a string. Both are left alone, so those sites
 reject rather than compute.
 
+## A written binding's result is Top
+
+A binding whose initializer is a lambda records that lambda's body type, and
+every call to the binding reads it as a proof. An `assign` puts a different
+lambda in the binding, and no pass can say which one a given call reaches: the
+write can sit inside a function an earlier call runs.
+
+So the binder records **Top** for a binding this unit writes anywhere, whatever
+its initializer computes. The rule is asked once, where the body type is
+recorded, so no route to the write defeats it. Functionalization rewrites a
+write to a mutated binding into `MakeCell`/`SetCell`, whose arm records no body
+type at all; the `Assign` arm records one for a binding that rewrite left alone.
+
+Recording Top is what the join needs, and recording nothing is not enough. An
+absent entry reads as Bottom, and a Bottom no later pass raises joins away at
+the first branch it meets — `(if c (f 0) 1)` joins it with Int and hands the
+site an Int proof. `settle` never sees it, because the join has already
+replaced it (§ "Bottom is not a proof").
+
+```lisp
+(var f (fn [x] 1))
+(assign f (fn [x] "s"))
+(%bit-and (f 0) 1)
+```
+
+That is a compile error at both call sites, the one before the write included.
+The pass has no flow, so it cannot order the write against a call.
+
 ## What still does not prove
 
 - **A mutated binding.** An `assign` gives a binding flow that a per-pass
   recomputation cannot see, so a mutated parameter never receives call-site
   proofs and keeps whatever a guard proves of it. The loop-accumulator spelling
   of a numeric kernel is unproven for this reason, where the recursive spelling
-  of the same kernel proves.
+  of the same kernel proves. A mutated lambda binding's result answers the same
+  way, and for the same reason (§ "A written binding's result is Top").
 - **A binding used as a value.** One use outside callee position — stored,
   passed to a higher-order function, returned, exported — means callers this
   unit cannot enumerate, so the call-site join over the visible ones proves
@@ -187,6 +216,11 @@ reject rather than compute.
   declaration each refining the Kleene start and each meeting a fact that
   contradicts it, and the postcondition that the map the pass hands out carries
   no Bottom.
+- `hir::typeinfer::tests::mutation::*` — a written lambda binding proves nothing
+  about its result: the write after the call and the write before it, the write
+  reached from inside another function, the branch a Bottom would have joined
+  away, and the unwritten control that still proves.
 - `tests/elle/typed-int-ops.lisp` — the corpus peer, on every tier: a
-  self-recursive integer `fib` emits `AddInt` and computes with it, and a float
-  base case is refused at compile time.
+  self-recursive integer `fib` emits `AddInt` and computes with it, a float
+  base case is refused at compile time, and a reassigned local lambda binding
+  is refused where its unreassigned twin emits `AddInt`.

--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -36,7 +36,8 @@ estimate rises, and the limit of the ascent is the least fixpoint.
 
 | Callee | The call's type |
 |---|---|
-| a lambda binding this unit defines | that lambda's body type, as the previous pass left it |
+| a lambda binding this unit writes | Top (§ "A written binding's result is Top") |
+| a lambda binding this unit defines and never writes | that lambda's body type, as the previous pass left it |
 | a registered primitive | its declared `RetType`, read from the primitive tables |
 | a stdlib arithmetic wrapper (`+`, `abs`, `min`, …) | Number — the wrapper raises on everything else |
 | anything else | Top |
@@ -184,13 +185,14 @@ the first branch it meets — `(if c (f 0) 1)` joins it with Int and hands the
 site an Int proof. `settle` never sees it, because the join has already
 replaced it (§ "Bottom is not a proof").
 
-```lisp
+```text
 (var f (fn [x] 1))
+(%bit-and (f 0) 1)
 (assign f (fn [x] "s"))
 (%bit-and (f 0) 1)
 ```
 
-That is a compile error at both call sites, the one before the write included.
+That is a compile error at both call sites, the one above the write included.
 The pass has no flow, so it cannot order the write against a call.
 
 ## What still does not prove

--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -167,6 +167,17 @@ recorded, so no route to the write defeats it. Functionalization rewrites a
 write to a mutated binding into `MakeCell`/`SetCell`, whose arm records no body
 type at all; the `Assign` arm records one for a binding that rewrite left alone.
 
+Which binding a call names is functionalization's answer rather than the
+source's. A straight-line write to a function-local binding is SSA-renamed:
+each version has one initializer, and the call names the version the write
+made. No version is written there, so that spelling keeps its proof and answers
+from the lambda the program last put in the name.
+
+What renaming cannot reach is a binding a **cell** holds — file scope, a loop,
+a capture, a write from inside another function — and that is the shape this
+rule covers. A version a branch merges is neither: its initializer is the
+merge, so nothing records a body type for it and a call already reads Top.
+
 Recording Top is what the join needs, and recording nothing is not enough. An
 absent entry reads as Bottom, and a Bottom no later pass raises joins away at
 the first branch it meets — `(if c (f 0) 1)` joins it with Int and hands the
@@ -218,8 +229,9 @@ The pass has no flow, so it cannot order the write against a call.
   no Bottom.
 - `hir::typeinfer::tests::mutation::*` — a written lambda binding proves nothing
   about its result: the write after the call and the write before it, the write
-  reached from inside another function, the branch a Bottom would have joined
-  away, and the unwritten control that still proves.
+  reached from inside another function, a write that stores the same type, the
+  branch a Bottom would have joined away, and two controls — the unwritten
+  binding, and the SSA-renamed function-local write that still proves.
 - `tests/elle/typed-int-ops.lisp` — the corpus peer, on every tier: a
   self-recursive integer `fib` emits `AddInt` and computes with it, a float
   base case is refused at compile time, and a reassigned local lambda binding

--- a/src/hir/typeinfer/infer.rs
+++ b/src/hir/typeinfer/infer.rs
@@ -47,10 +47,13 @@ pub(super) struct Infer<'a> {
     // ── the program's facts: collected once, never rewritten ──
     /// Which bindings are lambdas, and what their parameters are.
     lambda_params: HashMap<Binding, Vec<Binding>>,
-    /// Bindings written by `Assign`/`SetCell`. A parameter in this set has flow
-    /// the per-pass recomputation cannot see, so it never receives call-site
-    /// proofs (guards only).
-    mutated_params: HashSet<Binding>,
+    /// Bindings written by `Assign`/`SetCell` anywhere in the unit. A write
+    /// gives a binding flow the per-pass recomputation cannot see, and that
+    /// costs the binding two proofs: a parameter in this set never receives
+    /// call-site proofs (guards only), and a lambda binding in it records Top
+    /// for its result rather than its initializer's body type
+    /// (docs/impl/typeinfer.md).
+    mutated: HashSet<Binding>,
     /// Bindings with at least one value-position use
     /// (`collect_value_position_uses`): their callers are not all visible, so
     /// call-site joins must not prove their parameters.
@@ -84,7 +87,7 @@ impl<'a> Infer<'a> {
     pub(super) fn new(hir: &Hir, arena: &'a BindingArena) -> Self {
         let mut lambda_params: HashMap<Binding, Vec<Binding>> = HashMap::new();
         collect_lambda_info(hir, arena, &mut lambda_params);
-        let mutated_params = collect_mutated_bindings(hir);
+        let mutated = collect_mutated_bindings(hir);
         let mut value_used = HashSet::new();
         collect_value_position_uses(hir, &mut value_used);
         let mut typeof_aliases: HashMap<Binding, Binding> = HashMap::new();
@@ -108,7 +111,7 @@ impl<'a> Infer<'a> {
                 continue;
             }
             for p in params {
-                if !mutated_params.contains(p) {
+                if !mutated.contains(p) {
                     binding_types.insert(*p, TypeInterner::BOTTOM);
                 }
             }
@@ -118,7 +121,7 @@ impl<'a> Infer<'a> {
             interner: TypeInterner::new(),
             arena,
             lambda_params,
-            mutated_params,
+            mutated,
             value_used,
             typeof_aliases,
             binding_types,

--- a/src/hir/typeinfer/infer/fixpoint.rs
+++ b/src/hir/typeinfer/infer/fixpoint.rs
@@ -114,7 +114,7 @@ impl Infer<'_> {
         let ty = self.infer(hir);
         self.hir_types.insert(hir.id, ty);
         for (param, joined) in std::mem::take(&mut self.param_joins) {
-            if self.mutated_params.contains(&param) {
+            if self.mutated.contains(&param) {
                 continue;
             }
             let floored = declared_floor(param, joined, self.arena, &self.interner);

--- a/src/hir/typeinfer/infer/node/binder.rs
+++ b/src/hir/typeinfer/infer/node/binder.rs
@@ -1,33 +1,57 @@
-// audited: 2026-09-08
+// audited: 2026-09-09
 // src/hir/AGENTS.md
 // docs/impl/typeinfer.md
 //! What a binder records: the type a `let`, a `def` or a cell write leaves for
 //! every later read of that binding. A lambda init also records its body type,
-//! which is what the binding's callers read.
+//! which is what the binding's callers read — unless the unit writes the
+//! binding, where no body type is an answer about the call.
 
 use super::*;
 
 impl Infer<'_> {
+    /// Record what a call to `binding` may prove about its result, given the
+    /// initializer the binder is walking. A non-lambda initializer records
+    /// nothing — the binding is not a callee this unit can read a body off.
+    ///
+    /// For a lambda (possibly cell-wrapped when self-recursive or captured)
+    /// that is the body's return type, which every call to the binding reads, a
+    /// self-call included (docs/impl/typeinfer.md). REPLACE, don't join: each
+    /// pass re-derives the body type from strictly more information, and a join
+    /// could never come back down from the estimate an earlier pass computed
+    /// with less.
+    ///
+    /// A binding this unit WRITES records Top instead. An `assign` puts a
+    /// different lambda there and no pass can say which one a given call
+    /// reaches, so the initializer's body type is not an answer about the call.
+    /// Recording Top rather than recording nothing is what a branch needs:
+    /// an absent entry reads as Bottom, and `Int ⊔ ⊥` is Int, so the arm the
+    /// program did write would prove the site.
+    ///
+    /// One rule, asked where the record is made, so no route to the write
+    /// defeats it — functionalization sends a mutated binding's write to
+    /// `SetCell`, which records no body type, and leaves the rest to `Assign`.
+    fn record_lambda_body_type(&mut self, binding: Binding, init: &Hir) {
+        let HirKind::Lambda { body, .. } = &unwrap_make_cell(init).kind else {
+            return;
+        };
+        let ty = if self.mutated.contains(&binding) {
+            TypeInterner::TOP
+        } else {
+            self.hir_types
+                .get(&body.id)
+                .copied()
+                .unwrap_or(TypeInterner::TOP)
+        };
+        self.lambda_body_type.insert(binding, ty);
+    }
+
     /// Let/Letrec — seed binding types from init values.
     pub(super) fn infer_let(&mut self, bindings: &[(Binding, Hir)], body: &Hir) -> TyId {
         for (binding, init) in bindings {
             let ty = self.infer(init);
             self.hir_types.insert(init.id, ty);
-            // For lambda bindings (possibly cell-wrapped when
-            // self-recursive/captured), record their body's return type:
-            // this is what every call to the binding reads, a self-call
-            // included (docs/impl/typeinfer.md).
-            // REPLACE, don't join: each pass re-derives the body type from
-            // strictly more information, and a join could never come back
-            // down from the estimate an earlier pass computed with less.
-            if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(init).kind {
-                let body_ty = self
-                    .hir_types
-                    .get(&lam_body.id)
-                    .copied()
-                    .unwrap_or(TypeInterner::TOP);
-                self.lambda_body_type.insert(*binding, body_ty);
-            } else {
+            self.record_lambda_body_type(*binding, init);
+            if !matches!(unwrap_make_cell(init).kind, HirKind::Lambda { .. }) {
                 let old = self
                     .binding_types
                     .get(binding)
@@ -59,14 +83,7 @@ impl Infer<'_> {
     /// `collect_lambda_info` records its params.
     pub(super) fn infer_define(&mut self, target: Binding, value: &Hir) -> TyId {
         let ty = self.infer(value);
-        if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(value).kind {
-            let body_ty = self
-                .hir_types
-                .get(&lam_body.id)
-                .copied()
-                .unwrap_or(TypeInterner::TOP);
-            self.lambda_body_type.insert(target, body_ty);
-        }
+        self.record_lambda_body_type(target, value);
         self.hir_types.insert(value.id, ty);
         let old = self
             .binding_types

--- a/src/hir/typeinfer/tests.rs
+++ b/src/hir/typeinfer/tests.rs
@@ -6,9 +6,9 @@
 //!
 //! One module per subject: `narrow` for what a guard or a dispatch arm proves,
 //! `rettype` for what an op's result proves, `recursion` for what a recursive
-//! call's result proves, `bottom` for what the lattice's start proves,
-//! `prune` for dead-arm removal, `contract` for prove-or-reject,
-//! `monomorphize` for wrapper collapse.
+//! call's result proves, `mutation` for what a written binding proves,
+//! `bottom` for what the lattice's start proves, `prune` for dead-arm removal,
+//! `contract` for prove-or-reject, `monomorphize` for wrapper collapse.
 
 use super::infer_and_rewrite;
 use crate::hir::types::TyId;
@@ -18,6 +18,7 @@ use crate::symbol::SymbolTable;
 mod bottom;
 mod contract;
 mod monomorphize;
+mod mutation;
 mod narrow;
 mod prune;
 mod recursion;

--- a/src/hir/typeinfer/tests/mutation.rs
+++ b/src/hir/typeinfer/tests/mutation.rs
@@ -1,0 +1,88 @@
+// audited: 2026-09-09
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! What a written binding proves about the lambda a call to it reaches —
+//! nothing.
+//!
+//! A binding whose initializer is a lambda records that lambda's body type, and
+//! every call reads it as a proof. An `assign` puts a different lambda there,
+//! and no pass can say which one a given call reaches, so the record is Top.
+
+use super::compile_result;
+
+/// The rule, over every route a write takes. The reproducer is the first row;
+/// the rest reach the same binding differently — before the call, from inside
+/// another function, and with a value that is no lambda at all.
+///
+/// The counter-factual: every one of these compiled against the first
+/// initializer's body type. `%bit-and` ran the integer opcode over the string
+/// "s" and printed 0, and the row that assigns 3 got as far as calling it.
+#[test]
+fn a_written_lambda_binding_proves_nothing_about_its_result() {
+    for src in [
+        // The write after the call site.
+        "(var f (fn [x] 1)) (assign f (fn [x] \"s\")) (%bit-and (f 0) 1)",
+        // The write after a call site that reads the initializer it names. The
+        // pass has no flow, so it cannot order the write against the call.
+        "(var f (fn [x] 1)) (%bit-and (f 0) 1) (assign f (fn [x] \"s\"))",
+        // The write from inside another function, which runs between the two.
+        "(var f (fn [x] 1)) (defn swap [] (assign f (fn [x] \"s\"))) \
+         (swap) (%bit-and (f 0) 1)",
+        // The write of a value that is not callable at all.
+        "(var f (fn [x] 1)) (assign f 3) (%bit-and (f 0) 1)",
+    ] {
+        let Err(err) = compile_result(src) else {
+            panic!("a written lambda binding proves no int result: {src}");
+        };
+        assert!(
+            err.contains("%bit-and"),
+            "error must name %bit-and; got: {err}"
+        );
+    }
+}
+
+/// The rule is about the write, not about what the write stores. Both lambdas
+/// return an int here, so the body type the binder recorded was right by
+/// accident — and a pass that reads it is proving something it cannot know.
+///
+/// The counter-factual: this compiled, and the same reasoning compiled the
+/// string row above.
+#[test]
+fn a_write_that_keeps_the_type_still_stops_the_proof() {
+    let src = "(defn top [] (var g (fn [x] 1)) (assign g (fn [x] 2)) \
+               (%bit-and (g 1) 1)) (top)";
+    let err = compile_result(src).expect_err("a written binding proves no result, int or not");
+    assert!(
+        err.contains("%bit-and"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+}
+
+/// What the record has to be, rather than what it has to stop being. An absent
+/// entry reads as Bottom, and `subtype(⊥, b)` holds for every `b` — but the
+/// gate never sees this one, because the branch joins it with the Int arm
+/// first and `Int ⊔ ⊥` is Int.
+///
+/// The counter-factual: refusing to record a body type closes every row above
+/// and leaves this one compiling, with the bitwise opcode over the string.
+#[test]
+fn a_branch_does_not_join_a_written_binding_result_away() {
+    let src = "(var f (fn [x] 1)) (assign f (fn [x] \"s\")) \
+               (%bit-and (if (%eq 1 1) (f 0) 1) 1)";
+    let err = compile_result(src).expect_err("a branch arm must not join an absent record away");
+    assert!(
+        err.contains("%bit-and"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+}
+
+/// The over-rejection guard. A binding nothing writes still records its one
+/// initializer's body type, so the everyday spelling keeps the proof the whole
+/// ascent exists to hand out — at file scope and inside a function alike.
+#[test]
+fn an_unwritten_lambda_binding_still_proves_its_result() {
+    compile_result("(var f (fn [x] 1)) (%bit-and (f 0) 1)")
+        .expect("one initializer and no write proves the result at file scope");
+    compile_result("(defn top [] (var g (fn [x] (%add x 1))) (%add (g 1) 1)) (top)")
+        .expect("and inside a function, where the binding is a local");
+}

--- a/src/hir/typeinfer/tests/mutation.rs
+++ b/src/hir/typeinfer/tests/mutation.rs
@@ -101,6 +101,29 @@ fn a_branch_does_not_join_a_written_binding_result_away() {
     );
 }
 
+/// The loop, which is what makes the write-before-the-call row above a
+/// soundness rule rather than a precision cost. The call stands above every
+/// write in the file and still reaches the string, because the second turn runs
+/// over what the first turn assigned. A loop is one of the shapes the document
+/// names as beyond SSA renaming, and this is the row that checks it.
+///
+/// The counter-factual: this compiled and printed `1` then `0`. The second turn
+/// ran the integer opcode over the string the first turn assigned.
+#[test]
+fn a_loop_that_rewrites_its_own_callee_proves_nothing() {
+    let src = "(let [@g (fn [x] 1)] \
+                 (var i 0) \
+                 (while (%lt i 2) \
+                   (%bit-and (g 0) 1) \
+                   (assign g (fn [x] \"s\")) \
+                   (assign i (%add i 1))))";
+    let err = compile_result(src).expect_err("a callee the loop rewrites proves no int");
+    assert!(
+        err.contains("%bit-and"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+}
+
 /// The over-rejection guard. A binding nothing writes still records its one
 /// initializer's body type, so the everyday spelling keeps the proof the whole
 /// ascent exists to hand out — at file scope and inside a function alike.

--- a/src/hir/typeinfer/tests/mutation.rs
+++ b/src/hir/typeinfer/tests/mutation.rs
@@ -49,12 +49,37 @@ fn a_written_lambda_binding_proves_nothing_about_its_result() {
 /// string row above.
 #[test]
 fn a_write_that_keeps_the_type_still_stops_the_proof() {
-    let src = "(defn top [] (var g (fn [x] 1)) (assign g (fn [x] 2)) \
-               (%bit-and (g 1) 1)) (top)";
+    let src = "(var f (fn [x] 1)) (assign f (fn [x] 2)) (%bit-and (f 0) 1)";
     let err = compile_result(src).expect_err("a written binding proves no result, int or not");
     assert!(
         err.contains("%bit-and"),
         "the error must name the op that could not prove; got: {err}"
+    );
+}
+
+/// The other over-rejection guard, and the reason the rule is stated over the
+/// binding a call NAMES. Functionalization SSA-renames a straight-line write to
+/// a function-local binding, so each version carries one initializer and the
+/// call reads the version the write made — a proof about one lambda, not a
+/// guess between two.
+///
+/// The trap: both spellings read `(assign g …)` in the source, and only the
+/// cell-held one is a binding this rule can say anything about.
+#[test]
+fn a_renamed_function_local_write_keeps_its_proof() {
+    compile_result(
+        "(defn top [] (var g (fn [x] 1)) (assign g (fn [x] 2)) \
+                    (%bit-and (g 1) 1)) (top)",
+    )
+    .expect("the call names the version the write made, whose one body is an int");
+    let err = compile_result(
+        "(defn top [] (var g (fn [x] 1)) (assign g (fn [x] \"s\")) \
+         (%bit-and (g 1) 1)) (top)",
+    )
+    .expect_err("and that version's body decides the answer when it is a string");
+    assert!(
+        err.contains("string"),
+        "the error must report the body the call reaches; got: {err}"
     );
 }
 

--- a/tests/elle/typed-int-ops.lisp
+++ b/tests/elle/typed-int-ops.lisp
@@ -1,5 +1,5 @@
 (elle/epoch 12)
-# audited: 2026-09-08
+# audited: 2026-09-09
 # The operand proof, end to end.
 #
 # A %-intrinsic whose operands the front end proved are integers emits the
@@ -143,6 +143,29 @@
                  "  (if (%lt n 2) 1.5 (%bit-and (%add (f (%sub n 1)) 1) 3))) "
                  "(f 4)") "<typed-int-ops>"))]
   (assert (not (get r 0)) "a float base case must not prove an int result")
+  (assert (string/contains? (get (get r 1) :message) "%bit-and")
+          (string "the diagnostic must name the refusing op, got "
+                  (get (get r 1) :message))))
+
+# ── A reassigned lambda binding proves nothing ───────────────────
+
+(defn call-local-lambda []
+  "One initializer and no write, so the call reads the lambda's body type."
+  (var g (fn [x] (%add x 1)))
+  (%add (g 1) 1))
+
+(assert (string/contains? (disasm-text call-local-lambda) "AddInt")
+        "a call to an unwritten local lambda binding proves the %add")
+(assert (= (call-local-lambda) 3) "AddInt computes over the call's result")
+
+# The counter-factual: the binder kept the first initializer's body type
+# through every later write, so this compiled and `%bit-and` ran the integer
+# opcode over the string "s", printing 0.
+(let [r (protect (compile/barrier-module (string "(var f (fn [x] 1)) "
+                 "(assign f (fn [x] \"s\")) " "(%bit-and (f 0) 1)")
+                 "<typed-int-ops>"))]
+  (assert (not (get r 0))
+          "a reassigned lambda binding must not prove its result")
   (assert (string/contains? (get (get r 1) :message) "%bit-and")
           (string "the diagnostic must name the refusing op, got "
                   (get (get r 1) :message))))


### PR DESCRIPTION
A binding whose initializer is a lambda records that lambda's body type, and
every call to the binding reads it as a proof. A write to the binding did not
update that record, so calls proved against a body the program had already
replaced.

```lisp
(var f (fn [x] 1))
(print (%bit-and (f 0) 1))       # 1
(assign f (fn [x] "s"))
(print (%bit-and (f 0) 1))       # 0 — the integer opcode over the string "s"
```

## What the change does

The binder records **Top** for a binding this unit writes anywhere, whatever
the initializer computes. A pass cannot tell which lambda a call reaches — the
write can sit inside a function an earlier call runs — so no body type is an
answer about the call.

The rule is asked once, where the body type is recorded, so no route to the
write defeats it. Functionalization sends a cell-held binding's write to
`SetCell`, whose arm records no body type at all; the `Assign` arm records one
for a binding that rewrite left alone.

Top rather than nothing. Recording nothing leaves the entry absent, an absent
entry reads as Bottom, and `Int ⊔ ⊥` is Int — so
`(%bit-and (if c (f 0) 1) 1)` still compiled and still ran the integer opcode
over the string. `settle` never sees that Bottom, because the join has already
replaced it.

The rule reaches the spelling a cell holds: file scope, a loop, a capture, a
write from inside another function. A straight-line write to a function-local
binding is SSA-renamed, so each version carries one initializer and the call
names the version the write made — that spelling keeps its proof.

The set the rule reads now governs two proofs rather than one, so it is
`mutated` instead of `mutated_params`.

## How it was measured

- `cargo test -p elle --lib` — 2554 passed, 0 failed.
- `make qa` — clean.
- `make smoke-elle ELLE=./target/release/elle CARGO_PROFILE=--release` — the
  whole corpus, VM and JIT, 0 fail and 0 diverge.
- `./target/debug/elle tests/elle/oracle.lisp` — `oracle: ok`, 0 open defects
  across 0 roots.
- `cargo test -p elle --test lib region_ -- --test-threads=1` — the guardfree
  UAF pins.

Each new test was run against the tree before the code commit and failed
there.

## What pins it

- `hir::typeinfer::tests::mutation::a_written_lambda_binding_proves_nothing_about_its_result`
  — the rule over four routes to the write: after the call, before it, from
  inside another function, and a write of a value that is not callable.
- `…::a_write_that_keeps_the_type_still_stops_the_proof` — both lambdas return
  an int, so the record was right by accident.
- `…::a_branch_does_not_join_a_written_binding_result_away` — why the record is
  Top rather than absent.
- `…::a_renamed_function_local_write_keeps_its_proof` and
  `…::an_unwritten_lambda_binding_still_proves_its_result` — the two
  over-rejection guards.
- `tests/elle/typed-int-ops.lisp` — the corpus peer, beside the existing proof
  rows: the reassigned binding is refused at compile time where its unwritten
  local twin emits `AddInt`.

Closes #1086.
