### PR TITLE
eval: an unresolved name in an eval'd datum is a named resolution error

### DIFF
--- a/src/hir/analyze/forms/registry.rs
+++ b/src/hir/analyze/forms/registry.rs
@@ -1,3 +1,4 @@
+// audited: 2026-09-10
 //! The special-form registry: the single source of truth for the names the
 //! analyzer treats as special forms.
 //!
@@ -324,7 +325,7 @@ pub(crate) const SPECIAL_FORMS: &[SpecialForm] = &[
     SpecialForm {
         name: "eval",
         handler: Some(sf_eval),
-        doc: "Compile and execute an expression at runtime. The expression is a quoted datum that goes through the full compilation pipeline (expand, analyze, lower, emit, execute). An optional second argument provides an environment struct — its symbol-keyed entries become immutable bindings visible to the expression.",
+        doc: "Compile and execute an expression at runtime. The expression is a quoted datum that goes through the full compilation pipeline (expand, analyze, lower, emit, execute). It compiles against the primitives and the prelude only: the enclosing program's own bindings are not visible. An optional second argument provides an environment struct — its symbol-keyed entries become immutable bindings visible to the expression; pass (environment) to hand over the caller's lexical scope. A name that resolves against none of these is an undefined-variable error, surfaced as an :eval-error.",
         params: &["expr", "env?"],
         arity: Arity::Range(1, 2),
         signal: Signal::yields(),

--- a/src/vm/eval.rs
+++ b/src/vm/eval.rs
@@ -1,3 +1,4 @@
+// audited: 2026-09-10
 //! Runtime eval instruction handler.
 //!
 //! Compiles and executes a datum (quoted value) at runtime.
@@ -182,6 +183,15 @@ fn eval_in_arena(
     let mut analysis = analyzer
         .analyze(&expanded)
         .map_err(|e| LError::generic(format!("eval: analysis failed: {}", e)))?;
+    // Recoverable analysis errors (undefined variables, signal mismatches)
+    // accumulate as poison nodes; unreported they reach the lowerer and die
+    // as "internal: error poison node in lowerer".
+    if !analysis.errors.is_empty() {
+        return Err(LError::generic(format!(
+            "eval: analysis failed: {}",
+            analysis.errors[0].description()
+        )));
+    }
     let prim_values = analyzer.primitive_values().clone();
     drop(analyzer);
 

--- a/tests/elle/eval.lisp
+++ b/tests/elle/eval.lisp
@@ -1,7 +1,6 @@
 (elle/epoch 12)
+# audited: 2026-09-10
 # Integration tests for the eval special form
-#
-# Migrated from tests/integration/eval.rs (46 tests)
 
 
 # Helper: assert that an expression errors (uses protect to capture VM-level signals)
@@ -45,11 +44,16 @@
 (assert (= (eval (list '+ 1 2)) 3) "eval list construction")
 
 # ============================================================
-# Env argument handling (REMOVED)
+# Env argument handling
 # ============================================================
-# Environment argument support was intentionally removed from eval.
-# Tests that relied on (eval expr env) have been removed.
-# Lexical scoping via closures is the recommended pattern.
+# The optional second argument is a struct; its symbol-keyed entries
+# become immutable bindings visible to the evaluated expression.
+
+# test_eval_with_env_struct
+(assert (= (eval '(+ x y) {'x 10 'y 20}) 30) "eval with explicit env struct")
+
+# test_eval_env_nil_is_no_env
+(assert (= (eval '(+ 1 2) nil) 3) "eval with nil env")
 
 # ============================================================
 # Prelude macros in eval'd code
@@ -130,8 +134,10 @@
   (assert (not ok?) "eval runtime error (division by zero)"))
 
 # test_eval_undefined_variable
-(let [[ok? _] (protect ((fn () (eval 'undefined_var))))]
-  (assert (not ok?) "eval undefined variable"))
+# The failure is a named resolution error, never an internal one (#1094).
+(assert-err-contains (fn () (eval 'undefined_var))
+                     "undefined variable: undefined_var"
+                     "eval undefined variable")
 
 # ============================================================
 # Sequential evals (expander caching)
@@ -156,12 +162,10 @@
 # Eval with match
 # ============================================================
 
-# test_eval_with_match — bind match result to var first (known bug workaround)
-(def @match-result
-  (eval '(match 42
-           42 "found"
-           _ "not found")))
-(assert (= match-result "found") "eval with match")
+# test_eval_with_match
+(assert (= (eval '(match 42
+                    42 "found"
+                    _ "not found")) "found") "eval with match")
 
 # ============================================================
 # Eval with list operations
@@ -230,14 +234,26 @@
 (assert (= (eval '(length "hello")) 5) "eval with string length")
 
 # ============================================================
-# Eval with multiple env bindings (REMOVED)
+# Same-unit definitions and eval
 # ============================================================
-# This test relied on environment argument support, which was removed.
+# A top-level defn is a letrec binding of the enclosing file, not a
+# global: a bare eval cannot see it, and the failure names the symbol
+# (#1094). Passing (environment) hands the lexical scope over.
 
-# ============================================================
-# Eval with env binding shadowing primitives (REMOVED)
-# ============================================================
-# This test relied on environment argument support, which was removed.
+(defn same-unit-fn [x]
+  (+ x 1))
+
+# The defn is live in this unit...
+(assert (= (same-unit-fn 1) 2) "same-unit defn callable directly")
+
+# ...but invisible to a bare eval, with a resolution error naming it.
+(assert-err-contains (fn () (eval '(same-unit-fn 5)))
+                     "undefined variable: same-unit-fn"
+                     "bare eval does not see same-unit definitions")
+
+# (environment) makes it visible.
+(assert (= (eval '(same-unit-fn 5) (environment)) 6)
+        "eval with (environment) sees same-unit definitions")
 
 # ============================================================
 # Eval returns keyword


### PR DESCRIPTION
`eval` of a form that calls a function the same program defines died in the
lowerer with `internal: error poison node in lowerer at 0:0`, before the form
ran. The analyzer records an unresolved name as a recoverable error and
returns a poison node so analysis can continue; every other pipeline consumer
drains those errors after analysis, but the runtime eval handler did not, so
the poison node reached the lowerer.

The resolution question settles as: the name should not resolve. A top-level
`defn` is a letrec binding of the enclosing file, not a global, and eval
compiles its datum against the primitives and the prelude only. The caller
passes its lexical scope explicitly — `(eval '(ok 5) (environment))` already
works. So the correct failure is a resolution error naming the symbol.

The change drains the accumulated analysis errors in the runtime eval handler
(`src/vm/eval.rs`), exactly as the sibling paths in `src/pipeline/eval.rs` and
`src/pipeline/compile.rs` do. The failure now reads:

```
eval: analysis failed: undefined variable: ok (did you mean: or, -, <?)
```

The eval docstring now states the environment rule, and
`tests/elle/eval.lisp` pins all three behaviors: the bare eval fails with an
error naming the symbol, the same eval given `(environment)` resolves and
runs, and an undefined variable in an eval'd datum names itself. The message
assertions failed before the fix. The test audit also repaired stale prose:
the file claimed the env argument was removed (it exists and is documented —
new assertions cover it), and the match test carried a workaround for a bug
that is gone.

Verified with `make test` (smoke + qa + unit + integration), all green.

Closes #1094.
