### PR TITLE
typeinfer: a call to a written binding reads Top

### DIFF
--- a/docs/impl/typeinfer.md
+++ b/docs/impl/typeinfer.md
@@ -36,7 +36,8 @@ estimate rises, and the limit of the ascent is the least fixpoint.
 
 | Callee | The call's type |
 |---|---|
-| a lambda binding this unit defines | that lambda's body type, as the previous pass left it |
+| a lambda binding this unit writes with `assign` | Top |
+| a lambda binding this unit defines and never writes | that lambda's body type, as the previous pass left it |
 | a registered primitive | its declared `RetType`, read from the primitive tables |
 | a stdlib arithmetic wrapper (`+`, `abs`, `min`, …) | Number — the wrapper raises on everything else |
 | anything else | Top |
@@ -166,6 +167,29 @@ reject rather than compute.
   unit cannot enumerate, so the call-site join over the visible ones proves
   nothing about the parameters.
 
+### A written binding's result is Top
+
+The same argument covers what a call to a mutated binding returns. An
+initializer records the body type of the lambda it holds, and a later `assign`
+puts a different lambda in the same binding. The pass walks both and cannot say
+which one a call reaches, so the recorded type is not a fact about the call.
+
+```text
+(var f (fn [x] 1))
+(assign f (fn [x] "s"))
+(%bit-and (f 0) 1)
+```
+
+That is a compile error at the `%bit-and`. Both calls in the two-call spelling
+answer the same way: the rule is about the binding, and the pass reads no order
+between a call and the write.
+
+The rule sits where a body type is recorded, not where the write happens: a
+binding in `mutated_params` records Top. `functionalize` rewrites this `assign`
+into a `SetCell` that records no body type at all, and a route reaching the
+write some other way would do the same. Keying on the binding covers all of
+them.
+
 ## Pinning tests
 
 - `hir::typeinfer::tests::recursion::self_recursive_call_result_is_the_body_type`
@@ -182,11 +206,16 @@ reject rather than compute.
 - `…::a_chain_deeper_than_the_budget_proves_nothing` — the widening: eleven
   functions in reverse walk order outrun the ten passes, and the site that
   reads the unsettled entry is rejected rather than compiled.
+- `hir::typeinfer::tests::mutation::*` — a written binding's result: the
+  reassigned lambda, the call that stands above the write, the `let`-bound
+  spelling, and the over-rejection guard that a binding nothing writes still
+  proves.
 - `hir::typeinfer::tests::bottom::*` — Bottom is not a proof: one rejection per
   contract row that asks a subtype question, a guard and a `(numeric!)`
   declaration each refining the Kleene start and each meeting a fact that
   contradicts it, and the postcondition that the map the pass hands out carries
   no Bottom.
 - `tests/elle/typed-int-ops.lisp` — the corpus peer, on every tier: a
-  self-recursive integer `fib` emits `AddInt` and computes with it, and a float
-  base case is refused at compile time.
+  self-recursive integer `fib` emits `AddInt` and computes with it, a float
+  base case is refused at compile time, and a reassigned lambda binding is
+  refused while the reassignment itself still runs.

--- a/src/hir/typeinfer/infer/node/binder.rs
+++ b/src/hir/typeinfer/infer/node/binder.rs
@@ -1,33 +1,53 @@
-// audited: 2026-09-08
+// audited: 2026-09-09
 // src/hir/AGENTS.md
 // docs/impl/typeinfer.md
 //! What a binder records: the type a `let`, a `def` or a cell write leaves for
 //! every later read of that binding. A lambda init also records its body type,
-//! which is what the binding's callers read.
+//! which is what the binding's callers read — unless something writes the
+//! binding, and then they read Top.
 
 use super::*;
 
 impl Infer<'_> {
+    /// Record a lambda binding's body type, which is what every call to the
+    /// binding reads, a self-call included. Reports whether `init` held a
+    /// lambda at all; a cell wrapper around a self-recursive or captured one is
+    /// peeled off first.
+    ///
+    /// REPLACE, don't join: each pass re-derives the body type from strictly
+    /// more information, and a join could never come back down from the
+    /// estimate an earlier pass computed with less.
+    ///
+    /// A binding something writes records Top. The initializer's body type
+    /// describes one lambda, an `assign` puts a different lambda in the same
+    /// binding, and the pass cannot tell which one a call reaches — the same
+    /// argument that denies a mutated parameter its call-site proofs. The rule
+    /// sits here rather than on the write, so a route that reaches the write
+    /// differently cannot defeat it: `functionalize` rewrites a top-level
+    /// `assign` into a `SetCell`, which records no body type at all
+    /// (docs/impl/typeinfer.md § "What still does not prove").
+    fn record_lambda_body_type(&mut self, binding: Binding, init: &Hir) -> bool {
+        let HirKind::Lambda { body, .. } = &unwrap_make_cell(init).kind else {
+            return false;
+        };
+        let body_ty = if self.mutated_params.contains(&binding) {
+            TypeInterner::TOP
+        } else {
+            self.hir_types
+                .get(&body.id)
+                .copied()
+                .unwrap_or(TypeInterner::TOP)
+        };
+        self.lambda_body_type.insert(binding, body_ty);
+        true
+    }
+
     /// Let/Letrec — seed binding types from init values.
     pub(super) fn infer_let(&mut self, bindings: &[(Binding, Hir)], body: &Hir) -> TyId {
         for (binding, init) in bindings {
             let ty = self.infer(init);
             self.hir_types.insert(init.id, ty);
-            // For lambda bindings (possibly cell-wrapped when
-            // self-recursive/captured), record their body's return type:
-            // this is what every call to the binding reads, a self-call
-            // included (docs/impl/typeinfer.md).
-            // REPLACE, don't join: each pass re-derives the body type from
-            // strictly more information, and a join could never come back
-            // down from the estimate an earlier pass computed with less.
-            if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(init).kind {
-                let body_ty = self
-                    .hir_types
-                    .get(&lam_body.id)
-                    .copied()
-                    .unwrap_or(TypeInterner::TOP);
-                self.lambda_body_type.insert(*binding, body_ty);
-            } else {
+            if !self.record_lambda_body_type(*binding, init) {
                 let old = self
                     .binding_types
                     .get(binding)
@@ -59,14 +79,7 @@ impl Infer<'_> {
     /// `collect_lambda_info` records its params.
     pub(super) fn infer_define(&mut self, target: Binding, value: &Hir) -> TyId {
         let ty = self.infer(value);
-        if let HirKind::Lambda { body: lam_body, .. } = &unwrap_make_cell(value).kind {
-            let body_ty = self
-                .hir_types
-                .get(&lam_body.id)
-                .copied()
-                .unwrap_or(TypeInterner::TOP);
-            self.lambda_body_type.insert(target, body_ty);
-        }
+        self.record_lambda_body_type(target, value);
         self.hir_types.insert(value.id, ty);
         let old = self
             .binding_types

--- a/src/hir/typeinfer/tests.rs
+++ b/src/hir/typeinfer/tests.rs
@@ -6,9 +6,10 @@
 //!
 //! One module per subject: `narrow` for what a guard or a dispatch arm proves,
 //! `rettype` for what an op's result proves, `recursion` for what a recursive
-//! call's result proves, `bottom` for what the lattice's start proves,
-//! `prune` for dead-arm removal, `contract` for prove-or-reject,
-//! `monomorphize` for wrapper collapse.
+//! call's result proves, `mutation` for what a call to a written binding
+//! proves, `bottom` for what the lattice's start proves, `prune` for dead-arm
+//! removal, `contract` for prove-or-reject, `monomorphize` for wrapper
+//! collapse.
 
 use super::infer_and_rewrite;
 use crate::hir::types::TyId;
@@ -18,6 +19,7 @@ use crate::symbol::SymbolTable;
 mod bottom;
 mod contract;
 mod monomorphize;
+mod mutation;
 mod narrow;
 mod prune;
 mod recursion;

--- a/src/hir/typeinfer/tests/mutation.rs
+++ b/src/hir/typeinfer/tests/mutation.rs
@@ -1,0 +1,82 @@
+// audited: 2026-09-09
+// src/hir/AGENTS.md
+// docs/impl/typeinfer.md
+//! What a call to a written binding proves about its result — nothing.
+//!
+//! An initializer records the body type of one lambda, and an `assign` puts a
+//! different lambda in the same binding. Neither the order between a call and
+//! the write nor the binder spelling changes that answer, and a binding nothing
+//! writes still proves.
+
+use super::compile_result;
+
+/// The reassigned binding, with the call below the write. `functionalize`
+/// rewrites this `assign` into a `SetCell`, which records no body type at all,
+/// so the map held the first initializer's answer for the rest of the compile.
+///
+/// The counter-factual: this compiled. `%bit-and` ran the integer opcode over
+/// the string `"s"`, raised nothing, and the program printed 0.
+#[test]
+fn a_reassigned_lambda_binding_proves_nothing_about_its_result() {
+    let err = compile_result("(var f (fn [x] 1)) (assign f (fn [x] \"s\")) (%bit-and (f 0) 1)")
+        .expect_err("a written binding's result proves no int");
+    assert!(
+        err.contains("%bit-and"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+}
+
+/// The rule is about the binding, not about a position in the file. One pass
+/// walks the whole tree and records one type per binding, so a call standing
+/// above the write reads that same Top.
+///
+/// The trap: this call does reach the first lambda every time the program runs,
+/// so the rejection costs precision a flow-sensitive pass would keep. The loop
+/// below is why a pass that reads text order cannot have that precision.
+///
+/// The counter-factual: this compiled.
+#[test]
+fn a_call_above_the_write_proves_nothing_either() {
+    let err =
+        compile_result("(var f (fn [x] 1)) (%bit-and (f 0) 1) (assign f (fn [x] \"s\")) (f 0)")
+            .expect_err("standing above the write is not a proof");
+    assert!(
+        err.contains("%bit-and"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+}
+
+/// The other binder arm, and the reason text order proves nothing. An `assign`
+/// to a `let`-bound mutable binding records the assigned lambda's body type,
+/// and the call above it goes on reading the initializer's — which the loop's
+/// second turn has already replaced.
+///
+/// The counter-factual: this compiled and printed `1` then `0`. The second turn
+/// ran the integer opcode over the string the first turn assigned, at a call
+/// site that stands above every write in the file.
+#[test]
+fn a_loop_that_rewrites_its_own_callee_proves_nothing() {
+    let src = "(let [@g (fn [x] 1)] \
+                 (var i 0) \
+                 (while (%lt i 2) \
+                   (%bit-and (g 0) 1) \
+                   (assign g (fn [x] \"s\")) \
+                   (assign i (%add i 1))))";
+    let err = compile_result(src).expect_err("a callee the loop rewrites proves no int");
+    assert!(
+        err.contains("%bit-and"),
+        "the error must name the op that could not prove; got: {err}"
+    );
+}
+
+/// The over-rejection guard: the pass keys on the write, not on the
+/// declaration. A mutable binding nothing ever assigns holds the lambda its
+/// initializer put there, so its body type is a fact about every call to it and
+/// the proof survives.
+#[test]
+fn a_binding_nothing_writes_still_proves_its_result() {
+    compile_result("(var f (fn [x] 1)) (%bit-and (f 0) 1)")
+        .expect("an unwritten binding's body type is a fact about every call to it");
+    compile_result("(let [@g (fn [x] 1)] (%bit-and (g 0) 1))")
+        .expect("and the same holds for the let-bound spelling");
+}

--- a/tests/elle/typed-int-ops.lisp
+++ b/tests/elle/typed-int-ops.lisp
@@ -1,5 +1,5 @@
 (elle/epoch 12)
-# audited: 2026-09-08
+# audited: 2026-09-09
 # The operand proof, end to end.
 #
 # A %-intrinsic whose operands the front end proved are integers emits the
@@ -8,7 +8,8 @@
 #
 # A proven op's result carries a type of its own, so the proof reaches the next
 # op in the chain — and a float operand denies it there. A call's result carries
-# one too, a recursive call included.
+# one too, a recursive call included. A call to a reassigned binding carries
+# none.
 # docs/impl/lir.md
 # docs/intrinsics.md
 
@@ -146,6 +147,29 @@
   (assert (string/contains? (get (get r 1) :message) "%bit-and")
           (string "the diagnostic must name the refusing op, got "
                   (get (get r 1) :message))))
+
+# ── A reassigned lambda binding proves nothing ───────────────────
+
+# The trap: a binding's initializer and its replacement are two different
+# lambdas, and the pass walks both. A body type recorded from either one
+# describes a lambda the call may not reach, so it is not a proof.
+#
+# The counter-factual: this compiled, %bit-and ran the integer opcode over the
+# string the assign left in f, and the program printed 0 instead of raising.
+(let [r (protect (compile/barrier-module (string "(var f (fn [x] 1)) "
+                 "(assign f (fn [x] \"s\")) " "(%bit-and (f 0) 1)")
+                 "<typed-int-ops>"))]
+  (assert (not (get r 0)) "a written binding's result must not prove an int")
+  (assert (string/contains? (get (get r 1) :message) "%bit-and")
+          (string "the diagnostic must name the refusing op, got "
+                  (get (get r 1) :message))))
+
+# The refusal belongs to the operand proof, not to the assignment: the write
+# itself still runs, and a call reaches whichever lambda the binding holds.
+(var swap-me (fn [x] 1))
+(assert (= (swap-me 0) 1) "the initializer's lambda answers before the write")
+(assign swap-me (fn [x] "s"))
+(assert (= (swap-me 0) "s") "and the assigned lambda answers after it")
 
 # ── A float operand proves nothing to a bitwise op ───────────────
 


### PR DESCRIPTION
A binding whose initializer is a lambda recorded that lambda's return type,
and every call to the binding read it as a proof. A write puts a different
lambda in the same binding, so the recorded type described a lambda the call
may not reach.

## What was wrong

```lisp
(var f (fn [x] 1))
(assign f (fn [x] "s"))
(print (%bit-and (f 0) 1))       ; => 0
```

`%bit-and` ran the integer opcode over the string `"s"` and raised nothing.
The control is rejected as it should be:

```
$ elle -e '(defn c [a b] (%bit-and a b)) (print (c "s" 1))'
✗ Compile error: %bit-and: operand 1 is not a proven int (inferred: string) …
```

This is not the ⊥ class of #1079. The type read here is a concrete `Int`, from
an initializer the program has already overwritten.

Both binder arms gave a wrong answer, and text order decided which one. A
top-level `assign` becomes a `SetCell` that records no body type at all, so
the map kept the first initializer's. An `assign` to a `let`-bound mutable
binding records the assigned lambda's, and a call above it goes on reading the
initializer's:

```lisp
(let [@g (fn [x] 1)]
  (var i 0)
  (while (%lt i 2)
    (print (%bit-and (g 0) 1))    ; => 1 then 0
    (assign g (fn [x] "s"))
    (assign i (%add i 1))))
```

## What the change does

Both arms record through one helper, `record_lambda_body_type`, and a binding
in `mutated_params` records Top. A mutated parameter already receives no
call-site proofs by design; the same argument covers the result, because the
pass cannot tell which lambda a call reaches.

The rule sits where a body type is recorded rather than on the write. The
`SetCell` that `functionalize` makes of a top-level `assign` then needs no rule
of its own, and a route reaching the write some other way cannot defeat it.

The cost is stated in the docs: the rule is about the binding, so a call
standing above every write is rejected too. That call does reach the first
lambda in a straight-line program, and the loop above is why a pass that reads
text order cannot keep the precision.

## How it was measured

`make test` in full, exit 0: smoke (corpus through `elle test` on vm and jit
policies with cross-tier divergence, the per-file VM and eager-JIT passes,
doctest, embedding), `smoke-nouring`, `qa` (rustfmt, workspace clippy,
crosscheck, rustdoc, doctests), `cargo test --workspace --lib` (2627), and
`cargo test --test '*'` (1030 integration). The corpus reported 0 fail, 0
diverge, 0 timeout across every batch.

## What pins it

- `hir::typeinfer::tests::mutation::a_reassigned_lambda_binding_proves_nothing_about_its_result`
  — the reproducer above.
- `…::a_call_above_the_write_proves_nothing_either` — the rule is about the
  binding, not about a position in the file.
- `…::a_loop_that_rewrites_its_own_callee_proves_nothing` — the other binder
  arm, and the reason text order proves nothing.
- `…::a_binding_nothing_writes_still_proves_its_result` — the over-rejection
  guard: the pass keys on the write, not on the declaration.
- `tests/elle/typed-int-ops.lisp` — the corpus peer, on every tier: the
  reassigned binding is refused, and the reassignment itself still runs.

Every one of the first three compiled before the change.

Closes #1086
