### PR TITLE
jit: a call made from compiled code promotes its callee

### DIFF
--- a/docs/impl/jit.md
+++ b/docs/impl/jit.md
@@ -1,6 +1,6 @@
 # JIT
 
-<!-- audited: 2026-09-06 -->
+<!-- audited: 2026-09-11 -->
 
 The JIT compiles hot functions from LIR to native code using Cranelift.
 
@@ -19,7 +19,7 @@ LIR → FunctionTranslator → Cranelift IR → Native code → JitCode
 - **`JitCode`** — wraps the native function pointer; keeps the module
   alive for the code's lifetime
 - **`RuntimeHelpers`** — extern symbols the JIT calls back into the
-  VM (allocation, GC barriers, signal checks)
+  VM (allocation, region accounting, calls, signal checks)
 
 ## Memory flags on emitted loads
 
@@ -36,7 +36,8 @@ is worth keeping: a handle means "trusted" only inside the function whose
 table minted it, so a handle cached across functions would index a table where
 the same slot holds different flags, or nothing at all.
 
-`load_value_slot` (`src/jit/translate.rs`) is where the JIT names those flags.
+`load_value_slot` ([translate.rs](../../src/jit/translate.rs)) is where the JIT
+names those flags.
 It emits both halves of a `Value` — tag at `+0`, payload at `+8` — so the
 16-byte stride is written once, from `size_of`/`offset_of` rather than as a
 literal.
@@ -44,7 +45,7 @@ literal.
 ## Arithmetic: the tag-check diamond, and skipping it
 
 A binary operation, a comparison and a negation each compile to a diamond
-(`src/jit/fastpath.rs`): test both tags for `TAG_INT`, then either the native
+([fastpath.rs](../../src/jit/fastpath.rs)): test both tags for `TAG_INT`, then either the native
 integer instruction or a call to the runtime helper, merging on a two-parameter
 block. Division and remainder add a second test for a zero divisor.
 
@@ -59,9 +60,28 @@ because the operands are integers.
 
 ## Function selection
 
-Functions become JIT candidates based on a hotness threshold
-(default 10, controlled by `--jit=N`). The VM increments a counter on
-each call; when it crosses the threshold, the function is compiled.
+Functions become JIT candidates based on a hotness threshold, which `--jit`
+sets. The VM increments a counter on each call; when it crosses the threshold,
+the function is compiled.
+
+**A non-tail call is counted by whichever tier makes it.** The interpreter
+counts in `try_jit_call`; compiled code counts in `elle_jit_call`, on the arm
+that finds no compiled code for the callee. Both reach the counter through
+`VM::profile_jit_candidate`, the one place a call is counted and a hot function
+is submitted.
+
+Counting the interpreter's calls alone stops promotion one level below whatever
+has already compiled. A compiled caller no longer reaches its callees through
+the interpreter, so a callee called from nowhere else never becomes hot. The
+worker's latency masks that, because the caller keeps running interpreted while
+Cranelift works. `--trace=syncjit` installs on the first call and leaves no such
+window, so it is where the two policies are held to the same answer
+([jit-compiled-caller-promotes-callee.lisp](../../tests/elle/jit-compiled-caller-promotes-callee.lisp)).
+
+A tail call is counted by neither tier. It replaces the frame rather than
+building one — `tail_call_inner` in the interpreter, the tail-call sentinel in
+compiled code — so a function only ever reached in tail position stays
+interpreted.
 
 ## Rejection tracking
 
@@ -86,6 +106,16 @@ thread, re-compiling the same function thousands of times and burning CPU that
 dwarfs the program's real work. The `jit/rejections` report exposes a per-
 function `:attempts` count; the negative cache holds `attempts == 1` no matter
 how many times the function is called.
+
+**Every failed compile is recorded**, whichever kind it is, so the negative
+cache covers all of them. A refusal the translator plans for —
+`UnsupportedInstruction`, `Polymorphic`, `Yielding` — is recorded and says
+nothing further. A Cranelift failure or an invalid-LIR result is a defect in
+the compiler, so it is recorded and also printed on stderr, once. Every path
+that takes a result classifies it through `VM::record_jit_failure`: the
+background poll, the diagnostic drain, and the synchronous compile that
+`--trace=syncjit` runs. A flag meant to show a codegen failure must not be the
+one place that swallows it.
 
 ## Cache identity
 
@@ -115,13 +145,14 @@ An alternative — validating entries at hit time by content — was rejected:
 it puts an O(bytecode) compare (or a hash plus per-template caching) on the
 hot dispatch path to detect a situation the pin makes impossible.
 
-Pinning tests: `src/vm/jit_entry/tests.rs`.
+Pinning tests: [jit_entry/tests.rs](../../src/vm/jit_entry/tests.rs).
 
 Native samplers (`/usr/bin/sample`, `eu-stack`) cannot name JIT frames: the
 code lives in anonymous Cranelift mappings, so a wedged thread's stack shows
 `??? (in <unknown binary>)` exactly where the answer is. The registry closes
 that gap. Every successful compile — solo and batch, on every thread — records
-`(entry address, label)` in one process-global table (`src/jit/registry.rs`).
+`(entry address, label)` in one process-global table
+([registry.rs](../../src/jit/registry.rs)).
 The label is the function's declared name when one exists, else its
 smallest-offset source location (`ClosureTemplate::display_label`) — lowering
 names almost nothing, so the location is what actually identifies a function
@@ -131,7 +162,7 @@ since been dropped.
 
 `(vm/query "jit/map" nil)` renders the table as one `0x<addr> <name>` line per
 entry, sorted by address. The test runner prints it after the thread
-photograph when a form misses its deadline (`src/test.lisp`,
+photograph when a form misses its deadline ([test.lisp](../../src/test.lisp),
 `note-timeout-stacks`), so a sampled JIT frame resolves to the nearest
 preceding entry — the registry records entry addresses, not sizes, and
 Cranelift lays functions out contiguously enough for nearest-preceding to
@@ -164,10 +195,11 @@ save/restore sequences so a yielded fiber can resume into JIT code.
 ## CLI flags
 
 ```text
---jit=0       Disable JIT entirely
---jit=N       Compile after N-1 calls (default: --jit=11, threshold 10)
---jit=1       Compile on first call
---stats       Print compilation stats on exit
+--jit=off       Disable the JIT. This is what the binary starts with
+--jit=eager     Compile on the first call (threshold 0)
+--jit=adaptive  Compile after 10 calls
+--jit=N         0 is off, 1 is eager, N above 1 compiles after N-1 calls
+--stats         Print compilation stats on exit
 ```
 
 ## Files

--- a/src/jit/calls/callops.rs
+++ b/src/jit/calls/callops.rs
@@ -1,3 +1,9 @@
+// audited: 2026-09-12
+// docs/impl/jit.md
+// docs/impl/region/owner.md
+//! The helpers a compiled call site enters: dispatch by callee kind, and the
+//! call-depth, tail-call and parameter-frame steps around it.
+
 use super::*;
 
 /// Call a function from JIT code.
@@ -67,17 +73,10 @@ pub extern "C" fn elle_jit_call(
         }
         let result = vm.resolve_parameter(id, default);
         // Pass-through retain, mirror of `call_inner`'s parameter branch: a
-        // resolve returns a value bound in the dynamic-binding frame (region ≠
-        // this call's region_id), so hand the caller one owning reference for
-        // its `DecrefValueRegion` to consume.
-        // FIXME(leak): preserves the historical cross-id-space comparison
-        // (runtime `result_region` vs static `region_id`); see the matching
-        // note in `VM::dispatch_native_call`. Revisited in the leak phase.
-        // A parameter resolve never allocates a fresh region — always hand the
-        // caller one owning reference for its `DecrefValueRegion` to consume.
-        // `incref_for_escape(None, …)` no-ops an immediate. (Was gated on a
-        // static-vs-runtime `r.get() == region_id` compare — see the leak note
-        // in `VM::dispatch_native_call`.)
+        // resolve returns a value bound in the dynamic-binding frame, never a
+        // fresh allocation into this call's region, so hand the caller one
+        // owning reference for its `DecrefValueRegion` to consume. The retain
+        // is unconditional; `incref_for_escape(None, …)` no-ops an immediate.
         let heap = unsafe { &mut *vm.heap_ptr };
         let result_region = crate::value::arena::region_of(heap, result);
         crate::value::arena::incref_for_escape(
@@ -96,9 +95,19 @@ pub extern "C" fn elle_jit_call(
 
         let closure_squelch_mask = closure.squelch_mask;
 
-        // JIT-to-JIT fast path: check if callee has JIT code
+        // JIT-to-JIT fast path: check if callee has JIT code.
+        //
+        // The bare lookup comes first so a hit stays one hash probe. Only the
+        // miss counts the call and submits a hot callee, which is what keeps a
+        // function called from nowhere but compiled code reaching the JIT at
+        // all (docs/impl/jit.md § "Function selection"). The counter and the
+        // worker poll are worth their cost exactly where the alternative is an
+        // interpreter frame, which is the arm below.
         let bytecode_ptr = closure.template.bytecode().as_ptr();
-        if let Some(jit_code) = vm.jit_code_for(bytecode_ptr) {
+        let compiled = vm
+            .jit_code_for(bytecode_ptr)
+            .or_else(|| vm.profile_jit_candidate(closure));
+        if let Some(jit_code) = compiled {
             vm.fiber.call_depth += 1;
 
             // Stack overflow guard: resource exhaustion (not signal-theoretic).

--- a/src/vm/jit_entry.rs
+++ b/src/vm/jit_entry.rs
@@ -1,10 +1,11 @@
-//! JIT compilation entry points and interpreter trampolines.
+// audited: 2026-09-12
+// docs/impl/jit.md
+//! Where a closure call meets the JIT: the hotness counter, the code cache, and
+//! the trampolines back into the interpreter.
 //!
-//! Handles:
-//! - JIT compilation profiling and caching
-//! - JIT code execution and result dispatch
-//! - Batch JIT compilation for call peers
-//! - Fallback to interpreter on compilation failure
+//! Both tiers promote through here. The interpreter arrives at `try_jit_call`,
+//! compiled code at `profile_jit_candidate` from `elle_jit_call`, and a
+//! compiled callee's result comes back through `run_jit`.
 
 use crate::jit::{JitCode, JitRejectionInfo, JitValue, TAIL_CALL_SENTINEL, YIELD_SENTINEL};
 use crate::value::{SignalBits, Value, SIG_ERROR, SIG_HALT, SIG_YIELD};
@@ -44,23 +45,25 @@ impl VM {
             .insert(template.bytecode().as_ptr() as usize, template);
     }
 
-    /// Try JIT compilation/dispatch for a closure call.
+    /// Count one call of `closure`, and hand back the compiled code to run it
+    /// with when the cache holds some.
     ///
-    /// Returns `Some(Option<SignalBits>)` if JIT handled the call (the inner
-    /// Option follows handle_call's convention), or `None` to fall through
-    /// to the interpreter path. Caller is responsible for decrementing
-    /// call_depth on the `Some` path.
+    /// The promotion step of a non-tail call, and the only one: the interpreter
+    /// reaches it through `try_jit_call`, compiled code through `elle_jit_call`
+    /// (docs/impl/jit.md § "Function selection"). A tier that counted only its
+    /// own calls would stop promotion one level below whatever has already
+    /// compiled, because a compiled caller stops reaching its callees through
+    /// the other tier.
     ///
-    /// Compilation is asynchronous: when a function becomes hot, its LIR
-    /// is sent to a background thread for Cranelift compilation. The
-    /// interpreter continues running the function until compiled code
-    /// is ready. Zero stall on the event loop.
-    pub(super) fn try_jit_call(
+    /// A compile submitted here never runs this call. A hot function's LIR goes
+    /// to the background worker and the caller falls back meanwhile, so nothing
+    /// stalls the event loop and the next call picks the code up.
+    /// `--trace=syncjit` compiles on this thread instead, and is held to that
+    /// same schedule rather than given a second one.
+    pub(crate) fn profile_jit_candidate(
         &mut self,
         closure: &crate::value::Closure,
-        args: &[Value],
-        func: Value,
-    ) -> Option<Option<SignalBits>> {
+    ) -> Option<Arc<JitCode>> {
         if !self.runtime_config.jit.enabled() {
             return None;
         }
@@ -72,7 +75,7 @@ impl VM {
 
         // Check cache (may have been populated by poll above)
         if let Some(jit_code) = self.jit_code_for(bytecode_ptr) {
-            return Some(self.run_jit(&jit_code, closure, args, func));
+            return Some(jit_code);
         }
 
         // If hot, not already pending, and not already rejected, submit
@@ -92,6 +95,22 @@ impl VM {
         }
 
         None // Interpreter fallback while compilation proceeds in background
+    }
+
+    /// Try JIT compilation/dispatch for a closure call.
+    ///
+    /// Returns `Some(Option<SignalBits>)` if JIT handled the call (the inner
+    /// Option follows handle_call's convention), or `None` to fall through
+    /// to the interpreter path. Caller is responsible for decrementing
+    /// call_depth on the `Some` path.
+    pub(super) fn try_jit_call(
+        &mut self,
+        closure: &crate::value::Closure,
+        args: &[Value],
+        func: Value,
+    ) -> Option<Option<SignalBits>> {
+        let jit_code = self.profile_jit_candidate(closure)?;
+        Some(self.run_jit(&jit_code, closure, args, func))
     }
 
     /// Poll the background JIT worker for completed compilations.
@@ -122,22 +141,42 @@ impl VM {
                     }
                     self.install_jit_code(pin, Arc::new(jit_code));
                 }
-                Err(e) => match &e {
-                    crate::jit::JitError::UnsupportedInstruction(_)
-                    | crate::jit::JitError::Polymorphic
-                    | crate::jit::JitError::Yielding => {
-                        // Expected rejection — record for diagnostics.
-                        let bytecode_ptr = result.bytecode_key as *const u8;
-                        self.jit_rejections
-                            .entry(bytecode_ptr)
-                            .or_insert_with(|| JitRejectionInfo::new(e, pin));
-                    }
-                    _ => {
-                        eprintln!("[jit] background compilation failed: {}", e);
-                    }
-                },
+                Err(e) => {
+                    self.record_jit_failure(result.bytecode_key as *const u8, e, pin);
+                }
             }
         }
+    }
+
+    /// Record a compile that failed, and name the failures nobody planned for.
+    ///
+    /// Every failure enters the negative cache, so the function is never
+    /// re-submitted whichever kind it was. A refusal the translator plans for
+    /// says nothing further; a Cranelift failure or an invalid-LIR result is a
+    /// defect in the compiler and prints one line on stderr
+    /// (docs/impl/jit.md § "Rejection tracking"). Both the worker's results and
+    /// the synchronous compile come through here, so a flag meant to show a
+    /// codegen failure cannot be the one place that swallows it.
+    ///
+    /// `pin` is the code object the key was derived from, and is `None` only
+    /// where the submission's pin was already lost.
+    fn record_jit_failure(
+        &mut self,
+        bytecode_ptr: *const u8,
+        error: crate::jit::JitError,
+        pin: Option<crate::value::ClosureTemplate>,
+    ) {
+        if !matches!(
+            error,
+            crate::jit::JitError::UnsupportedInstruction(_)
+                | crate::jit::JitError::Polymorphic
+                | crate::jit::JitError::Yielding
+        ) {
+            eprintln!("[jit] compilation failed: {}", error);
+        }
+        self.jit_rejections
+            .entry(bytecode_ptr)
+            .or_insert_with(|| JitRejectionInfo::new(error, pin));
     }
 
     /// Submit a background JIT compilation task for a hot function.
@@ -176,11 +215,7 @@ impl VM {
                     }
                     self.install_jit_code(template, Arc::new(jit_code));
                 }
-                Err(e) => {
-                    self.jit_rejections
-                        .entry(bytecode_ptr)
-                        .or_insert_with(|| JitRejectionInfo::new(e, Some(template)));
-                }
+                Err(e) => self.record_jit_failure(bytecode_ptr, e, Some(template)),
             }
             *self.jit_compile_attempts.entry(bytecode_ptr).or_insert(0) += 1;
             return;
@@ -227,12 +262,7 @@ impl VM {
                             let Some(pin) = pin else { continue };
                             self.install_jit_code(pin, Arc::new(jit_code));
                         }
-                        Err(e) => {
-                            let bytecode_ptr = result.bytecode_key as *const u8;
-                            self.jit_rejections
-                                .entry(bytecode_ptr)
-                                .or_insert_with(|| JitRejectionInfo::new(e, pin));
-                        }
+                        Err(e) => self.record_jit_failure(result.bytecode_key as *const u8, e, pin),
                     }
                 }
                 None => break, // Worker exited

--- a/tests/elle/AGENTS.md
+++ b/tests/elle/AGENTS.md
@@ -1,141 +1,70 @@
 # tests/elle
 
-Elle script tests: behavioral tests in Elle that verify language semantics.
+<!-- audited: 2026-09-11 -->
 
-## Responsibility
+The Elle corpus: one self-contained `.lisp` program per subject, each asserting
+what the language does and exiting non-zero when an assertion fails.
 
-Test language behavior by running Elle code directly. Each `.lisp` file in this directory is a self-contained test that:
-1. Uses the built-in `(assert)` primitive for all assertions
-2. Exits with code 0 on success, 1 on failure
+## What a file here is
 
-Read [`QUICKSTART.md`](../../QUICKSTART.md) for the complete language reference.
+A file is a whole program. It asserts with the built-in `(assert expr msg)`,
+which signals `:failed-assertion` and exits 1, so a file that runs to the end
+has passed. It carries no harness, no setup, and no dependency on another file.
 
-Does NOT:
-- Test Rust APIs (that's unit tests)
-- Test invariants across random inputs (that's property tests)
-- Test individual modules in isolation (that's integration tests)
+Name the file for its subject, and keep one subject per file. The directory is
+its own index: `ls tests/elle` names every subject the corpus covers.
 
-## Test structure
+Does NOT belong here:
 
-Each Elle script follows this pattern:
+- A test that inspects Rust types or a Rust API.
+- Source that must fail to compile.
+- An error-message substring match.
+- A property over generated inputs.
 
-```janet
-(elle/epoch 1)
-## Test description
+[docs/analysis/testing.md](../../docs/analysis/testing.md) is the decision tree
+that says which kind of test a thing wants.
+
+## Shape
+
+```lisp
+(elle/epoch 12)
+# What this file pins, and the trap or counter-factual behind it.
 
 (assert (= (+ 1 2) 3) "addition")
-(assert (> 5 3) "greater than")
 (assert (not (< 5 3)) "not less than")
 ```
 
-Start every file with `(elle N)` where N is the current epoch (check
-`CURRENT_EPOCH` in `src/epoch/rules.rs`). Use `(assert expr msg)` for all
-assertions. It signals a `:failed-assertion` error on failure, which causes
-the script to exit with code 1.
+Open every file with `(elle/epoch N)` for the current epoch — `CURRENT_EPOCH`
+in [src/epoch/rules.rs](../../src/epoch/rules.rs).
 
-## Test organization
+## Running
 
-Tests are organized by feature area:
+The agent-first runner owns this directory. `elle test`, which
+`make smoke-elle` drives, compiles and runs every file once per JIT policy
+(`:off` → `vm`, `:eager` → `jit`), plus per-tier divergence for a single-form
+file. A new file is picked up by being here; there is nothing to register.
 
-| File | Coverage |
-|------|----------|
-| `eval.lisp` | Evaluation and basic forms |
-| `prelude.lisp` | Prelude macros (defn, let*, when, unless, etc.) |
-| `destructuring.lisp` | Destructuring patterns |
-| `core.lisp` | Core language features |
-| `splice.lisp` | Splice syntax |
-| `blocks.lisp` | Block and break control flow |
-| `functional.lisp` | Functional programming (map, filter, fold, etc.) |
-| `arithmetic.lisp` | Arithmetic operations |
-| `determinism.lisp` | Deterministic behavior |
-| `property-eval.lisp` | Property-based evaluation |
-| `convert.lisp` | Type conversions |
-| `sequences.lisp` | List and array operations |
-| `macros.lisp` | Macro behavior |
-| `strings.lisp` | String operations |
-| `tables.lisp` | Table operations |
-| `fibers.lisp` | Fiber operations |
-| `coroutines.lisp` | Fiber behavior |
-| `signals.lisp` | Signal system |
-| `closures.lisp` | Closure behavior |
-| `recursion.lisp` | Recursive functions |
-| `higher-order.lisp` | Higher-order functions |
-| `match.lisp` | Pattern matching |
-| `parameters.lisp` | Dynamic parameters |
-| `ports.lisp` | I/O ports |
-| `json.lisp` | JSON serialization |
-| `regex.lisp` | Regular expressions |
-| `bytes.lisp` | Bytes operations |
-| `string.lisp` | String and @string operations |
-| `symbol-identity.lisp` | Symbol identity across worker symbol tables |
+[docs/testing.md](../../docs/testing.md) covers the runner and the commands,
+and [docs/test-runner.md](../../docs/test-runner.md) is its specification.
 
-## Running Elle scripts
+One file at a time, `elle tests/elle/NAME.lisp` runs it as a plain program.
 
-Elle scripts are run via the `integration::elle_scripts` harness in `tests/integration/elle_scripts.rs`:
+[tests/integration/elle_scripts.rs](../integration/elle_scripts.rs) pins the
+few files that need a process-global mode the runner cannot vary per file — the
+page-guard oracle, the I/O backend, a backend toggle paired with the adaptive
+JIT. A file that needs no such mode does not go there, because the runner
+already runs it under more policies than one subprocess call would.
 
-```bash
-cargo test elle_scripts::eval    # Run tests/elle/eval.lisp
-cargo test elle_scripts          # Run all Elle scripts
-```
-
-Each script is executed with the `elle` binary:
-
-```bash
-./target/debug/elle tests/elle/eval.lisp
-```
-
-If the script exits with code 0, the test passes. If it exits with code 1, the test fails.
-
-## Writing a new Elle script
-
-1. Create `tests/elle/myfeature.lisp`
-2. Add a test function to `tests/integration/elle_scripts.rs`:
-   ```rust
-   #[test]
-   fn myfeature() {
-       run_elle_script("myfeature");
-   }
-   ```
-3. Write the script:
-   ```janet
-   (elle/epoch 1)
-   ## My feature test
-
-   (assert (= (my-feature 42) 42) "my-feature identity")
-   ```
 ## Invariants
 
-1. **Scripts are self-contained.** Each script uses `(assert)` directly and runs independently.
-
-2. **Scripts exit with code 0 on success, 1 on failure.** The test harness checks the exit code.
-
-3. **Scripts use assertions, not print statements.** Assertions provide clear failure messages and exit codes.
-
-4. **Scripts are deterministic.** Same script always produces same result. No randomness or timing dependencies.
-
-5. **Scripts test language semantics, not implementation details.** They verify what the language does, not how it does it.
-
-## When to add a test
-
-- **New language feature**: Add a script that exercises the feature
-- **Bug regression**: Add a script that reproduces the bug
-- **Behavioral change**: Add a script that verifies the new behavior
-- **Documentation example**: Add a script that demonstrates the feature
-
-## Common pitfalls
-
-- **Using print instead of assertions**: Use `(assert expr msg)` instead of `(print ...)` for clear failure messages.
-- **Forgetting to register the test**: New scripts must be added to `tests/integration/elle_scripts.rs` with a test function.
-- **Testing implementation details**: Test language semantics, not internal behavior (e.g., don't test bytecode structure).
-- **Non-deterministic tests**: Don't use `time::now()` or other non-deterministic functions (except in dedicated time tests).
-
-## Decision tree for test placement
-
-Use this decision tree to decide where to place a new test:
-
-1. **Does it test Elle language semantics?** → Elle script (`tests/elle/`)
-2. **Does it test an invariant across all inputs?** → Property test (`tests/property/`)
-3. **Does it test end-to-end pipeline behavior?** → Integration test (`tests/integration/`)
-4. **Does it test a Rust API in isolation?** → Unit test (`tests/unittests/` or inline in `src/`)
-
-See `docs/testing.md` for the full decision tree.
+1. **A file is self-contained.** It asserts directly and runs on its own.
+2. **Exit 0 is pass, 1 is fail.** Every runner reads the exit code.
+3. **A file is deterministic.** No clock, no randomness, no dependence on how
+   fast a background thread happens to be. Where a result depends on work that
+   is in flight, drain it first — `(jit/rejections)` drains pending JIT
+   compilations, and
+   [jit-compiled-caller-promotes-callee.lisp](jit-compiled-caller-promotes-callee.lisp)
+   shows the shape.
+4. **A file tests what the language does**, not how the implementation does it.
+   An exception a file must earn in its own comment: a tier probe such as
+   `(jit? f)`, where the behavior under test IS which tier ran the code.

--- a/tests/elle/jit-compiled-caller-promotes-callee.lisp
+++ b/tests/elle/jit-compiled-caller-promotes-callee.lisp
@@ -1,0 +1,58 @@
+(elle/epoch 12)
+# audited: 2026-09-11
+# JIT promotion across the tier boundary (docs/impl/jit.md, "Function selection").
+#
+# A non-tail call is counted by whichever tier makes it. `hand-to` is warmed on
+# `decoy` until it compiles, so every later `(hand-to callee 1)` runs as native
+# code and reaches `callee` through `elle_jit_call`. Count only the
+# interpreter's calls and `callee` is called from nowhere the counter can see:
+# it never becomes hot, never compiles, and `(jit? callee)` reads false.
+#
+# The trap: the background worker hides this. A caller keeps running
+# interpreted while Cranelift works, which is long enough for its callees to be
+# counted on the interpreter's path, so the reading depends on how fast the
+# worker happens to be. `(jit/rejections)` drains pending compilations as a
+# side effect, so the first drain puts `hand-to` in the cache before `callee`
+# is called at all, and the answer stops depending on timing.
+# `--trace=syncjit` reaches the same state by installing on the first call.
+#
+# The counter-factual: `(f x)` sits under a `begin` on purpose. In tail
+# position it lowers to a TailCall, which replaces the frame instead of
+# building one and is counted by neither tier — so a tail-position probe
+# would read false whatever the call path does, and prove nothing.
+#
+# Under `--jit=off` nothing compiles and `(jit? f)` is always false, so the
+# assertions are gated on an active policy.
+
+(defn hand-to [f x]
+  (begin
+    (f x)
+    0))
+
+(defn decoy [x]
+  x)
+
+(defn callee [x]
+  (+ x 1))
+
+# Warm the caller alone. `decoy` takes the interpreter's path here, which is
+# what leaves `callee` with no interpreted call site of its own.
+(def @i 0)
+(while (< i 30)
+  (hand-to decoy 1)
+  (assign i (+ i 1)))
+(jit/rejections)
+
+(assign i 0)
+(while (< i 30)
+  (hand-to callee 1)
+  (assign i (+ i 1)))
+(jit/rejections)
+
+(when (not (= (vm/config :jit) :off))
+  (assert (jit? hand-to)
+          "precondition: the caller must be JIT-compiled, else the callee is still reached through the interpreter and the assertion below is vacuous")
+  (assert (jit? callee)
+          "a callee reached only from compiled code must still be promoted (docs/impl/jit.md, Function selection)"))
+
+(println "ok: a compiled caller promotes its callee")

--- a/tests/integration/elle_scripts.rs
+++ b/tests/integration/elle_scripts.rs
@@ -1,4 +1,4 @@
-// audited: 2026-09-05
+// audited: 2026-09-11
 // Elle scripts that must run under a PROCESS-GLOBAL runtime mode the `elle test`
 // harness cannot vary per file.
 //
@@ -11,7 +11,8 @@
 //
 // What the harness CANNOT do is set a process-global mode for one file: the
 // page-guard UAF oracle (`--trace=guardfree`), the I/O backend (`--no-uring`),
-// or a backend toggle paired with the adaptive JIT (`--jit=adaptive --mlir=off`).
+// the JIT's compile schedule (`--trace=syncjit`), or a backend toggle paired
+// with the adaptive JIT (`--jit=adaptive --mlir=off`).
 // These live in config.rs as static, once-per-process settings (the runner
 // shares one process across every file's worker thread), and a guardfree UAF
 // deliberately SIGSEGVs — which would take the single-process harness down with
@@ -73,6 +74,9 @@ mod frames {
 }
 mod modes {
     include!("elle_scripts/modes.rs");
+}
+mod syncjit {
+    include!("elle_scripts/syncjit.rs");
 }
 mod tailcalls {
     include!("elle_scripts/tailcalls.rs");

--- a/tests/integration/elle_scripts/syncjit.rs
+++ b/tests/integration/elle_scripts/syncjit.rs
@@ -1,0 +1,47 @@
+// audited: 2026-09-11
+// Corpus files run with the JIT compiling on the VM thread (`--trace=syncjit`).
+//
+// docs/impl/jit.md
+
+use super::*;
+
+// `--trace=syncjit` is a process-global trace, so the runner cannot turn it on
+// for one file; these pins are the only way the corpus meets it.
+//
+// What it buys is a schedule rather than a feature. The background worker
+// installs a compile some unbounded time after the call that asked for it, so
+// anything that depends on WHEN code is installed reads whatever the worker's
+// queue happened to do. Syncjit installs before the submitting call returns,
+// which fixes that schedule at one end of its range: a caller is compiled from
+// its first call onward, and every later call it makes runs as native code.
+//
+// Codegen inputs are identical either way (same `prepare_task` output), so a
+// disagreement between these runs and the runner's `--jit=eager` pass is never
+// about codegen. It is about what the tier does once code is installed, which
+// is exactly what an eager-only corpus cannot see.
+const SYNCJIT: &[&str] = &["--jit=eager", "--trace=syncjit"];
+
+// A caller compiled on its first call reaches its callees through
+// `elle_jit_call` from then on. These two files call their hot functions
+// indirectly through a `repeat2` helper, so under syncjit that helper is
+// compiled before it ever passes `push-imm-hot` along — and the file's own
+// `(jit? push-imm-hot)` is the reading that says whether the compiled call
+// path promotes what it calls.
+#[test]
+fn jit_bytes_push_syncjit() {
+    run_elle_script_with_args("jit-bytes-push", SYNCJIT);
+}
+
+#[test]
+fn jit_string_push_syncjit() {
+    run_elle_script_with_args("jit-string-push", SYNCJIT);
+}
+
+// The same claim with the schedule written into the file rather than into the
+// flags: the corpus file drains between the two loops, so it holds under the
+// runner's policies too. Pinned here as well because syncjit is the shape that
+// leaves the compiled caller no interpreted window at all.
+#[test]
+fn compiled_caller_promotes_callee_syncjit() {
+    run_elle_script_with_args("jit-compiled-caller-promotes-callee", SYNCJIT);
+}


### PR DESCRIPTION
Closes #1113.

## What was wrong

Neither guess in the issue is the cause. `(*closure.template).clone()` copies a
`(ptr, len)` pair into the same payload, so the clone's `bytecode().as_ptr()`
is the address `record_jit_pending` would have pinned — the key is sound. And
`push-imm-hot` is not compiled and rejected under `syncjit`; it is never
submitted at all.

Promotion only counted the interpreter's calls. `elle_jit_call` looked the
callee up in `jit_cache` and, on a miss, built an interpreter frame and said
nothing further — no counter, no submission. So the tier stopped one level
below whatever had already compiled: once a caller is native, its callees stop
arriving on the path that counts, and a callee called from nowhere else never
becomes hot.

The background worker hides that. A caller keeps running interpreted while
Cranelift works, which is long enough for its callees to be counted through
`try_jit_call`. `--trace=syncjit` installs before the submitting call returns
and leaves no such window, so the two policies disagree — which is what the two
corpus files were reporting. In `jit-bytes-push.lisp`, `repeat2` is already
cached by the time it is handed `push-imm-hot`, so every one of those 30 calls
is a JIT-to-JIT call, and `(jit? push-imm-hot)` reads false.

The same file's direct `(push-imm-hot orig 4)` does not save it: the compiler
resolves that call to the `%bytes-push` intrinsic, so no closure call is made
there on either policy.

The issue's second reading is real, and is fixed here. Three paths took a
compile result and classified a failure three ways: the poll recorded the
planned refusals and printed the rest, the drain recorded everything silently,
and the synchronous compile recorded everything silently too. The flag meant to
show a codegen failure was the one path that swallowed it.

## What the change does

`try_jit_call`'s profiling half moves to `VM::profile_jit_candidate` — count
the call, poll the worker, answer with cached code, else submit when hot — and
the miss arm of `elle_jit_call` calls it. The lookup still comes first, so a
JIT-to-JIT hit costs the one hash probe it always did; the counter and the poll
are paid only where the alternative is an interpreter frame.

A tail call is counted by neither tier, as before. It replaces the frame rather
than building one — `tail_call_inner` in the interpreter, the tail-call
sentinel in compiled code — so the two tiers stay symmetric there too.

`VM::record_jit_failure` is now the one classifier for a failed compile. Every
failure enters the negative cache, so none is re-submitted whichever kind it
was, and a Cranelift or invalid-LIR failure prints one line.

## How it was measured

`--stats compiled:`, which is the cache's length. Where the two policies
disagreed, they now agree, and at the higher count:

| file | policy | before | after |
|---|---|---:|---:|
| `functional.lisp` | `--jit=eager` | 91 | 95 |
| `functional.lisp` | `--jit=eager --trace=syncjit` | 87 | 95 |
| `jit-nqueens.lisp` | `--jit=eager` | 28 | 28 |
| `jit-nqueens.lisp` | `--jit=eager --trace=syncjit` | 27 | 28 |
| `jit-variadic.lisp` | `--jit=eager` | 20 | 20 |
| `jit-variadic.lisp` | `--jit=eager --trace=syncjit` | 19 | 20 |

`sequences`, `match`, `strings`, `closures`, `recursion`, `jit`, and `tables`
already agreed and are unchanged.

Wall clock on a kernel reached only from a compiled caller — 20000 × 500
self-recursive iterations behind a `drive` helper warmed on a decoy, six
interleaved runs, median:

| tier | before | after |
|---|---:|---:|
| `--jit=eager` | 6.79s | 0.85s |

`jit-nqueens.lisp` compiles the same set either way and is the no-regression
reading for the counter on the miss arm: 0.70s before, 0.71s after, six
interleaved runs.

`tests/elle/jit-compiled-caller-promotes-callee.lisp` fails before this change
under `--jit=eager` and passes after. `jit-bytes-push.lisp` and
`jit-string-push.lisp` fail before it under `--trace=syncjit` and pass after;
all three are pinned under that flag in `integration::elle_scripts::syncjit`.

`make smoke`, `make smoke-nouring`, `make qa`, the workspace unit tests and the
integration tests are green.
