### PR TITLE
regions: a native tail callee takes a cycle member by-move

### DIFF
--- a/docs/impl/region/letrec.md
+++ b/docs/impl/region/letrec.md
@@ -43,7 +43,7 @@ the cell↔closure structure is not one SCC in the graphs the other passes build
   binding is its *closure* region), and — unlike `capture_containment_edges`, which
   drops the `r == closure_r` self-edge — the **self-edge is admitted**. An SCC of
   size ≥ 2 is a mutual cycle. The single-closure self-edge is redundant for a genuine
-  mutual cycle (the sibling edges already close the SCC); it is load-bearing only for
+  mutual cycle (the sibling edges already close the SCC); it matters only for
   the one mixed shape that still has a cell — a self-recursive member a *sibling* also
   captures (so it keeps a cell for that sibling) but that is not itself in a mutual
   cycle, a size-1 SCC the self-edge admits so its retained cell can merge into the
@@ -102,7 +102,7 @@ something else still reads the arena.
 
   So *which* channel carries the release does not enter the ordering argument, and
   neither does whether the compiler can classify the callee: the merge wires both
-  channels precisely because it cannot, and both are late enough. This is the same
+  channels rather than choose between them, and both are late enough. This is the same
   ordering argument as the cell-free self-recursive deferral's return admission
   ([selfrec.md](../selfrec.md) § "The deferral's escape gate is the fiber frontier
   alone") — the release runs *after* the mint, so unlike the frame-exit relocation

--- a/docs/impl/region/letrec.md
+++ b/docs/impl/region/letrec.md
@@ -1,5 +1,7 @@
 # The letrec closure-cycle merge
 
+<!-- audited: 2026-09-09 -->
+
 The builder-idiom seed merges one tight `child → parent` store edge. The same
 collapse-to-one-region mechanism reclaims a shape per-region RC cannot: the
 **immutable reference cycle mutual recursion forms** (`ping`/`pong`). Each member is a
@@ -220,13 +222,17 @@ point keeps the Shared baseline.
 **A tail-call letrec body hands the drop to a tail-call deferred release — for a member *or* a
 non-member callee.** When the letrec body ends in a frame-replacing tail call, the
 binding-scope `DecrefRegion` is emitted past the `TailCall` — dead code — so the
-release must ride the activation's completion instead. **The compiler cannot know at
-compile time whether a tail call replaces the frame**: that is decided at runtime by
-the callee *value* (a `func.as_closure()` replaces the frame and trampolines; a
-`func.as_native_def()` keeps the frame and falls through to the live scope-exit drop),
-and any binding — a redefined operator `+`, a `%`-intrinsic — may be rebound to
-either. So the merge never classifies the callee; it wires **both** arena release
-channels and lets exactly one fire.
+release must ride the activation's completion instead. **For nearly every callee the
+compiler cannot know at compile time whether a tail call replaces the frame**: that is
+decided at runtime by the callee *value* (a `func.as_closure()` replaces the frame and
+trampolines; a `func.as_native_def()` keeps the frame and falls through to the live
+scope-exit drop), and a name that looks native reaches a closure often enough — the
+stdlib binds a bytecode `+` over the native one. The single callee the compiler does
+read is a binding whose compile-time constant IS a native function: immutable, never
+mutated, lowered as a `LoadConst` of that native, so no value but that native is ever
+called (`BindingInner::may_replace_frame`). The release channel does not use the
+reading. The merge wires **both** channels and lets exactly one fire, which costs
+nothing and gives every callee one shape.
 
 - **A tail call to an SCC member** rides the existing stranded-cycle channel:
   `lower_letrec` marks the member bindings the letrec body tail-calls
@@ -307,6 +313,21 @@ fresh aggregate then passed (`(g (%pair od 1))`) is RC-counted, and a member *ca
 in an argument (`(g (ev k))`) contributes its result, not itself — both admitted. An
 unresolvable non-member callee (no site to key the deferred release at) likewise refuses.
 
+**The refusal answers a callee that REPLACES the frame.** What collides is the new
+activation's owned-parameter release and the deferred release that frame replacement
+made necessary, so a callee the compiler reads as a native (above) never reaches the
+collision: it borrows its arguments and releases none of them, and it keeps the frame,
+which leaves the binding-scope `DecrefRegion` live as the arena's single release. The
+gate therefore asks whether the tail callee can replace the frame before it refuses,
+and a **struct literal in tail position** — `{:a fa :b fb}`, a `struct` native call
+taking both members as direct arguments — merges. That is the everyday factory: a
+`letrec` of mutually-recursive closures over some shared state, handed back in one
+struct. Where the native's fresh result keeps the members, it holds them by a
+cross-region reference into the arena, RC-counted exactly as a foreign capture is
+(§ "Drop site — the binding scope"), so the arena survives the binding-scope drop. A
+callee the compiler cannot read that way — a foreign closure `g`, a redefined
+operator, an expression — keeps the refusal.
+
 **All-tier, unconditional.** The merge extends the same `merged_parent` forest the
 builder seed populates and rides the same `merged_root` canonicalization and
 `merged_slots` mint-or-reuse every tier already resolves — so it adds no opcode and no
@@ -319,7 +340,11 @@ onto one `merged_root`; `merge_collapses_in_lambda_mutual_recursion_letrec_closu
 `merge_admits_native_tail` — a non-member (foreign closure / native) body
 tail now MERGES and records `cycle_tail_release`;
 `merge_refuses_member_passed_by_move_to_foreign_tail` — the by-move boundary (`(g od)`
-double-free) still refuses;
+double-free) still refuses, while `merge_admits_member_passed_by_move_to_native_tail`
+takes the factory whose tail is a struct literal over its own members, and
+`merge_refuses_member_passed_by_move_to_shadowed_native_tail` — a user `def` of
+`struct` over the native, which the literal then calls — holds the reading to the
+callee's compile-time VALUE rather than its spelling;
 `merge_mutual_recursion_cycle_drops_at_binding_scope_not_enclosing`;
 `self_recursive_letrec_is_cell_free_not_merged` — a pure self-recursive letrec has no cell
 and is never a member; `merge_collapses_self_and_sibling_captured_member_cell` — the mixed
@@ -362,7 +387,8 @@ drop's promptness (a discarded top-level cycle freed at its letrec, not held to
 teardown — the case that must NOT pick up a later drop site). The oracle reads
 `recur-local-mutual-ret`, `recur-local-mutual-ret-foreign`,
 `recur-local-mutual-ret-value` and `recur-local-mutual-ret-bound` — the four body
-shapes, all closed at 0.
+shapes, all closed at 0 — and `recur-local-mutual-factory` for the struct-literal
+tail that carries both members into a native by-move.
 `region_ownership_reclaims_self_recursion_closure_cycle` pins the same bounded growth for a
 pure self-recursive closure, which is reclaimed cell-free (ordinary RC / the tail-call
 deferred release — [selfrec.md](../selfrec.md)), not by this merge.

--- a/src/hir/analyze/env.rs
+++ b/src/hir/analyze/env.rs
@@ -1,0 +1,86 @@
+// audited: 2026-09-09
+//! The ambient environment every compilation starts from: the primitives, and the
+//! compile-time values a `begin-for-syntax` or the core library exports.
+//!
+//! docs/impl/hir.md
+//!
+//! Both bind a name to a compile-time constant VALUE, which is what the lowerer
+//! emits as `LoadConst` instead of a global lookup. Both therefore record from the
+//! value, never from the name: the core env's whole purpose is to bind a bytecode
+//! closure over a name a native also answers to.
+
+use super::{Analyzer, Binding, BindingScope, HashMap, PrimitiveMeta, Value};
+
+impl Analyzer<'_> {
+    /// Bind all registered primitives as immutable Local bindings in the
+    /// analyzer's initial scope.
+    ///
+    /// Called before `analyze_file_letrec` so that primitives are in scope
+    /// during file analysis. Primitives are `BindingScope::Local` with
+    /// `mark_immutable()` set. File-level `def` bindings shadow primitives
+    /// because `analyze_file_letrec` pushes a new scope.
+    ///
+    /// The lowerer uses `immutable_values` to emit `LoadConst` for these
+    /// bindings — the `NativeFn` values are baked into the constant pool.
+    /// No slot allocation is needed.
+    pub fn bind_primitives(&mut self, meta: &PrimitiveMeta) {
+        for (&sym_id, &signal) in &meta.signals {
+            let binding = self.bind_by_sym(sym_id, BindingScope::Local);
+            self.arena.get_mut(binding).is_immutable = true;
+            self.arena.get_mut(binding).is_primitive = true;
+            self.signal_env.insert(binding, signal);
+            if let Some(&arity) = meta.arities.get(&sym_id) {
+                self.arity_env.insert(binding, arity);
+            }
+            if let Some(&func_value) = meta.functions.get(&sym_id) {
+                self.primitive_values.insert(binding, func_value);
+                self.arena.get_mut(binding).is_native_fn = func_value.is_native_fn();
+            }
+        }
+    }
+
+    /// Return the primitive binding→value map for the lowerer.
+    ///
+    /// The lowerer seeds its `immutable_values` from this so that
+    /// primitive references compile to `LoadConst`.
+    pub fn primitive_values(&self) -> &HashMap<Binding, Value> {
+        &self.primitive_values
+    }
+
+    /// Bind compile-time values (from `begin-for-syntax`) into the Analyzer's
+    /// current scope as immutable local bindings backed by constant values.
+    ///
+    /// Called from `eval_syntax` after `bind_primitives` so that compile-time
+    /// names are visible in macro body analysis. The Lowerer emits `LoadConst`
+    /// for these bindings (same mechanism as primitive functions).
+    ///
+    /// `env`: map from name string to Value, from `Expander.compile_time_env`.
+    ///
+    /// `is_primitive`: mark each binding as a primitive. This is for the
+    /// **core.lisp export env** (`fold`/`reduce`/`concat`/`append`/`reverse`/…),
+    /// whose bindings here are the *canonical* definitions user code calls — they
+    /// deliberately override any earlier `meta` entry (e.g. `reverse` was once a
+    /// native, now core.lisp), so this binding must win *and* be recognizable to
+    /// passes that key on `is_primitive` (loop fusion, dispatch monomorphization),
+    /// exactly as stdlib exports are. Without the flag a core HOF is invisible to
+    /// those passes even though it is as canonical as `map`/`filter`. Passed false
+    /// for genuine compile-time / REPL envs, where a binding is a user value that
+    /// must *not* be treated as a canonical primitive.
+    pub fn bind_compile_time_env(
+        &mut self,
+        env: &std::collections::HashMap<String, crate::value::Value>,
+        is_primitive: bool,
+    ) {
+        for (name, value) in env {
+            let sym = self.symbols.intern(name);
+            let binding = self.bind_by_sym(sym, BindingScope::Local);
+            self.arena.get_mut(binding).is_immutable = true;
+            self.arena.get_mut(binding).is_primitive = is_primitive;
+            // From the VALUE, not from `is_primitive`: the core env's whole point is
+            // to bind a bytecode CLOSURE over a name a native also answers to, and a
+            // call to that name replaces the frame (`may_replace_frame`).
+            self.arena.get_mut(binding).is_native_fn = value.is_native_fn();
+            self.primitive_values.insert(binding, *value);
+        }
+    }
+}

--- a/src/hir/analyze/env.rs
+++ b/src/hir/analyze/env.rs
@@ -1,6 +1,6 @@
 // audited: 2026-09-09
-//! The ambient environment every compilation starts from: the primitives, and the
-//! compile-time values a `begin-for-syntax` or the core library exports.
+//! The ambient environment a compilation starts from: the primitives, and what
+//! `begin-for-syntax` or the core library exports.
 //!
 //! docs/impl/hir.md
 //!

--- a/src/hir/analyze/mod.rs
+++ b/src/hir/analyze/mod.rs
@@ -1,4 +1,7 @@
+// audited: 2026-09-09
 //! Syntax to HIR analysis
+//!
+//! docs/impl/hir.md
 //!
 //! This module converts expanded Syntax trees into HIR by:
 //! 1. Resolving all variable references to Bindings
@@ -17,6 +20,7 @@
 mod binding;
 mod call;
 mod destructure;
+mod env;
 mod fileletrec;
 mod letrec;
 pub use fileletrec::classify_form;
@@ -446,122 +450,6 @@ impl<'a> Analyzer<'a> {
     pub fn set_unicode_generation(&mut self, gen: crate::segment::Generation) {
         self.unicode_generation = gen;
     }
-
-    /// Levenshtein edit distance between two strings.
-    fn levenshtein(a: &str, b: &str) -> usize {
-        let m = a.len();
-        let n = b.len();
-        if m == 0 {
-            return n;
-        }
-        if n == 0 {
-            return m;
-        }
-
-        let mut prev: Vec<usize> = (0..=n).collect();
-        let mut curr = vec![0; n + 1];
-
-        for (i, ca) in a.chars().enumerate() {
-            curr[0] = i + 1;
-            for (j, cb) in b.chars().enumerate() {
-                let cost = if ca == cb { 0 } else { 1 };
-                curr[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(curr[j] + 1);
-            }
-            std::mem::swap(&mut prev, &mut curr);
-        }
-        prev[n]
-    }
-
-    /// Find bindings in scope with names similar to `name` (edit distance <= 2).
-    ///
-    /// Spelling-based, so unlike resolution this does need the memo. A binding
-    /// whose name this instance never learned simply cannot be suggested — the
-    /// message degrades, nothing resolves differently.
-    fn suggest_similar(&self, name: &str) -> Vec<String> {
-        let mut candidates: Vec<(usize, String)> = Vec::new();
-        for scope in self.scopes.iter().rev() {
-            for scope_sym in scope.bindings.keys() {
-                let Some(scope_name) = self.symbols.name(*scope_sym) else {
-                    continue;
-                };
-                let dist = Self::levenshtein(name, scope_name);
-                if dist > 0 && dist <= 2 && !candidates.iter().any(|(_, n)| n == scope_name) {
-                    candidates.push((dist, scope_name.to_string()));
-                }
-            }
-        }
-        candidates.sort_by_key(|(d, _)| *d);
-        candidates.into_iter().map(|(_, n)| n).take(3).collect()
-    }
-
-    /// Bind all registered primitives as immutable Local bindings in the
-    /// analyzer's initial scope.
-    ///
-    /// Called before `analyze_file_letrec` so that primitives are in scope
-    /// during file analysis. Primitives are `BindingScope::Local` with
-    /// `mark_immutable()` set. File-level `def` bindings shadow primitives
-    /// because `analyze_file_letrec` pushes a new scope.
-    ///
-    /// The lowerer uses `immutable_values` to emit `LoadConst` for these
-    /// bindings — the `NativeFn` values are baked into the constant pool.
-    /// No slot allocation is needed.
-    pub fn bind_primitives(&mut self, meta: &PrimitiveMeta) {
-        for (&sym_id, &signal) in &meta.signals {
-            let binding = self.bind_by_sym(sym_id, BindingScope::Local);
-            self.arena.get_mut(binding).is_immutable = true;
-            self.arena.get_mut(binding).is_primitive = true;
-            self.signal_env.insert(binding, signal);
-            if let Some(&arity) = meta.arities.get(&sym_id) {
-                self.arity_env.insert(binding, arity);
-            }
-            if let Some(&func_value) = meta.functions.get(&sym_id) {
-                self.primitive_values.insert(binding, func_value);
-            }
-        }
-    }
-
-    /// Return the primitive binding→value map for the lowerer.
-    ///
-    /// The lowerer seeds its `immutable_values` from this so that
-    /// primitive references compile to `LoadConst`.
-    pub fn primitive_values(&self) -> &HashMap<Binding, Value> {
-        &self.primitive_values
-    }
-
-    /// Bind compile-time values (from `begin-for-syntax`) into the Analyzer's
-    /// current scope as immutable local bindings backed by constant values.
-    ///
-    /// Called from `eval_syntax` after `bind_primitives` so that compile-time
-    /// names are visible in macro body analysis. The Lowerer emits `LoadConst`
-    /// for these bindings (same mechanism as primitive functions).
-    ///
-    /// `env`: map from name string to Value, from `Expander.compile_time_env`.
-    ///
-    /// `is_primitive`: mark each binding as a primitive. This is for the
-    /// **core.lisp export env** (`fold`/`reduce`/`concat`/`append`/`reverse`/…),
-    /// whose bindings here are the *canonical* definitions user code calls — they
-    /// deliberately override any earlier `meta` entry (e.g. `reverse` was once a
-    /// native, now core.lisp), so this binding must win *and* be recognizable to
-    /// passes that key on `is_primitive` (loop fusion, dispatch monomorphization),
-    /// exactly as stdlib exports are. Without the flag a core HOF is invisible to
-    /// those passes even though it is as canonical as `map`/`filter`. Passed false
-    /// for genuine compile-time / REPL envs, where a binding is a user value that
-    /// must *not* be treated as a canonical primitive.
-    pub fn bind_compile_time_env(
-        &mut self,
-        env: &std::collections::HashMap<String, crate::value::Value>,
-        is_primitive: bool,
-    ) {
-        for (name, value) in env {
-            let sym = self.symbols.intern(name);
-            let binding = self.bind_by_sym(sym, BindingScope::Local);
-            self.arena.get_mut(binding).is_immutable = true;
-            self.arena.get_mut(binding).is_primitive = is_primitive;
-            self.primitive_values.insert(binding, *value);
-        }
-    }
-
-    // === Scope Management ===
 }
 
 #[cfg(test)]

--- a/src/hir/analyze/scopes.rs
+++ b/src/hir/analyze/scopes.rs
@@ -1,3 +1,11 @@
+// audited: 2026-09-09
+//! Lexical scopes and the name resolution over them: binding, looking up, the
+//! capture a lookup across a function boundary records, and the near-miss
+//! suggestion an unresolved name gets.
+//!
+//! docs/bindings.md
+//! docs/macros.md
+
 use super::*;
 
 /// Duplicate-definition guard for `letrec*` contexts (explicit `letrec`,
@@ -312,5 +320,54 @@ impl<'a> Analyzer<'a> {
                         .map(|c| c.binding)
                 })
         })
+    }
+
+    // === Suggesting a name the reader may have meant ===
+
+    /// Levenshtein edit distance between two strings.
+    fn levenshtein(a: &str, b: &str) -> usize {
+        let m = a.len();
+        let n = b.len();
+        if m == 0 {
+            return n;
+        }
+        if n == 0 {
+            return m;
+        }
+
+        let mut prev: Vec<usize> = (0..=n).collect();
+        let mut curr = vec![0; n + 1];
+
+        for (i, ca) in a.chars().enumerate() {
+            curr[0] = i + 1;
+            for (j, cb) in b.chars().enumerate() {
+                let cost = if ca == cb { 0 } else { 1 };
+                curr[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(curr[j] + 1);
+            }
+            std::mem::swap(&mut prev, &mut curr);
+        }
+        prev[n]
+    }
+
+    /// Find bindings in scope with names similar to `name` (edit distance <= 2).
+    ///
+    /// Spelling-based, so unlike resolution this does need the memo. A binding
+    /// whose name this instance never learned simply cannot be suggested — the
+    /// message degrades, nothing resolves differently.
+    pub(super) fn suggest_similar(&self, name: &str) -> Vec<String> {
+        let mut candidates: Vec<(usize, String)> = Vec::new();
+        for scope in self.scopes.iter().rev() {
+            for scope_sym in scope.bindings.keys() {
+                let Some(scope_name) = self.symbols.name(*scope_sym) else {
+                    continue;
+                };
+                let dist = Self::levenshtein(name, scope_name);
+                if dist > 0 && dist <= 2 && !candidates.iter().any(|(_, n)| n == scope_name) {
+                    candidates.push((dist, scope_name.to_string()));
+                }
+            }
+        }
+        candidates.sort_by_key(|(d, _)| *d);
+        candidates.into_iter().map(|(_, n)| n).take(3).collect()
     }
 }

--- a/src/hir/analyze/scopes.rs
+++ b/src/hir/analyze/scopes.rs
@@ -1,7 +1,8 @@
 // audited: 2026-09-09
-//! Lexical scopes and the name resolution over them: binding, looking up, the
-//! capture a lookup across a function boundary records, and the near-miss
-//! suggestion an unresolved name gets.
+//! Lexical scopes and name resolution over them.
+//!
+//! Binding, looking up, the capture a lookup across a function boundary records,
+//! and the near-miss suggestion an unresolved name gets.
 //!
 //! docs/bindings.md
 //! docs/macros.md

--- a/src/hir/analyze/tests/basics.rs
+++ b/src/hir/analyze/tests/basics.rs
@@ -1,3 +1,8 @@
+// audited: 2026-09-09
+// docs/impl/hir.md
+//! The analyzer's ground floor: each form it recognises, the binding metadata it
+//! records, scope-aware name resolution, and collection literals.
+
 use super::*;
 
 #[test]
@@ -98,6 +103,44 @@ fn test_binding_info() {
     // of the (module-private) capture flag, observed through `needs_capture()`.
     arena.get_mut(binding).mark_captured();
     assert!(arena.get(binding).needs_capture());
+}
+
+#[test]
+fn test_native_constant_binding_never_replaces_the_frame() {
+    // A tail call replaces the frame when its callee turns out to be a closure, which
+    // the compiler cannot read off a name it resolves at run time. The one callee it
+    // can read is a binding whose compile-time constant IS a native function — the
+    // lowerer emits `LoadConst` of that native, so no other value is ever called. The
+    // closure-cycle merge's by-move tail gate asks this before it refuses
+    // (docs/impl/region/letrec.md).
+    //
+    // The counter-factual each mutation below covers: a name that merely LOOKS native
+    // is not one. `is_native_fn` alone would take a primitive-scope name the stdlib
+    // rebinds to a bytecode closure, and a mutable binding's value is whatever the
+    // last `assign` left there.
+    use crate::hir::arena::{BindingArena, BindingScope};
+    let mut arena = BindingArena::new();
+    let ordinary = arena.alloc(SymbolId(3), BindingScope::Local);
+    assert!(
+        arena.get(ordinary).may_replace_frame(),
+        "an ordinary binding is resolved at run time — it may name a closure"
+    );
+
+    let native = arena.alloc(SymbolId(4), BindingScope::Local);
+    arena.get_mut(native).is_native_fn = true;
+    arena.get_mut(native).is_immutable = true;
+    assert!(
+        !arena.get(native).may_replace_frame(),
+        "an immutable, unmutated binding whose constant is a native function keeps \
+         the frame"
+    );
+
+    arena.get_mut(native).is_mutated = true;
+    assert!(
+        arena.get(native).may_replace_frame(),
+        "a mutated binding holds whatever the last assign left there, native \
+         constant or not"
+    );
 }
 
 #[test]

--- a/src/hir/arena.rs
+++ b/src/hir/arena.rs
@@ -1,3 +1,5 @@
+// audited: 2026-09-09
+// docs/impl/hir.md
 //! Arena-backed binding storage for the compilation pipeline.
 //!
 //! `BindingArena` owns all `BindingInner` values for a compilation unit.
@@ -84,6 +86,8 @@ pub struct BindingInner {
     /// bodies"). Carried on the binding, the declared floor survives that splice,
     /// so the spliced intrinsic proves exactly as it did inside the function.
     pub declared_numeric: bool,
+    /// Whether this binding's compile-time constant value is a NATIVE function.
+    pub is_native_fn: bool,
     /// Whether this binding is a MODULE-SCOPE (file-letrec) name — a direct
     /// binding of `analyze_file_letrec` (top-level `def`/`var`/expr statement).
     /// Such a binding's lifetime is the whole module/program: its demise is the
@@ -112,8 +116,14 @@ impl BindingInner {
             is_primitive: false,
             is_synthetic: false,
             declared_numeric: false,
+            is_native_fn: false,
             is_file_scope: false,
         }
+    }
+
+    /// Can a call to this binding REPLACE the frame?
+    pub fn may_replace_frame(&self) -> bool {
+        true
     }
 
     /// A binding needs a cell if captured (for locals) or mutated (for params).

--- a/src/hir/arena.rs
+++ b/src/hir/arena.rs
@@ -86,7 +86,13 @@ pub struct BindingInner {
     /// bodies"). Carried on the binding, the declared floor survives that splice,
     /// so the spliced intrinsic proves exactly as it did inside the function.
     pub declared_numeric: bool,
-    /// Whether this binding's compile-time constant value is a NATIVE function.
+    /// Whether this binding's compile-time constant value is a NATIVE function —
+    /// the lowerer reads such a binding as a `LoadConst` of that native, never as a
+    /// global lookup. Written from the VALUE at the two sites that bind one
+    /// (`bind_primitives`, `bind_compile_time_env`), so a primitive-scope name whose
+    /// constant is a CLOSURE — core.lisp binds a bytecode `+` over the native — is
+    /// false here while `is_primitive` is true of both. Read through
+    /// [`may_replace_frame`](Self::may_replace_frame).
     pub is_native_fn: bool,
     /// Whether this binding is a MODULE-SCOPE (file-letrec) name — a direct
     /// binding of `analyze_file_letrec` (top-level `def`/`var`/expr statement).
@@ -121,9 +127,18 @@ impl BindingInner {
         }
     }
 
-    /// Can a call to this binding REPLACE the frame?
+    /// Can a call to this binding REPLACE the frame? A closure callee does — the
+    /// `TailCall` trampolines into a new activation, which owns the arguments and
+    /// releases each one. A native callee does not: the dispatch loop stays in this
+    /// frame, borrows the arguments, and falls through.
+    ///
+    /// Which of the two a name reaches is a runtime fact about the callee VALUE, so
+    /// the answer is yes for every binding but one — an immutable, unmutated binding
+    /// whose compile-time constant is a native function, where no other value can be
+    /// called. The closure-cycle merge's by-move tail gate asks this before it
+    /// refuses (docs/impl/region/letrec.md).
     pub fn may_replace_frame(&self) -> bool {
-        true
+        !(self.is_native_fn && self.is_immutable && !self.is_mutated)
     }
 
     /// A binding needs a cell if captured (for locals) or mutated (for params).

--- a/src/hir/region/infer/merge/cycle.rs
+++ b/src/hir/region/infer/merge/cycle.rs
@@ -1,18 +1,25 @@
-//! The `letrec` closure-cycle merge (docs/impl/region/letrec.md § The letrec
-//! closure-cycle merge): one SCC of mutually-recursive closures ∪ their prebound
-//! capture cells, collapsed onto one arena and freed by a single `DecrefRegion` at
-//! the cycle's binding scope — or, where the letrec hands a member out, where that
-//! member's own release already sits.
+// audited: 2026-09-09
+//! The `letrec` closure-cycle merge: one SCC of mutually-recursive closures ∪ their
+//! prebound capture cells, collapsed onto one arena and freed by a single
+//! `DecrefRegion`.
+//!
+//! docs/impl/region/letrec.md
+//!
+//! The single `DecrefRegion` fires at the cycle's binding scope — or, where the
+//! letrec hands a member out, where that member's own release already sits. How the
+//! letrec BODY reads at its tail, which two of the gates below ask about, is
+//! [`body`].
+
+mod body;
 
 use super::super::*;
+use body::{collect_letrec_tail_callees, LetrecTail};
 use rustc_hash::{FxHashMap, FxHashSet};
 
-/// A `letrec` closure-cycle merge (docs/impl/region/letrec.md § The letrec closure-cycle merge): one SCC of
-/// mutually-recursive closures (plus a self-recursive member a sibling also
-/// captures), plus their prebound capture cells, collapsed onto one arena and freed
-/// by a single `DecrefRegion` at the [`ClosureCycleMerge::drop_site`]. A *purely* self-recursive
-/// closure is cell-free (its self-edge does not mark it captured — `hir/analyze/scopes.rs`)
-/// and so never reaches the merge; the merge serves the cell-bearing cases.
+/// One admitted `letrec` closure-cycle merge: an SCC of mutually-recursive closures
+/// (plus a self-recursive member a sibling also captures) and their prebound capture
+/// cells, collapsed onto one arena and freed by a single `DecrefRegion` at the
+/// [`drop_site`](ClosureCycleMerge::drop_site).
 pub(crate) struct ClosureCycleMerge {
     /// The canonical root every member stars onto (its `merged_root`).
     pub root: Region,
@@ -41,97 +48,35 @@ pub(crate) struct ClosureCycleMerge {
     pub tail_release_sites: Vec<HirId>,
 }
 
-/// One tail call in a `letrec` body, as the closure-cycle merge's tail gate reads
-/// it (docs/impl/region/letrec.md § The letrec closure-cycle merge). A tail call
-/// replaces the frame, stranding the merged arena's binding-scope `DecrefRegion`;
-/// the gate must know both the callee and whether any cycle MEMBER flows in as an
-/// argument, so a member passed by-move (`(g od)`) is refused — its own
-/// move/return machinery would decref the arena a second time, colliding with the
-/// deferred release (a double-free), where a member merely STORED into a fresh aggregate then
-/// passed is RC-counted and safe (after ANF the argument is a temp, not a member
-/// reference, so it is admitted).
-struct TailCallSite {
-    /// The tail-call `Call` node's HirId — the key the lowerer sets
-    /// `deferred_release_slot` at for a non-member callee.
-    hir_id: HirId,
-    /// The callee, unwrapped through `functionalize`'s `DerefCell`: `Some(b)` for a
-    /// binding reference (a member, a native, a redefined operator, a foreign fn),
-    /// `None` for a callee the gate cannot resolve (which refuses — no site to key
-    /// the deferred release at).
-    callee: Option<crate::hir::Binding>,
-    /// Every binding referenced in the tail call's ARGUMENT subtrees (Var reads,
-    /// including a cell read's inner `Var`; nested lambdas are not descended). A
-    /// member passed by-move is exactly a binding here whose source region is in the
-    /// SCC. After ANF a nested aggregate/call argument is a fresh temp whose source
-    /// region is the aggregate/call-result region — never the member's — so the
-    /// RC-safe stored-then-passed case is not caught here (correctly admitted).
-    arg_bindings: Vec<crate::hir::Binding>,
-}
-
-/// Detect the mergeable `letrec` closure cycles (docs/impl/region/letrec.md § The letrec closure-cycle merge).
+/// Detect the mergeable `letrec` closure cycles. Every gate below is argued in
+/// docs/impl/region/letrec.md; each one's own comment says what this reading of it
+/// depends on.
 ///
-/// A `letrec` mutually-recursive closure is a capture-cell↔closure cycle: each
-/// member's prebound forward-reference cell holds the closure (`StoreCaptureCell`) and
-/// the sibling closures capture the cell. Per-region RC cannot collect the immutable
-/// cycle (region/rules.md Rule 8); the merge instead collapses the whole SCC ∪ its
-/// cells onto one region, so the interior cell↔closure references become intra-region —
-/// the alloc-scan incref, the capture-store incref, and the free-time cascade all
-/// self-skip same-region refs (`regionpool/introspect.rs` `rid != own_id`,
-/// `value/arena/mutate.rs::capture_store_with_rebind`), so the arena's RC is 1 and
-/// one `DecrefRegion` frees the cycle wholesale. A *purely* self-recursive closure is
-/// cell-free — the self-edge does not mark it captured (`hir/analyze/scopes.rs`), so it
-/// has no forward cell and its self-reference resolves to the executing closure
-/// (`LoadSelf` / a self-call), never a cell — so there is no cell↔closure cycle for the
-/// merge to collapse; it is reclaimed by ordinary RC / the tail-call deferred release, RC-identical
-/// to a top-level recursive `defn`.
+/// Detection is two-layer, because the cell↔closure structure is not one SCC in the
+/// graphs the other passes build. The **closures** carry the cycle: a
+/// `closure ⊇ closure` capture graph keeping the `r == closure_r` self-edge that
+/// `capture_containment_edges` drops, which is what admits the one mixed shape with a
+/// cell and no mutual cycle — a self-recursive member a sibling also captures. The
+/// **cells** are paired in from each member binding's `begin_cell_regions` entry, so
+/// a member with no static-slot cell (a mutated in-lambda letrec binding, a purely
+/// self-recursive closure) never reaches the gates at all.
 ///
-/// Two-layer detection. The **closures** carry the cycle: a `closure ⊇ closure`
-/// capture graph with the `r == closure_r` self-edge ADMITTED (the very edge
-/// `capture_containment_edges` drops). For a genuine mutual cycle the self-edge is
-/// redundant (the sibling edges already close the SCC); it is load-bearing for the one
-/// mixed shape that still has a cell — a self-recursive member a sibling ALSO captures
-/// (so it keeps a cell for that sibling) but that is not itself in a mutual cycle: a
-/// size-1 SCC the self-edge admits, whose cell the merge then collapses into the
-/// closure (`merge_collapses_self_and_sibling_captured_member_cell`). The **cells** are
-/// coincident-lifetime members, each paired in from its binding's `begin_cell_regions`
-/// cell. A cycle is mergeable only when every member is **sole-held** (waived for a
-/// member the letrec hands out, whose adopted release point below counts every holder
-/// directly), every closure has a **static-slot cell**, and every closure clears the
-/// **frontier gate**: the FIBER half (emit / send) refuses outright, while the RETURN
-/// half is admitted where the arena's release provably runs after the mint that funds
-/// the consumer (docs/impl/region/letrec.md § The frontier gate). The
-/// cell requirement is met in every position: an immutable, lambda-initialized letrec
-/// binding's forward cell is a compiled `MakeCaptureCell` at top level AND inside a
-/// lambda body (`BindingInner::letrec_compiled_cell`). A mutated/reassigned in-lambda
-/// letrec binding keeps the runtime env-cell route (no `begin_cell_regions` cell) and
-/// is refused here to Shared, the always-legal baseline; a purely self-recursive
-/// member has no cell at all and is likewise never a member. Two further gates:
-/// every member's allocation must lie within the binding-scope letrec's own subtree
-/// (so that scope is a structural ancestor-or-self of every member), and the
-/// letrec BODY's tail calls must each have a **release channel** for the merged
-/// arena's binding-scope drop, which a frame-replacing tail call strands as dead
-/// code. Two channels: a MEMBER callee rides `stranded_cycle_bindings` →
-/// `tail_callee_defers_release` (`region_of(callee)` is the arena); a NON-member callee — a
-/// native, a redefined operator, a foreign fn — rides the explicit `deferred_release_slot`
-/// (this cycle's root slot, recorded in `tail_release_sites`), so a closure callee's
-/// frame replacement is balanced by the activation-completion deferred release while a native
-/// callee falls through to the live scope-exit drop (the two are mutually exclusive
-/// per call, so exactly one release fires — the compiler never classifies the callee).
-/// A non-member tail is refused only when its callee is unresolvable (no site to key
-/// the deferred release at) or when a cycle MEMBER flows into it **by-move** as an argument
-/// (`(g od)`): the member's own move/return machinery would decref the arena a second
-/// time, colliding with the deferred release (a double-free). A member merely STORED into a fresh
-/// aggregate then passed is RC-counted and safe, and after ANF is a temp argument, not
-/// a member reference, so it is admitted. When a member carries the return facet the body
-/// is read once more, for a different question — where the mint that funds the consumer
-/// stands relative to the arena's release. Either every tail EXIT of the body LEAVES THE
-/// FRAME (a `Return`, or a tail `Call`), putting that mint inside the body and so ahead
-/// of a release at the binding scope; or the body falls out to a bare member value, and
-/// the release instead FOLLOWS THAT MEMBER to the point the last-use rule already
-/// computed for it, which post-dates every consumer's claim. A body doing neither keeps
-/// the Shared baseline. The result extends the same `merged_parent` forest the
-/// builder-idiom seed populates and rides the same `merged_root` canonicalization,
-/// unconditionally (not flag-gated) and on every tier.
+/// The gates, in the order the loop asks them:
+///
+///  1. ONE binding scope for the whole SCC — the `letrec` prebinding every cell;
+///  2. per member: off the FIBER frontier, sole-held (waived for a handed-out
+///     member), with a sole-held static-slot cell;
+///  3. the DROP SITE — that binding scope, or the release point a handed-out
+///     member's own region already carries;
+///  4. LETREC-SUBTREE CONTAINMENT of every member's allocation site;
+///  5. a RELEASE CHANNEL for every tail call in the letrec body;
+///  6. for a member on the RETURN frontier, that the body hands the value over
+///     itself.
+///
+/// A cycle failing any gate keeps the Shared baseline, which is always legal. The
+/// result extends the same `merged_parent` forest the builder-idiom seed populates
+/// and rides the same `merged_root` canonicalization, unconditionally (not
+/// flag-gated) and on every tier.
 pub(crate) fn compute_closure_cycle_merges(
     hir: &Hir,
     arena: &BindingArena,
@@ -150,21 +95,12 @@ pub(crate) fn compute_closure_cycle_merges(
     let closure_regs: FxHashSet<Region> = lambda_of.keys().copied().collect();
 
     // The frontier gate (docs/impl/region/letrec.md § The frontier gate), read as its
-    // two halves rather than the combined Shared-seed set. A closure escapes its
-    // activation only by crossing a FRONTIER (return / emit / send); the capture facet
-    // is deliberately excluded, because `lambda_escapes_definition` folds in a
-    // CONTAINMENT relation — and a `letrec` SCC's closures capture each other, so one
-    // member crossing a frontier would propagate "escaping" around the whole cycle and
-    // over-refuse a mergeable one.
-    //
-    // The halves are then admitted differently, because the merge's release is a
-    // decref, not a free. The FIBER half refuses outright: an emitted or sent member
-    // reaches a holder the compiler did not place, and a parked frame may borrow it
-    // uncounted, so no ordering argument funds it. The RETURN half is **return-funded**
-    // — the merge collapses the returned member's region onto the arena, so the value
-    // handed out lives in the arena and the callee's `Return` mint raises the arena's
-    // own count — but only where the arena's release provably runs AFTER that mint,
-    // which is the tail-shape gate further down.
+    // two halves rather than the combined Shared-seed set, and NOT through
+    // `lambda_escapes_definition`: that method folds in a CONTAINMENT relation, and a
+    // `letrec` SCC's closures capture each other, so one member crossing a frontier
+    // would propagate "escaping" around the whole cycle and over-refuse a mergeable
+    // one. The FIBER half refuses outright below; the RETURN half raises
+    // `return_facet`, which the tail-shape gate further down has to fund.
     let fiber = super::super::escape::fiber_frontier_regions(escape, info);
     let returned = super::super::escape::return_frontier_regions(
         escape,
@@ -409,13 +345,17 @@ pub(crate) fn compute_closure_cycle_merges(
         // stranded-cycle deferral (`stranded_cycle_bindings` → `tail_callee_defers_release`,
         // `lir/lower/binding.rs`). A NON-member callee rides the explicit
         // `deferred_release_slot` (recorded below) — admissible only when the callee is
-        // resolvable (a site to key the deferred release at) AND no cycle member flows into the
-        // tail call BY-MOVE as an argument: a member passed by-value (`(g od)`) has
-        // its own move/return machinery decref the arena a SECOND time, colliding
-        // with the deferred release (a double-free), where a member stored into a fresh
-        // aggregate then passed is RC-counted and (after ANF) a temp argument, so it
-        // is admitted. Any tail call failing both channels refuses the cycle to
-        // Shared (the always-legal baseline).
+        // resolvable (a site to key the deferred release at) AND nothing collides with
+        // that deferred release. What collides is a cycle member flowing into the tail
+        // call BY-MOVE (`(g od)`): the new activation owns the member as a parameter
+        // and releases it, decrefing the arena a SECOND time (a double-free), where a
+        // member stored into a fresh aggregate then passed is RC-counted and (after
+        // ANF) a temp argument, so it is admitted. That collision needs a callee which
+        // REPLACES the frame, so a callee `may_replace_frame` reads out — an immutable
+        // binding whose compile-time constant is a native — carries the members in: it
+        // borrows its arguments, and the frame it keeps runs the live binding-scope
+        // drop. Any tail call failing both channels refuses the cycle to Shared (the
+        // always-legal baseline).
         let sites = tail.map(|t| &t.sites);
         let is_member = |b: crate::hir::Binding| -> bool {
             info.binding_source_regions
@@ -424,11 +364,15 @@ pub(crate) fn compute_closure_cycle_merges(
         };
         let strands = sites.is_none_or(|sites| {
             !sites.iter().all(|site| {
-                if site.callee.is_some_and(is_member) {
+                let Some(callee) = site.callee else {
+                    return false; // unresolvable → no site to key the deferred release
+                };
+                if is_member(callee) {
                     return true; // member callee → existing stranded-cycle adopt
                 }
-                // Non-member (or unresolvable) callee → explicit arena adopt.
-                site.callee.is_some() && !site.arg_bindings.iter().copied().any(is_member)
+                // Non-member callee → explicit arena adopt.
+                !arena.get(callee).may_replace_frame()
+                    || !site.arg_bindings.iter().copied().any(is_member)
             })
         });
         if strands {
@@ -519,7 +463,7 @@ fn collect_closures(hir: &Hir, info: &RegionInfo, out: &mut FxHashMap<Region, Hi
 /// `r == closure_r` self-edge and restricting to closure regions. Mirrors
 /// `capture_containment_edges`' live-region filter but admits the self-edge that scan
 /// drops. The self-edge is redundant for a genuine mutual cycle (the sibling edges
-/// already close the SCC); it is load-bearing only for the mixed shape — a
+/// already close the SCC); it matters only for the mixed shape — a
 /// self-recursive member a sibling ALSO captures, a size-1 SCC whose retained
 /// (sibling-owned) cell the merge collapses via this self-edge
 /// (`compute_closure_cycle_merges`).
@@ -543,208 +487,4 @@ fn collect_closure_capture_edges(
         }
     }
     hir.for_each_child(|c| collect_closure_capture_edges(c, info, closure_regs, succ));
-}
-
-/// What one `Letrec`'s BODY looks like at its tail, as the merge's two tail gates
-/// read it.
-struct LetrecTail {
-    /// One [`TailCallSite`] per tail call in the body — the release-channel gate's
-    /// input. A body tail call replaces the frame, stranding the binding-scope drop,
-    /// so each must supply a release channel (a member callee's stranded-cycle
-    /// deferral, or a non-member callee's explicit arena adopt) and must not pass a
-    /// cycle member in by-move.
-    sites: Vec<TailCallSite>,
-    /// Does EVERY tail exit of the body leave the frame itself — a `Return`, or a
-    /// tail `Call`? The **return-funded** admission needs this reading rather than
-    /// `sites`: it decides whether the value the frame hands its caller is minted
-    /// INSIDE the body, ahead of the binding-scope drop the lowerer emits at the
-    /// `Letrec` node (docs/impl/region/letrec.md § The frontier gate).
-    exits_frame: bool,
-    /// The bindings the body's tail region-transparently evaluates TO — the value the
-    /// `Letrec` node itself yields. Read only where `exits_frame` is false, i.e. where
-    /// that value goes to an ENCLOSING consumer: a cycle member among them leaves the
-    /// binding scope on an uncounted read, so the arena's release follows it instead of
-    /// staying at the scope (docs/impl/region/letrec.md § "Drop site — following a
-    /// handed-out member").
-    value_bindings: Vec<crate::hir::Binding>,
-}
-
-/// For every `Letrec` node, how its BODY exits at the tail ([`LetrecTail`]).
-fn collect_letrec_tail_callees(hir: &Hir, out: &mut FxHashMap<HirId, LetrecTail>) {
-    if let HirKind::Letrec { body, .. } = &hir.kind {
-        let mut sites = Vec::new();
-        body_tail_callees(body, &mut sites);
-        let mut value_bindings = Vec::new();
-        value_flow_bindings(body, &mut value_bindings);
-        out.insert(
-            hir.id,
-            LetrecTail {
-                sites,
-                exits_frame: body_tail_exits_frame(body),
-                value_bindings,
-            },
-        );
-    }
-    hir.for_each_child(|c| collect_letrec_tail_callees(c, out));
-}
-
-/// Does every tail EXIT of a letrec body leave the frame — is the value the frame
-/// hands its caller produced (and minted) INSIDE this body?
-///
-/// The return-funded admission reads this to know that the merge's binding-scope
-/// release runs after that mint (docs/impl/region/letrec.md § The frontier gate).
-/// Descends only the tail position of the pure control forms, and deliberately answers
-/// `false` for everything it does not recognise: a body it cannot read may hand its
-/// value to an enclosing consumer, whose mint is outside the letrec node and therefore
-/// after the release. A bare value tail out of tail position
-/// (`(let [c (letrec [ev …] ev)] … c)`), a loop, a short-circuit `And`/`Or`, and a
-/// `Cond` with no else arm all read that way.
-fn body_tail_exits_frame(hir: &Hir) -> bool {
-    match &hir.kind {
-        // The two nodes that hand a value to the CALLER from inside this body: the
-        // `Return` mints for it here, and a tail `Call` mints either at the callee's
-        // own `Return` (a closure, which replaces the frame) or at the post-`TailCall`
-        // fall-through retain emitted right here (a native, which does not).
-        HirKind::Return { .. } | HirKind::Call { is_tail: true, .. } => true,
-        HirKind::Let { body, .. }
-        | HirKind::Letrec { body, .. }
-        | HirKind::Parameterize { body, .. } => body_tail_exits_frame(body),
-        HirKind::Begin(exprs) | HirKind::Block { body: exprs, .. } => {
-            exprs.last().is_some_and(body_tail_exits_frame)
-        }
-        HirKind::If {
-            then_branch,
-            else_branch,
-            ..
-        } => body_tail_exits_frame(then_branch) && body_tail_exits_frame(else_branch),
-        HirKind::Cond {
-            clauses,
-            else_branch,
-        } => {
-            // No else arm means an implicit nil fall-through — an exit that does not
-            // leave the frame, so the whole `Cond` does not.
-            else_branch
-                .as_ref()
-                .is_some_and(|e| body_tail_exits_frame(e))
-                && clauses.iter().all(|(_, b)| body_tail_exits_frame(b))
-        }
-        // `Match` is absent deliberately, where branch compensation admits it exactly as
-        // an `If`: this reading needs the arms to be EXHAUSTIVE (a fall-through with no
-        // arm taken is an exit that does not leave the frame), which an `If` and a
-        // `Cond` with an else arm have and a pattern match does not.
-        _ => false,
-    }
-}
-
-/// The [`TailCallSite`]s within one letrec body. Never descends into a `Lambda`
-/// — a nested closure's tail calls run in that closure's own activation, not the
-/// letrec's, so they neither strand nor may adopt the merged arena (mirrors the
-/// lowerer's `collect_body_tail_callees`, `lir/lower/binding.rs`). The callee is
-/// unwrapped through the `DerefCell` `functionalize` adds around a needs-capture
-/// binding read; each argument subtree contributes its referenced bindings.
-fn body_tail_callees(hir: &Hir, out: &mut Vec<TailCallSite>) {
-    if matches!(hir.kind, HirKind::Lambda { .. }) {
-        return;
-    }
-    if let HirKind::Call {
-        func,
-        args,
-        is_tail: true,
-        ..
-    } = &hir.kind
-    {
-        let callee_node = match &func.kind {
-            HirKind::DerefCell { cell } => cell,
-            _ => func,
-        };
-        let callee = match &callee_node.kind {
-            HirKind::Var(b) => Some(*b),
-            _ => None,
-        };
-        let mut arg_bindings = Vec::new();
-        for a in args {
-            value_flow_bindings(&a.expr, &mut arg_bindings);
-        }
-        out.push(TailCallSite {
-            hir_id: hir.id,
-            callee,
-            arg_bindings,
-        });
-    }
-    hir.for_each_child(|c| body_tail_callees(c, out));
-}
-
-/// The bindings an expression region-transparently evaluates **to** — the values that
-/// flow out of it with no incref of their own. This mirrors escape's `tail_sources`
-/// descent (`hir/escape/flow.rs`): pass through the pure control / select / deref /
-/// bind wrappers, but STOP at a `Call`, an `Intrinsic`, and a `Lambda`. A member
-/// reached only past a stopped node did not flow uncounted:
-///
-///  - a nested `Call` — `(g (ev k))` — has `ev` as its callee, so `ev`'s RESULT (a
-///    value) flows, not `ev` itself; a member passed as a nested-call argument is
-///    incref-balanced (a non-tail call owns its params), not moved;
-///  - an `Intrinsic` — `(g (%pair od 1))` — stores the member into a fresh aggregate,
-///    an RC-counted reference the aggregate's cascade releases;
-///  - a `Lambda` — a closure argument's captures are RC-counted.
-///
-/// Two readers, asking the same question of different expressions. Over a **tail-call
-/// argument** it names what flows BY-MOVE into the call: only a bare member value in a
-/// direct argument (`(g od)`, or through an `If`/`Begin`/`DerefCell` that selects one)
-/// is moved with no incref, and its own move/return decref would double-free the arena,
-/// which the tail gate reads this to refuse. Over a **letrec body** it names the value
-/// the `Letrec` node yields, so a member there is one the cycle hands to an enclosing
-/// consumer — read only where the body does not leave the frame, hence never through
-/// the `Return` arm below.
-fn value_flow_bindings(hir: &Hir, out: &mut Vec<crate::hir::Binding>) {
-    match &hir.kind {
-        HirKind::Var(b) => out.push(*b),
-        HirKind::DerefCell { cell } => value_flow_bindings(cell, out),
-        HirKind::Let { body, .. }
-        | HirKind::Letrec { body, .. }
-        | HirKind::Loop { body, .. }
-        | HirKind::Parameterize { body, .. } => value_flow_bindings(body, out),
-        HirKind::If {
-            then_branch,
-            else_branch,
-            ..
-        } => {
-            value_flow_bindings(then_branch, out);
-            value_flow_bindings(else_branch, out);
-        }
-        HirKind::Cond {
-            clauses,
-            else_branch,
-        } => {
-            for (_, b) in clauses {
-                value_flow_bindings(b, out);
-            }
-            if let Some(eb) = else_branch {
-                value_flow_bindings(eb, out);
-            }
-        }
-        HirKind::Begin(exprs) | HirKind::Block { body: exprs, .. } => {
-            if let Some(last) = exprs.last() {
-                value_flow_bindings(last, out);
-            }
-        }
-        HirKind::And(exprs) | HirKind::Or(exprs) => {
-            for e in exprs {
-                value_flow_bindings(e, out);
-            }
-        }
-        HirKind::Match { arms, .. } => {
-            for (_, _, body) in arms {
-                value_flow_bindings(body, out);
-            }
-        }
-        HirKind::Return { value }
-        | HirKind::MakeCell { value }
-        | HirKind::Assign { value, .. }
-        | HirKind::Define { value, .. }
-        | HirKind::Destructure { value, .. }
-        | HirKind::SetCell { value, .. } => value_flow_bindings(value, out),
-        // A Call / Intrinsic / Lambda / immediate: a fresh, incref-balanced, or
-        // RC-counted result — no member flows by-move. Stop.
-        _ => {}
-    }
 }

--- a/src/hir/region/infer/merge/cycle.rs
+++ b/src/hir/region/infer/merge/cycle.rs
@@ -1,7 +1,6 @@
 // audited: 2026-09-09
-//! The `letrec` closure-cycle merge: one SCC of mutually-recursive closures ∪ their
-//! prebound capture cells, collapsed onto one arena and freed by a single
-//! `DecrefRegion`.
+//! The `letrec` closure-cycle merge: one SCC of mutually-recursive closures and their
+//! prebound capture cells, collapsed onto one arena.
 //!
 //! docs/impl/region/letrec.md
 //!

--- a/src/hir/region/infer/merge/cycle/body.rs
+++ b/src/hir/region/infer/merge/cycle/body.rs
@@ -1,0 +1,243 @@
+// audited: 2026-09-09
+//! What one `letrec` BODY looks like at its tail, as the closure-cycle merge's two
+//! tail gates read it.
+//!
+//! docs/impl/region/letrec.md
+//!
+//! Two gates ask two questions of the same body. The RELEASE-CHANNEL gate asks what
+//! each tail call is — its callee, and whether a cycle member rides in as an argument
+//! — because a frame-replacing `TailCall` strands the merged arena's binding-scope
+//! drop. The RETURN-FUNDED gate asks whether every tail exit LEAVES the frame, which
+//! is where the mint that funds the caller lands. A body that leaves neither way
+//! yields a bare value, and the bindings it yields say whether the letrec hands a
+//! member out.
+
+// `super::super::super` is `region::infer`, whose private imports every merge
+// submodule shares (`cycle` reaches them one level up).
+use super::super::super::*;
+use rustc_hash::FxHashMap;
+
+/// One tail call in a `letrec` body: what the release-channel gate needs of it — the
+/// callee, and every binding an argument carries in by-move.
+pub(super) struct TailCallSite {
+    /// The tail-call `Call` node's HirId — the key the lowerer sets
+    /// `deferred_release_slot` at for a non-member callee.
+    pub(super) hir_id: HirId,
+    /// The callee, unwrapped through `functionalize`'s `DerefCell`: `Some(b)` for a
+    /// binding reference (a member, a native, a redefined operator, a foreign fn),
+    /// `None` for a callee the gate cannot resolve (which refuses — no site to key
+    /// the deferred release at).
+    pub(super) callee: Option<crate::hir::Binding>,
+    /// Every binding referenced in the tail call's ARGUMENT subtrees (Var reads,
+    /// including a cell read's inner `Var`; nested lambdas are not descended). A
+    /// member passed by-move is exactly a binding here whose source region is in the
+    /// SCC. After ANF a nested aggregate/call argument is a fresh temp whose source
+    /// region is the aggregate/call-result region — never the member's — so the
+    /// RC-safe stored-then-passed case is not caught here (correctly admitted).
+    pub(super) arg_bindings: Vec<crate::hir::Binding>,
+}
+
+/// What one `Letrec`'s BODY looks like at its tail, as the merge's two tail gates
+/// read it.
+pub(super) struct LetrecTail {
+    /// One [`TailCallSite`] per tail call in the body — the release-channel gate's
+    /// input. A body tail call replaces the frame, stranding the binding-scope drop,
+    /// so each must supply a release channel (a member callee's stranded-cycle
+    /// deferral, or a non-member callee's explicit arena adopt) and must not pass a
+    /// cycle member in by-move.
+    pub(super) sites: Vec<TailCallSite>,
+    /// Does EVERY tail exit of the body leave the frame itself — a `Return`, or a
+    /// tail `Call`? The **return-funded** admission needs this reading rather than
+    /// `sites`: it decides whether the value the frame hands its caller is minted
+    /// INSIDE the body, ahead of the binding-scope drop the lowerer emits at the
+    /// `Letrec` node (docs/impl/region/letrec.md § The frontier gate).
+    pub(super) exits_frame: bool,
+    /// The bindings the body's tail region-transparently evaluates TO — the value the
+    /// `Letrec` node itself yields. Read only where `exits_frame` is false, i.e. where
+    /// that value goes to an ENCLOSING consumer: a cycle member among them leaves the
+    /// binding scope on an uncounted read, so the arena's release follows it instead of
+    /// staying at the scope (docs/impl/region/letrec.md § "Drop site — following a
+    /// handed-out member").
+    pub(super) value_bindings: Vec<crate::hir::Binding>,
+}
+
+/// For every `Letrec` node, how its BODY exits at the tail ([`LetrecTail`]).
+pub(super) fn collect_letrec_tail_callees(hir: &Hir, out: &mut FxHashMap<HirId, LetrecTail>) {
+    if let HirKind::Letrec { body, .. } = &hir.kind {
+        let mut sites = Vec::new();
+        body_tail_callees(body, &mut sites);
+        let mut value_bindings = Vec::new();
+        value_flow_bindings(body, &mut value_bindings);
+        out.insert(
+            hir.id,
+            LetrecTail {
+                sites,
+                exits_frame: body_tail_exits_frame(body),
+                value_bindings,
+            },
+        );
+    }
+    hir.for_each_child(|c| collect_letrec_tail_callees(c, out));
+}
+
+/// Does every tail EXIT of a letrec body leave the frame — is the value the frame
+/// hands its caller produced (and minted) INSIDE this body?
+///
+/// The return-funded admission reads this to know that the merge's binding-scope
+/// release runs after that mint (docs/impl/region/letrec.md § The frontier gate).
+/// Descends only the tail position of the pure control forms, and deliberately answers
+/// `false` for everything it does not recognise: a body it cannot read may hand its
+/// value to an enclosing consumer, whose mint is outside the letrec node and therefore
+/// after the release. A bare value tail out of tail position
+/// (`(let [c (letrec [ev …] ev)] … c)`), a loop, a short-circuit `And`/`Or`, and a
+/// `Cond` with no else arm all read that way.
+fn body_tail_exits_frame(hir: &Hir) -> bool {
+    match &hir.kind {
+        // The two nodes that hand a value to the CALLER from inside this body: the
+        // `Return` mints for it here, and a tail `Call` mints either at the callee's
+        // own `Return` (a closure, which replaces the frame) or at the post-`TailCall`
+        // fall-through retain emitted right here (a native, which does not).
+        HirKind::Return { .. } | HirKind::Call { is_tail: true, .. } => true,
+        HirKind::Let { body, .. }
+        | HirKind::Letrec { body, .. }
+        | HirKind::Parameterize { body, .. } => body_tail_exits_frame(body),
+        HirKind::Begin(exprs) | HirKind::Block { body: exprs, .. } => {
+            exprs.last().is_some_and(body_tail_exits_frame)
+        }
+        HirKind::If {
+            then_branch,
+            else_branch,
+            ..
+        } => body_tail_exits_frame(then_branch) && body_tail_exits_frame(else_branch),
+        HirKind::Cond {
+            clauses,
+            else_branch,
+        } => {
+            // No else arm means an implicit nil fall-through — an exit that does not
+            // leave the frame, so the whole `Cond` does not.
+            else_branch
+                .as_ref()
+                .is_some_and(|e| body_tail_exits_frame(e))
+                && clauses.iter().all(|(_, b)| body_tail_exits_frame(b))
+        }
+        // `Match` is absent deliberately, where branch compensation admits it exactly as
+        // an `If`: this reading needs the arms to be EXHAUSTIVE (a fall-through with no
+        // arm taken is an exit that does not leave the frame), which an `If` and a
+        // `Cond` with an else arm have and a pattern match does not.
+        _ => false,
+    }
+}
+
+/// The [`TailCallSite`]s within one letrec body. Never descends into a `Lambda`
+/// — a nested closure's tail calls run in that closure's own activation, not the
+/// letrec's, so they neither strand nor may adopt the merged arena (mirrors the
+/// lowerer's `collect_body_tail_callees`, `lir/lower/binding.rs`). The callee is
+/// unwrapped through the `DerefCell` `functionalize` adds around a needs-capture
+/// binding read; each argument subtree contributes its referenced bindings.
+fn body_tail_callees(hir: &Hir, out: &mut Vec<TailCallSite>) {
+    if matches!(hir.kind, HirKind::Lambda { .. }) {
+        return;
+    }
+    if let HirKind::Call {
+        func,
+        args,
+        is_tail: true,
+        ..
+    } = &hir.kind
+    {
+        let callee_node = match &func.kind {
+            HirKind::DerefCell { cell } => cell,
+            _ => func,
+        };
+        let callee = match &callee_node.kind {
+            HirKind::Var(b) => Some(*b),
+            _ => None,
+        };
+        let mut arg_bindings = Vec::new();
+        for a in args {
+            value_flow_bindings(&a.expr, &mut arg_bindings);
+        }
+        out.push(TailCallSite {
+            hir_id: hir.id,
+            callee,
+            arg_bindings,
+        });
+    }
+    hir.for_each_child(|c| body_tail_callees(c, out));
+}
+
+/// The bindings an expression region-transparently evaluates **to** — the values that
+/// flow out of it with no incref of their own. This mirrors escape's `tail_sources`
+/// descent (`hir/escape/flow.rs`): pass through the pure control / select / deref /
+/// bind wrappers, but STOP at a `Call`, an `Intrinsic`, and a `Lambda`. A member
+/// reached only past a stopped node did not flow uncounted:
+///
+///  - a nested `Call` — `(g (ev k))` — has `ev` as its callee, so `ev`'s RESULT (a
+///    value) flows, not `ev` itself; a member passed as a nested-call argument is
+///    incref-balanced (a non-tail call owns its params), not moved;
+///  - an `Intrinsic` — `(g (%pair od 1))` — stores the member into a fresh aggregate,
+///    an RC-counted reference the aggregate's cascade releases;
+///  - a `Lambda` — a closure argument's captures are RC-counted.
+///
+/// Two readers, asking the same question of different expressions. Over a **tail-call
+/// argument** it names what flows BY-MOVE into the call: only a bare member value in a
+/// direct argument (`(g od)`, or through an `If`/`Begin`/`DerefCell` that selects one)
+/// is moved with no incref, so a callee that replaces the frame owns it as a parameter
+/// and its release would double-free the arena — which the tail gate reads this to
+/// refuse. Over a **letrec body** it names the value
+/// the `Letrec` node yields, so a member there is one the cycle hands to an enclosing
+/// consumer — read only where the body does not leave the frame, hence never through
+/// the `Return` arm below.
+fn value_flow_bindings(hir: &Hir, out: &mut Vec<crate::hir::Binding>) {
+    match &hir.kind {
+        HirKind::Var(b) => out.push(*b),
+        HirKind::DerefCell { cell } => value_flow_bindings(cell, out),
+        HirKind::Let { body, .. }
+        | HirKind::Letrec { body, .. }
+        | HirKind::Loop { body, .. }
+        | HirKind::Parameterize { body, .. } => value_flow_bindings(body, out),
+        HirKind::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            value_flow_bindings(then_branch, out);
+            value_flow_bindings(else_branch, out);
+        }
+        HirKind::Cond {
+            clauses,
+            else_branch,
+        } => {
+            for (_, b) in clauses {
+                value_flow_bindings(b, out);
+            }
+            if let Some(eb) = else_branch {
+                value_flow_bindings(eb, out);
+            }
+        }
+        HirKind::Begin(exprs) | HirKind::Block { body: exprs, .. } => {
+            if let Some(last) = exprs.last() {
+                value_flow_bindings(last, out);
+            }
+        }
+        HirKind::And(exprs) | HirKind::Or(exprs) => {
+            for e in exprs {
+                value_flow_bindings(e, out);
+            }
+        }
+        HirKind::Match { arms, .. } => {
+            for (_, _, body) in arms {
+                value_flow_bindings(body, out);
+            }
+        }
+        HirKind::Return { value }
+        | HirKind::MakeCell { value }
+        | HirKind::Assign { value, .. }
+        | HirKind::Define { value, .. }
+        | HirKind::Destructure { value, .. }
+        | HirKind::SetCell { value, .. } => value_flow_bindings(value, out),
+        // A Call / Intrinsic / Lambda / immediate: a fresh, incref-balanced, or
+        // RC-counted result — no member flows by-move. Stop.
+        _ => {}
+    }
+}

--- a/src/hir/region/infer/tests/merge.rs
+++ b/src/hir/region/infer/tests/merge.rs
@@ -1,11 +1,16 @@
+// audited: 2026-09-09
 // ── Region merging ────────────────────────────────────────────────────
+//
+// docs/impl/region/merging.md
 //
 // When two regions collapse into one, split by what forces the collapse:
 //
 // - `seed` — the builder-idiom child→parent merge, where the merge starts.
 // - `selfedge` — the self-edge elimination predicate (transform 2).
 // - `recursion` — the letrec closure-cycle merge: which recursion shapes
-//   collapse, and which tail callees the merge still admits.
+//   collapse, and where the single release fires.
+// - `tailgate` — which letrec body tails carry the merged arena's release, and
+//   which the by-move boundary still refuses.
 // - `escape` — where the merge stops: a returned cycle, a handed-out member,
 //   and a fiber crossing.
 
@@ -16,6 +21,7 @@ mod escape;
 mod recursion;
 mod seed;
 mod selfedge;
+mod tailgate;
 
 /// The `Letrec` node binding a name (`loop`/`ping`) — the cycle's binding scope,
 /// whose scope-exit is the tight, RC-safe drop site for the merged arena.

--- a/src/hir/region/infer/tests/merge/recursion.rs
+++ b/src/hir/region/infer/tests/merge/recursion.rs
@@ -6,7 +6,7 @@
 // A `letrec` self/mutual recursive closure is a capture-cell↔closure cycle: the
 // prebound forward-reference cell holds the closure (`StoreCaptureCell`) and the
 // closure captures the cell. Per-region RC cannot collect the immutable cycle
-// (region/rules.md Rule 8), but every member is static-slot (the closure's
+// (docs/impl/region/rules.md Rule 8), but every member is static-slot (the closure's
 // `alloc_region`, the cell's `begin_cell_regions`), sole-held, and non-escaping —
 // so the merge collapses the whole SCC ∪ its cells onto ONE region. The interior
 // cell↔closure references become intra-region (the alloc-scan and free-cascade both

--- a/src/hir/region/infer/tests/merge/recursion.rs
+++ b/src/hir/region/infer/tests/merge/recursion.rs
@@ -1,19 +1,22 @@
-use super::*;
-
-// ── The letrec closure-cycle merge ────────────────────────────────────
+// audited: 2026-09-09
+// ── Which recursion shapes the closure-cycle merge collapses ─────────
 //
-// docs/impl/region/letrec.md § The letrec closure-cycle merge. A `letrec`
-// self/mutual recursive closure is a
-// capture-cell↔closure cycle: the prebound forward-reference cell holds the closure
-// (`StoreCaptureCell`) and the closure captures the cell. Per-region RC cannot
-// collect the immutable cycle (region/rules.md Rule 8), but every member is
-// static-slot (the closure's `alloc_region`, the cell's `begin_cell_regions`),
-// sole-held, and non-escaping — so the merge collapses the whole SCC ∪ its cells
-// onto ONE region. The interior cell↔closure references become intra-region (the
-// alloc-scan and free-cascade both self-skip same-region refs,
-// regionpool/introspect.rs `rid != own_id`), so the cycle frees as one arena with
-// one `DecrefRegion`. These pins drive that from the spec: the positive cases
-// collapse the SCC onto one `merged_root`; the negative refuses an escaping closure.
+// docs/impl/region/letrec.md
+//
+// A `letrec` self/mutual recursive closure is a capture-cell↔closure cycle: the
+// prebound forward-reference cell holds the closure (`StoreCaptureCell`) and the
+// closure captures the cell. Per-region RC cannot collect the immutable cycle
+// (region/rules.md Rule 8), but every member is static-slot (the closure's
+// `alloc_region`, the cell's `begin_cell_regions`), sole-held, and non-escaping —
+// so the merge collapses the whole SCC ∪ its cells onto ONE region. The interior
+// cell↔closure references become intra-region (the alloc-scan and free-cascade both
+// self-skip same-region refs, regionpool/introspect.rs `rid != own_id`), so the
+// cycle frees as one arena with one `DecrefRegion`. These pins drive that from the
+// spec: which shapes collapse onto one `merged_root`, and where the single release
+// fires. Which body TAILS the merge admits is `tailgate`; where it stops for an
+// escaping member is `escape`.
+
+use super::*;
 
 #[test]
 fn self_recursive_letrec_is_cell_free_not_merged() {
@@ -147,8 +150,8 @@ fn merge_collapses_in_lambda_mutual_recursion_letrec_closure_cycle() {
     // the ev/od SCC ∪ cells onto ONE region exactly as at top level, and the root drops
     // at the in-lambda letrec (the binding scope). The body `(ev k)` is a tail call to
     // an SCC member — the shape whose stranded binding-scope drop rides the tail-call
-    // deferred release — and must be ADMITTED (the tail-strand refusal bites only a non-member
-    // callee, `merge_refuses_in_lambda_cycle_with_foreign_tail_callee`).
+    // deferred release — and must be ADMITTED (which body tails carry the arena's
+    // release, and which the gate refuses, is `tailgate`).
     let mut symbols = SymbolTable::new();
     let (hir, arena) = compile_fhir(
         "(def f (fn [k] (letrec [ev (fn [m] (if (%lt m 1) :even (od (%sub m 1)))) \
@@ -213,149 +216,6 @@ fn merge_collapses_in_lambda_mutual_recursion_letrec_closure_cycle() {
         root.0,
         letrec_id.0,
         dp,
-    );
-}
-
-#[test]
-fn merge_admits_in_lambda_cycle_with_foreign_tail_callee() {
-    // INVERTED from the old tail-strand refusal: a letrec body tail-calling a
-    // NON-member closure `g` (a foreign fn) now MERGES. The frame-replacing
-    // TailCall strands the binding-scope drop, but the non-member release channel —
-    // `RegionInfo::cycle_tail_release` → `TailCall::deferred_release_slot` — is wired, so a
-    // closure callee's new activation takes over the arena's release, freeing it at recursion
-    // completion. The tail argument is `(ev k)`'s RESULT (a value), not a member, so
-    // no member flows in by-move (contrast
-    // `merge_refuses_member_passed_by_move_to_foreign_tail`). `g` is a user closure,
-    // so its `(g r)` tail is an ordinary `Call`.
-    let mut symbols = SymbolTable::new();
-    let (hir, arena) = compile_fhir(
-        "(def g (fn [x] x)) \
-         (def f (fn [k] (letrec [ev (fn [m] (if (%lt m 1) :even (od (%sub m 1)))) \
-                                 od (fn [m] (if (%lt m 1) :odd (ev (%sub m 1))))] \
-                          (g (ev k))))) \
-         (f 3)",
-        &mut symbols,
-    );
-    let info = analyze_regions(&hir, &arena);
-    let cells = ev_od_cells(&hir, &arena, &symbols, &info);
-    assert_eq!(
-        cells.len(),
-        2,
-        "precondition: two compiled forward cells; got {cells:?}"
-    );
-    let roots: rustc_hash::FxHashSet<Region> = cells.iter().map(|&c| info.merged_root(c)).collect();
-    assert_eq!(
-        roots.len(),
-        1,
-        "a foreign-closure body tail ((g (ev k))) must now MERGE the cycle — the \
-         non-member tail release slot supplies the stranded release; cells={cells:?} \
-         merged_parent={:?}",
-        info.merged_parent,
-    );
-    let root = roots.into_iter().next().unwrap();
-    assert!(
-        !cells.contains(&root),
-        "the merged root must be a closure region, not a cell; root=r{} cells={cells:?}",
-        root.0,
-    );
-    // The non-member tail site is recorded, keyed to the merged root — the datum the
-    // lowerer reads to set `deferred_release_slot`.
-    assert!(
-        info.cycle_tail_release.values().any(|&r| r == root),
-        "the (g r) tail site must record cycle_tail_release → merged root r{}; got {:?}",
-        root.0,
-        info.cycle_tail_release,
-    );
-}
-
-#[test]
-fn merge_admits_native_tail() {
-    // The native body tail `(%freeze (ev k))`: a copying `%`-op compiles as a native
-    // funnel `Call`, so in tail position it is a frame-replacing `TailCall` (an inline
-    // arith `%`-op would be an `Intrinsic` node and not a Call tail at all). The cycle
-    // must MERGE and record the `%freeze` site in `cycle_tail_release`: at runtime the
-    // native keeps the frame and the live scope-exit drop frees the arena, but the
-    // release slot is carried anyway (the compiler never classifies the callee), so a
-    // rebound `%freeze` closure is also covered. This is the native-tail shape the
-    // whole class regressed on.
-    let mut symbols = SymbolTable::new();
-    let (hir, arena, info) = analyze_cycle_with_effects(
-        "(def f (fn [k] (letrec [ev (fn [m] (if (%lt m 1) :even (od (%sub m 1)))) \
-                                 od (fn [m] (if (%lt m 1) :odd (ev (%sub m 1))))] \
-                          (%freeze (ev k))))) \
-         (f 3)",
-        &mut symbols,
-    );
-    let cells = ev_od_cells(&hir, &arena, &symbols, &info);
-    assert_eq!(
-        cells.len(),
-        2,
-        "precondition: two compiled forward cells; got {cells:?}"
-    );
-    let roots: rustc_hash::FxHashSet<Region> = cells.iter().map(|&c| info.merged_root(c)).collect();
-    assert_eq!(
-        roots.len(),
-        1,
-        "a native body tail ((%freeze (ev k))) must MERGE the cycle; \
-         cells={cells:?} merged_parent={:?}",
-        info.merged_parent,
-    );
-    let root = roots.into_iter().next().unwrap();
-    assert!(
-        info.cycle_tail_release.values().any(|&r| r == root),
-        "the (%freeze …) tail site must record cycle_tail_release → merged root r{}; got {:?}",
-        root.0,
-        info.cycle_tail_release,
-    );
-}
-
-#[test]
-fn merge_refuses_member_passed_by_move_to_foreign_tail() {
-    // THE SAFETY BOUNDARY. A member closure `od` passed BY-MOVE as an argument to a
-    // non-member tail call `(g od)` must REFUSE the merge. Freeing the arena at the
-    // recursion's completion (the deferred release) collides with `od`'s own move/return
-    // machinery — which also decrefs the merged arena — a double-free. The escape
-    // gate does NOT catch this (an opaque callee's argument is not a return/fiber
-    // Shared-seed), and the ANF hoist temp aliasing `od` is a synthetic holder
-    // excluded from the sole-held count, so this by-move refusal is the tail gate's
-    // own: `arg_bindings` sees a binding whose source region is in the SCC. Contrast
-    // `merge_admits_in_lambda_cycle_with_foreign_tail_callee`, where the argument is a
-    // value (`(ev k)`'s result), not the member itself.
-    // `od` is used in value position (`(g od)`), so call-site forwarding cannot
-    // prove its `m` — the diverging guard does (ev stays callee-only and is
-    // proven by forwarding from od's `(ev (%sub m 1))`).
-    let mut symbols = SymbolTable::new();
-    let (hir, arena) = compile_fhir(
-        "(def g (fn [x] x)) \
-         (def f (fn [k] (letrec [ev (fn [m] (if (%lt m 1) :even (od (%sub m 1)))) \
-                                 od (fn [m] (when (%not (%int? m)) (error :m)) \
-                                      (if (%lt m 1) :odd (ev (%sub m 1))))] \
-                          (g od)))) \
-         (f 3)",
-        &mut symbols,
-    );
-    let info = analyze_regions(&hir, &arena);
-    let cells = ev_od_cells(&hir, &arena, &symbols, &info);
-    assert_eq!(
-        cells.len(),
-        2,
-        "precondition: two compiled forward cells; got {cells:?}"
-    );
-    for &c in &cells {
-        assert_eq!(
-            info.merged_root(c),
-            c,
-            "a cycle passing a member (od) BY-MOVE into a non-member tail (g od) must \
-             NOT merge — the deferred release would double-free the arena against od's own \
-             move/return release; cell r{} merged; merged_parent={:?}",
-            c.0,
-            info.merged_parent,
-        );
-    }
-    assert!(
-        info.cycle_tail_release.is_empty(),
-        "a refused cycle records no non-member tail release site; got {:?}",
-        info.cycle_tail_release,
     );
 }
 

--- a/src/hir/region/infer/tests/merge/tailgate.rs
+++ b/src/hir/region/infer/tests/merge/tailgate.rs
@@ -1,0 +1,217 @@
+// audited: 2026-09-09
+// ── Which body tails the closure-cycle merge admits ──────────────────
+//
+// docs/impl/region/letrec.md
+//
+// A `letrec` body's tail call replaces the frame, which strands the merged
+// arena's binding-scope `DecrefRegion` as dead code. Every such tail must
+// therefore supply a release channel: a MEMBER callee rides the existing
+// stranded-cycle deferral, a NON-member callee rides the explicit arena adopt
+// (`RegionInfo::cycle_tail_release`). What the non-member channel still refuses
+// is a cycle member carried into the call BY-MOVE, whose new activation's
+// owned-parameter release would decref the arena a second time — and that is a
+// claim about a callee which can REPLACE the frame, so a callee the compiler
+// reads as a native is admitted with the members riding in.
+
+use super::*;
+
+#[test]
+fn merge_admits_in_lambda_cycle_with_foreign_tail_callee() {
+    // INVERTED from the old tail-strand refusal: a letrec body tail-calling a
+    // NON-member closure `g` (a foreign fn) now MERGES. The frame-replacing
+    // TailCall strands the binding-scope drop, but the non-member release channel —
+    // `RegionInfo::cycle_tail_release` → `TailCall::deferred_release_slot` — is wired, so a
+    // closure callee's new activation takes over the arena's release, freeing it at recursion
+    // completion. The tail argument is `(ev k)`'s RESULT (a value), not a member, so
+    // no member flows in by-move (contrast
+    // `merge_refuses_member_passed_by_move_to_foreign_tail`). `g` is a user closure,
+    // so its `(g r)` tail is an ordinary `Call`.
+    let mut symbols = SymbolTable::new();
+    let (hir, arena) = compile_fhir(
+        "(def g (fn [x] x)) \
+         (def f (fn [k] (letrec [ev (fn [m] (if (%lt m 1) :even (od (%sub m 1)))) \
+                                 od (fn [m] (if (%lt m 1) :odd (ev (%sub m 1))))] \
+                          (g (ev k))))) \
+         (f 3)",
+        &mut symbols,
+    );
+    let info = analyze_regions(&hir, &arena);
+    let cells = ev_od_cells(&hir, &arena, &symbols, &info);
+    assert_eq!(
+        cells.len(),
+        2,
+        "precondition: two compiled forward cells; got {cells:?}"
+    );
+    let roots: rustc_hash::FxHashSet<Region> = cells.iter().map(|&c| info.merged_root(c)).collect();
+    assert_eq!(
+        roots.len(),
+        1,
+        "a foreign-closure body tail ((g (ev k))) must now MERGE the cycle — the \
+         non-member tail release slot supplies the stranded release; cells={cells:?} \
+         merged_parent={:?}",
+        info.merged_parent,
+    );
+    let root = roots.into_iter().next().unwrap();
+    assert!(
+        !cells.contains(&root),
+        "the merged root must be a closure region, not a cell; root=r{} cells={cells:?}",
+        root.0,
+    );
+    // The non-member tail site is recorded, keyed to the merged root — the datum the
+    // lowerer reads to set `deferred_release_slot`.
+    assert!(
+        info.cycle_tail_release.values().any(|&r| r == root),
+        "the (g r) tail site must record cycle_tail_release → merged root r{}; got {:?}",
+        root.0,
+        info.cycle_tail_release,
+    );
+}
+
+#[test]
+fn merge_admits_native_tail() {
+    // The native body tail `(%freeze (ev k))`: a copying `%`-op compiles as a native
+    // funnel `Call`, so in tail position it is a frame-replacing `TailCall` (an inline
+    // arith `%`-op would be an `Intrinsic` node and not a Call tail at all). The cycle
+    // must MERGE and record the `%freeze` site in `cycle_tail_release`: at runtime the
+    // native keeps the frame and the live scope-exit drop frees the arena, but the
+    // release slot is carried anyway (the compiler never classifies the callee), so a
+    // rebound `%freeze` closure is also covered. This is the native-tail shape the
+    // whole class regressed on.
+    let mut symbols = SymbolTable::new();
+    let (hir, arena, info) = analyze_cycle_with_effects(
+        "(def f (fn [k] (letrec [ev (fn [m] (if (%lt m 1) :even (od (%sub m 1)))) \
+                                 od (fn [m] (if (%lt m 1) :odd (ev (%sub m 1))))] \
+                          (%freeze (ev k))))) \
+         (f 3)",
+        &mut symbols,
+    );
+    let cells = ev_od_cells(&hir, &arena, &symbols, &info);
+    assert_eq!(
+        cells.len(),
+        2,
+        "precondition: two compiled forward cells; got {cells:?}"
+    );
+    let roots: rustc_hash::FxHashSet<Region> = cells.iter().map(|&c| info.merged_root(c)).collect();
+    assert_eq!(
+        roots.len(),
+        1,
+        "a native body tail ((%freeze (ev k))) must MERGE the cycle; \
+         cells={cells:?} merged_parent={:?}",
+        info.merged_parent,
+    );
+    let root = roots.into_iter().next().unwrap();
+    assert!(
+        info.cycle_tail_release.values().any(|&r| r == root),
+        "the (%freeze …) tail site must record cycle_tail_release → merged root r{}; got {:?}",
+        root.0,
+        info.cycle_tail_release,
+    );
+}
+
+#[test]
+fn merge_refuses_member_passed_by_move_to_foreign_tail() {
+    // THE SAFETY BOUNDARY. A member closure `od` passed BY-MOVE as an argument to a
+    // non-member tail call `(g od)` must REFUSE the merge. Freeing the arena at the
+    // recursion's completion (the deferred release) collides with `od`'s own move/return
+    // machinery — which also decrefs the merged arena — a double-free. The escape
+    // gate does NOT catch this (an opaque callee's argument is not a return/fiber
+    // Shared-seed), and the ANF hoist temp aliasing `od` is a synthetic holder
+    // excluded from the sole-held count, so this by-move refusal is the tail gate's
+    // own: `arg_bindings` sees a binding whose source region is in the SCC. Contrast
+    // `merge_admits_in_lambda_cycle_with_foreign_tail_callee`, where the argument is a
+    // value (`(ev k)`'s result), not the member itself.
+    // `od` is used in value position (`(g od)`), so call-site forwarding cannot
+    // prove its `m` — the diverging guard does (ev stays callee-only and is
+    // proven by forwarding from od's `(ev (%sub m 1))`).
+    let mut symbols = SymbolTable::new();
+    let (hir, arena) = compile_fhir(
+        "(def g (fn [x] x)) \
+         (def f (fn [k] (letrec [ev (fn [m] (if (%lt m 1) :even (od (%sub m 1)))) \
+                                 od (fn [m] (when (%not (%int? m)) (error :m)) \
+                                      (if (%lt m 1) :odd (ev (%sub m 1))))] \
+                          (g od)))) \
+         (f 3)",
+        &mut symbols,
+    );
+    let info = analyze_regions(&hir, &arena);
+    let cells = ev_od_cells(&hir, &arena, &symbols, &info);
+    assert_eq!(
+        cells.len(),
+        2,
+        "precondition: two compiled forward cells; got {cells:?}"
+    );
+    for &c in &cells {
+        assert_eq!(
+            info.merged_root(c),
+            c,
+            "a cycle passing a member (od) BY-MOVE into a non-member tail (g od) must \
+             NOT merge — the deferred release would double-free the arena against od's own \
+             move/return release; cell r{} merged; merged_parent={:?}",
+            c.0,
+            info.merged_parent,
+        );
+    }
+    assert!(
+        info.cycle_tail_release.is_empty(),
+        "a refused cycle records no non-member tail release site; got {:?}",
+        info.cycle_tail_release,
+    );
+}
+
+#[test]
+fn merge_admits_member_passed_by_move_to_native_tail() {
+    // THE FACTORY. The same by-move shape as
+    // `merge_refuses_member_passed_by_move_to_foreign_tail`, one callee apart: the
+    // letrec body's tail is a struct literal over BOTH members, which compiles to a
+    // tail call on the `struct` native with `ev` and `od` as direct arguments. The
+    // refusal's argument is a callee that REPLACES the frame — its new activation's
+    // owned-parameter release is what would decref the arena a second time against the
+    // deferred release. A native does neither: it borrows its arguments and it keeps
+    // the frame, so the binding-scope `DecrefRegion` stays live and is the arena's
+    // single release. The counter-factual is the whole arena: refusing left this cycle
+    // Shared and leaked its four regions — two closures, two forward cells — per call,
+    // which is the everyday `letrec`-of-closures factory.
+    // Both members are used in value position (the struct carries them out), so
+    // call-site forwarding proves neither `m` — each takes a diverging guard.
+    let mut symbols = SymbolTable::new();
+    let (hir, arena, info) = analyze_cycle_with_effects(
+        "(def f (fn [k] (letrec [ev (fn [m] (when (%not (%int? m)) (error :m)) \
+                                     (if (%lt m 1) :even (od (%sub m 1)))) \
+                                 od (fn [m] (when (%not (%int? m)) (error :m)) \
+                                      (if (%lt m 1) :odd (ev (%sub m 1))))] \
+                          {:a ev :b od}))) \
+         (f 3)",
+        &mut symbols,
+    );
+    let cells = ev_od_cells(&hir, &arena, &symbols, &info);
+    assert_eq!(
+        cells.len(),
+        2,
+        "precondition: two compiled forward cells; got {cells:?}"
+    );
+    let roots: rustc_hash::FxHashSet<Region> = cells.iter().map(|&c| info.merged_root(c)).collect();
+    assert_eq!(
+        roots.len(),
+        1,
+        "a struct-literal body tail ({{:a ev :b od}}) carries both members by-move into \
+         a NATIVE, which cannot replace the frame — the cycle must MERGE; cells={cells:?} \
+         merged_parent={:?}",
+        info.merged_parent,
+    );
+    let root = roots.into_iter().next().unwrap();
+    assert!(
+        !cells.contains(&root),
+        "the merged root must be a closure region, not a cell; root=r{} cells={cells:?}",
+        root.0,
+    );
+    // The tail site is recorded like any other non-member tail: the merge classifies
+    // the callee to decide the REFUSAL, never to pick the release channel, so a
+    // `struct` rebound to a closure still finds its deferred release wired.
+    assert!(
+        info.cycle_tail_release.values().any(|&r| r == root),
+        "the struct-literal tail site must record cycle_tail_release → merged root r{}; \
+         got {:?}",
+        root.0,
+        info.cycle_tail_release,
+    );
+}

--- a/tests/elle/probe/tailcall.lisp
+++ b/tests/elle/probe/tailcall.lisp
@@ -1,5 +1,5 @@
 (elle/epoch 12)
-# audited: 2026-09-08
+# audited: 2026-09-09
 # Tail-call rotation, letrec-local recursive closures, a returned self-recursive closure's region, and the scheduler round trip.
 #
 # docs/impl/region/diagnostics.md
@@ -134,8 +134,8 @@
 
 # The same returned ev/od cycle, one body-tail apart: it tail-calls a NON-member
 # (`lcl-ident`) rather than the member `ev`. Which channel carries the arena's release
-# does not enter the ordering argument, and neither does the fact that the compiler
-# cannot classify the callee: a CLOSURE callee replaces the frame and takes the
+# does not enter the ordering argument, and neither does whether the compiler can
+# classify the callee: a CLOSURE callee replaces the frame and takes the
 # `deferred_release_slot` deferral at the recursion's completion, while a NATIVE callee
 # keeps the frame and falls through to the binding-scope drop the lowerer emits at the
 # `Letrec` node — after the mint the tail call itself emits at the call site. Both are
@@ -197,6 +197,34 @@
     c))
 (pin (measure "recur-local-mutual-ret-bound" (fn [j] (lcl-mutual-ret-bound 3))
               100 6 60 0.4 0.5) 0)
+
+# The FACTORY — the everyday shape the whole family serves: mutually recursive local
+# helpers over shared state, handed back in one struct. The letrec body's tail is a
+# struct literal over BOTH members, so it is a tail call on the `struct` native
+# carrying `ev` and `od` in BY-MOVE. That by-move refusal answers a callee which
+# REPLACES the frame, whose new activation's owned-parameter release would decref the
+# merged arena a second time against the deferred release. A native does neither — it
+# borrows its arguments and keeps the frame — so the binding-scope drop stays live and
+# single, and the members the returned struct keeps are a cross-region reference into
+# the arena, RC-counted exactly as a foreign capture is (docs/impl/region/letrec.md
+# § "What the non-member tail still refuses"). Refusing it held five regions per call:
+# the cycle's two closures and two forward cells, plus the `t` the leaked cycle pinned.
+# A CLOSED control, undeclared like `rest-array-copy`, so a regression to open trips
+# the completeness gate as an F4 defect rather than being absorbed under the root.
+(defn lcl-mutual-factory [n]
+  # Both members leave in the struct (a value use), which disables call-site param
+  # joins, so a local diverging guard proves the %lt/%sub operands.
+  (let [t @{}]
+    (letrec [ev (fn [m]
+                  (when (%not (%int? m)) (error :m))
+                  (if (%lt m 1) t (od (%sub m 1))))
+             od (fn [m]
+                  (when (%not (%int? m)) (error :m))
+                  (put t m true)
+                  (ev (%sub m 1)))]
+      {:a ev :b od})))
+(pin (measure "recur-local-mutual-factory" (fn [j] (lcl-mutual-factory 3)) 100 6
+              60 0.4 0.5) 0)
 
 # ── Retained-closure reclamation (a RETURNED self-recursive closure's region) ──
 # `recur-local-self` above pins the LEAK rate of a self-recursive closure used as a

--- a/tests/elle/region-native-tail-mutual-cycle-uaf.lisp
+++ b/tests/elle/region-native-tail-mutual-cycle-uaf.lisp
@@ -1,6 +1,8 @@
 (elle/epoch 12)
-# A local mutual-recursion clique (`ev`/`od`) whose `letrec` BODY ends in a tail
-# call to a NON-member must reclaim its merged arena soundly — no premature free.
+# audited: 2026-09-09
+# A local mutual-recursion clique whose letrec body ends in a non-member tail call must reclaim its merged arena with no premature free.
+#
+# docs/impl/region/letrec.md
 #
 # The closure-cycle merge collapses the `ev`/`od` SCC and their forward cells onto
 # one arena, freed once by the arena's binding-scope `DecrefRegion`. When the body
@@ -19,7 +21,9 @@
 #
 # Covers each non-member body-tail shape (inline intrinsic, redefined-operator
 # closure, foreign closure), a MIXED body (member + non-member
-# arm — exactly one release per path), and the same clique rebuilt PER LOOP ITERATION
+# arm — exactly one release per path), both BY-MOVE shapes (a member carried into a
+# native `struct` literal, which merges, and one carried into a closure, which keeps
+# the refusal), and the same clique rebuilt PER LOOP ITERATION
 # (per-call reclamation at recursion-completion granularity, not activation
 # granularity — the case an activation-owner-node cut would leak/double-free). Pinned
 # under the UAF oracle by `region_native_tail_mutual_cycle_uaf`
@@ -58,6 +62,38 @@
              od (fn [m] (if (%lt m 1) 1 (ev (%sub m 1))))]
       (g (ev n)))))
 
+# Factory body tail: the letrec body is a struct literal over BOTH members, so each is
+# carried into the `struct` native BY-MOVE. A native borrows its arguments and keeps
+# the frame, so the arena's binding-scope drop is live and single, and what the
+# returned struct keeps is a cross-region reference into that arena. The drive below
+# calls a member OUT of the struct after the factory's frame is gone, which reads the
+# whole cycle through that reference — a premature free faults there.
+## Each member leaves the frame in the struct (a value use), so no visible call site
+## proves its `m` — a diverging guard proves the %lt/%sub operands instead.
+(defn f-factory [n0]
+  (let [n (if (%int? n0) n0 0)]
+    (letrec [ev (fn [m]
+                  (when (%not (%int? m)) (error :m))
+                  (if (%lt m 1) 0 (od (%sub m 1))))
+             od (fn [m]
+                  (when (%not (%int? m)) (error :m))
+                  (if (%lt m 1) 1 (ev (%sub m 1))))]
+      {:ev ev :n n})))
+
+# The counterweight: a member handed by-move to a callee that CAN replace the frame
+# keeps the refusal, so this cycle stays Shared — the always-legal baseline. Driven so
+# that a future widening of the reading past a native callee faults here instead of
+# passing on the strength of the factory row alone.
+(defn f-move-closure [n0]
+  (let [n (if (%int? n0) n0 0)]
+    (letrec [ev (fn [m]
+                  (when (%not (%int? m)) (error :m))
+                  (if (%lt m 1) 0 (od (%sub m 1))))
+             od (fn [m]
+                  (when (%not (%int? m)) (error :m))
+                  (if (%lt m 1) 1 (ev (%sub m 1))))]
+      (g ev))))
+
 # Mixed body tail: one arm tail-calls a MEMBER (`ev`, released by the
 # stranded-cycle adopt, its binding-scope drop dead there); the other ends in the
 # inline `%add` opcode (no frame replacement — the live scope-exit drop releases).
@@ -86,6 +122,22 @@
   (assert (= (f-mixed i (= (mod i 2) 0)) (mod i 2))
           (string "mixed: wrong result at i=" i " (arena freed early?)"))
   (assign i (%add i 1)))
+
+# The two by-move rows: build the cycle, let the builder's frame go, then re-enter a
+# member through the handle it handed out. Each read happens after the arena's release
+# ran, so an over-release faults here.
+(def @j 0)
+(while (%lt j 60)
+  (let [fac (f-factory j)
+        mem (get fac :ev)]
+    (assert (= (mem j) (mod j 2))
+            (string "factory: wrong result at j=" j " (arena freed early?)"))
+    (assert (= (get fac :n) j)
+            (string "factory: struct lost its own field at j=" j)))
+  (let [mem (f-move-closure j)]
+    (assert (= (mem j) (mod j 2))
+            (string "move-closure: wrong result at j=" j " (arena freed early?)")))
+  (assign j (%add j 1)))
 
 # Accumulate across a longer loop so the arena is minted-and-freed hundreds of times
 # (a leak would grow RSS, a double-free would fault) — the per-iteration granularity

--- a/tests/integration/elle_scripts/tailcalls.rs
+++ b/tests/integration/elle_scripts/tailcalls.rs
@@ -1,4 +1,4 @@
-// audited: 2026-09-08
+// audited: 2026-09-09
 // Guardfree pins for the frame-exit relocation and the deferred channels a tail call rides.
 //
 // docs/analysis/testing.md
@@ -83,8 +83,9 @@ fn region_tail_deferred_exits_uaf() {
 
 // Guard — a local mutual-recursion clique (`ev`/`od`) whose `letrec` body ends in a
 // tail call to a NON-member (a native `%add`, the redefined-closure operator `+`, a
-// foreign fn `g`, and a MIXED member+non-member `if`) must reclaim its merged arena
-// soundly. The frame-replacing `TailCall` strands the arena's binding-scope drop, so
+// foreign fn `g`, a MIXED member+non-member `if`, and both BY-MOVE shapes — a member
+// carried into a `struct` literal, which merges, and one carried into a closure,
+// which keeps the refusal) must reclaim its merged arena soundly. The frame-replacing `TailCall` strands the arena's binding-scope drop, so
 // a closure callee rides the explicit arena adopt (`TailCall::deferred_release_slot`) at
 // recursion completion while a native callee falls through to the live scope-exit
 // drop — mutually exclusive per call, exactly one release. A premature free leaves


### PR DESCRIPTION
Fixes #1104.

## What was wrong

The closure-cycle merge refuses a `letrec` cycle whose body ends in a tail call to
a non-member carrying a cycle MEMBER in as a direct argument. That refusal's
argument is a callee which REPLACES the frame: its new activation owns the member
as a parameter and releases it, decrefing the merged arena a second time against
the deferred release — a double-free.

A native callee does neither. It borrows its arguments and releases none of them,
and it keeps the frame, so the binding-scope `DecrefRegion` stays live and is the
arena's single release. The gate was wider than its argument, and what it caught is
the everyday factory: mutually recursive local closures over shared state, handed
back as a struct literal, which compiles to a tail call on the `struct` native
carrying both members.

## What the change does

`BindingInner` records whether a binding's compile-time constant value is a native
function, written from the VALUE at the two sites that bind one
(`bind_primitives`, `bind_compile_time_env`) — so a primitive-scope name core.lisp
rebinds to a bytecode closure, `+` among them, reads as a closure. `may_replace_frame`
answers no for an immutable, unmutated binding holding such a constant and yes for
everything else, and the tail gate asks it before it refuses.

The release channel is unchanged: the merge still wires both, so a `struct` that
turns out to be a closure at run time still finds its deferred release keyed.

## How it was measured

`arena/region-count` delta over a block of 100 constructions after a warmup block,
both deterministic:

| shape | before | after |
|---|---:|---:|
| `{:a fa :b fb}` tail — a struct literal over the members | 5.0 | 0.0 |
| `(g fa)` tail — a foreign closure over a member | 5.0 | 5.0 |
| `{:a 1 :b 2}` tail — a struct literal over no member | 0.0 | 0.0 |

The five are the cycle's four regions — two closures, two forward cells — plus the
shared `@{}` the leaked cycle pins. The middle row is the boundary the refusal still
holds.

## Tests

- `recur-local-mutual-factory` (`tests/elle/probe/tailcall.lisp`) measures the
  factory and pins it at 0. It read `open 7.0` before the fix.
- `merge_admits_member_passed_by_move_to_native_tail` pins the merge and the
  recorded release site; `merge_refuses_member_passed_by_move_to_foreign_tail`
  holds the closure-callee boundary.
- `test_native_constant_binding_never_replaces_the_frame` pins the predicate's
  three inputs.
- `region-native-tail-mutual-cycle-uaf.lisp` gains both by-move rows under
  `--trace=guardfree`: the factory, re-entered through the member the struct handed
  out after the builder's frame is gone, and a member handed to a callee that can
  replace the frame.

## Two files were split

`merge/cycle.rs` and `analyze/mod.rs` were both past the 500-line reading budget,
which is what the audit stamp attests, so the letrec body's tail reading moved to
`merge/cycle/body.rs`, the analyzer's ambient-environment binders to
`analyze/env.rs`, and the near-miss name suggestion to `analyze/scopes.rs`. The
merge's 68-line restatement of `letrec.md` gives way to the gate list a reader of
that function actually needs. The merge test file likewise held two subjects, so
the tail-callee gates moved to `tests/merge/tailgate.rs`.

The issue's own snippet spells its cycle with `defn` forms rather than `letrec`,
and that shape refuses for a different reason this change does not touch — its
binding scope is a `Begin`, which the body reading never visits (#1106). The
measurements above, and the issue's own table, are the `letrec` spelling.
