### PR TITLE
tests: the two timing gates measure against a control, not a clock

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,17 +1,19 @@
 # Testing
 
+<!-- audited: 2026-09-10 -->
+
 Elle has two test systems:
 
 1. **The Elle corpus** — `.lisp` files under `tests/elle/`, run through the
    **agent-first runner** (`elle test`). This is what `make smoke` gates on.
 2. **The Rust suite** — unit, integration, and property tests under `tests/` and
    inline `#[cfg(test)]` modules, run through `cargo test`. See
-   [`tests/AGENTS.md`](../tests/AGENTS.md) for categories, helpers, and how to add
-   one, and [`docs/analysis/testing.md`](analysis/testing.md) for the
+   [tests/AGENTS.md](../tests/AGENTS.md) for categories, helpers, and how to add
+   one, and [docs/analysis/testing.md](analysis/testing.md) for the
    decision tree (which kind of Rust test to write).
 
 This document covers the Elle corpus and the runner; the runner's full
-specification is [`docs/test-runner.md`](test-runner.md).
+specification is [docs/test-runner.md](test-runner.md).
 
 ## Quick start
 
@@ -39,12 +41,13 @@ You read results from the run itself — never by hand-writing SQLite.
 
 The runner compiles and runs the **whole corpus in one process**, recording every
 `(form × tier)` result into a **SQLite DB** plus a filesystem CAS for
-artifacts. The thesis (see [`docs/test-runner.md`](test-runner.md)): *capture
+artifacts. The thesis (see [docs/test-runner.md](test-runner.md)): *capture
 everything once; query forever* — so an agent issues SQL against the stored run
 instead of re-running with `--dump`/`--trace`.
 
 - **The corpus is the source of truth, in git.** The DB is a derived, rebuildable
-  index living outside the repo (default `$ELLE_CACHE/elle-tests.db`).
+  index living outside the repo (`$ELLE_CACHE/elle-tests.db`, or
+  `target/elle-tests.db` when that variable is unset).
 - **The DB tracks all runs.** Each invocation appends a `run` row; `--summary`
   shows the *latest* run (`run N of M` makes the history visible).
 
@@ -58,7 +61,8 @@ form-by-form. Two shapes:
   forced onto **every backend tier** via `compile/run-on` (`vm`, `jit`, and
   `wasm`/`mlir-cpu` when the build carries them). If two tiers return *different*
   values, the runner records a synthetic `diverge` row — this *is* the
-  differential (cross-tier) testing path (docs/impl/differential.md).
+  differential (cross-tier) testing path
+  ([docs/impl/differential.md](impl/differential.md)).
 - **A legacy multi-form file** (most of `tests/elle/`) is an imperative script, so
   it is wrapped as one whole-file thunk and run under each **JIT policy**: once
   with `jit=off` (recorded tier `vm`) and once with `jit=eager` (recorded tier
@@ -114,7 +118,7 @@ records a reasoned `skip` (and a direct `elle FILE` run exits 0 cleanly):
 
 Name a plugin through `import`, not through an `import-file` path. `import`
 resolves `plugin/X` against the running binary's own build profile
-([`modules.md`](modules.md) § "Module search path"); a written-out
+([modules.md](modules.md) § "Module search path"); a written-out
 `target/release/…` names a file only a release build has, so under a debug
 binary that test gates itself out and reports nothing.
 
@@ -143,6 +147,37 @@ same prefix:
 
 A per-file namespace does not cover this. It separates different files, not two
 runs of one file.
+
+### A performance gate measures against a control
+
+A test that pins a *cost* — a bulk copy against a per-byte copy, a linear pass
+against a quadratic one — cannot assert a wall-clock number. The runner shares
+its machine, so a bound wide enough to survive a stall is wider than the
+regression it exists to catch. `tests/elle/bytes-linear.lisp` failed at 0.5055s
+against a 0.5 bound, on a commit that costs 0.003s on a quiet box.
+
+Measure a **control** instead. Pick an operation of the same size, in the same
+process, that runs the path the regression cannot reach, and require the
+subject to stay within a small multiple of it. A starved machine slows both
+measurements, so the ratio survives what an absolute bound does not, and a
+per-byte path costs about a hundred times the bulk one.
+
+Two rules keep the ratio steady:
+
+- **Alternate the two measurements, and keep the smallest of several rounds.**
+  Both thunks then sample the same stretch of machine, and one stalled round
+  decides nothing.
+- **Build the operands outside the timed thunk.** `length` on a string counts
+  graphemes, so a loop that re-reads it times the walk instead of the work.
+
+The two worked examples are `tests/elle/bytes-linear.lisp`, which gates a
+binary append against the same-size text append, and
+`tests/elle/concat-linear.lisp`, which gates a string concat against the
+same-size bytes concat.
+
+A **timeout** test is the other case, and it keeps its absolute bound. There
+the deadline is the specification: a 50 ms `chan/select` has to return in about
+50 ms, and no ratio can say what that means.
 
 ### Per-thread native teardown
 
@@ -173,11 +208,12 @@ elle test --query \
 ```
 
 The schema (`run`, `form`, `result`, `asset`, `changed_file`) is documented in
-[`docs/test-runner.md`](test-runner.md) § Schema (with the v1 implemented-subset
+[docs/test-runner.md](test-runner.md) § Schema (with the v1 implemented-subset
 note — the `run` code-state/resource columns are deferred). Captured stdout/stderr
 live in the CAS at `<db-dir>/cas/<hash>`, referenced by `asset` rows. `--dump`
 artifact capture (the LIR-as-a-hash-lookup path) is currently **omitted** — it
-OOMs the corpus run and does not dedup (test-runner.md § CAS asset capture) — so
+OOMs the corpus run and does not dedup
+([docs/test-runner.md](test-runner.md) § CAS asset capture) — so
 today only stdout/stderr assets exist; the LIR of a failing form still needs a
 re-run until that capture is re-enabled.
 
@@ -200,7 +236,7 @@ A run killed mid-flight (OOM, signal) is recorded honestly: its `run` row's
 partial tally (computed from `result` rows — the stored counters are written
 only at completion), and the next `elle test` warns about it. An all-pass
 result set from a truncated run is partial coverage, not green
-(see [`docs/test-runner.md`](test-runner.md) § Run honesty).
+(see [docs/test-runner.md](test-runner.md) § Run honesty).
 
 ## Correctness the leak and UAF oracles cannot see
 
@@ -236,7 +272,7 @@ The **order of two correctly-counted releases** is the other hazard of this kind
 it needs a third detector rather than a behavioral pin. A captured binding's value and
 its env cell are two regions addressed by one env index; the value's release loads the
 box raw and unwraps it, so it reads the page the box's release frees
-([`docs/impl/region/bindings.md`](impl/region/bindings.md) § "A cell's release lands at
+([docs/impl/region/bindings.md](impl/region/bindings.md) § "A cell's release lands at
 or after every release routed through that cell"). Emit the two in the wrong order and
 both counts are still right: nothing leaks, so the leak oracle reads flat, and no count
 reaches zero early, so guardfree unmaps nothing to fault on. What catches it is a
@@ -250,12 +286,13 @@ see the other, which is why the claim is stated once more over the finished emis
 
 `make test` runs the Rust gate after the corpus: `cargo fmt --check`, clippy,
 `make crosscheck`, rustdoc, `cargo test --lib`, and the integration tests. For
-what kind of Rust test to write and where, see [`tests/AGENTS.md`](../tests/AGENTS.md) and
-[`docs/analysis/testing.md`](analysis/testing.md). (`elle test --rust`, which folds
+what kind of Rust test to write and where, see [tests/AGENTS.md](../tests/AGENTS.md) and
+[docs/analysis/testing.md](analysis/testing.md). (`elle test --rust`, which folds
 the cargo suite into the same DB, is specced but not yet implemented.)
 
 **Symbol names in assertions.** A name lives in the owning instance's display
-memo, not in a global table (docs/impl/symbol.md), and `fmt` cannot reach it. So
+memo, not in a global table ([docs/impl/symbol.md](impl/symbol.md)), and `fmt`
+cannot reach it. So
 a bare `{:?}`/`{}` on a symbol-bearing `Value` renders `#<symbol:hash>`. To read
 names in assertion output, thread the table:
 `format!("{}", v.display_with(Some(&symbols)))`, which renders the bare `name`
@@ -265,10 +302,6 @@ name needs no table and no formatting at all — use
 
 ## Known gaps
 
-- **`subprocess.lisp` hangs in a worker** — `subprocess/wait` relies on SIGCHLD,
-  which is masked on worker threads, so the reaper never wakes; the runner records
-  a `timeout`. It is quarantined from `make smoke` (`ELLE_TEST_SKIP` in the
-  Makefile) until reaping moves to the main thread or such files route in-process.
 - **No cross-file parallelism yet** — the runner maps over files sequentially
   (parallelism is per-form within a file), so a full corpus run is minutes, not
   seconds. Fanning out across files (single SQLite writer) is the next perf step.
@@ -280,7 +313,7 @@ name needs no table and no formatting at all — use
 
 ## See also
 
-- [`docs/test-runner.md`](test-runner.md) — the runner's full specification and schema.
-- [`tests/AGENTS.md`](../tests/AGENTS.md) — Rust test categories, helpers, fixtures.
-- [`docs/analysis/testing.md`](analysis/testing.md) — Rust test decision tree.
-- [`docs/threads.md`](threads.md) — worker threads, `os/spawn`, the scheduler the runner ships into workers.
+- [docs/test-runner.md](test-runner.md) — the runner's full specification and schema.
+- [tests/AGENTS.md](../tests/AGENTS.md) — Rust test categories, helpers, fixtures.
+- [docs/analysis/testing.md](analysis/testing.md) — Rust test decision tree.
+- [docs/threads.md](threads.md) — worker threads, `os/spawn`, the scheduler the runner ships into workers.

--- a/tests/elle/bytes-linear.lisp
+++ b/tests/elle/bytes-linear.lisp
@@ -1,4 +1,5 @@
 (elle/epoch 12)
+# audited: 2026-09-10
 # tests/elle/bytes-linear.lisp — binary concat/append must be BULK, not per-byte.
 #
 # The binary sibling of concat-linear.lisp (which pins string concat).
@@ -14,46 +15,83 @@
 # The fix gives %bytes-push a whole-bytes bulk form (mirroring %string-push);
 # push-all then bulk-appends bytes sources too. Pinned in Rust by
 # `bytes_push_bulk_appends_bytes_value` (primitives::intrinsics::tests).
+#
+# The text append of the same size is the control, because it is the branch of
+# push-all that never regressed. A wall-clock bound cannot tell a per-byte
+# binary path from a runner that lost its CPU inside the measured window; the
+# ratio between the two appends can. docs/testing.md § "A performance gate
+# measures against a control" holds the argument.
 
-# A 20 KiB immutable bytes chunk (the shape read-exact appends per socket read).
+# Time both thunks over `rounds` alternating rounds and return [control subject]
+# — the smallest elapsed each one reached. Alternating samples the same stretch
+# of machine, and the minimum discards a round the scheduler stalled, so one
+# starved run cannot decide the comparison.
+(defn best-of [rounds control subject]
+  (let [@a nil
+        @b nil
+        @i 0]
+    (while (< i rounds)
+      (let [ca (second (time/elapsed control))
+            cb (second (time/elapsed subject))]
+        (when (or (nil? a) (< ca a)) (assign a ca))
+        (when (or (nil? b) (< cb b)) (assign b cb)))
+      (assign i (+ i 1)))
+    [a b]))
+
+# A 20 KiB immutable bytes chunk (the shape read-exact appends per socket read),
+# and the 20 KiB text chunk that is its control.
 (def chunk
-  (let [@b (@bytes)]
-    (def @i 0)
+  (let [@b (@bytes)
+        @i 0]
     (while (< i 20000)
       (%bytes-push b (bit/and i 0xff))
       (assign i (+ i 1)))
     (freeze b)))
+(def text
+  (let [@s (@string)
+        @i 0]
+    (while (< i 20000)
+      (%string-push s "x")
+      (assign i (+ i 1)))
+    (freeze s)))
+(assert (= (length text) (length chunk))
+        "the control chunk and the measured chunk are the same size")
 
 # Accumulate ~2 MiB by appending the chunk 100 times, exactly as read-exact
 # accumulates a large body from many socket reads. Pre-fix (per-byte push) this
 # is ~2M interpreted %bytes-push calls and runs into whole seconds; post-fix it
-# is ~100 bulk memcpies and completes in milliseconds.
-(def t0 (clock/monotonic))
-(def buf
-  (let [@acc (@bytes)]
-    (def @i 0)
+# is ~100 bulk memcpies and completes in milliseconds. `make` hands back a fresh
+# accumulator per run, so every timed round does the same work from scratch.
+(defn accumulate [make chunk]
+  (let [@acc (make)
+        @i 0]
     (while (< i 100)
       (append acc chunk)
       (assign i (+ i 1)))
-    (freeze acc)))
-(def elapsed (- (clock/monotonic) t0))
+    acc))
+(def binary (fn () (accumulate (fn () (@bytes)) chunk)))
+(def textual (fn () (accumulate (fn () (@string)) text)))
 
+(def buf (freeze (binary)))
 (assert (= (length buf) 2000000) "accumulated the full 2 MiB")
 (assert (= (slice buf 0 4) (bytes 0 1 2 3)) "content preserved at head")
 (assert (= (slice buf 20000 20004) (bytes 0 1 2 3))
         "content preserved across chunks")
 
-# A generous bound: the per-byte path takes seconds and blows it; the bulk
-# path takes milliseconds and clears it with wide margin.
-(assert (< elapsed 0.5)
+# Both appends walk the same push-all branch over the same byte count, so they
+# cost about the same and the multiple is slack, not a budget: the per-byte path
+# is ~100 chunk-copies where the bulk path is one.
+(def [control measured] (best-of 5 textual binary))
+(assert (< measured (* 8 control))
         (concat "binary append must be bulk; 100×20KiB append took "
-                (string elapsed) "s (per-byte regression)"))
+                (string measured) "s against " (string control)
+                "s for the same-size text append (per-byte regression)"))
 
 # concat over many binary chunks (the `(apply concat ...)` body-assembly path)
 # must be bulk too.
 (def parts
-  (let [@ps @[]]
-    (def @i 0)
+  (let [@ps @[]
+        @i 0]
     (while (< i 100)
       (push ps chunk)
       (assign i (+ i 1)))
@@ -61,4 +99,5 @@
 (def joined (apply concat parts))
 (assert (= (length joined) 2000000) "apply concat over 100 binary chunks")
 
-(println "bytes-linear ok: |buf|=" (length buf) " append took " elapsed "s")
+(println "bytes-linear ok: |buf|=" (length buf) " append took " measured
+         "s against " control "s for text")

--- a/tests/elle/concat-linear.lisp
+++ b/tests/elle/concat-linear.lisp
@@ -1,40 +1,74 @@
 (elle/epoch 12)
+# audited: 2026-09-10
 # tests/elle/concat-linear.lisp — string concat must be linear.
 #
 # Counterfactual for the O(n²) string-concat regression introduced by
 # commit 40f918aa ("make concat and push-all linear"): it rewrote
 # `push-all` (src/core.lisp) to walk its source with `(get src i)`, but
-# `get` on a *string* is `s.graphemes(true).nth(i)` = O(i), so
+# `get` on a *string* is `segment::graphemes(s, gen).nth(i)` = O(i), so
 # `push-all` over an L-grapheme string is O(L²) and `(concat s s)` is
 # O(L²).  `%string-push` already bulk-appends a whole string's bytes
-# (intrinsics.rs), so a string concat MUST be linear.
+# (src/primitives/intrinsics.rs), so a string concat MUST be linear.
 #
 # Pre-fix this file times out: it is the `port-read-exact` /
 # `port-shortread-framing` smoke hang in miniature (both build a large
 # payload string by doubling concat).  Arrays/bytes (`get` is O(1)) were
 # never affected — only grapheme-clustered strings.
+#
+# That is also what makes the bytes concat of the same size the control here:
+# it runs the branch this defect cannot reach. A wall-clock bound cannot tell a
+# quadratic walk from a runner that lost its CPU inside the measured window;
+# the ratio between the two concats can. docs/testing.md § "A performance gate
+# measures against a control" holds the argument.
 
-# Build a >100k-grapheme string by doubling (O(log n) concats).
+# Time both thunks over `rounds` alternating rounds and return [control subject]
+# — the smallest elapsed each one reached. Alternating samples the same stretch
+# of machine, and the minimum discards a round the scheduler stalled, so one
+# starved run cannot decide the comparison.
+(defn best-of [rounds control subject]
+  (let [@a nil
+        @b nil
+        @i 0]
+    (while (< i rounds)
+      (let [ca (second (time/elapsed control))
+            cb (second (time/elapsed subject))]
+        (when (or (nil? a) (< ca a)) (assign a ca))
+        (when (or (nil? b) (< cb b)) (assign b cb)))
+      (assign i (+ i 1)))
+    [a b]))
+
+# Build a >100k-grapheme string by doubling (O(log n) concats), and the
+# same-length bytes value that is its control. `length` on a string counts
+# graphemes, so both loops read it once per doubling and never inside a
+# measurement.
 (def big
   (let [@s "0123456789"]
     (while (< (length s) 100000) (assign s (concat s s)))
     s))
+(def n (length big))
+(def bigb
+  (let [@b (bytes 0 1 2 3 4 5 6 7 8 9)]
+    (while (< (length b) n) (assign b (concat b b)))
+    b))
 
-(assert (>= (length big) 100000) "built a large string by doubling concat")
+(assert (>= n 100000) "built a large string by doubling concat")
 (assert (= (slice big 0 10) "0123456789") "content preserved across doublings")
+(assert (= (length bigb) n) "the control value is the same size as the string")
 
-# A single concat of the large string must complete in linear time.
-# Pre-fix this one concat is O((1.6e5)²) ≈ tens of seconds to minutes;
-# post-fix it is a couple of byte-buffer extends, well under a second.
-(def t0 (clock/monotonic))
 (def doubled (concat big big))
-(def elapsed (- (clock/monotonic) t0))
-
-(assert (= (length doubled) (* 2 (length big))) "concat length is the sum")
+(assert (= (length doubled) (* 2 n)) "concat length is the sum")
 (assert (= (slice doubled 0 10) "0123456789") "concat content head correct")
-(assert (< elapsed 5.0)
+
+# A single concat of the large string must complete in linear time. Post-fix it
+# is a couple of byte-buffer extends, the same work the bytes concat does, so
+# the multiple is slack rather than a budget. Pre-fix this one concat is
+# O((1.6e5)²) — tens of seconds to minutes against tens of microseconds.
+(def [control measured]
+  (best-of 5 (fn () (concat bigb bigb)) (fn () (concat big big))))
+(assert (< measured (* 8 control))
         (concat "string concat must be linear; (concat big big) took "
-                (string elapsed) "s (quadratic regression)"))
+                (string measured) "s against " (string control)
+                "s for the same-size bytes concat (quadratic regression)"))
 
 # The linear path bulk-appends a whole string via %string-push, which must
 # accept BOTH an immutable string and a mutable @string as the pushed value
@@ -55,4 +89,5 @@
 (%string-push b "de")
 (assert (= (concat a b) "abcde") "concat @string + @string source")
 
-(println "concat-linear ok: |big|=" (length big) " concat took " elapsed "s")
+(println "concat-linear ok: |big|=" n " concat took " measured "s against "
+         control "s for bytes")


### PR DESCRIPTION
Closes #1105.

## What was wrong

`tests/elle/bytes-linear.lisp` asserted `(< elapsed 0.5)` over a 100×20 KiB
binary append. The bulk path costs 3–7 ms on every runner, so the bound
normally carries a ~100x margin. A shared runner that stalls inside the
measured window spends that margin at once: the `macOS Smoke` job of #1101
failed at 0.5055s, and the same commit passed on a re-run.

Raising the bound deletes the detection. The file's own header records the
pre-fix per-byte cost as ~0.5 s, so 0.5 is the cost the gate exists to catch.
`tests/elle/concat-linear.lisp` had the same shape at `(< elapsed 5.0)`.

## What the change does

Each file now measures a same-size operation on the branch its defect cannot
reach, and holds the subject to 8x it.

| file | subject | control |
|---|---|---|
| bytes-linear | 100×20 KiB binary append | the same append over text |
| concat-linear | `(concat big big)`, 163840 graphemes | the same concat over bytes |

`push-all` bulk-appends both families through one branch, so the two
measurements do the same work and cost the same. A starved machine slows both,
so the ratio survives what an absolute bound does not.

Every measurement runs five alternating rounds and keeps the smallest of each.
Alternating puts both thunks on the same stretch of machine. The minimum
discards a round the scheduler stalled, which is what the observed failure was:
one ~0.5 s stall against a 0.005 s norm.

`docs/testing.md` § "A performance gate measures against a control" carries the
argument, and the distinction it turns on. A timeout test keeps its absolute
bound, because there the deadline is the specification.

## How it was measured

On this box, release build, smallest of five alternating rounds:

| gate | subject | control | ratio |
|---|---:|---:|---:|
| binary append | 0.00214s | 0.00213s | 1.00 |
| string concat | 0.0000392s | 0.0000366s | 1.07 |

Both gates were then watched fail. `push-all`'s byte-family test in
`src/core.lisp` was narrowed to one family at a time and the binary rebuilt:

| regression | subject | control | ratio |
|---|---:|---:|---:|
| a bytes source walks per element | 2.48s | 0.0017s | 1436 |
| a string source walks per grapheme | 0.289s | 0.000029s | 9945 |

The second row is measured at 1/32 the file's size. At full size the quadratic
walk runs past the runner's 60 s budget while it is still building the string,
so `concat-linear` reports `timeout` before it reaches the gate. That is the
counter-factual its header already records.

Green on this branch: `make smoke ELLE=./target/release/elle
CARGO_PROFILE=--release` — the whole corpus on both policies, 0 fail, 0
diverge, 0 timeout; `make qa`; `cargo test --workspace --lib --all-features`;
`cargo test --test '*' -- --skip property`.

## The audit that came with it

`docs/testing.md` is stamped now, so the repairs it needed landed with the new
section. Its `subprocess.lisp` known gap is gone — the Makefile records the
signal-mask fix that closed it. Three file references become links, and the
session DB's default path names its `target/` fallback.

`concat-linear.lisp`'s header named `s.graphemes(true).nth(i)` for a call the
segment seam now spells `segment::graphemes(s, gen).nth(i)`, and named
`intrinsics.rs` without its directory. Both test files carry a stamp now.
