### PR TITLE
regions: a tail call built in compiled code hands its release forward

### DIFF
--- a/docs/impl/region/letrec.md
+++ b/docs/impl/region/letrec.md
@@ -1,6 +1,6 @@
 # The letrec closure-cycle merge
 
-<!-- audited: 2026-09-09 -->
+<!-- audited: 2026-09-10 -->
 
 Mutually recursive closures hold each other through forward cells, so RC never reaches zero; the merge collapses the cycle onto one arena.
 
@@ -428,11 +428,15 @@ teardown — the case that must NOT pick up a later drop site). The oracle reads
 shapes, all closed at 0 — `recur-local-mutual-factory` for the struct-literal
 tail that carries both members into a native by-move, and `recur-local-defn-mutual`
 and `defn-module-factory` for the `defn` run and the closure-as-module factory
-built from one. Both factory probes CONSTRUCT the module per op and stop there;
-calling a member back through the returned struct grows on both spellings under
-`--jit=eager` and on neither on the VM, which is the tier's
-(elle-lisp/elle#1103). `region_ownership_reclaims_defn_module_factory_per_call`
-gauges both drivers on the VM. The `defn` run's own guardfree fixture is
+built from one. The `defn-module-factory` op constructs the module and calls a
+member back through the returned struct, which is the driver the interpreter and
+the JIT must agree on. `region_ownership_reclaims_defn_module_factory_per_call`
+gauges both drivers on the VM, and
+`region_ownership_defn_module_member_call_under_jit` gauges the member call with
+the CALLER compiled — the tier where the tail call into the member hands its
+deferral forward to the callee's activation ([relocate.md](relocate.md) § "A
+channel built in compiled code hands its release forward"). The `defn` run's own
+guardfree fixture is
 `region_defn_cycle_uaf`, which re-enters a member of a returned factory after the
 arena's drop site has passed and drives the factory across churn that recycles a
 freed page.

--- a/docs/impl/region/relocate.md
+++ b/docs/impl/region/relocate.md
@@ -1,6 +1,6 @@
 # A release past a frame-replacing tail call
 
-<!-- audited: 2026-09-05 -->
+<!-- audited: 2026-09-10 -->
 
 Every release the lowerer emits after a `TailCall` is dead on the closure path,
 and what it costs to move one ahead of that call.
@@ -317,6 +317,36 @@ The sibling's forward **cell** is not the callee's own region, so it relocates l
 any other holder and its cascade drops the `cell ⊇ closure` edge ahead of the call.
 What the deferral drops afterwards is the frame's own slot reference, the last one
 standing.
+
+### A channel built in compiled code hands its release forward
+
+The exemption reads the same on every tier, so the channel must run on every tier.
+The interpreter records a deferral on the activation slot the tail call is built in,
+and the callee reuses that activation ([owner.md](owner.md) § "A deferred tail-call
+release has the node's life"). A compiled caller reuses nothing.
+`jit_tail_call_inner` sets the pending call, and the compiled body then pops its own
+region-remap frame and returns the tail-call sentinel. The slot the helper would have
+recorded on is gone before the callee starts, so a release recorded there is a release
+nothing runs.
+
+The compiled tier writes both channels instead — the callee closure's region, and the
+merged arena the `deferred_release_slot` resolves to — into a one-shot
+(`VM::pending_tail_deferrals`) that `push_activation_region_map` drains into the fresh
+dues. The next push is always the callee's: every sentinel consumer takes the pending
+call and enters the callee through `execute_bytecode_saving_stack`, whose push is the
+first one after the helper returns. The helper writes the one-shot only once the
+pending call is set, so a path that fails earlier writes nothing. A hand-off no push
+collects holds the region to the caller's own teardown, which is an over-keep and
+never an over-free.
+
+The everyday shape is the closure-as-module factory whose member is called back
+through the struct it handed out: the caller's tail call into the member strands the
+merged cycle arena, and the whole cycle plus the state it captures grows once per
+call. Pinned by
+`runtime::tests::ownership::region_ownership_defn_module_member_call_under_jit`, whose
+compiled-caller reading sits beside the interpreter's in
+`…::region_ownership_reclaims_defn_module_factory_per_call`, and gauged per op by the
+oracle's `defn-module-factory` probe.
 
 ### A collector parameter takes the moved reference over itself
 

--- a/src/jit/calls.rs
+++ b/src/jit/calls.rs
@@ -1,3 +1,6 @@
+// audited: 2026-09-10
+// docs/impl/jit.md
+// docs/impl/region/owner.md
 //! Function call dispatch helpers for JIT-compiled code.
 //!
 //! These `extern "C"` functions handle calling Elle closures, native functions,
@@ -6,6 +9,7 @@
 //! by the interpreter fallback paths.
 
 use crate::jit::value::{JitValue, TAIL_CALL_SENTINEL_JV, YIELD_SENTINEL_JV};
+use crate::jit::TailDeferrals;
 use crate::signals::dispatch::{classify, SignalAction};
 use crate::value::fiber::{SignalBits, MAX_CALL_DEPTH, SIG_ERROR, SIG_HALT};
 use crate::value::Value;
@@ -96,8 +100,8 @@ fn jit_handle_primitive_signal(vm: &mut crate::vm::VM, bits: SignalBits, value: 
             // becomes the resume result, co-located in one region). Without this
             // incref the region's only reference is dropped when the resume
             // consumer's `DecrefValueRegion` fires, and the scheduler's release
-            // of the same region double-frees it (the redis eager/adaptive-JIT
-            // crash; tests/elle/region-jit-io-suspend-uaf.lisp). `region_of`, NOT
+            // of the same region frees it a second time
+            // (tests/elle/region-jit-io-suspend-uaf.lisp). `region_of`, NOT
             // `result_region_of`: the escaping value's own region is the one held
             // live across the suspend.
             let heap = unsafe { &mut *vm.heap_ptr };

--- a/src/jit/calls/callops/arraycall.rs
+++ b/src/jit/calls/callops/arraycall.rs
@@ -1,3 +1,6 @@
+// audited: 2026-09-10
+// docs/impl/jit.md
+// docs/impl/region/relocate.md
 //! Array-call, closure-construction, tail-call, and env-building JIT entry points.
 
 use super::*;
@@ -107,6 +110,9 @@ pub extern "C" fn elle_jit_tail_call_array(
     };
 
     let nargs = args.len() as u32;
+    // A spliced tail call carries neither deferral channel on either tier —
+    // `handle_tail_call_array` passes `false`/`None` for the same reason.
+    let defer = TailDeferrals::NONE;
     let result = if args.is_empty() {
         jit_tail_call_inner(
             func_tag,
@@ -116,6 +122,7 @@ pub extern "C" fn elle_jit_tail_call_array(
             vm,
             region_id,
             true,
+            defer,
         )
     } else {
         jit_tail_call_inner(
@@ -126,6 +133,7 @@ pub extern "C" fn elle_jit_tail_call_array(
             vm,
             region_id,
             true,
+            defer,
         )
     };
     unsafe { &mut *(vm as *mut crate::vm::VM) }.release_splice_args(args_array);
@@ -248,9 +256,12 @@ pub(super) fn exec_result_to_jit_value(vm: &mut crate::vm::VM, bits: SignalBits)
 
 /// Handle a non-self tail call from JIT code.
 ///
-/// If the target closure has JIT code in the cache, calls it directly.
-/// Falls back to TAIL_CALL_SENTINEL (interpreter trampoline) only when
-/// the target has no JIT code.
+/// A native, parameter or collection callee answers here. A CLOSURE callee always
+/// leaves through `TAIL_CALL_SENTINEL`, so the interpreter trampoline runs it and
+/// mutual tail recursion costs no native stack.
+///
+/// `defer_callee` and `arena_slot` are the `TailCall`'s own deferral channels,
+/// flattened to `u32` for the C ABI (`TailDeferrals`).
 #[no_mangle]
 pub extern "C" fn elle_jit_tail_call(
     func_tag: u64,
@@ -259,6 +270,8 @@ pub extern "C" fn elle_jit_tail_call(
     nargs: u32,
     vm: *mut (),
     region_id: u32,
+    defer_callee: u32,
+    arena_slot: u32,
 ) -> JitValue {
     jit_tail_call_inner(
         func_tag,
@@ -268,6 +281,10 @@ pub extern "C" fn elle_jit_tail_call(
         vm,
         region_id,
         false,
+        TailDeferrals {
+            callee: defer_callee,
+            arena_slot,
+        },
     )
 }
 
@@ -287,6 +304,7 @@ fn jit_tail_call_inner(
     vm: *mut (),
     region_id: u32,
     spliced_args: bool,
+    defer: TailDeferrals,
 ) -> JitValue {
     let vm = unsafe { &mut *(vm as *mut crate::vm::VM) };
     let func = Value {
@@ -300,8 +318,8 @@ fn jit_tail_call_inner(
         let args_slice = args_ptr_to_value_slice(args_ptr, nargs);
         // Capability gate — identical to the interpreter's tail path
         // (`tail_call_inner`, src/vm/call/inner/tail.rs): a native whose signal
-        // overlaps the fiber's withheld capabilities is denied, not run. Same gap
-        // and fix as `elle_jit_call`'s Call-position path.
+        // overlaps the fiber's withheld capabilities is denied, not run. The
+        // Call-position path (`elle_jit_call`) asks the same question.
         let blocked = def
             .signal
             .bits
@@ -330,14 +348,10 @@ fn jit_tail_call_inner(
             return JitValue::nil();
         }
         let result = vm.resolve_parameter(id, default);
-        // Pass-through retain, mirror of `tail_call_inner`'s parameter branch.
-        // FIXME(leak): preserves the historical cross-id-space comparison; see
-        // `VM::dispatch_native_call`. Revisited in the leak phase.
-        // A parameter resolve never allocates a fresh region — always hand the
-        // caller one owning reference for its `DecrefValueRegion` to consume.
-        // `incref_for_escape(None, …)` no-ops an immediate. (Was gated on a
-        // static-vs-runtime `r.get() == region_id` compare — see the leak note
-        // in `VM::dispatch_native_call`.)
+        // Pass-through retain, mirror of `tail_call_inner`'s parameter branch. A
+        // parameter resolve never allocates a fresh region, so it always hands the
+        // caller one owning reference for its `DecrefValueRegion` to consume, with
+        // no gate of its own; `incref_for_escape(None, …)` no-ops an immediate.
         let heap = unsafe { &mut *vm.heap_ptr };
         let result_region = crate::value::arena::region_of(heap, result);
         crate::value::arena::incref_for_escape(
@@ -360,6 +374,17 @@ fn jit_tail_call_inner(
             .map(|i| unsafe { *args_ptr.add(i) })
             .collect();
 
+        // The two releases this frame replacement strands, resolved while THIS
+        // activation's region map is still the current one — the compiled caller's,
+        // which its `Return` path has not popped yet. Read exactly as the
+        // interpreter's `tail_call_inner` reads them, and before `build_tail_call_env`
+        // copies the closure's env uncounted.
+        let arena = crate::hir::region::StaticRegion::new(defer.arena_slot)
+            .and_then(|slot| vm.runtime_region_for_release_slot(slot));
+        let callee = (defer.callee != 0)
+            .then(|| vm.tail_callee_release_region(func))
+            .flatten();
+
         // Tail call: pure MOVE (own_params=false) — the caller's arg references
         // transfer to the callee, which releases them. A SPLICED tail call has
         // no such reference of the frame's: its arguments came out of the args
@@ -375,12 +400,14 @@ fn jit_tail_call_inner(
             closure: func,
             squelch_mask: closure.squelch_mask,
         });
-        // A deferral this spliced JIT tail call strands is not recorded on the
-        // activation's dues: the callee-release and merged-arena channels are not
-        // wired on this path, so the region stays held to the activation's own
-        // teardown — a bounded over-keep, never an over-free — until they are
-        // (docs/impl/region/owner.md § "A deferred tail-call release has the
-        // node's life").
+        // Hand both stranded releases to the activation that runs the callee. This
+        // activation is the compiled caller's, and it pops its own dues slot on the
+        // way out with the sentinel, so recording there would drop them
+        // (docs/impl/region/relocate.md § "A channel built in compiled code hands
+        // its release forward"). Written after the pending call is set, so a path
+        // that fails earlier leaves nothing for another activation's push to take.
+        vm.pending_tail_deferrals
+            .extend(arena.into_iter().chain(callee));
 
         return TAIL_CALL_SENTINEL;
     }
@@ -391,10 +418,10 @@ fn jit_tail_call_inner(
     // like the native-tail Ok path above (`jit_handle_primitive_signal` →
     // `JitValue::from_value`): the value is handed back in the return register
     // with its one owning reference, and the JIT-compiled caller's
-    // post-`TailCall` block runs the owned-arg releases + result handling. The
-    // old code set `fiber.signal = (SIG_OK, value)` AND skipped the retain, so a
-    // tail-position call-index freed the returned co-located element under the
-    // caller's borrow (JIT crash; the interpreter sibling leaked).
+    // post-`TailCall` block runs the owned-arg releases + result handling.
+    // Handing the value over through `fiber.signal` instead reaches neither, and
+    // a returned element co-located in its collection's region is then freed
+    // under the caller's borrow.
     if let Some(result) = {
         let region = crate::hir::region::StaticRegion::new(region_id)
             .expect("JIT region slot is nonzero — emitter invariant");
@@ -419,9 +446,10 @@ fn jit_tail_call_inner(
 // Environment Building
 // =============================================================================
 //
-// JIT closure-env construction is now unified on the interpreter's
-// `VM::populate_env` (via `build_closure_env` / `build_tail_call_env` in
-// `src/vm/env.rs`): the interpreter-fallback and tail paths call those directly
-// so the owned-params `CallArgument` incref and per-value env-region minting are
-// shared, not duplicated. The old `build_closure_env_for_jit` (which did neither,
-// causing the owned-param over-release UAF and env-region commingling) is gone.
+// JIT closure-env construction is the interpreter's `VM::populate_env`, reached
+// through `build_closure_env` / `build_tail_call_env` (`src/vm/env.rs`). The
+// interpreter-fallback and tail paths call those directly, so the owned-params
+// `CallArgument` incref and the per-value env-region minting are one
+// implementation. A second construction here would owe both, and an env built
+// without them over-releases every owned param and commingles the env cells of
+// two calls through one slot.

--- a/src/jit/helpers.rs
+++ b/src/jit/helpers.rs
@@ -1,4 +1,4 @@
-// audited: 2026-09-06
+// audited: 2026-09-10
 // src/jit/AGENTS.md
 //! What a `FunctionTranslator` reaches for: constants, fast paths, call shapes
 //! and register pairs.
@@ -7,7 +7,7 @@
 
 mod checks;
 
-use cranelift_codegen::ir::types::I64;
+use cranelift_codegen::ir::types::{I32, I64};
 use cranelift_codegen::ir::InstBuilder;
 use cranelift_frontend::FunctionBuilder;
 use cranelift_module::{FuncId, Module};
@@ -20,6 +20,7 @@ use crate::value::SymbolId;
 
 use super::translate::FunctionTranslator;
 use super::JitError;
+use super::TailDeferrals;
 
 /// Helper to create a Variable from a register/slot index
 #[inline]
@@ -270,7 +271,8 @@ impl<'a> FunctionTranslator<'a> {
     }
 
     /// Call the elle_jit_call helper.
-    /// Signature: (func_tag, func_payload, args_ptr, nargs, vm) -> (tag, payload)
+    /// Signature: (func_tag, func_payload, args_ptr, nargs, vm, region_id)
+    /// -> (tag, payload)
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn call_helper_call(
         &mut self,
@@ -293,7 +295,9 @@ impl<'a> FunctionTranslator<'a> {
     }
 
     /// Call the elle_jit_tail_call helper.
-    /// Signature: (func_tag, func_payload, args_ptr, nargs, vm) -> (tag, payload)
+    /// Signature: (func_tag, func_payload, args_ptr, nargs, vm, region_id,
+    /// defer_callee, arena_slot) -> (tag, payload). The last two are the deferral
+    /// channels this `TailCall` carries; see `LirInstr::TailCall`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn call_helper_tail_call(
         &mut self,
@@ -304,13 +308,25 @@ impl<'a> FunctionTranslator<'a> {
         nargs: cranelift_codegen::ir::Value,
         vm: cranelift_codegen::ir::Value,
         region_id: cranelift_codegen::ir::Value,
+        defer: TailDeferrals,
     ) -> Result<(cranelift_codegen::ir::Value, cranelift_codegen::ir::Value), JitError> {
+        let defer_callee = builder.ins().iconst(I32, defer.callee as i64);
+        let arena_slot = builder.ins().iconst(I32, defer.arena_slot as i64);
         let func_ref = self
             .module
             .declare_func_in_func(self.helpers.tail_call, builder.func);
         let call = builder.ins().call(
             func_ref,
-            &[func_tag, func_payload, args_ptr, nargs, vm, region_id],
+            &[
+                func_tag,
+                func_payload,
+                args_ptr,
+                nargs,
+                vm,
+                region_id,
+                defer_callee,
+                arena_slot,
+            ],
         );
         Ok((builder.inst_results(call)[0], builder.inst_results(call)[1]))
     }

--- a/src/jit/mod.rs
+++ b/src/jit/mod.rs
@@ -1,14 +1,18 @@
-//! JIT compilation for Elle
-//!
-//! This module provides JIT compilation of LIR functions to native code
-//! using Cranelift. Functions with `Signal::silent()` or `Signal::yields()` are
-//! JIT candidates. Polymorphic functions remain excluded.
+// audited: 2026-09-10
+// docs/impl/jit.md
+//! Cranelift JIT compilation of LIR functions, and the types every stage of it
+//! shares.
 //!
 //! ## Architecture
 //!
 //! ```text
 //! LirFunction -> JitCompiler -> Cranelift IR -> Native code -> JitCode
 //! ```
+//!
+//! A polymorphic or yielding function compiles like any other — the runtime
+//! dispatch helper handles an arbitrary callable, and a callee that suspends
+//! leaves through the yield side-exit. What `JitCompiler::compile` refuses is
+//! listed there.
 //!
 //! ## Calling Convention
 //!
@@ -20,15 +24,16 @@
 //!     args: *const Value,     // arguments array
 //!     nargs: u32,             // number of arguments
 //!     vm: *mut VM,            // pointer to VM (for globals, function calls)
-//!     self_bits: u64,         // closure identity bits (for self-tail-call detection)
+//!     self_tag: u64,          // the executing closure's own Value, tag half
+//!     self_payload: u64,      // and its payload half
 //! ) -> Value;
 //! ```
 //!
-//! The 5th parameter `self_bits` enables self-tail-call optimization: when a
-//! function tail-calls itself, the JIT compares the callee against `self_bits`.
-//! If equal, it updates the arg variables and jumps to the loop header instead
-//! of calling `elle_jit_tail_call`. This turns self-recursive tail calls into
-//! native loops.
+//! The last two parameters carry the executing closure as a `Value`, which is
+//! what makes the self-tail-call optimization possible: a tail call compares its
+//! callee against that pair, and on a match updates the argument variables and
+//! jumps to the loop header instead of calling `elle_jit_tail_call`. So a
+//! self-recursive tail call is a native loop.
 
 mod calls;
 mod code;
@@ -98,6 +103,45 @@ impl JitCtx {
     #[inline]
     pub(crate) fn vm(&self) -> *mut crate::vm::VM {
         self.vm
+    }
+}
+
+/// The two deferral channels one `TailCall` carries to `elle_jit_tail_call`: the
+/// callee closure's own region, and the merged closure-cycle arena's static slot
+/// (see `LirInstr::TailCall`). A frame-replacing tail call strands both releases,
+/// and the activation that runs the callee takes them over
+/// (docs/impl/region/relocate.md § "A channel built in compiled code hands its
+/// release forward").
+///
+/// Both are `u32` at the C ABI and neither is the other, so they cross as one
+/// named pair rather than as two bare arguments a call site could swap.
+#[derive(Clone, Copy)]
+pub(crate) struct TailDeferrals {
+    /// 1 when the new activation takes over the callee closure's own release.
+    pub(crate) callee: u32,
+    /// The merged arena's static slot, or 0 for none (`StaticRegion` is nonzero,
+    /// so 0 is never a real slot).
+    pub(crate) arena_slot: u32,
+}
+
+impl TailDeferrals {
+    /// The pair a call site carries no deferral on: the spliced tail call, which
+    /// carries neither channel on either tier, and the self-tail-call loop, which
+    /// replaces no frame.
+    pub(crate) const NONE: TailDeferrals = TailDeferrals {
+        callee: 0,
+        arena_slot: 0,
+    };
+
+    /// Read the pair off a `LirInstr::TailCall`'s own fields.
+    pub(crate) fn of(
+        defer_callee_release: bool,
+        deferred_release_slot: Option<crate::hir::region::StaticRegion>,
+    ) -> Self {
+        TailDeferrals {
+            callee: u32::from(defer_callee_release),
+            arena_slot: deferred_release_slot.map_or(0, |s| s.get()),
+        }
     }
 }
 

--- a/src/jit/translate.rs
+++ b/src/jit/translate.rs
@@ -1,7 +1,7 @@
-//! LIR to Cranelift IR translation
-//!
-//! This module contains `FunctionTranslator`, which translates individual
-//! LIR instructions and terminators to Cranelift IR.
+// audited: 2026-09-10
+// docs/impl/jit.md
+//! `FunctionTranslator`: the register-to-variable mapping every LIR instruction
+//! and terminator is lowered to Cranelift IR through.
 //!
 //! ## Variable layout
 //!
@@ -33,6 +33,7 @@ use crate::value::SymbolId;
 
 use super::vtable::RuntimeHelpers;
 use super::JitError;
+use super::TailDeferrals;
 
 mod instr;
 mod region;
@@ -105,13 +106,12 @@ pub(crate) struct FunctionTranslator<'a> {
     /// (`elle_jit_release_activation_dues`) only for a function that can
     /// have minted a node; the common path pays no extra helper call.
     ///
-    /// The node is the whole of what a COMPILED activation can owe: the deferred
-    /// tail-call releases are recorded by the interpreter's `tail_call_inner`
-    /// alone, and the JIT's own tail-call path leaves both channels unwired
-    /// (`jit_tail_call_inner`). Wiring them means gating this on the deferral
-    /// too, or the release the compiled `Return` skips is the one nothing else
-    /// runs (docs/impl/region/owner.md § "A deferred tail-call release has the
-    /// node's life").
+    /// The node is the whole of what a COMPILED activation can owe. A tail call
+    /// this function makes strands releases too, but they belong to the activation
+    /// that runs the callee rather than to this one, and `jit_tail_call_inner`
+    /// hands them straight there (docs/impl/region/relocate.md § "A channel built
+    /// in compiled code hands its release forward"). So a function with no
+    /// `AdoptIntoActivation` reaches its `Return` owing nothing.
     pub(crate) uses_activation_owner_node: bool,
 }
 

--- a/src/jit/translate/instr/calls.rs
+++ b/src/jit/translate/instr/calls.rs
@@ -1,4 +1,4 @@
-// audited: 2026-09-05
+// audited: 2026-09-10
 // docs/impl/jit.md
 //! How a call leaves compiled code: a direct call to an SCC peer, the
 //! self-tail-call loop, the generic dispatch helper, and a `MakeClosure`.
@@ -120,12 +120,23 @@ impl<'a> FunctionTranslator<'a> {
             }
 
             LirInstr::TailCall {
-                dst, func, args, ..
+                dst,
+                func,
+                args,
+                defer_callee_release,
+                deferred_release_slot,
+                ..
             } => {
                 let (ft, fp) = self.use_var_pair(builder, func.0);
                 let vm = self.vm_ptr.ok_or_else(|| {
                     JitError::InvalidLir("TailCall without vm pointer".to_string())
                 })?;
+                // The releases this call strands past the frame replacement. The
+                // helper hands them to the activation that runs the callee, this
+                // one having popped its own dues slot by then
+                // (docs/impl/region/relocate.md § "A channel built in compiled
+                // code hands its release forward").
+                let defer = TailDeferrals::of(*defer_callee_release, *deferred_release_slot);
 
                 // Self-tail-call optimization
                 if let (Some((self_tag, self_payload)), Some(loop_header)) =
@@ -156,7 +167,10 @@ impl<'a> FunctionTranslator<'a> {
                             .collect();
 
                         // Every new argument is read above, before any is
-                        // written, so `(f b a)` swaps rather than clobbers.
+                        // written, so `(f b a)` swaps rather than clobbers. The
+                        // loop replaces no frame and stays in this activation, so
+                        // it hands `defer` nowhere: the callee IS this function,
+                        // and the release the deferral would supply is its own.
                         for (i, (at, ap)) in new_arg_vals.into_iter().enumerate() {
                             let base = self.arg_var_base + i as u32;
                             self.def_var_pair(builder, base, at, ap);
@@ -187,11 +201,12 @@ impl<'a> FunctionTranslator<'a> {
                             args,
                             vm,
                             region_id_const,
+                            defer,
                         )?;
                         // Generic dispatch: a native that completes normally
-                        // falls through so the post-`TailCall` releases run
-                        // (Inc4 native-tail). Builder is left on the continue
-                        // block; keep translating the rest of this LIR block.
+                        // falls through so the post-`TailCall` releases run.
+                        // Builder is left on the continue block; keep
+                        // translating the rest of this LIR block.
                         self.emit_tail_call_result_branch(builder, *dst, rt, rp)?;
                         return Ok(false);
                     }
@@ -210,8 +225,15 @@ impl<'a> FunctionTranslator<'a> {
                     return Ok(true);
                 }
 
-                let (rt, rp) =
-                    self.emit_tail_call_with_args(builder, ft, fp, args, vm, region_id_const)?;
+                let (rt, rp) = self.emit_tail_call_with_args(
+                    builder,
+                    ft,
+                    fp,
+                    args,
+                    vm,
+                    region_id_const,
+                    defer,
+                )?;
                 // A native that completes normally falls through to run the
                 // post-`TailCall` owned-arg releases; a closure (sentinel),
                 // yield, or error returns. Builder is left on the continue

--- a/src/jit/translate/terminator.rs
+++ b/src/jit/translate/terminator.rs
@@ -1,8 +1,11 @@
+// audited: 2026-09-10
+// docs/impl/jit.md
+// docs/impl/region/relocate.md
 //! Terminator translation and the generic tail-call result branch.
 //!
-//! `translate_terminator` lowers each LIR `Terminator`; the two tail-call
-//! helpers implement the interpreter's native-vs-closure tail dispatch (the
-//! Inc4 native-tail trick) that a generic `TailCall` in `instr::calls` relies on.
+//! `translate_terminator` lowers each LIR `Terminator`; the two tail-call helpers
+//! carry the interpreter's native-vs-closure tail dispatch, which a generic
+//! `TailCall` in `instr::calls` relies on.
 
 use super::*;
 
@@ -20,16 +23,13 @@ impl<'a> FunctionTranslator<'a> {
     ///   that completed normally. Bind `dst` and fall through so the caller
     ///   keeps translating the post-`TailCall` block — the compiler's own
     ///   per-arg `DecrefValueRegion`/`DecrefRegion`s that release each moved
-    ///   native arg. This is the Inc4 native-tail trick the interpreter
-    ///   performs by NOT replacing the frame for a normally-completing native;
-    ///   without it the moved arg leaks (region-native-tail-move.lisp;
+    ///   native arg. The interpreter reaches the same block by NOT replacing the
+    ///   frame for a normally-completing native; a tier that returns at the call
+    ///   instead strands every moved arg (tests/elle/region-native-tail-move.lisp;
     ///   docs/impl/region/rules.md Rule 8).
     ///
     /// On return the builder is positioned on the continue (fall-through)
     /// block, with `dst` defined.
-    // `pub(super)` (was private in the translate root): the sibling
-    // `instr::calls` submodule calls this; widen to the minimal
-    // `translate`-scoped visibility so it stays reachable after the move.
     pub(super) fn emit_tail_call_result_branch(
         &mut self,
         builder: &mut FunctionBuilder,
@@ -205,9 +205,9 @@ impl<'a> FunctionTranslator<'a> {
 
             Terminator::Unreachable => {
                 // User trap code 1 — `unwrap_user(0)` panics (Cranelift user
-                // trap codes are `NonZeroU8`). Reachable now that a generic
-                // tail call can fall through to its block's terminator instead
-                // of self-terminating (the native-tail continue path); a
+                // trap codes are `NonZeroU8`). This arm is reached, because a
+                // generic tail call falls through to its block's terminator on
+                // the native-tail continue path rather than self-terminating; a
                 // genuinely-unreachable block must still compile to a valid
                 // trap.
                 builder
@@ -219,9 +219,7 @@ impl<'a> FunctionTranslator<'a> {
     }
 
     /// Helper: emit a tail call with args spilled to stack.
-    // `pub(super)` (was private in the translate root): the sibling
-    // `instr::calls` submodule calls this; widen to the minimal
-    // `translate`-scoped visibility so it stays reachable after the move.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn emit_tail_call_with_args(
         &mut self,
         builder: &mut FunctionBuilder,
@@ -230,11 +228,12 @@ impl<'a> FunctionTranslator<'a> {
         args: &[Reg],
         vm: cranelift_codegen::ir::Value,
         region_id_const: cranelift_codegen::ir::Value,
+        defer: TailDeferrals,
     ) -> Result<(cranelift_codegen::ir::Value, cranelift_codegen::ir::Value), JitError> {
         if args.is_empty() {
             let null_ptr = builder.ins().iconst(I64, 0);
             let nargs = builder.ins().iconst(I64, 0);
-            self.call_helper_tail_call(builder, ft, fp, null_ptr, nargs, vm, region_id_const)
+            self.call_helper_tail_call(builder, ft, fp, null_ptr, nargs, vm, region_id_const, defer)
         } else {
             let slot = builder.create_sized_stack_slot(cranelift_codegen::ir::StackSlotData::new(
                 cranelift_codegen::ir::StackSlotKind::ExplicitSlot,
@@ -250,7 +249,16 @@ impl<'a> FunctionTranslator<'a> {
             }
             let args_addr = builder.ins().stack_addr(I64, slot, 0);
             let nargs = builder.ins().iconst(I64, args.len() as i64);
-            self.call_helper_tail_call(builder, ft, fp, args_addr, nargs, vm, region_id_const)
+            self.call_helper_tail_call(
+                builder,
+                ft,
+                fp,
+                args_addr,
+                nargs,
+                vm,
+                region_id_const,
+                defer,
+            )
         }
     }
 }

--- a/src/jit/vtable/helpers.rs
+++ b/src/jit/vtable/helpers.rs
@@ -1,3 +1,8 @@
+// audited: 2026-09-10
+// docs/impl/jit.md
+//! One Cranelift signature per `elle_jit_*` runtime helper, declared into the
+//! module before any function is translated.
+
 use super::*;
 
 /// Declare all runtime helper functions in the JITModule, returning their FuncIds.
@@ -50,6 +55,17 @@ pub(crate) fn declare_helpers(module: &mut JITModule) -> Result<RuntimeHelpers, 
     // region_id (I32) routes native-result allocation and gates the
     // pass-through retain, mirroring the interpreter's `call_inner`.
     let call_sig = make_sig(module, &[I64, I64, I64, I64, I64, I32], &[I64, I64]);
+    // tail_call: the call signature plus the two deferral channels a
+    // frame-replacing tail call strands — `defer_callee` (0/1, the callee closure's
+    // own region) and `arena_slot` (0 for none, else the merged closure-cycle
+    // arena's static slot). Both reach the helper because a compiled caller cannot
+    // record them on its own dues (docs/impl/region/relocate.md § "A channel built
+    // in compiled code hands its release forward").
+    let tail_call_sig = make_sig(
+        module,
+        &[I64, I64, I64, I64, I64, I32, I32, I32],
+        &[I64, I64],
+    );
     // resolve_tail_call: (result_tag, result_payload, vm) -> (tag, payload)
     let resolve_tc_sig = make_sig(module, &[I64, I64, I64], &[I64, I64]);
     // store_capture: (env_ptr, index, val_tag, val_payload, vm) -> (tag, payload)
@@ -180,7 +196,7 @@ pub(crate) fn declare_helpers(module: &mut JITModule) -> Result<RuntimeHelpers, 
         )?,
         store_capture: declare(module, "elle_jit_store_capture", &store_capture_sig)?,
         call: declare(module, "elle_jit_call", &call_sig)?,
-        tail_call: declare(module, "elle_jit_tail_call", &call_sig)?,
+        tail_call: declare(module, "elle_jit_tail_call", &tail_call_sig)?,
         has_exception: declare(module, "elle_jit_has_exception", &vm_only)?,
         resolve_tail_call: declare(module, "elle_jit_resolve_tail_call", &resolve_tc_sig)?,
         call_depth_enter: declare(module, "elle_jit_call_depth_enter", &vm_only)?,

--- a/src/runtime/tests/ownership/jit.rs
+++ b/src/runtime/tests/ownership/jit.rs
@@ -1,3 +1,9 @@
+// audited: 2026-09-10
+// docs/impl/region/owner.md
+// docs/impl/region/relocate.md
+//! VM≡JIT parity for the ownership forest: what each cut still reclaims when the
+//! function that owes the release runs compiled.
+
 use super::*;
 
 /// VM≡JIT parity for the landed ownership ops (the `AdoptRegion`/`FreeRegionGroup`
@@ -64,6 +70,118 @@ pub(super) fn jit_region_growth(body: &str) -> (i64, bool) {
     }
     let delta = rt.heap().active_region_count() as i64 - baseline;
     (delta, jit_compiled)
+}
+
+/// [`mid_run_growth`] with the driving lambda COMPILED, plus the receipt that says
+/// it was.
+///
+/// The program is compiled once and run twice. The first run calls `body` 250
+/// times, which submits every closure it reaches for background compilation;
+/// `drain_jit_pending` then blocks until those finish, so the second run — the one
+/// whose mid-run delta is returned — dispatches through cached native code. Re-running
+/// the same bytecode is what keeps the closure templates' pointers stable, so the
+/// cache keyed by them still hits after the `def`s rebuild their closures.
+///
+/// The program's last form must be `[delta caller]`: the gauge delta, and the very
+/// closure whose compiled body the reading is about. Handing that closure back is
+/// what makes the receipt exact — `jit_code_for` on its own bytecode answers whether
+/// THIS function ran compiled, where an "is the cache non-empty" test would pass on
+/// any stdlib closure the program happened to warm.
+#[cfg(feature = "jit")]
+fn jit_mid_run_growth(prelude: &str, body: &str, gauge: &str) -> (i64, bool) {
+    use crate::config::JitPolicy;
+    use crate::pipeline::compile_file_repl;
+    let mut rt = Runtime::new();
+    rt.vm().runtime_config.jit = JitPolicy::Eager;
+    let src = format!(
+        "{prelude} (var n 0) \
+         (while (%lt n 50) {body} (assign n (%add n 1))) \
+         (def c50 ({gauge})) \
+         (while (%lt n 250) {body} (assign n (%add n 1))) \
+         (def c250 ({gauge})) \
+         [(match (type-of c250) :integer \
+            (match (type-of c50) :integer (%sub c250 c50) _ -1) _ -1) caller]"
+    );
+    let prog = {
+        let (_vm, symbols, cctx) = rt.parts();
+        compile_file_repl(&src, symbols, cctx, "<embed>")
+            .expect("compiles")
+            .0
+    };
+    {
+        let (vm, _symbols, cctx) = rt.parts();
+        vm.execute_scheduled(&prog.bytecode, cctx)
+            .expect("runs (submits the JIT tasks)");
+    }
+    rt.vm().drain_jit_pending();
+    let (vm, _symbols, cctx) = rt.parts();
+    let pair = vm.execute_scheduled(&prog.bytecode, cctx).expect("runs");
+    let (delta, caller_bytecode) = {
+        let slots = pair.as_array().expect("the program returns [delta caller]");
+        (
+            slots[0].as_int().expect("the delta is an integer"),
+            slots[1]
+                .as_closure()
+                .expect("the program hands back the driving closure")
+                .template
+                .bytecode(),
+        )
+    };
+    let compiled = vm.jit_code_for(caller_bytecode.as_ptr()).is_some();
+    (delta, compiled)
+}
+
+/// Per-call reclamation of the closure-as-module factory when a member is called
+/// back through the struct it handed out, with the CALLING function compiled.
+///
+/// The factory itself carries a `MakeClosure` and so never compiles; the caller
+/// does, and its tail call into the member is where the tiers can disagree. That
+/// call strands the merged cycle arena's release, and the compiled tier has to hand
+/// the deferral to the activation that runs the member, its own having popped its
+/// region-remap frame at the tail-call sentinel
+/// (docs/impl/region/relocate.md § "A channel built in compiled code hands its
+/// release forward").
+///
+/// The counter-factual: with the hand-off missing, the caller's activation records
+/// nothing, no clean break ever runs the arena's decref, and each call strands the
+/// cycle's two closures, its two forward cells and the table they capture — two
+/// regions per call, which is a growth of ~400 over the measured window. The VM
+/// reading of the same driver is
+/// `selfrec::region_ownership_reclaims_defn_module_factory_per_call`, so a
+/// regression that reads bounded there and open here is exactly the tier gap.
+#[cfg(feature = "jit")]
+#[test]
+fn region_ownership_defn_module_member_call_under_jit() {
+    let prelude = "(def mk (fn [] \
+        (let [t @{}] \
+          (defn fa [m] (when (%not (%int? m)) (error :m)) \
+                       (if (%lt m 1) t (fb (%sub m 1)))) \
+          (defn fb [m] (when (%not (%int? m)) (error :m)) \
+                       (put t m true) (fa (%sub m 1))) \
+          (let [s {:a fa :b fb}] s)))) \
+        (def caller (fn [] ((get (mk) :a) 2)))";
+
+    let live_chain_growth = mid_run_discriminator(Runtime::new(), "arena/region-count");
+    assert!(
+        live_chain_growth > 150,
+        "precondition: the live accumulator retains every prior, so region growth \
+         over 200 iterations must be large (~200) — got {live_chain_growth}; if \
+         small, the gauge is dead and the assertion below is vacuous",
+    );
+
+    let (used, jit_compiled) = jit_mid_run_growth(prelude, "(caller)", "arena/region-count");
+    assert!(
+        jit_compiled,
+        "the calling lambda must run compiled for this to read the JIT tail-call \
+         path — its bytecode is absent from the jit cache, so the reading below is \
+         the interpreter's and proves nothing about the tier",
+    );
+    assert!(
+        used < 50,
+        "calling a member back through the returned struct must reclaim the merged \
+         cycle arena per call on the compiled tier too — region growth over 200 \
+         calls is {used} (the discriminator grows {live_chain_growth})",
+    );
 }
 
 /// VM≡JIT parity for the **flat store-adopt**. A discarded mutable container

--- a/src/runtime/tests/ownership/jit.rs
+++ b/src/runtime/tests/ownership/jit.rs
@@ -291,7 +291,7 @@ fn region_ownership_reclaims_bare_cycle_group_under_jit() {
 /// as `reassign_toplevel_prior_release_is_bounded` samples its gauge. The returned
 /// closure escapes via return, so it is the caller that holds it.
 ///
-/// The retain route is load-bearing and must stay a chain rather than a push into a
+/// The retain route decides the reading, and must stay a chain rather than a push into a
 /// container. A `%pair` records a COUNTED cross-region edge to the closure, so the
 /// closure's region stays in the active accounting `arena/count` sums. A container
 /// store instead lets the ownership forest ADOPT the stored region as a member of the

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -1,7 +1,7 @@
 // audited: 2026-09-10
 // docs/impl/vm.md
-//! The `VM` struct — every piece of per-instance state a running program reaches
-//! — and the accessors that reborrow the allocations it points at.
+//! The `VM` struct — the per-instance state a running program reaches — and the
+//! accessors that reborrow the allocations it points at.
 
 use crate::error::StackFrame;
 use crate::ffi::FFISubsystem;

--- a/src/vm/core.rs
+++ b/src/vm/core.rs
@@ -1,3 +1,8 @@
+// audited: 2026-09-10
+// docs/impl/vm.md
+//! The `VM` struct — every piece of per-instance state a running program reaches
+//! — and the accessors that reborrow the allocations it points at.
+
 use crate::error::StackFrame;
 use crate::ffi::FFISubsystem;
 use crate::hir::region::{MappedRegion, RuntimeRegion, StaticRegion};
@@ -151,6 +156,17 @@ pub struct VM {
     /// instance — a top-level program, module body, or eval'd form. `NIL`
     /// between calls; never read except by the immediately following entry.
     pub(crate) pending_entry_closure: Value,
+    /// One-shot "the activation about to start takes these releases over", set by
+    /// a tail call BUILT in compiled code and taken by the activation that runs
+    /// the callee (`execute_bytecode_saving_stack`). The interpreter's
+    /// `tail_call_inner` records a deferral on the activation slot it stands in,
+    /// which the callee reuses; a compiled caller pops that slot at the tail-call
+    /// sentinel, so its deferrals travel here instead
+    /// (docs/impl/region/relocate.md § "A channel built in compiled code hands its
+    /// release forward"). Written only once the pending tail call is set, and every
+    /// sentinel consumer enters the callee through that one entry; empty between
+    /// calls.
+    pub(crate) pending_tail_deferrals: Vec<RuntimeRegion>,
     /// One-shot "the caller parks this activation's frame on an error exit", set
     /// immediately before entering a body via `execute_bytecode_saving_stack`,
     /// which takes it (resetting to `false`) at entry. A parked frame is
@@ -264,6 +280,7 @@ pub struct VM {
 }
 
 mod decode;
+mod discard;
 mod format;
 mod lifecycle;
 mod region;
@@ -340,148 +357,6 @@ impl VM {
     /// notice instead of reporting a failure. See `gated_exit_reason`.
     pub fn take_gated_exit_reason(&mut self) -> Option<String> {
         self.gated_exit_reason.take()
-    }
-
-    /// Check a signal against a squelch mask. If the signal is squelched,
-    /// sets the fiber to a signal-violation error and returns `true`.
-    /// Callers handle any additional side effects (stack push, call_stack pop, etc.).
-    ///
-    /// Which bits a boundary enforces is `signals::squelched_bits`' answer, shared
-    /// with the JIT's inlined checks.
-    pub(crate) fn enforce_squelch(&mut self, bits: SignalBits, mask: SignalBits) -> bool {
-        let squelched = crate::signals::squelched_bits(bits, mask);
-        if squelched.is_empty() {
-            return false;
-        }
-        // The park this boundary ends is the fiber's own live signal here: every
-        // site reaching the boundary through this predicate is still holding it
-        // (the two that are not pass their own — see `squelch_violation`).
-        let err = self.squelch_violation(squelched, self.fiber.signal);
-        self.fiber.signal = Some((crate::value::SIG_ERROR, err));
-        true
-    }
-
-    /// Build the `signal-violation` error a squelch/attune boundary raises for
-    /// `squelched`, and discard the suspended frames the boundary abandons.
-    ///
-    /// The error value is returned rather than stored: each enforcement site
-    /// delivers it differently — the interpreter sets `fiber.signal`, the
-    /// `compile/run-on` entry returns it as the call's result. `squelched` must
-    /// be non-empty, the answer `signals::squelched_bits` gives.
-    ///
-    /// `parked` is the signal whose park this boundary ends, named by the site
-    /// rather than read from `fiber.signal`: two sites reach here through
-    /// `invoke_closure_jit`, which restores the CALLER's signal before it asks
-    /// the boundary's question and holds the parked one in a local. What the
-    /// park owed is released against it (docs/impl/region/owner.md § "A boundary
-    /// ends a park with no reader and no install").
-    pub(crate) fn squelch_violation(
-        &mut self,
-        squelched: SignalBits,
-        parked: Option<(SignalBits, Value)>,
-    ) -> Value {
-        let squelched_str = crate::signals::registry::format_bits(squelched);
-        let err = self.escaping_error(
-            "signal-violation",
-            format!("squelch: signal {} caught at boundary", squelched_str),
-        );
-        // The error the boundary raises is what leaves with the signal, so it is
-        // the payload the discard's own releases must leave standing — built in a
-        // fresh region of its own, so in practice it exempts nothing and the
-        // abandoned frames' tables run in full.
-        self.discard_suspended_frames(err, parked);
-        err
-    }
-
-    /// Discard the LIVE fiber's suspended frames (squelch / abort) — the
-    /// chokepoint for abandoning suspended work while the fiber runs on, the
-    /// discard counterpart of `resume_suspended` (docs/impl/region/owner.md
-    /// § "A discard runs what the abandoned frames owed"; a fiber reaching a
-    /// TERMINAL state instead releases through
-    /// `vm::fiber::take_fiber_owned`/`release_fiber_owned`, which also frees the
-    /// fiber owner node this discard leaves alone — the fiber survives a squelch
-    /// and may still own it).
-    ///
-    /// The discarded frames' continuations will never run, so every release that
-    /// lived in one is at its last chance here. What each frame owes it carries
-    /// itself, in three readings [`crate::value::fiber::ParkedDues`] collects
-    /// together: its parked owner node and the releases its activation took over
-    /// from its own frame-replacing tail calls (both MOVED into the frame at the
-    /// suspend — the record's only home, so no completion or resume can reach
-    /// them a second time), and the releases its two emitter-recorded tables name,
-    /// read against its saved locals and its saved activation map.
-    ///
-    /// Each reading names regions this chokepoint is entitled to release: a
-    /// node's members are exactly the regions the inference proved externally
-    /// unique and moved in through `AdoptIntoActivation`, a deferred region is one
-    /// the compiler itself named as this activation's to release, and a table
-    /// entry is a release the executing function emitted for its own slot with a
-    /// receipt that says it did not run. The fiber's survival is not part of that
-    /// reading: a frame's saved stack and saved map were taken and cloned at its
-    /// own park, and its activation returned before this point, so no live frame
-    /// shares the state the receipts are read against.
-    ///
-    /// What stays refused is a blanket release of the rest of the frame's
-    /// `activation_region_map`. It is a borrowed view carrying no receipt, and a
-    /// region it names can still be live in an outer, non-discarded frame or in
-    /// the activation that catches the squelch. Those regions stay leaked on this
-    /// path until an ownership cut adopts them (UAF-safe, bounded per discard).
-    ///
-    /// A fourth reading answers for the PARK rather than for the frames, and it
-    /// is the delivery ledger's: this exit is neither the reader that consumes a
-    /// park's delivery retain nor the install that releases a runtime-built
-    /// payload, so both are owed here (docs/impl/region/owner.md § "A boundary
-    /// ends a park with no reader and no install").
-    ///
-    /// `payload` is the value the exit leaves with — the boundary's own
-    /// `signal-violation` error — whose region no release here may take, on the
-    /// same reading the abandoned-frame walk makes
-    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
-    /// still owes"). `parked` is the signal whose park this ends, named by the
-    /// enforcement site (see `squelch_violation`).
-    pub(crate) fn discard_suspended_frames(
-        &mut self,
-        payload: Value,
-        parked: Option<(SignalBits, Value)>,
-    ) {
-        if let Some(frames) = self.fiber.suspended.take() {
-            let dues = crate::value::fiber::ParkedDues::of(frames);
-            let protect = Some(payload).filter(|v| !self.fiber.delivery.mint_names(*v));
-            let heap = unsafe { &mut *self.heap_ptr };
-            crate::vm::fiber::release_parked_dues(heap, dues, protect, None);
-        }
-        // The park's own references run after the tables above, which still find
-        // the payload's region live: a body-allocated payload's own release is
-        // one of those entries, and the delivery retain dropped here is what
-        // keeps it from being the region's last.
-        let heap = unsafe { &mut *self.heap_ptr };
-        crate::vm::fiber::release_abandoned_park(heap, &mut self.fiber.delivery, parked);
-        // The abandoned park's funding has no consumer — the delivery funnel
-        // that would have taken it will never run for these frames.
-        self.fiber.delivery.discharge();
-    }
-
-    /// A host that drives a thunk on the CURRENT fiber (`eval`, `import`,
-    /// `arena/allocs`, `compile/run-on`, the root driver) refuses a
-    /// suspend-class signal it cannot host: it extracts the signal as a value
-    /// or reports it, and the fiber runs on. The park that raised the signal
-    /// is dead at that moment, so its funding record must not survive into
-    /// the fiber's next park — the delivery funnel that would consume it
-    /// belongs to a resume no host will ever run (docs/impl/region/owner.md
-    /// § "A park names its funding in the delivery ledger"). A no-op for a
-    /// completion, an error (an `:error` fiber is resumable and its records
-    /// are identity-gated), a halt, or the switch trampoline — none of those
-    /// abandons a suspend-class park.
-    pub(crate) fn abandon_hosted_park(&mut self, bits: SignalBits) {
-        use crate::value::{SIG_ERROR, SIG_HALT, SIG_SWITCH};
-        if bits.is_empty()
-            || bits.intersects(SIG_ERROR)
-            || bits.intersects(SIG_HALT)
-            || bits == SIG_SWITCH
-        {
-            return;
-        }
-        self.fiber.delivery.discharge();
     }
 
     /// Record a closure call and return whether it's "hot" (called N+ times,

--- a/src/vm/core/discard.rs
+++ b/src/vm/core/discard.rs
@@ -1,9 +1,8 @@
 // audited: 2026-09-10
 // docs/impl/region/owner.md
 // docs/impl/region/mechanism.md
-//! Abandoning suspended work: the squelch boundary that raises a
-//! signal-violation, and the one chokepoint that runs what the discarded frames
-//! still owed.
+//! Abandoning suspended work: the squelch boundary, and the chokepoint that runs
+//! what the discarded frames still owed.
 
 use super::VM;
 use crate::value::{SignalBits, Value};

--- a/src/vm/core/discard.rs
+++ b/src/vm/core/discard.rs
@@ -1,0 +1,153 @@
+// audited: 2026-09-10
+// docs/impl/region/owner.md
+// docs/impl/region/mechanism.md
+//! Abandoning suspended work: the squelch boundary that raises a
+//! signal-violation, and the one chokepoint that runs what the discarded frames
+//! still owed.
+
+use super::VM;
+use crate::value::{SignalBits, Value};
+
+impl VM {
+    /// Check a signal against a squelch mask. If the signal is squelched,
+    /// sets the fiber to a signal-violation error and returns `true`.
+    /// Callers handle any additional side effects (stack push, call_stack pop, etc.).
+    ///
+    /// Which bits a boundary enforces is `signals::squelched_bits`' answer, shared
+    /// with the JIT's inlined checks.
+    pub(crate) fn enforce_squelch(&mut self, bits: SignalBits, mask: SignalBits) -> bool {
+        let squelched = crate::signals::squelched_bits(bits, mask);
+        if squelched.is_empty() {
+            return false;
+        }
+        // The park this boundary ends is the fiber's own live signal here: every
+        // site reaching the boundary through this predicate is still holding it
+        // (the two that are not pass their own — see `squelch_violation`).
+        let err = self.squelch_violation(squelched, self.fiber.signal);
+        self.fiber.signal = Some((crate::value::SIG_ERROR, err));
+        true
+    }
+
+    /// Build the `signal-violation` error a squelch/attune boundary raises for
+    /// `squelched`, and discard the suspended frames the boundary abandons.
+    ///
+    /// The error value is returned rather than stored: each enforcement site
+    /// delivers it differently — the interpreter sets `fiber.signal`, the
+    /// `compile/run-on` entry returns it as the call's result. `squelched` must
+    /// be non-empty, the answer `signals::squelched_bits` gives.
+    ///
+    /// `parked` is the signal whose park this boundary ends, named by the site
+    /// rather than read from `fiber.signal`: two sites reach here through
+    /// `invoke_closure_jit`, which restores the CALLER's signal before it asks
+    /// the boundary's question and holds the parked one in a local. What the
+    /// park owed is released against it (docs/impl/region/owner.md § "A boundary
+    /// ends a park with no reader and no install").
+    pub(crate) fn squelch_violation(
+        &mut self,
+        squelched: SignalBits,
+        parked: Option<(SignalBits, Value)>,
+    ) -> Value {
+        let squelched_str = crate::signals::registry::format_bits(squelched);
+        let err = self.escaping_error(
+            "signal-violation",
+            format!("squelch: signal {} caught at boundary", squelched_str),
+        );
+        // The error the boundary raises is what leaves with the signal, so it is
+        // the payload the discard's own releases must leave standing — built in a
+        // fresh region of its own, so in practice it exempts nothing and the
+        // abandoned frames' tables run in full.
+        self.discard_suspended_frames(err, parked);
+        err
+    }
+
+    /// Discard the LIVE fiber's suspended frames (squelch / abort) — the
+    /// chokepoint for abandoning suspended work while the fiber runs on, the
+    /// discard counterpart of `resume_suspended` (docs/impl/region/owner.md
+    /// § "A discard runs what the abandoned frames owed"; a fiber reaching a
+    /// TERMINAL state instead releases through
+    /// `vm::fiber::take_fiber_owned`/`release_fiber_owned`, which also frees the
+    /// fiber owner node this discard leaves alone — the fiber survives a squelch
+    /// and may still own it).
+    ///
+    /// The discarded frames' continuations will never run, so every release that
+    /// lived in one is at its last chance here. What each frame owes it carries
+    /// itself, in three readings [`crate::value::fiber::ParkedDues`] collects
+    /// together: its parked owner node and the releases its activation took over
+    /// from its own frame-replacing tail calls (both MOVED into the frame at the
+    /// suspend — the record's only home, so no completion or resume can reach
+    /// them a second time), and the releases its two emitter-recorded tables name,
+    /// read against its saved locals and its saved activation map.
+    ///
+    /// Each reading names regions this chokepoint is entitled to release: a
+    /// node's members are exactly the regions the inference proved externally
+    /// unique and moved in through `AdoptIntoActivation`, a deferred region is one
+    /// the compiler itself named as this activation's to release, and a table
+    /// entry is a release the executing function emitted for its own slot with a
+    /// receipt that says it did not run. The fiber's survival is not part of that
+    /// reading: a frame's saved stack and saved map were taken and cloned at its
+    /// own park, and its activation returned before this point, so no live frame
+    /// shares the state the receipts are read against.
+    ///
+    /// What stays refused is a blanket release of the rest of the frame's
+    /// `activation_region_map`. It is a borrowed view carrying no receipt, and a
+    /// region it names can still be live in an outer, non-discarded frame or in
+    /// the activation that catches the squelch. Those regions stay leaked on this
+    /// path until an ownership cut adopts them (UAF-safe, bounded per discard).
+    ///
+    /// A fourth reading answers for the PARK rather than for the frames, and it
+    /// is the delivery ledger's: this exit is neither the reader that consumes a
+    /// park's delivery retain nor the install that releases a runtime-built
+    /// payload, so both are owed here (docs/impl/region/owner.md § "A boundary
+    /// ends a park with no reader and no install").
+    ///
+    /// `payload` is the value the exit leaves with — the boundary's own
+    /// `signal-violation` error — whose region no release here may take, on the
+    /// same reading the abandoned-frame walk makes
+    /// (docs/impl/region/mechanism.md § "An abandoned frame runs the releases it
+    /// still owes"). `parked` is the signal whose park this ends, named by the
+    /// enforcement site (see `squelch_violation`).
+    pub(crate) fn discard_suspended_frames(
+        &mut self,
+        payload: Value,
+        parked: Option<(SignalBits, Value)>,
+    ) {
+        if let Some(frames) = self.fiber.suspended.take() {
+            let dues = crate::value::fiber::ParkedDues::of(frames);
+            let protect = Some(payload).filter(|v| !self.fiber.delivery.mint_names(*v));
+            let heap = unsafe { &mut *self.heap_ptr };
+            crate::vm::fiber::release_parked_dues(heap, dues, protect, None);
+        }
+        // The park's own references run after the tables above, which still find
+        // the payload's region live: a body-allocated payload's own release is
+        // one of those entries, and the delivery retain dropped here is what
+        // keeps it from being the region's last.
+        let heap = unsafe { &mut *self.heap_ptr };
+        crate::vm::fiber::release_abandoned_park(heap, &mut self.fiber.delivery, parked);
+        // The abandoned park's funding has no consumer — the delivery funnel
+        // that would have taken it will never run for these frames.
+        self.fiber.delivery.discharge();
+    }
+
+    /// A host that drives a thunk on the CURRENT fiber (`eval`, `import`,
+    /// `arena/allocs`, `compile/run-on`, the root driver) refuses a
+    /// suspend-class signal it cannot host: it extracts the signal as a value
+    /// or reports it, and the fiber runs on. The park that raised the signal
+    /// is dead at that moment, so its funding record must not survive into
+    /// the fiber's next park — the delivery funnel that would consume it
+    /// belongs to a resume no host will ever run (docs/impl/region/owner.md
+    /// § "A park names its funding in the delivery ledger"). A no-op for a
+    /// completion, an error (an `:error` fiber is resumable and its records
+    /// are identity-gated), a halt, or the switch trampoline — none of those
+    /// abandons a suspend-class park.
+    pub(crate) fn abandon_hosted_park(&mut self, bits: SignalBits) {
+        use crate::value::{SIG_ERROR, SIG_HALT, SIG_SWITCH};
+        if bits.is_empty()
+            || bits.intersects(SIG_ERROR)
+            || bits.intersects(SIG_HALT)
+            || bits == SIG_SWITCH
+        {
+            return;
+        }
+        self.fiber.delivery.discharge();
+    }
+}

--- a/src/vm/core/lifecycle.rs
+++ b/src/vm/core/lifecycle.rs
@@ -1,3 +1,7 @@
+// audited: 2026-09-10
+// docs/impl/vm.md
+//! Building a VM over a heap it owns or shares, and resetting one for reuse.
+
 use super::*;
 
 /// A dummy root closure for the root fiber.
@@ -101,6 +105,7 @@ impl VM {
             tail_call_env_cache: Vec::with_capacity(256),
             env_cache: Vec::with_capacity(256),
             pending_tail_call: None,
+            pending_tail_deferrals: Vec::new(),
             pending_fiber_resume: None,
             pending_entry_closure: crate::value::Value::NIL,
             pending_error_park: false,
@@ -153,6 +158,7 @@ impl VM {
         self.current_fiber_handle = None;
         self.current_fiber_value = None;
         self.pending_tail_call = None;
+        self.pending_tail_deferrals.clear();
         self.pending_entry_closure = crate::value::Value::NIL;
         self.pending_error_park = false;
         self.pending_fiber_resume = None;

--- a/src/vm/execute.rs
+++ b/src/vm/execute.rs
@@ -1,3 +1,6 @@
+// audited: 2026-09-10
+// docs/impl/vm.md
+// docs/impl/region/relocate.md
 //! Bytecode execution entry points.
 //!
 //! ## Re-entrancy
@@ -350,6 +353,17 @@ impl VM {
         #[cfg(debug_assertions)]
         let entry_depth = self.fiber.activation_region_maps.len();
         self.push_activation_region_map();
+        // A tail call BUILT in compiled code strands its releases on an activation
+        // that pops its own dues slot at the tail-call sentinel, so it leaves them
+        // on `pending_tail_deferrals` for the activation that runs the callee
+        // (docs/impl/region/relocate.md § "A channel built in compiled code hands
+        // its release forward"). Every sentinel consumer enters that callee here,
+        // so this is where the hand-off is collected.
+        if !self.pending_tail_deferrals.is_empty() {
+            for region in std::mem::take(&mut self.pending_tail_deferrals) {
+                self.activation_dues().defer(region);
+            }
+        }
         let mut result = self.trampoline_loop(code, closure_env, 0, !parks_error_frame);
         #[cfg(debug_assertions)]
         debug_assert_eq!(
@@ -395,9 +409,9 @@ impl VM {
     /// thunk's continuation and returns `SIG_SWITCH` for a driving trampoline
     /// rather than executing inline (`handle_fiber_resume_signal`). Without
     /// driving it here the switch unwinds out of the re-entrant boundary and the
-    /// continuation resumes OUTSIDE the caller's scope — the `arena/allocs`
-    /// measurement returned the resumed child's value instead of `(result .
-    /// net)` and never finished the thunk (`tests/elle/arena.lisp`,
+    /// continuation resumes OUTSIDE the caller's scope, so the `arena/allocs`
+    /// measurement answers with the resumed child's value instead of `(result .
+    /// net)` and never finishes the thunk (`tests/elle/arena.lisp`,
     /// `tests/elle/resource.lisp` `fiber-spawn-10`).
     ///
     /// Returns the final signal bits; the result value is left in

--- a/tests/elle/probe/tailcall.lisp
+++ b/tests/elle/probe/tailcall.lisp
@@ -1,5 +1,5 @@
 (elle/epoch 12)
-# audited: 2026-09-09
+# audited: 2026-09-10
 # Tail-call rotation, letrec-local recursive closures, a returned self-recursive closure's region, and the scheduler round trip.
 #
 # docs/impl/region/diagnostics.md
@@ -254,11 +254,14 @@
 # twin of `recur-local-mutual-factory` above, so the two together read the
 # binder-form claim on the shape the merge was extended for.
 #
-# The op CONSTRUCTS the module and stops there. Calling a member back through the
-# returned struct grows ~7 objects and ~2 regions per op under `--jit=eager` — on
-# BOTH binder spellings, and flat on the VM, so the growth is the tier's rather than
-# this mechanism's (elle-lisp/elle#1103). Put the call back into the op when that
-# closes.
+# The op CONSTRUCTS the module and then CALLS a member back through the returned
+# struct, which is the half the two tiers can disagree on. The construction is the
+# merge's; the call is a tail call into a member out of a caller the JIT compiles,
+# whose stranded arena release the compiled tier must hand to the activation that
+# runs the member (docs/impl/region/relocate.md § "A channel built in compiled code
+# hands its release forward"). Dropping the call left the whole cycle — two closures,
+# two forward cells, and the table they capture — growing ~7 objects and ~2 regions
+# per op under `--jit=eager`, and flat on the VM.
 (defn defn-module-factory []
   (let [t @{}]
     (defn fa [m]
@@ -270,8 +273,8 @@
       (fa (%sub m 1)))
     (let [s {:a fa :b fb}]
       s)))
-(pin (measure "defn-module-factory" (fn [j] (defn-module-factory)) 100 6 60 0.4
-              0.5) 0)
+(pin (measure "defn-module-factory" (fn [j] ((get (defn-module-factory) :a) 2))
+              100 6 60 0.4 0.5) 0)
 
 # ── Retained-closure reclamation (a RETURNED self-recursive closure's region) ──
 # `recur-local-self` above pins the LEAK rate of a self-recursive closure used as a


### PR DESCRIPTION
Closes #1103.

## What was wrong

A frame-replacing tail call strands the releases the lowerer emitted past the
`TailCall`, and the activation that runs the callee owes each one: the callee
closure's own per-call region (`defer_callee_release`) and the merged
closure-cycle arena a letrec body tail-calls out of (`deferred_release_slot`).
The interpreter records both in `tail_call_inner`. `jit_tail_call_inner`
recorded neither — the `TailCall`'s two fields never crossed to
`elle_jit_tail_call` at all — so a tail call built in compiled code dropped the
arena's decref outright.

The everyday shape is the closure-as-module factory calling a member back
through the struct it handed out. `((get (defn-module-factory) :a) 2)` compiles
the caller (the factory itself carries a `MakeClosure` and never compiles), and
its tail call into `fa` stranded the whole cycle: two closures, two forward
cells, and the mutable table they capture — 7 objects and 2 regions per call,
forever, on any tier that compiled the caller.

Recording the deferral on the compiled caller's own dues does not work either:
the compiled body pops its region-remap frame at the tail-call sentinel, so the
slot is gone before the callee starts.

## What the change does

`LirInstr::TailCall` now carries both channels to `elle_jit_tail_call` as one
`TailDeferrals` pair. The helper resolves them while the caller's region map is
still current, and — once the pending call is set — leaves them on
`VM::pending_tail_deferrals`, which `execute_bytecode_saving_stack` takes into
the callee's fresh dues. Every sentinel consumer enters the callee through that
one entry, so the hand-off cannot be collected by anything else; a hand-off
nobody collects would be an over-keep, never an over-free.

The audit that comes with the stamps splits the squelch boundary and the discard
chokepoint out of `vm/core.rs` into `vm/core/discard.rs` (the file was past the
reading budget), and repairs three claims the touched headers had outgrown: the
JIT entry convention passes the executing closure as a `(tag, payload)` pair
rather than one `self_bits`, a closure tail callee always leaves through
`TAIL_CALL_SENTINEL`, and a polymorphic or yielding function compiles like any
other.

## How it was measured

`tests/elle/oracle.lisp`, `defn-module-factory`, driving construct-and-call per
op:

| tier | before | after |
|---|---:|---:|
| `--jit=eager --trace=syncjit` | 7.00 ± 0.00 | 0.0 ± 0.0 |
| `--jit=eager` | 6.94 ± 4.53 | 0.0 ± 0.0 |
| `--jit=off` | 0.0 ± 0.0 | 0.0 ± 0.0 |

`--trace=syncjit` is what makes the reading deterministic: under the background
worker the growth starts only once the compile lands, which in a small program
is thousands of ops in.

`make smoke`, `make smoke-nouring`, `make qa`, the workspace unit tests and the
integration tests are green, and the region corpus is panic-clean under
`--jit=eager --trace=guardfree`.

## What pins it

- `runtime::tests::ownership::jit::region_ownership_defn_module_member_call_under_jit`
  — the deterministic pin. It drains the background compiler, then reads
  per-call region growth with the calling lambda compiled. The program hands the
  caller closure back beside the gauge delta, so the test asks `jit_code_for`
  about that exact bytecode rather than about a non-empty cache. Counter-factual:
  400 over the measured window, beside a discriminator that grows 200.
- The oracle's `defn-module-factory` probe, whose op #1081 withdrew, restored to
  construct AND call.
- `selfrec::region_ownership_reclaims_defn_module_factory_per_call` is the VM
  reading of the same driver, so a regression that reads bounded there and open
  in the new test is exactly the tier gap.
